### PR TITLE
chore(release): bump version to 0.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leviathan",
-  "version": "0.4.1",
+  "version": "0.6.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leviathan",
-      "version": "0.4.1",
+      "version": "0.6.0",
       "dependencies": {
         "@lit-labs/context": "^0.5.0",
         "@tauri-apps/api": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leviathan",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "description": "A fully-featured, open-source, cross-platform Git GUI client",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2927,7 +2927,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leviathan"
-version = "0.5.4"
+version = "0.6.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leviathan"
-version = "0.5.4"
+version = "0.6.0"
 description = "A fully-featured, open-source, cross-platform Git GUI client"
 authors = ["Leviathan Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Leviathan",
-  "version": "0.5.4",
+  "version": "0.6.0",
   "identifier": "io.github.hegsie.leviathan",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Bumps the app version from 0.5.4 to 0.6.0 across `package.json`, `package-lock.json`, `src-tauri/Cargo.toml`, `src-tauri/Cargo.lock`, and `src-tauri/tauri.conf.json`.

Minor release shipping the commit-graph overhaul from #271:
- Topological commit ordering with stable lanes and per-branch colors; HEAD mainline pinned to lane 0
- Cached backend pagination with a true commit total and incremental layout append
- Zoom/density control, graph minimap, and full-history scrollbar with catch-up loading
- Jump-to-HEAD and reveal branch/tag from the command palette
- Optional author/date columns, PNG export improvements
- Accessibility: screen-reader mirror rows, dashed merge edges, contrast-aware icon colors

After this merges, tagging the merge commit `v0.6.0` will trigger the Build &amp; Release workflow to produce the draft GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7gxVU7ZroGxLTHducrmPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7gxVU7ZroGxLTHducrmPb)_