### PR TITLE
fix(azure-devops): scope work-items query to @Me (avoid VS402337 20000-item cap)

### DIFF
--- a/e2e/tests/azure-devops-dialog.spec.ts
+++ b/e2e/tests/azure-devops-dialog.spec.ts
@@ -97,7 +97,7 @@ test.describe('Azure DevOps Dialog - Display', () => {
           targetRefName: 'refs/heads/main',
         },
       ],
-      list_ado_work_items: [
+      query_ado_work_items: [
         {
           id: 45,
           title: 'Bug: Application crashes',
@@ -352,7 +352,7 @@ test.describe('Azure DevOps Dialog - Tabs Content', () => {
           targetRefName: 'refs/heads/main',
         },
       ],
-      list_ado_work_items: [
+      query_ado_work_items: [
         {
           id: 45,
           title: 'Bug: Application crashes',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leviathan",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "description": "A fully-featured, open-source, cross-platform Git GUI client",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2927,7 +2927,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leviathan"
-version = "0.5.3"
+version = "0.5.4"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leviathan"
-version = "0.5.3"
+version = "0.5.4"
 description = "A fully-featured, open-source, cross-platform Git GUI client"
 authors = ["Leviathan Contributors"]
 edition = "2021"

--- a/src-tauri/src/commands/azure_devops.rs
+++ b/src-tauri/src/commands/azure_devops.rs
@@ -102,6 +102,10 @@ pub struct CreateAdoWorkItemInput {
     pub work_item_type: Option<String>,
     pub title: String,
     pub description: Option<String>,
+    /// Identity (unique name / UPN) to assign the new work item to. The dialog
+    /// passes the signed-in user so a created item shows up in the `@Me`-scoped
+    /// Work Items list instead of being created unassigned and vanishing.
+    pub assigned_to: Option<String>,
 }
 
 /// Pipeline run summary
@@ -852,9 +856,23 @@ fn build_work_items_wiql(state: Option<&str>) -> String {
         .map(|s| format!(" AND [System.State] = '{}'", s.replace('\'', "''")))
         .unwrap_or_default();
     format!(
-        "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.AssignedTo] = @Me{} ORDER BY [System.ChangedDate] DESC",
+        "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.AssignedTo] = @Me{} ORDER BY [System.CreatedDate] DESC",
         state_clause
     )
+}
+
+/// Map an Azure DevOps WIQL error body to a friendly, actionable message.
+/// Returns `None` when the body is not a recognized size-limit error.
+fn map_wiql_error_body(body: &str) -> Option<String> {
+    if body.contains("VS402337") || body.contains("QueryResultSizeLimitExceeded") {
+        // The list is already scoped to the signed-in user, so this only happens
+        // with an unusually large personal backlog — point the user at the web UI.
+        Some(
+            "You have too many assigned work items to list here. Open this project in Azure DevOps to view them.".to_string(),
+        )
+    } else {
+        None
+    }
 }
 
 /// Query work items assigned to current user
@@ -893,10 +911,8 @@ pub async fn query_ado_work_items(
         let body = response.text().await.unwrap_or_default();
         // Azure DevOps caps a flat WIQL result at 20000 work items (VS402337).
         // Surface a clear, actionable message instead of the raw API JSON.
-        if body.contains("VS402337") || body.contains("QueryResultSizeLimitExceeded") {
-            return Err(LeviathanError::OperationFailed(
-                "This project has too many work items to list. Try filtering by state to narrow the results.".to_string(),
-            ));
+        if let Some(message) = map_wiql_error_body(&body) {
+            return Err(LeviathanError::OperationFailed(message));
         }
         return Err(LeviathanError::OperationFailed(format!(
             "Azure DevOps API error {}: {}",
@@ -944,6 +960,18 @@ fn build_create_work_item_patch(input: &CreateAdoWorkItemInput) -> serde_json::V
                 "op": "add",
                 "path": "/fields/System.Description",
                 "value": description,
+            }));
+        }
+    }
+
+    // Assign to the given identity so a created item appears in the @Me-scoped
+    // Work Items list (the dialog passes the signed-in user).
+    if let Some(assigned_to) = &input.assigned_to {
+        if !assigned_to.is_empty() {
+            ops.push(serde_json::json!({
+                "op": "add",
+                "path": "/fields/System.AssignedTo",
+                "value": assigned_to,
             }));
         }
     }
@@ -1283,6 +1311,44 @@ mod tests {
     }
 
     #[test]
+    fn test_build_work_items_wiql_orders_by_created_date() {
+        // Must match the date the UI displays (System.CreatedDate) so the list
+        // isn't sorted by a hidden key.
+        assert!(build_work_items_wiql(None).contains("ORDER BY [System.CreatedDate] DESC"));
+    }
+
+    #[test]
+    fn test_map_wiql_error_body() {
+        assert!(map_wiql_error_body("...\"message\":\"VS402337: ...\"").is_some());
+        assert!(map_wiql_error_body("QueryResultSizeLimitExceededException").is_some());
+        // Unrelated errors are not swallowed by the friendly mapping.
+        assert_eq!(map_wiql_error_body("TF401019: project not found"), None);
+        assert_eq!(map_wiql_error_body(""), None);
+    }
+
+    #[test]
+    fn test_create_work_item_patch_includes_assigned_to() {
+        let input = CreateAdoWorkItemInput {
+            work_item_type: Some("Task".into()),
+            title: "T".into(),
+            description: None,
+            assigned_to: Some("user@example.com".into()),
+        };
+        let patch = build_create_work_item_patch(&input).to_string();
+        assert!(patch.contains("/fields/System.AssignedTo"));
+        assert!(patch.contains("user@example.com"));
+
+        // Omitted when not provided.
+        let unassigned = CreateAdoWorkItemInput {
+            assigned_to: None,
+            ..input
+        };
+        assert!(!build_create_work_item_patch(&unassigned)
+            .to_string()
+            .contains("System.AssignedTo"));
+    }
+
+    #[test]
     fn test_ado_pr_status_param() {
         // A concrete status yields the searchCriteria fragment.
         assert_eq!(
@@ -1572,6 +1638,7 @@ mod tests {
             work_item_type: Some("Bug".to_string()),
             title: "Fix the thing".to_string(),
             description: Some("It is broken".to_string()),
+            assigned_to: None,
         };
 
         let json = serde_json::to_string(&input).unwrap();
@@ -1586,6 +1653,7 @@ mod tests {
             work_item_type: Some("Task".to_string()),
             title: "My Task".to_string(),
             description: Some("Do the work".to_string()),
+            assigned_to: None,
         };
 
         let patch = build_create_work_item_patch(&input);
@@ -1609,6 +1677,7 @@ mod tests {
             work_item_type: None,
             title: "Title only".to_string(),
             description: None,
+            assigned_to: None,
         };
 
         let patch = build_create_work_item_patch(&input);
@@ -1624,6 +1693,7 @@ mod tests {
             work_item_type: Some("Task".to_string()),
             title: "Title".to_string(),
             description: Some(String::new()),
+            assigned_to: None,
         };
 
         let patch = build_create_work_item_patch(&input);

--- a/src-tauri/src/commands/azure_devops.rs
+++ b/src-tauri/src/commands/azure_devops.rs
@@ -839,6 +839,24 @@ pub async fn get_ado_work_items(
         .collect())
 }
 
+/// Build the WIQL for the work-items list.
+///
+/// Scoped to the signed-in user's assigned items (`@Me`): a project-wide flat
+/// query returns every work item, which Azure DevOps rejects with VS402337
+/// ("size limit of 20000") on large projects — and "my work items" is the
+/// intended result anyway. `@Me` keeps the result set well under the cap. The
+/// optional `state` value is single-quote-escaped so it can't break out of the
+/// WIQL string literal.
+fn build_work_items_wiql(state: Option<&str>) -> String {
+    let state_clause = state
+        .map(|s| format!(" AND [System.State] = '{}'", s.replace('\'', "''")))
+        .unwrap_or_default();
+    format!(
+        "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project AND [System.AssignedTo] = @Me{} ORDER BY [System.ChangedDate] DESC",
+        state_clause
+    )
+}
+
 /// Query work items assigned to current user
 #[command]
 pub async fn query_ado_work_items(
@@ -849,14 +867,7 @@ pub async fn query_ado_work_items(
 ) -> Result<Vec<AdoWorkItem>> {
     let token = resolve_ado_token(token)?;
 
-    let state_clause = state
-        .map(|s| format!(" AND [System.State] = '{}'", s))
-        .unwrap_or_default();
-
-    let wiql = format!(
-        "SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project{} ORDER BY [System.CreatedDate] DESC",
-        state_clause
-    );
+    let wiql = build_work_items_wiql(state.as_deref());
 
     let url = build_api_url(&organization, &project, "wit/wiql");
 
@@ -880,6 +891,13 @@ pub async fn query_ado_work_items(
     if !response.status().is_success() {
         let status = response.status();
         let body = response.text().await.unwrap_or_default();
+        // Azure DevOps caps a flat WIQL result at 20000 work items (VS402337).
+        // Surface a clear, actionable message instead of the raw API JSON.
+        if body.contains("VS402337") || body.contains("QueryResultSizeLimitExceeded") {
+            return Err(LeviathanError::OperationFailed(
+                "This project has too many work items to list. Try filtering by state to narrow the results.".to_string(),
+            ));
+        }
         return Err(LeviathanError::OperationFailed(format!(
             "Azure DevOps API error {}: {}",
             status, body
@@ -1242,6 +1260,27 @@ pub async fn list_ado_organizations(token: Option<String>) -> Result<Vec<AdoOrga
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_build_work_items_wiql_scopes_to_me() {
+        let wiql = build_work_items_wiql(None);
+        // Must scope to the current user so a large project's flat query can't
+        // exceed Azure DevOps' 20000-item WIQL limit (VS402337).
+        assert!(wiql.contains("[System.AssignedTo] = @Me"));
+        assert!(wiql.contains("[System.TeamProject] = @project"));
+        // No state filter when none is given.
+        assert!(!wiql.contains("[System.State]"));
+    }
+
+    #[test]
+    fn test_build_work_items_wiql_adds_and_escapes_state() {
+        let wiql = build_work_items_wiql(Some("Active"));
+        assert!(wiql.contains("[System.State] = 'Active'"));
+        // A single quote in the state value is escaped (doubled) so it can't
+        // break out of the WIQL string literal.
+        let injected = build_work_items_wiql(Some("O'Brien"));
+        assert!(injected.contains("'O''Brien'"));
+    }
 
     #[test]
     fn test_ado_pr_status_param() {

--- a/src-tauri/src/commands/azure_devops.rs
+++ b/src-tauri/src/commands/azure_devops.rs
@@ -843,6 +843,10 @@ pub async fn get_ado_work_items(
         .collect())
 }
 
+/// Max work items fetched for the "My Work Items" list. When the caller receives
+/// exactly this many, more may exist — the dialog surfaces a "capped" hint.
+const WORK_ITEMS_LIMIT: usize = 50;
+
 /// Build the WIQL for the work-items list.
 ///
 /// Scoped to the signed-in user's assigned items (`@Me`): a project-wide flat
@@ -935,8 +939,15 @@ pub async fn query_ado_work_items(
         LeviathanError::OperationFailed(format!("Failed to parse WIQL response: {}", e))
     })?;
 
-    // Get first 50 work items
-    let ids: Vec<u32> = data.work_items.into_iter().take(50).map(|w| w.id).collect();
+    // Fetch full details for at most WORK_ITEMS_LIMIT of the user's most-recent
+    // items. The dialog flags the list as capped when it receives this many (kept
+    // in sync with WORK_ITEMS_PAGE_SIZE on the frontend).
+    let ids: Vec<u32> = data
+        .work_items
+        .into_iter()
+        .take(WORK_ITEMS_LIMIT)
+        .map(|w| w.id)
+        .collect();
 
     if ids.is_empty() {
         return Ok(vec![]);

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Leviathan",
-  "version": "0.5.3",
+  "version": "0.5.4",
   "identifier": "io.github.hegsie.leviathan",
   "build": {
     "beforeBuildCommand": "npm run build",

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -497,6 +497,56 @@ describe('lv-azure-devops-dialog', () => {
       const secondItem = workItems[1];
       expect(secondItem.querySelector('.work-item-type')?.textContent).to.include('Bug');
     });
+
+    it('shows the @Me-scoped empty state when the user has no assigned work items', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const origMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'query_ado_work_items') return [];
+        return origMock(command, args);
+      };
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'My Work Items'
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      // Empty-state copy makes the @Me scope explicit (not a generic "none found").
+      expect(el.shadowRoot!.querySelector('.empty-state')?.textContent).to.include(
+        'No work items assigned to you'
+      );
+    });
+
+    it('surfaces the friendly size-limit message when the query exceeds the cap', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const origMock = mockInvoke;
+      // The backend maps VS402337 to this actionable message; the dialog must show it.
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'query_ado_work_items') {
+          throw new Error('You have too many assigned work items to list here. Open this project in Azure DevOps to view them.');
+        }
+        return origMock(command, args);
+      };
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'My Work Items'
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelector('.error')?.textContent).to.include(
+        'too many assigned work items'
+      );
+    });
   });
 
   describe('Create Work Item', () => {
@@ -597,6 +647,9 @@ describe('lv-azure-devops-dialog', () => {
       expect(input.title).to.equal('New task');
       expect(input.workItemType).to.equal('Task');
       expect(input.description).to.equal('Do it');
+      // Assigns the new item to the signed-in user so it appears in the
+      // @Me-scoped list instead of being created unassigned and vanishing.
+      expect(input.assignedTo).to.equal(mockAdoUser.uniqueName);
 
       // Refreshes work items list
       expect(invokeHistory.some((c) => c.command === 'query_ado_work_items')).to.be.true;

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -284,7 +284,7 @@ describe('lv-azure-devops-dialog', () => {
       const tabTexts = Array.from(tabs).map((t) => t.textContent?.trim());
       expect(tabTexts).to.include('Connection');
       expect(tabTexts).to.include('Pull Requests');
-      expect(tabTexts).to.include('Work Items');
+      expect(tabTexts).to.include('My Work Items');
       expect(tabTexts).to.include('Pipelines');
     });
 
@@ -481,7 +481,7 @@ describe('lv-azure-devops-dialog', () => {
 
       // Switch to Work Items tab
       const tabs = el.shadowRoot!.querySelectorAll('.tab');
-      const wiTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Work Items') as HTMLButtonElement;
+      const wiTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'My Work Items') as HTMLButtonElement;
       wiTab.click();
       await waitForLoad(el);
 
@@ -510,7 +510,7 @@ describe('lv-azure-devops-dialog', () => {
       await waitForLoad(el);
 
       const tabs = el.shadowRoot!.querySelectorAll('.tab');
-      (Array.from(tabs).find((t) => t.textContent?.trim() === 'Work Items') as HTMLButtonElement).click();
+      (Array.from(tabs).find((t) => t.textContent?.trim() === 'My Work Items') as HTMLButtonElement).click();
       await waitForLoad(el);
 
       const newBtn = Array.from(el.shadowRoot!.querySelectorAll('.btn')).find(
@@ -529,7 +529,7 @@ describe('lv-azure-devops-dialog', () => {
       await waitForLoad(el);
 
       const tabs = el.shadowRoot!.querySelectorAll('.tab');
-      (Array.from(tabs).find((t) => t.textContent?.trim() === 'Work Items') as HTMLButtonElement).click();
+      (Array.from(tabs).find((t) => t.textContent?.trim() === 'My Work Items') as HTMLButtonElement).click();
       await waitForLoad(el);
       (Array.from(el.shadowRoot!.querySelectorAll('.btn')).find(
         (b) => b.textContent?.trim().includes('New Work Item')
@@ -567,7 +567,7 @@ describe('lv-azure-devops-dialog', () => {
       await waitForLoad(el);
 
       const tabs = el.shadowRoot!.querySelectorAll('.tab');
-      (Array.from(tabs).find((t) => t.textContent?.trim() === 'Work Items') as HTMLButtonElement).click();
+      (Array.from(tabs).find((t) => t.textContent?.trim() === 'My Work Items') as HTMLButtonElement).click();
       await waitForLoad(el);
       (Array.from(el.shadowRoot!.querySelectorAll('.btn')).find(
         (b) => b.textContent?.trim().includes('New Work Item')
@@ -617,7 +617,7 @@ describe('lv-azure-devops-dialog', () => {
       await waitForLoad(el);
 
       const tabs = el.shadowRoot!.querySelectorAll('.tab');
-      (Array.from(tabs).find((t) => t.textContent?.trim() === 'Work Items') as HTMLButtonElement).click();
+      (Array.from(tabs).find((t) => t.textContent?.trim() === 'My Work Items') as HTMLButtonElement).click();
       await waitForLoad(el);
       (Array.from(el.shadowRoot!.querySelectorAll('.btn')).find(
         (b) => b.textContent?.trim().includes('New Work Item')

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -657,6 +657,53 @@ describe('lv-azure-devops-dialog', () => {
       expect(invokeHistory.some((c) => c.command === 'query_ado_work_items')).to.be.true;
     });
 
+    it('shows a just-created item even when it is not in the @Me-scoped reload (no-UPN identity)', async () => {
+      // A connected user whose uniqueName is not UPN-like (no '@') → the create
+      // handler omits assignedTo, so the created item is unassigned and absent
+      // from the @Me reload. It must still be shown (prepended).
+      connectionResponse = {
+        connected: true,
+        user: { id: 'u', displayName: 'Legacy User', uniqueName: 'DOMAIN\\legacy', imageUrl: null },
+        organization: 'testorg',
+      };
+      detectedRepoResponse = mockDetectedRepo;
+      const createdItem = {
+        id: 4242,
+        title: 'Orphan task',
+        workItemType: 'Task',
+        state: 'New',
+        assignedTo: null,
+        createdDate: '2025-03-01T10:00:00Z',
+        url: 'https://dev.azure.com/testorg/test-project/_workitems/edit/4242',
+      };
+      const origMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'create_azure_devops_work_item') return createdItem;
+        // The @Me reload never returns the (unassigned) created item.
+        if (command === 'query_ado_work_items') return [];
+        return origMock(command, args);
+      };
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      Object.assign(el as unknown as Record<string, unknown>, {
+        activeTab: 'create-work-item',
+        createWorkItemTitle: 'Orphan task',
+      });
+      await el.updateComplete;
+      await (el as unknown as { handleCreateWorkItem: () => Promise<void> }).handleCreateWorkItem();
+      await el.updateComplete;
+
+      // assignedTo was omitted (non-UPN identity), yet the created item is shown.
+      const createCall = invokeHistory.find((c) => c.command === 'create_azure_devops_work_item');
+      expect((createCall!.args as { input: Record<string, unknown> }).input.assignedTo).to.be.undefined;
+      const titles = Array.from(el.shadowRoot!.querySelectorAll('.work-item-title')).map((n) => n.textContent);
+      expect(titles.some((t) => t?.includes('Orphan task'))).to.be.true;
+    });
+
     it('shows an error when create_azure_devops_work_item fails (not silent)', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -546,6 +546,8 @@ describe('lv-azure-devops-dialog', () => {
       expect(el.shadowRoot!.querySelector('.error')?.textContent).to.include(
         'too many assigned work items'
       );
+      // The empty state must NOT render alongside the error (contradictory copy).
+      expect(el.shadowRoot!.querySelector('.empty-state')).to.be.null;
     });
   });
 

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -1118,6 +1118,10 @@ export class LvAzureDevOpsDialog extends LitElement {
   private async loadPipelineRuns(providedToken?: string): Promise<void> {
     if (!this.detectedRepo || !this.connectionStatus?.connected) return;
 
+    // Clear any stale error (e.g. from another tab) so a successful load starts
+    // clean — matches loadPullRequests / loadWorkItems.
+    this.error = null;
+
     try {
       const token = providedToken ?? await this.getSelectedAccountToken();
       const result = await gitService.listAdoPipelineRuns(

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -1085,6 +1085,10 @@ export class LvAzureDevOpsDialog extends LitElement {
   private async loadWorkItems(providedToken?: string): Promise<void> {
     if (!this.detectedRepo || !this.connectionStatus?.connected) return;
 
+    // Clear any stale error (e.g. from another tab) so a successful load starts
+    // clean — matches loadPullRequests.
+    this.error = null;
+
     try {
       const token = providedToken ?? await this.getSelectedAccountToken();
       const result = await gitService.queryAdoWorkItems(
@@ -1772,8 +1776,13 @@ export class LvAzureDevOpsDialog extends LitElement {
         description: this.createWorkItemDescription || undefined,
         // Assign to the signed-in user so the new item appears in the
         // @Me-scoped Work Items list (otherwise it's created unassigned and
-        // would be absent from the list that's reloaded right after).
-        assignedTo: this.connectionStatus?.user?.uniqueName || undefined,
+        // would be absent from the list that's reloaded right after). Only use a
+        // UPN-like identity (uniqueName can fall back to a non-unique display
+        // name when the profile has no email — assigning by that is ambiguous, so
+        // leave the item unassigned rather than risk the wrong person).
+        assignedTo: this.connectionStatus?.user?.uniqueName?.includes('@')
+          ? this.connectionStatus.user.uniqueName
+          : undefined,
       };
 
       const token = await this.getSelectedAccountToken();
@@ -2083,7 +2092,7 @@ export class LvAzureDevOpsDialog extends LitElement {
       `;
     }
 
-    if (this.workItems.length === 0) {
+    if (this.workItems.length === 0 && !this.error) {
       return html`
         <div class="filter-row">
           <button class="btn" @click=${() => this.activeTab = 'create-work-item'}>

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -34,6 +34,13 @@ import './lv-account-selector.ts';
 
 type TabType = 'connection' | 'pull-requests' | 'work-items' | 'pipelines' | 'create-pr' | 'create-work-item';
 
+/**
+ * Max work items the backend returns for the "My Work Items" list (kept in sync
+ * with WORK_ITEMS_LIMIT in commands/azure_devops.rs). When the list is exactly
+ * this long, more may exist and the tab shows a "capped" hint.
+ */
+const WORK_ITEMS_PAGE_SIZE = 50;
+
 /** OAuth tokens carried from an Entra sign-in through org resolution to persistence. */
 interface EntraTokens {
   accessToken: string;
@@ -1794,11 +1801,18 @@ export class LvAzureDevOpsDialog extends LitElement {
       );
 
       if (result.success && result.data) {
+        const created = result.data;
         this.createWorkItemType = 'Task';
         this.createWorkItemTitle = '';
         this.createWorkItemDescription = '';
         this.activeTab = 'work-items';
         await this.loadWorkItems();
+        // Ensure the just-created item is visible even in the edge case where it
+        // couldn't be self-assigned (no UPN), so it isn't reloaded out of the
+        // @Me-scoped list and replaced by a confusing "none assigned" empty state.
+        if (!this.workItems.some((w) => w.id === created.id)) {
+          this.workItems = [created, ...this.workItems];
+        }
         showToast('Work item created successfully', 'success');
       } else {
         this.error = result.error?.message ?? 'Failed to create work item';
@@ -2131,6 +2145,16 @@ export class LvAzureDevOpsDialog extends LitElement {
           </div>
         `)}
       </div>
+      ${this.workItems.length >= WORK_ITEMS_PAGE_SIZE ? html`
+        <p class="help-text" style="text-align:center;padding-top:8px">
+          Showing your ${WORK_ITEMS_PAGE_SIZE} most recent.
+          ${this.detectedRepo ? html`<a
+            class="help-link"
+            href="https://dev.azure.com/${this.detectedRepo.organization}/${this.detectedRepo.project}/_workitems/"
+            @click=${handleExternalLink}
+          >Open in Azure DevOps</a> for the full list.` : nothing}
+        </p>
+      ` : nothing}
     `;
   }
 

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -1770,6 +1770,10 @@ export class LvAzureDevOpsDialog extends LitElement {
         workItemType: this.createWorkItemType || 'Task',
         title: this.createWorkItemTitle,
         description: this.createWorkItemDescription || undefined,
+        // Assign to the signed-in user so the new item appears in the
+        // @Me-scoped Work Items list (otherwise it's created unassigned and
+        // would be absent from the list that's reloaded right after).
+        assignedTo: this.connectionStatus?.user?.uniqueName || undefined,
       };
 
       const token = await this.getSelectedAccountToken();
@@ -2091,7 +2095,7 @@ export class LvAzureDevOpsDialog extends LitElement {
             <path d="M9 11l3 3L22 4"></path>
             <path d="M21 12v7a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h11"></path>
           </svg>
-          <p>No work items found</p>
+          <p>No work items assigned to you</p>
         </div>
       `;
     }
@@ -2358,7 +2362,7 @@ export class LvAzureDevOpsDialog extends LitElement {
               class="tab ${this.activeTab === 'work-items' ? 'active' : ''}"
               @click=${() => { this.activeTab = 'work-items'; this.loadWorkItems(); }}
             >
-              Work Items
+              My Work Items
             </button>
             <button
               class="tab ${this.activeTab === 'pipelines' ? 'active' : ''}"

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -3601,6 +3601,8 @@ export interface CreateAdoWorkItemInput {
   workItemType?: string;
   title: string;
   description?: string;
+  /** Identity (unique name / UPN) to assign the new work item to. */
+  assignedTo?: string;
 }
 
 export async function createAzureDevOpsWorkItem(


### PR DESCRIPTION
## Summary

On a large Azure DevOps project, opening the integration (after a **successful** sign-in) showed a scary red banner on the Connection tab:

> Operation failed: Azure DevOps API error 400 Bad Request: … VS402337: The number of work items returned exceeds the size limit of 20000. Change the query to return fewer items.

`query_ado_work_items` ran a **project-wide flat WIQL** (`SELECT [System.Id] FROM WorkItems WHERE [System.TeamProject] = @project …`) that matched every work item in the project. Azure DevOps caps a flat WIQL result at 20000 and rejects anything larger — so on a big project (e.g. SEFE's BigBoy) the query 400s before we ever page the IDs. The `.take(50)` was client-side, too late. Despite the function's "assigned to current user" doc comment, the `@Me` filter was missing.

## Changes (`src-tauri/src/commands/azure_devops.rs`)

- **Scope the WIQL to the signed-in user's assigned items**: `AND [System.AssignedTo] = @Me`, `ORDER BY [System.ChangedDate] DESC`. This is the intended "my work items" view and stays well under the 20000 cap.
- **Extract `build_work_items_wiql`** as a pure, unit-tested helper.
- **Escape the optional `state` value** (single-quote doubling) so it can't break out of the WIQL string literal.
- **Map the VS402337 / `QueryResultSizeLimitExceeded` error** to a clear, actionable message instead of raw API JSON.

## Testing

- New unit tests: WIQL scopes to `@Me` and to the project; state filter is added and single-quote-escaped.
- `cargo fmt` / `clippy -D warnings` / azure_devops tests green (33 passed).
- Recursive multi-model review (Opus/Sonnet/Haiku) in progress.

Follow-up to the Azure DevOps sign-in (#256) and Windows token-storage (#258) work; ships in **v0.5.4**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ

---
_Generated by [Claude Code](https://claude.ai/code/session_015kYCBgnK6GeKH3C4G3D3BQ)_