### PR TITLE
ci: allow releasing via manual workflow dispatch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,6 +10,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      release:
+        description: 'Create the vX.Y.Z tag and draft release from the version in tauri.conf.json'
+        type: boolean
+        default: false
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -24,7 +29,7 @@ env:
 jobs:
   test-e2e:
     name: E2E Tests
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release)
     runs-on: ubuntu-latest
 
     steps:
@@ -121,12 +126,14 @@ jobs:
 
       # Build without release for non-tag pushes (skip signing, use specific bundles)
       - name: Build Tauri app
-        if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
+        if: ${{ !(startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release)) }}
         run: npm run tauri build -- --target ${{ matrix.target }} --bundles ${{ matrix.bundles }} --no-sign
 
-      # Build with release for tagged pushes
+      # Build with release for tagged pushes, or a manual dispatch with the
+      # release input — tauri-action then creates the v__VERSION__ tag (from
+      # tauri.conf.json) and the draft release itself.
       - name: Build Tauri app (Release)
-        if: startsWith(github.ref, 'refs/tags/v')
+        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release)
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Adds a `release` boolean input to the Build &amp; Release workflow's `workflow_dispatch` trigger, so a full release can be cut from the Actions tab ("Run workflow" → tick **release**) without pushing a tag manually.

When the input is checked, the dispatch takes the same path as a `v*` tag push:
- the E2E Tests gate runs first,
- the signed `tauri-action` build runs, and tauri-action creates the `vX.Y.Z` tag (from the version in `tauri.conf.json`) and the draft GitHub release itself.

A plain dispatch without the input keeps today's behaviour (unsigned build, no release). Tag pushes, main pushes, and PR builds are unchanged.

Motivation: the v0.6.0 release stalled because the remote session couldn't push tag refs — this makes future releases one click after the version-bump PR merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01N7gxVU7ZroGxLTHducrmPb

---
_Generated by [Claude Code](https://claude.ai/code/session_01N7gxVU7ZroGxLTHducrmPb)_