### PR TITLE
feat(conflicts): marker-free merge editor, hardened marker detection, and repo-pinned git operations

### DIFF
--- a/e2e/tests/merge-editor.spec.ts
+++ b/e2e/tests/merge-editor.spec.ts
@@ -440,6 +440,10 @@ test.describe('Merge Editor - Stash source certainty', () => {
       discard_changes: null,
     });
 
+    // The clean-state banner must not overclaim a stash source either.
+    await expect(page.locator('.operation-text')).toContainText('Conflicts need resolution');
+    await expect(page.locator('.operation-text')).not.toContainText('Stash');
+
     // Open via the conflicted-file click (state-derived: uncertain source).
     await page.locator('lv-file-status .file-item', { hasText: 'conflict.ts' }).first().click();
     await expect(page.locator('lv-conflict-resolution-dialog[open]')).toBeVisible();

--- a/e2e/tests/merge-editor.spec.ts
+++ b/e2e/tests/merge-editor.spec.ts
@@ -341,14 +341,21 @@ test.describe('Merge Editor - Conflict Resolution Dialog', () => {
   test('clicking a conflicted file in the sidebar opens the conflict dialog, not the diff view', async ({
     page,
   }) => {
-    // Click the conflicted file in the working-changes list
-    const fileItem = page.locator('lv-file-status .file-item', { hasText: 'conflict.ts' }).first();
+    // Click the SECOND conflicted file — the dialog must open on the file
+    // that was actually clicked, not just the first conflict in the list.
+    const fileItem = page.locator('lv-file-status .file-item', { hasText: 'another.ts' }).first();
     await expect(fileItem).toBeVisible();
     await fileItem.click();
 
     // The conflict resolution dialog opens instead of the raw diff view
     await expect(page.locator('lv-conflict-resolution-dialog[open]')).toBeVisible();
     await expect(page.locator('lv-merge-editor .toolbar')).toBeVisible();
+
+    // Preselected on the clicked file
+    await expect(page.locator('lv-merge-editor .toolbar-title')).toContainText('another.ts');
+    await expect(
+      page.locator('lv-conflict-resolution-dialog .file-item.selected')
+    ).toContainText('another.ts');
 
     // And no raw conflict markers are visible anywhere on the page
     const dialogText = await page.locator('lv-conflict-resolution-dialog').innerText();
@@ -484,10 +491,10 @@ test.describe('Merge Editor - UI Outcome Verification', () => {
     // The output panel should now reflect the ours content (no conflict markers)
     const outputPanel = page.locator('lv-merge-editor .output-panel');
     await expect(outputPanel).toBeVisible();
-    // There should be no conflict action buttons remaining in the output
-    const conflictActions = page.locator('lv-merge-editor .output-panel .conflict-actions');
-    const actionCount = await conflictActions.count();
-    expect(actionCount).toBe(0);
+    // There should be no conflict blocks remaining in the output
+    const conflictBlocks = page.locator('lv-merge-editor .output-panel .code-conflict-block');
+    const blockCount = await conflictBlocks.count();
+    expect(blockCount).toBe(0);
   });
 
   test('Use Theirs resolves conflicts and output panel reflects no remaining conflicts', async ({
@@ -517,9 +524,9 @@ test.describe('Merge Editor - UI Outcome Verification', () => {
     // The output panel should reflect the theirs content (no conflict markers)
     const outputPanel = page.locator('lv-merge-editor .output-panel');
     await expect(outputPanel).toBeVisible();
-    const conflictActions = page.locator('lv-merge-editor .output-panel .conflict-actions');
-    const actionCount = await conflictActions.count();
-    expect(actionCount).toBe(0);
+    const conflictBlocks = page.locator('lv-merge-editor .output-panel .code-conflict-block');
+    const blockCount = await conflictBlocks.count();
+    expect(blockCount).toBe(0);
   });
 
   test('Continue button enables after all conflicts are resolved', async ({ page }) => {

--- a/e2e/tests/merge-editor.spec.ts
+++ b/e2e/tests/merge-editor.spec.ts
@@ -364,6 +364,56 @@ test.describe('Merge Editor - Conflict Resolution Dialog', () => {
   });
 });
 
+test.describe('Merge Editor - Live diff transitions', () => {
+  test('an open diff transitions when its file becomes conflicted and closes when resolved', async ({
+    page,
+  }) => {
+    await setupOpenRepository(page, {
+      status: {
+        staged: [],
+        unstaged: [
+          { path: 'src/live.ts', status: 'modified', isStaged: false, isConflicted: false },
+        ],
+      },
+    });
+
+    // Open the diff on the (not yet conflicted) file
+    const fileItem = page.locator('lv-file-status .file-item', { hasText: 'live.ts' }).first();
+    await expect(fileItem).toBeVisible();
+    await fileItem.click();
+    await expect(page.locator('lv-diff-view')).toBeVisible();
+    await expect(page.locator('lv-diff-view .conflict-redirect')).toHaveCount(0);
+
+    // An external merge conflicts the file — the status refresh must flip the
+    // open diff to the merge-editor redirect instead of rendering marker text.
+    await page.evaluate(() => {
+      const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as {
+        repositoryStore: { getState: () => { setStatus: (s: unknown[]) => void } };
+      };
+      stores.repositoryStore.getState().setStatus([
+        { path: 'src/live.ts', status: 'conflicted', isStaged: false, isConflicted: true },
+      ]);
+    });
+
+    await expect(page.locator('lv-diff-view .conflict-redirect')).toBeVisible();
+    const text = await page.locator('lv-diff-view').innerText();
+    expect(text).not.toContain('<<<<<<<');
+
+    // The conflict is resolved and committed externally — the file leaves the
+    // status entirely. The stale interstitial must close, not claim conflicts
+    // forever.
+    await page.evaluate(() => {
+      const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as {
+        repositoryStore: { getState: () => { setStatus: (s: unknown[]) => void } };
+      };
+      stores.repositoryStore.getState().setStatus([]);
+    });
+
+    await expect(page.locator('lv-diff-view .conflict-redirect')).toHaveCount(0);
+    await expect(page.locator('lv-diff-view')).toHaveCount(0);
+  });
+});
+
 test.describe('Merge Editor - Error Handling', () => {
   const oneConflictFile = [
     {

--- a/e2e/tests/merge-editor.spec.ts
+++ b/e2e/tests/merge-editor.spec.ts
@@ -414,6 +414,64 @@ test.describe('Merge Editor - Live diff transitions', () => {
   });
 });
 
+test.describe('Merge Editor - Stash source certainty', () => {
+  test('inferred-stash wording does not leak into a later explicit stash flow', async ({
+    page,
+  }) => {
+    // Clean repository state with conflicted files = a state-INFERRED stash.
+    await setupOpenRepository(page, {
+      status: {
+        staged: [],
+        unstaged: [
+          { path: 'src/conflict.ts', status: 'conflicted', isStaged: false, isConflicted: true },
+        ],
+      },
+    });
+    await injectCommandMock(page, {
+      ...conflictMocks([
+        {
+          path: 'src/conflict.ts',
+          ancestor: { oid: 'ancestor_oid_123' },
+          ours: { oid: 'ours_oid_456' },
+          theirs: { oid: 'theirs_oid_789' },
+        },
+      ]),
+      unstage_files: null,
+      discard_changes: null,
+    });
+
+    // Open via the conflicted-file click (state-derived: uncertain source).
+    await page.locator('lv-file-status .file-item', { hasText: 'conflict.ts' }).first().click();
+    await expect(page.locator('lv-conflict-resolution-dialog[open]')).toBeVisible();
+
+    const abortBtn = page.locator('lv-conflict-resolution-dialog .footer-actions .btn-danger');
+    await abortBtn.click();
+    const confirmMsg = page.locator('lv-conflict-resolution-dialog .confirm-message');
+    await expect(confirmMsg).toContainText('not saved anywhere else');
+
+    // Abort for real to close the dialog.
+    await page.locator('lv-conflict-resolution-dialog .confirm-actions .btn-danger').click();
+    await expect(page.locator('lv-conflict-resolution-dialog[open]')).not.toBeVisible();
+
+    // Now an EXPLICIT stash conflict (as the stash panel dispatches it) —
+    // the earlier uncertainty must not leak into its wording.
+    await page.evaluate(() => {
+      const shell = document.querySelector('lv-app-shell');
+      shell?.dispatchEvent(
+        new CustomEvent('open-conflict-dialog', {
+          detail: { operationType: 'stash', stashIndex: 0, dropStashOnComplete: false },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    });
+    await expect(page.locator('lv-conflict-resolution-dialog[open]')).toBeVisible();
+
+    await abortBtn.click();
+    await expect(confirmMsg).toContainText('remains in the stash list');
+  });
+});
+
 test.describe('Merge Editor - Error Handling', () => {
   const oneConflictFile = [
     {

--- a/e2e/tests/merge-editor.spec.ts
+++ b/e2e/tests/merge-editor.spec.ts
@@ -159,7 +159,7 @@ test.describe('Merge Editor - Conflict Resolution Dialog', () => {
     await expect(markResolvedBtn).toContainText('Mark Resolved');
   });
 
-  test('output panel shows conflict blocks with Use Ours/Theirs/Both buttons', async ({
+  test('output panel shows conflict blocks with Use Ours/Theirs/Both/Edit buttons', async ({
     page,
   }) => {
     await openConflictResolutionDialog(page);
@@ -169,6 +169,74 @@ test.describe('Merge Editor - Conflict Resolution Dialog', () => {
     // The conflict count in the output header should indicate conflicts remaining
     const conflictCount = mergeEditor.locator('.conflict-count');
     await expect(conflictCount).toBeVisible();
+    await expect(conflictCount).toContainText('1 conflict remaining');
+
+    // The unresolved conflict renders as a structured block with per-block actions
+    const block = mergeEditor.locator('.code-conflict-block');
+    await expect(block).toBeVisible();
+    await expect(block.locator('button', { hasText: 'Use Ours' })).toBeVisible();
+    await expect(block.locator('button', { hasText: 'Use Theirs' })).toBeVisible();
+    await expect(block.locator('button', { hasText: 'Use Both' })).toBeVisible();
+    await expect(block.locator('button', { hasText: 'Edit' })).toBeVisible();
+
+    // Both sides are shown side by side inside the block
+    await expect(block.locator('.code-conflict-side-ours')).toContainText('ours');
+    await expect(block.locator('.code-conflict-side-theirs')).toContainText('theirs');
+  });
+
+  test('never renders raw conflict markers anywhere in the editor', async ({ page }) => {
+    await openConflictResolutionDialog(page);
+
+    const mergeEditor = page.locator('lv-merge-editor');
+    await expect(mergeEditor.locator('.code-conflict-block')).toBeVisible();
+
+    const text = await mergeEditor.innerText();
+    expect(text).not.toContain('<<<<<<<');
+    expect(text).not.toContain('=======');
+    expect(text).not.toContain('>>>>>>>');
+  });
+
+  test('per-block Use Theirs resolves just that block and enables Mark Resolved', async ({
+    page,
+  }) => {
+    await openConflictResolutionDialog(page);
+
+    // Mark Resolved is disabled while the conflict block is unresolved
+    const markResolvedBtn = page.locator('lv-merge-editor .toolbar-actions .btn-primary');
+    await expect(markResolvedBtn).toBeDisabled();
+
+    const block = page.locator('lv-merge-editor .code-conflict-block');
+    await block.locator('button', { hasText: 'Use Theirs' }).click();
+
+    // The block is resolved: count reads "No conflicts", theirs content is in
+    // the output, and Mark Resolved becomes clickable
+    await expect(page.locator('lv-merge-editor .conflict-count')).toContainText('No conflicts');
+    await expect(page.locator('lv-merge-editor #panel-output')).toContainText('theirs');
+    await expect(markResolvedBtn).toBeEnabled();
+  });
+
+  test('per-block Edit opens a marker-free editor and Apply resolves the block', async ({
+    page,
+  }) => {
+    await openConflictResolutionDialog(page);
+
+    const block = page.locator('lv-merge-editor .code-conflict-block');
+    await block.locator('button', { hasText: 'Edit' }).click();
+
+    // The edit textarea is prefilled from both sides, never with marker text
+    const textarea = page.locator('lv-merge-editor .segment-editor textarea');
+    await expect(textarea).toBeVisible();
+    const draft = await textarea.inputValue();
+    expect(draft).not.toContain('<<<<<<<');
+    expect(draft).not.toContain('=======');
+    expect(draft).toContain('ours');
+    expect(draft).toContain('theirs');
+
+    await textarea.fill('const value = "hand-merged";');
+    await page.locator('lv-merge-editor .segment-editor button', { hasText: 'Apply' }).click();
+
+    await expect(page.locator('lv-merge-editor .conflict-count')).toContainText('No conflicts');
+    await expect(page.locator('lv-merge-editor #panel-output')).toContainText('hand-merged');
   });
 
   test('clicking Use Ours in toolbar replaces output with ours content', async ({ page }) => {
@@ -270,22 +338,22 @@ test.describe('Merge Editor - Conflict Resolution Dialog', () => {
     await expect(subtitle).toContainText('0 of 2');
   });
 
-  test('can toggle between visual and raw edit mode in output', async ({ page }) => {
-    await openConflictResolutionDialog(page);
+  test('clicking a conflicted file in the sidebar opens the conflict dialog, not the diff view', async ({
+    page,
+  }) => {
+    // Click the conflicted file in the working-changes list
+    const fileItem = page.locator('lv-file-status .file-item', { hasText: 'conflict.ts' }).first();
+    await expect(fileItem).toBeVisible();
+    await fileItem.click();
 
-    const toggleBtn = page.locator('lv-merge-editor .output-mode-toggle');
-    await expect(toggleBtn).toBeVisible();
-    await expect(toggleBtn).toContainText('Raw Edit');
+    // The conflict resolution dialog opens instead of the raw diff view
+    await expect(page.locator('lv-conflict-resolution-dialog[open]')).toBeVisible();
+    await expect(page.locator('lv-merge-editor .toolbar')).toBeVisible();
 
-    // Click to switch to raw edit mode
-    await toggleBtn.click();
-
-    // Now should show "Visual" option (meaning we're in raw mode)
-    await expect(toggleBtn).toContainText('Visual');
-
-    // Raw edit mode should show a textarea
-    const textarea = page.locator('lv-merge-editor .editable-textarea');
-    await expect(textarea).toBeVisible();
+    // And no raw conflict markers are visible anywhere on the page
+    const dialogText = await page.locator('lv-conflict-resolution-dialog').innerText();
+    expect(dialogText).not.toContain('<<<<<<<');
+    expect(dialogText).not.toContain('>>>>>>>');
   });
 });
 

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -894,17 +894,28 @@ pub async fn get_conflicts(path: String) -> Result<Vec<ConflictFile>> {
             .map(|e| String::from_utf8_lossy(&e.path).to_string())
             .unwrap_or_default();
 
+        // Submodule (gitlink) conflicts have COMMIT OIDs, not blobs — every
+        // blob-based affordance (text editor, side panes, verbatim buttons)
+        // would dead-end on them. Flag them so the frontend routes to a
+        // commit-pointer chooser instead.
+        let is_submodule = [&conflict.our, &conflict.their, &conflict.ancestor]
+            .iter()
+            .filter_map(|e| e.as_ref())
+            .any(|e| e.mode == 0o160000);
+
         // Binary conflicts must not be routed through the text merge editor.
         // SYMLINK conflicts must not either: their blobs are text (the link
         // target path), but resolving them means recreating a LINK, not
         // writing text — the whole-blob chooser (take-side, which is
         // symlink-aware) is the only correct affordance.
-        let is_binary = [&conflict.our, &conflict.their, &conflict.ancestor]
-            .iter()
-            .filter_map(|e| e.as_ref())
-            .any(|e| {
-                e.mode == 0o120000 || repo.find_blob(e.id).map(|b| b.is_binary()).unwrap_or(false)
-            });
+        let is_binary = !is_submodule
+            && [&conflict.our, &conflict.their, &conflict.ancestor]
+                .iter()
+                .filter_map(|e| e.as_ref())
+                .any(|e| {
+                    e.mode == 0o120000
+                        || repo.find_blob(e.id).map(|b| b.is_binary()).unwrap_or(false)
+                });
 
         // How this file's conflict hunks were actually written. The
         // conflict-marker-size attribute and merge.conflictStyle config only
@@ -914,7 +925,9 @@ pub async fn get_conflicts(path: String) -> Result<Vec<ConflictFile>> {
         // Binary conflicts have no marker hunks to detect (and libgit2's
         // binary merge result has no content to replay against) — report
         // the defaults; the text merge editor never parses them anyway.
-        let (marker_size, conflict_style, conflict_hunks) = if is_binary {
+        // Submodule conflicts have no text either (the workdir path is a
+        // directory).
+        let (marker_size, conflict_style, conflict_hunks) = if is_binary || is_submodule {
             (
                 crate::models::conflict::default_marker_size(),
                 crate::models::conflict::default_conflict_style(),
@@ -937,6 +950,7 @@ pub async fn get_conflicts(path: String) -> Result<Vec<ConflictFile>> {
             ours: get_entry(conflict.our),
             theirs: get_entry(conflict.their),
             is_binary,
+            is_submodule,
             marker_size,
             conflict_style,
             conflict_hunks,
@@ -993,22 +1007,61 @@ fn has_complete_conflict(content: &str, size: usize) -> bool {
     false
 }
 
+/// A crafted file can demonstrate thousands of distinct sizes (escalating
+/// marker runs); each one downstream becomes up to three merge replays, so
+/// an uncapped list would let a hostile repo stall get_conflicts for
+/// minutes. Real emissions demonstrate one or two sizes; the earliest-seen
+/// ones are kept because the first complete conflict is git's own.
+const MAX_DETECTED_SIZES: usize = 16;
+
 /// Marker sizes the file's content DEMONSTRATES: distinct start-run lengths
-/// (7+, space/EOL-terminated) that form a complete conflict at their own
-/// size. Used when the conflict-marker-size attribute no longer matches
-/// what git wrote (it can change mid-operation via .gitattributes' own
-/// resolution). The 7+ floor avoids false positives on `< quoted` lines.
+/// (space/EOL-terminated) that form a complete conflict (start, then
+/// separator, then end) at their own size. Used when the
+/// conflict-marker-size attribute no longer matches what git wrote (it can
+/// change mid-operation via .gitattributes' own resolution). Callers pass
+/// `min_size` 7 for structural use (avoiding false positives on `< quoted`
+/// lines) or 1 for replay candidates (replay rejects wrong sizes safely).
+///
+/// Single pass: every marker-shaped line advances a per-size completeness
+/// state machine. Rescanning the file per distinct size would be
+/// O(sizes × lines) — a hostile file with escalating run lengths turns
+/// that into a multi-minute hang of get_conflicts.
 fn detected_marker_sizes(content: &str, min_size: usize) -> Vec<u32> {
+    use std::collections::HashMap;
+    // 0 = want start, 1 = want separator, 2 = want end, 3 = complete.
+    let mut stage: HashMap<usize, u8> = HashMap::new();
     let mut sizes: Vec<u32> = Vec::new();
     for line in content.lines() {
-        let n = line.chars().take_while(|&c| c == '<').count();
-        if n >= min_size
-            && n <= u16::MAX as usize
-            && matches!(line.chars().nth(n), None | Some(' '))
-            && !sizes.contains(&(n as u32))
-            && has_complete_conflict(content, n)
-        {
-            sizes.push(n as u32);
+        let (ch, exact) = match line.chars().next() {
+            Some('<') => ('<', false),
+            Some('=') => ('=', true),
+            Some('>') => ('>', false),
+            _ => continue,
+        };
+        let n = line.chars().take_while(|&c| c == ch).count();
+        if n < min_size || n > u16::MAX as usize {
+            continue;
+        }
+        // Start/end markers allow a trailing label; the separator is the
+        // bare run only (same shape has_complete_conflict matches).
+        if exact {
+            if line.chars().nth(n).is_some() {
+                continue;
+            }
+        } else if !matches!(line.chars().nth(n), None | Some(' ')) {
+            continue;
+        }
+        let s = stage.entry(n).or_insert(0);
+        match (ch, *s) {
+            ('<', 0) => *s = 1,
+            ('=', 1) => *s = 2,
+            ('>', 2) => {
+                *s = 3;
+                if sizes.len() < MAX_DETECTED_SIZES {
+                    sizes.push(n as u32);
+                }
+            }
+            _ => {}
         }
     }
     sizes.sort_unstable();
@@ -1298,7 +1351,11 @@ pub async fn resolve_conflict(
     let mut index = repo.index()?;
 
     if delete_file.unwrap_or(false) {
-        if full_path.exists() {
+        // symlink_metadata, not exists(): exists() FOLLOWS symlinks, so a
+        // dangling link reports false and would be left on disk while the
+        // index stages its deletion — an untracked leftover that blocks
+        // later checkouts.
+        if std::fs::symlink_metadata(&full_path).is_ok() {
             std::fs::remove_file(&full_path)?;
         }
         index.remove_path(Path::new(&file_path))?;
@@ -1366,6 +1423,20 @@ pub async fn resolve_conflict_take_side(
     };
 
     match entry {
+        Some(e) if e.mode == 0o160000 => {
+            // Submodule (gitlink) pointer — there is no blob to write and
+            // the path is a directory in the worktree. Stage the chosen
+            // COMMIT pointer directly (like `git checkout --ours -- path`
+            // followed by `git add`); the submodule's own worktree is left
+            // for `git submodule update` to move.
+            let resolved = git2::IndexEntry {
+                // Clear the stage bits — this is the resolution entry.
+                flags: e.flags & !0x3000,
+                ..e
+            };
+            index.remove_path(Path::new(&file_path))?;
+            index.add(&resolved)?;
+        }
         Some(e) => {
             let blob = repo.find_blob(e.id)?;
             // NEVER write through an existing symlink: fs::write follows
@@ -1377,10 +1448,18 @@ pub async fn resolve_conflict_take_side(
                 // link target path; recreate the link rather than writing
                 // a regular file containing the target as text.
                 #[cfg(unix)]
-                std::os::unix::fs::symlink(
-                    String::from_utf8_lossy(blob.content()).as_ref(),
-                    &full_path,
-                )?;
+                {
+                    // remove_if_symlink only cleared a symlink; in a
+                    // file↔symlink type conflict the workdir holds a REGULAR
+                    // file, and symlink() refuses to replace it (EEXIST).
+                    if std::fs::symlink_metadata(&full_path).is_ok() {
+                        std::fs::remove_file(&full_path)?;
+                    }
+                    std::os::unix::fs::symlink(
+                        String::from_utf8_lossy(blob.content()).as_ref(),
+                        &full_path,
+                    )?;
+                }
                 #[cfg(not(unix))]
                 std::fs::write(&full_path, blob.content())?;
             } else {
@@ -1403,9 +1482,19 @@ pub async fn resolve_conflict_take_side(
             index.add_path(Path::new(&file_path))?;
         }
         None => {
-            // The chosen side deleted the file — the resolution is removal
-            if full_path.exists() {
-                std::fs::remove_file(&full_path)?;
+            // The chosen side deleted the file — the resolution is removal.
+            // symlink_metadata, not exists(): a DANGLING symlink (common for
+            // links into ignored/generated trees) reports exists()==false
+            // and would survive on disk as an untracked leftover while the
+            // UI says the file was deleted.
+            if let Ok(meta) = std::fs::symlink_metadata(&full_path) {
+                // A DIRECTORY here is a submodule worktree (gitlink
+                // deletion) — git itself leaves it behind on `git rm`
+                // of a submodule; never delete a whole tree from a
+                // conflict resolution.
+                if !meta.file_type().is_dir() {
+                    std::fs::remove_file(&full_path)?;
+                }
             }
             index.remove_path(Path::new(&file_path))?;
         }
@@ -3187,6 +3276,38 @@ mod tests {
         let tiny = "<<<< HEAD\nours\n====\ntheirs\n>>>> f\n";
         assert_eq!(detected_marker_sizes(tiny, 1), vec![4]);
         assert!(detected_marker_sizes(tiny, 7).is_empty());
+
+        // The separator must be the bare run — a trailing label makes it
+        // content, exactly like has_complete_conflict treats it.
+        let labeled_sep = "<<<<<<< HEAD\nours\n======= label\ntheirs\n>>>>>>> f\n";
+        assert!(detected_marker_sizes(labeled_sep, 7).is_empty());
+
+        // Out-of-order marker lines (end before separator) demonstrate
+        // nothing at that size.
+        let out_of_order = "<<<<<<< HEAD\nours\n>>>>>>> f\n=======\n";
+        assert!(detected_marker_sizes(out_of_order, 7).is_empty());
+    }
+
+    #[test]
+    fn test_detected_marker_sizes_caps_hostile_escalating_runs() {
+        // A crafted file demonstrating thousands of distinct sizes must
+        // neither hang the scan (it is single-pass) nor hand thousands of
+        // replay candidates downstream — each candidate costs up to three
+        // merge replays in detect_conflict_emission.
+        let mut content = String::new();
+        for n in 1..=2000usize {
+            content.push_str(&"<".repeat(n));
+            content.push('\n');
+            content.push_str(&"=".repeat(n));
+            content.push('\n');
+            content.push_str(&">".repeat(n));
+            content.push('\n');
+        }
+        let sizes = detected_marker_sizes(&content, 1);
+        assert_eq!(sizes.len(), MAX_DETECTED_SIZES);
+        // The earliest-completed sizes are the ones kept — the first
+        // complete conflict in a real file is git's own emission.
+        assert_eq!(sizes, (1..=MAX_DETECTED_SIZES as u32).collect::<Vec<u32>>());
     }
 
     #[tokio::test]
@@ -3320,6 +3441,224 @@ mod tests {
         assert_eq!(staged.mode, 0o120000, "staged as a symlink");
         let staged_blob = git_repo.find_blob(staged.id).unwrap();
         assert_eq!(staged_blob.content(), b"target-b");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_take_side_replaces_a_regular_file_with_the_chosen_symlink() {
+        use std::os::unix::fs::symlink;
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        repo.create_commit(
+            "Add target and thing",
+            &[("target-a", "A CONTENT\n"), ("thing", "base thing\n")],
+        );
+
+        // Feature turns `thing` into a symlink; main keeps editing it as a
+        // regular file — a file<->symlink TYPE conflict.
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        let thing = repo.path.join("thing");
+        std::fs::remove_file(&thing).unwrap();
+        symlink("target-a", &thing).unwrap();
+        repo.stage_file("thing");
+        repo.create_commit("Feature turns thing into a link", &[]);
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main edits thing", &[("thing", "ours thing\n")]);
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let entry = conflicts
+            .iter()
+            .find(|c| c.path == "thing")
+            .expect("type conflict should be listed");
+        assert!(entry.is_binary, "file<->symlink conflicts use the chooser");
+        // The workdir holds ours' REGULAR file — exactly the shape a bare
+        // symlink() call refuses to overwrite (EEXIST).
+        let meta = std::fs::symlink_metadata(&thing).unwrap();
+        assert!(
+            meta.file_type().is_file(),
+            "precondition: a regular file is on disk"
+        );
+
+        resolve_conflict_take_side(repo.path_str(), "thing".to_string(), "theirs".to_string())
+            .await
+            .expect("taking the symlink side over a regular file must succeed");
+
+        let meta = std::fs::symlink_metadata(&thing).unwrap();
+        assert!(meta.file_type().is_symlink(), "resolved as a real symlink");
+        assert_eq!(
+            std::fs::read_link(&thing).unwrap().to_string_lossy(),
+            "target-a"
+        );
+        // The link's tracked target file is untouched.
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("target-a")).unwrap(),
+            "A CONTENT\n"
+        );
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        assert!(!index.has_conflicts());
+        let staged = index
+            .get_path(Path::new("thing"), 0)
+            .expect("stage-0 entry");
+        assert_eq!(staged.mode, 0o120000, "staged as a symlink");
+    }
+
+    /// Stage a gitlink (submodule pointer) entry at `path` pointing at
+    /// `commit_oid`. Gitlink OIDs reference the SUBMODULE's history, so
+    /// libgit2 does not require them in this repo's object database.
+    fn stage_gitlink(repo: &git2::Repository, path: &str, commit_oid: git2::Oid) {
+        let mut index = repo.index().unwrap();
+        let entry = git2::IndexEntry {
+            ctime: git2::IndexTime::new(0, 0),
+            mtime: git2::IndexTime::new(0, 0),
+            dev: 0,
+            ino: 0,
+            mode: 0o160000,
+            uid: 0,
+            gid: 0,
+            file_size: 0,
+            id: commit_oid,
+            flags: 0,
+            flags_extended: 0,
+            path: path.as_bytes().to_vec(),
+        };
+        index.add(&entry).unwrap();
+        index.write().unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_submodule_conflicts_are_flagged_and_take_side_stages_the_pointer() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        // Three distinct commit OIDs to use as submodule pointers.
+        let ptr_base = repo.create_commit("ptr base", &[("a.txt", "1")]);
+        let ptr_ours = repo.create_commit("ptr ours", &[("a.txt", "2")]);
+        let ptr_theirs = repo.create_commit("ptr theirs", &[("a.txt", "3")]);
+
+        let git_repo = repo.repo();
+        // The worktree presence of a gitlink is just a directory.
+        std::fs::create_dir(repo.path.join("sub")).unwrap();
+        stage_gitlink(&git_repo, "sub", ptr_base);
+        repo.create_commit("Add submodule", &[]);
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        stage_gitlink(&git_repo, "sub", ptr_theirs);
+        repo.create_commit("Feature moves submodule", &[]);
+
+        repo.checkout_branch(&initial_branch);
+        stage_gitlink(&git_repo, "sub", ptr_ours);
+        repo.create_commit("Main moves submodule", &[]);
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let entry = conflicts
+            .iter()
+            .find(|c| c.path == "sub")
+            .expect("submodule conflict should be listed");
+        // Routed to the submodule chooser: NOT binary (its OIDs are
+        // commits, not blobs) and never the text editor.
+        assert!(entry.is_submodule, "gitlink conflicts must be flagged");
+        assert!(!entry.is_binary);
+        assert!(entry.conflict_hunks.is_empty());
+
+        resolve_conflict_take_side(repo.path_str(), "sub".to_string(), "theirs".to_string())
+            .await
+            .expect("taking a side of a submodule conflict must not dead-end");
+
+        // Fresh handle: the earlier Repository caches its in-memory index
+        // and would not see the command's on-disk write.
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        assert!(!index.has_conflicts());
+        let staged = index.get_path(Path::new("sub"), 0).expect("stage-0 entry");
+        assert_eq!(staged.mode, 0o160000, "still a gitlink");
+        assert_eq!(staged.id, ptr_theirs, "the CHOSEN side's commit pointer");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_take_side_delete_removes_a_dangling_symlink_from_disk() {
+        use std::os::unix::fs::symlink;
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        // Base: a DANGLING symlink (its target is not tracked and does not
+        // exist — common for links into ignored/generated trees).
+        let link = repo.path.join("link");
+        symlink("missing-target", &link).unwrap();
+        repo.stage_file("link");
+        repo.create_commit("Add dangling link", &[]);
+
+        // Feature deletes the link; main retargets it — modify/delete.
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        std::fs::remove_file(&link).unwrap();
+        let git_repo = repo.repo();
+        let mut index = git_repo.index().unwrap();
+        index.remove_path(Path::new("link")).unwrap();
+        index.write().unwrap();
+        repo.create_commit("Feature deletes link", &[]);
+
+        repo.checkout_branch(&initial_branch);
+        std::fs::remove_file(&link).unwrap();
+        symlink("missing-target-2", &link).unwrap();
+        repo.stage_file("link");
+        repo.create_commit("Main retargets link", &[]);
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        assert!(
+            conflicts.iter().any(|c| c.path == "link"),
+            "modify/delete on the link should conflict"
+        );
+        // Precondition: the dangling link IS on disk — the exact shape
+        // Path::exists() lies about (it follows the link).
+        assert!(
+            std::fs::symlink_metadata(&link).is_ok(),
+            "precondition: the dangling link is in the worktree"
+        );
+        assert!(!link.exists(), "precondition: exists() follows the link");
+
+        resolve_conflict_take_side(repo.path_str(), "link".to_string(), "theirs".to_string())
+            .await
+            .unwrap();
+
+        // The deletion is real: gone from BOTH the index and the disk — a
+        // leftover link would resurface as untracked and block checkouts.
+        assert!(
+            std::fs::symlink_metadata(&link).is_err(),
+            "the dangling link must be removed from disk"
+        );
+        let index = git_repo.index().unwrap();
+        assert!(!index.has_conflicts());
+        assert!(index.get_path(Path::new("link"), 0).is_none());
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -900,17 +900,71 @@ pub async fn get_conflicts(path: String) -> Result<Vec<ConflictFile>> {
             .filter_map(|e| e.as_ref())
             .any(|e| repo.find_blob(e.id).map(|b| b.is_binary()).unwrap_or(false));
 
+        // The marker size git used when writing this file's conflict hunks.
+        // A raised size means 7-char marker-shaped lines are CONTENT, so the
+        // parser cannot guess — it needs the authoritative attribute value.
+        // BUT the attribute only describes what git's CLI writes: libgit2's
+        // own merge/checkout ignores conflict-marker-size and always emits
+        // 7-char markers, so a raised attribute is only trusted when the
+        // working file really contains a complete conflict at that size.
+        let attr_size = repo
+            .get_attr(
+                Path::new(&file_path),
+                "conflict-marker-size",
+                git2::AttrCheckFlags::default(),
+            )
+            .ok()
+            .flatten()
+            .and_then(|v| v.parse::<u32>().ok())
+            .filter(|&n| n >= 1)
+            .unwrap_or_else(crate::models::conflict::default_marker_size);
+        let marker_size = if attr_size == 7 {
+            7
+        } else {
+            match std::fs::read_to_string(Path::new(&path).join(&file_path)) {
+                Ok(content) if has_complete_conflict(&content, attr_size as usize) => attr_size,
+                Ok(_) => 7,
+                // Unreadable working file (deleted side, binary) — the size
+                // is moot for parsing, report the attribute value.
+                Err(_) => attr_size,
+            }
+        };
+
         conflicts.push(ConflictFile {
             path: file_path,
             ancestor: get_entry(conflict.ancestor),
             ours: get_entry(conflict.our),
             theirs: get_entry(conflict.their),
             is_binary,
+            marker_size,
         });
     }
 
     tracing::debug!("get_conflicts: returning {} conflicts", conflicts.len());
     Ok(conflicts)
+}
+
+/// True when `content` holds a complete conflict written at `size`: a start
+/// run, then a separator, then an end run — each exactly `size` marker
+/// characters followed by a space or end-of-line, in git's emission order.
+/// Used to verify that a raised conflict-marker-size attribute matches what
+/// was actually written (libgit2 ignores the attribute and emits 7).
+fn has_complete_conflict(content: &str, size: usize) -> bool {
+    let run_is = |line: &str, ch: char| -> bool {
+        let n = line.chars().take_while(|&c| c == ch).count();
+        n == size && matches!(line.chars().nth(n), None | Some(' '))
+    };
+    let sep: String = "=".repeat(size);
+    let mut stage = 0u8; // 0 = want start, 1 = want separator, 2 = want end
+    for line in content.lines() {
+        match stage {
+            0 if run_is(line, '<') => stage = 1,
+            1 if line == sep => stage = 2,
+            2 if run_is(line, '>') => return true,
+            _ => {}
+        }
+    }
+    false
 }
 
 /// Get content of a blob by OID
@@ -2336,6 +2390,111 @@ mod tests {
             .find(|c| c.path == "blob.bin")
             .expect("binary conflict should be listed");
         assert!(bin.is_binary, "binary conflict must be flagged");
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_reports_marker_size() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        // Raise the marker size for .txt files via gitattributes, committed
+        // on all branches so it is in effect during the merge.
+        repo.create_commit(
+            "Add attrs and shared",
+            &[
+                (".gitattributes", "*.txt conflict-marker-size=12\n"),
+                ("shared.txt", "base"),
+                ("other.md", "base"),
+            ],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit(
+            "Feature change",
+            &[("shared.txt", "feature content"), ("other.md", "feature")],
+        );
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit(
+            "Main change",
+            &[("shared.txt", "main content"), ("other.md", "main")],
+        );
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // libgit2's merge ignores conflict-marker-size and writes 7-char
+        // markers, so the raised attribute must NOT be reported for this
+        // file — the frontend would parse the real markers as content.
+        let written = std::fs::read_to_string(repo.path.join("shared.txt")).unwrap();
+        assert!(
+            written.lines().any(|l| l.starts_with("<<<<<<<")),
+            "precondition: libgit2 wrote default-size markers; got:\n{written}"
+        );
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("txt conflict should be listed");
+        assert_eq!(
+            txt.marker_size, 7,
+            "raised attribute must fall back to 7 when the file was written with 7-char markers"
+        );
+        let md = conflicts
+            .iter()
+            .find(|c| c.path == "other.md")
+            .expect("md conflict should be listed");
+        assert_eq!(md.marker_size, 7, "unset attribute must default to 7");
+
+        // Git's CLI (rebase/cherry-pick shell-outs, external git) DOES honor
+        // the attribute. Simulate its emission: with real 12-char markers on
+        // disk the raised size must be reported.
+        std::fs::write(
+            repo.path.join("shared.txt"),
+            "<<<<<<<<<<<< HEAD\nmain content\n<<<<<<< a 7-char sample in content\n============\nfeature content\n>>>>>>>>>>>> feature\n",
+        )
+        .unwrap();
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("txt conflict should be listed");
+        assert_eq!(
+            txt.marker_size, 12,
+            "raised attribute must be reported when the file really uses raised markers"
+        );
+    }
+
+    #[test]
+    fn test_has_complete_conflict() {
+        let raised = "<<<<<<<<<<<< HEAD\nours\n============\ntheirs\n>>>>>>>>>>>> feature\n";
+        assert!(has_complete_conflict(raised, 12));
+        assert!(
+            !has_complete_conflict(raised, 7),
+            "runs longer than the size must not match"
+        );
+
+        let default = "<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> feature\n";
+        assert!(!has_complete_conflict(default, 12));
+
+        // Emission order is required: an end marker before the separator
+        // (quoted docs) does not complete a conflict.
+        let out_of_order = "<<<<<<<<<<<< HEAD\n>>>>>>>>>>>> nope\n============\n";
+        assert!(!has_complete_conflict(out_of_order, 12));
+
+        // CRLF-terminated lines still match.
+        let crlf =
+            "<<<<<<<<<<<< HEAD\r\nours\r\n============\r\ntheirs\r\n>>>>>>>>>>>> feature\r\n";
+        assert!(has_complete_conflict(crlf, 12));
+
+        // A separator with trailing label text is not git's separator.
+        let labeled_sep = "<<<<<<<<<<<< HEAD\n============ x\n>>>>>>>>>>>> f\n";
+        assert!(!has_complete_conflict(labeled_sep, 12));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -894,11 +894,17 @@ pub async fn get_conflicts(path: String) -> Result<Vec<ConflictFile>> {
             .map(|e| String::from_utf8_lossy(&e.path).to_string())
             .unwrap_or_default();
 
-        // Binary conflicts must not be routed through the text merge editor
+        // Binary conflicts must not be routed through the text merge editor.
+        // SYMLINK conflicts must not either: their blobs are text (the link
+        // target path), but resolving them means recreating a LINK, not
+        // writing text — the whole-blob chooser (take-side, which is
+        // symlink-aware) is the only correct affordance.
         let is_binary = [&conflict.our, &conflict.their, &conflict.ancestor]
             .iter()
             .filter_map(|e| e.as_ref())
-            .any(|e| repo.find_blob(e.id).map(|b| b.is_binary()).unwrap_or(false));
+            .any(|e| {
+                e.mode == 0o120000 || repo.find_blob(e.id).map(|b| b.is_binary()).unwrap_or(false)
+            });
 
         // How this file's conflict hunks were actually written. The
         // conflict-marker-size attribute and merge.conflictStyle config only
@@ -1297,12 +1303,26 @@ pub async fn resolve_conflict(
         }
         index.remove_path(Path::new(&file_path))?;
     } else {
-        // Write the resolved content to the working directory
+        // Write the resolved content to the working directory. NEVER write
+        // THROUGH an existing symlink — fs::write follows it and would
+        // corrupt the link's target file (and stage the wrong blob).
+        remove_if_symlink(&full_path)?;
         std::fs::write(&full_path, &content)?;
         index.add_path(Path::new(&file_path))?;
     }
     index.write()?;
 
+    Ok(())
+}
+
+/// Remove `path` when it is a symlink, so a subsequent write creates a new
+/// file instead of following the link into its target.
+fn remove_if_symlink(path: &Path) -> Result<()> {
+    if let Ok(meta) = std::fs::symlink_metadata(path) {
+        if meta.file_type().is_symlink() {
+            std::fs::remove_file(path)?;
+        }
+    }
     Ok(())
 }
 
@@ -1347,19 +1367,38 @@ pub async fn resolve_conflict_take_side(
 
     match entry {
         Some(e) => {
-            // Write the chosen side's raw blob bytes (works for binary files)
             let blob = repo.find_blob(e.id)?;
-            std::fs::write(&full_path, blob.content())?;
-            #[cfg(unix)]
-            {
-                use std::os::unix::fs::PermissionsExt;
-                // Apply the chosen side's mode in BOTH directions: fs::write
-                // keeps the existing file's permissions, so taking a
-                // non-executable side over an executable on-disk file must
-                // chmod DOWN too, or the resolved file is staged with the
-                // mode of the side the user rejected.
-                let mode = if e.mode == 0o100755 { 0o755 } else { 0o644 };
-                std::fs::set_permissions(&full_path, std::fs::Permissions::from_mode(mode))?;
+            // NEVER write through an existing symlink: fs::write follows
+            // it, which would corrupt the link's TARGET file and stage the
+            // pre-existing (wrong) link blob instead of the chosen side.
+            remove_if_symlink(&full_path)?;
+            if e.mode == 0o120000 {
+                // The chosen side IS a symlink — its blob content is the
+                // link target path; recreate the link rather than writing
+                // a regular file containing the target as text.
+                #[cfg(unix)]
+                std::os::unix::fs::symlink(
+                    String::from_utf8_lossy(blob.content()).as_ref(),
+                    &full_path,
+                )?;
+                #[cfg(not(unix))]
+                std::fs::write(&full_path, blob.content())?;
+            } else {
+                // Write the chosen side's raw blob bytes (works for binary
+                // files).
+                std::fs::write(&full_path, blob.content())?;
+                #[cfg(unix)]
+                {
+                    use std::os::unix::fs::PermissionsExt;
+                    // Apply the chosen side's mode in BOTH directions:
+                    // fs::write keeps the existing file's permissions, so
+                    // taking a non-executable side over an executable
+                    // on-disk file must chmod DOWN too, or the resolved
+                    // file is staged with the mode of the side the user
+                    // rejected.
+                    let mode = if e.mode == 0o100755 { 0o755 } else { 0o644 };
+                    std::fs::set_permissions(&full_path, std::fs::Permissions::from_mode(mode))?;
+                }
             }
             index.add_path(Path::new(&file_path))?;
         }
@@ -3204,6 +3243,83 @@ mod tests {
             !txt.conflict_hunks.is_empty(),
             "replay-certified files get authoritative hunks"
         );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_take_side_recreates_symlinks_without_corrupting_targets() {
+        use std::os::unix::fs::symlink;
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        // Tracked target files the link may point at.
+        repo.create_commit(
+            "Add targets",
+            &[("target-a", "A CONTENT\n"), ("target-b", "B CONTENT\n")],
+        );
+        // Base: link -> target-a
+        let link = repo.path.join("link");
+        symlink("target-a", &link).unwrap();
+        repo.stage_file("link");
+        repo.create_commit("Add link", &[]);
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        std::fs::remove_file(&link).unwrap();
+        symlink("target-b", &link).unwrap();
+        repo.stage_file("link");
+        repo.create_commit("Feature retargets link", &[]);
+
+        repo.checkout_branch(&initial_branch);
+        std::fs::remove_file(&link).unwrap();
+        symlink("target-a-changed", &link).unwrap();
+        repo.stage_file("link");
+        repo.create_commit("Main retargets link", &[]);
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let entry = conflicts
+            .iter()
+            .find(|c| c.path == "link")
+            .expect("symlink conflict should be listed");
+        // Routed to the whole-blob chooser, never the text editor.
+        assert!(entry.is_binary, "symlink conflicts must use the chooser");
+
+        resolve_conflict_take_side(repo.path_str(), "link".to_string(), "theirs".to_string())
+            .await
+            .unwrap();
+
+        // The resolution is a real symlink to theirs' target...
+        let meta = std::fs::symlink_metadata(&link).unwrap();
+        assert!(meta.file_type().is_symlink(), "a LINK, not a text file");
+        assert_eq!(
+            std::fs::read_link(&link).unwrap().to_string_lossy(),
+            "target-b"
+        );
+        // ...the tracked target files are untouched...
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("target-a")).unwrap(),
+            "A CONTENT\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("target-b")).unwrap(),
+            "B CONTENT\n"
+        );
+        // ...and the index stages the CHOSEN side's blob at link mode.
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        assert!(!index.has_conflicts());
+        let staged = index.get_path(Path::new("link"), 0).expect("stage-0 entry");
+        assert_eq!(staged.mode, 0o120000, "staged as a symlink");
+        let staged_blob = git_repo.find_blob(staged.id).unwrap();
+        assert_eq!(staged_blob.content(), b"target-b");
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -1011,7 +1011,9 @@ fn has_complete_conflict(content: &str, size: usize) -> bool {
 /// marker runs); each one downstream becomes up to three merge replays, so
 /// an uncapped list would let a hostile repo stall get_conflicts for
 /// minutes. Real emissions demonstrate one or two sizes; the earliest-seen
-/// ones are kept because the first complete conflict is git's own.
+/// ones are kept because the first complete conflict is git's own. The
+/// SMALLEST demonstrated size is always retained on top of the cap (see
+/// below) — dropping a small real size is the one dangerous direction.
 const MAX_DETECTED_SIZES: usize = 16;
 
 /// Marker sizes the file's content DEMONSTRATES: distinct start-run lengths
@@ -1031,6 +1033,7 @@ fn detected_marker_sizes(content: &str, min_size: usize) -> Vec<u32> {
     // 0 = want start, 1 = want separator, 2 = want end, 3 = complete.
     let mut stage: HashMap<usize, u8> = HashMap::new();
     let mut sizes: Vec<u32> = Vec::new();
+    let mut min_complete: Option<u32> = None;
     for line in content.lines() {
         let (ch, exact) = match line.chars().next() {
             Some('<') => ('<', false),
@@ -1057,11 +1060,24 @@ fn detected_marker_sizes(content: &str, min_size: usize) -> Vec<u32> {
             ('=', 1) => *s = 2,
             ('>', 2) => {
                 *s = 3;
+                let sz = n as u32;
+                min_complete = Some(min_complete.map_or(sz, |m| m.min(sz)));
                 if sizes.len() < MAX_DETECTED_SIZES {
-                    sizes.push(n as u32);
+                    sizes.push(sz);
                 }
             }
             _ => {}
+        }
+    }
+    // Always retain the smallest demonstrated complete size, even if the
+    // cap already filled with larger (possibly hostile/quoted) ones. A
+    // small real conflict size (git honors conflict-marker-size as low as
+    // 1) evicted from the list would make the structural fallback floor to
+    // 7, and the frontend would then parse the real sub-7 markers as plain
+    // content and stage them silently.
+    if let Some(m) = min_complete {
+        if !sizes.contains(&m) {
+            sizes.push(m);
         }
     }
     sizes.sort_unstable();
@@ -1198,26 +1214,33 @@ fn detect_conflict_emission(
                     // unambiguous, and hand the frontend AUTHORITATIVE
                     // hunk positions instead of shape heuristics.
                     let replay_line_count = replay.lines().count();
-                    let star =
-                        collision_free_size(&[&anc_bytes, &our_bytes, &their_bytes], size as usize);
-                    let mut star_opts = git2::MergeFileOptions::new();
-                    star_opts.marker_size(star);
-                    star_opts.style_diff3(style == "diff3");
-                    star_opts.style_zdiff3(style == "zdiff3");
-                    let hunks = git2::merge_file(&anc_in, &our_in, &their_in, Some(&mut star_opts))
-                        .ok()
-                        .and_then(|star_result| {
-                            let star_replay =
-                                String::from_utf8_lossy(star_result.content()).to_string();
-                            // Marker lines are one line each at any
-                            // size, so the line counts must agree —
-                            // bail to heuristics if they somehow don't.
-                            if star_replay.lines().count() != replay_line_count {
-                                return None;
-                            }
-                            replay_hunks(&star_replay, star as usize, style != "merge")
-                        })
-                        .unwrap_or_default();
+                    // None when no collision-free size fits in u16 (a
+                    // pathological ~65k-char marker-char run) — fall back to
+                    // the frontend's blob-validated heuristics rather than
+                    // hand it a size that might itself collide.
+                    let hunks =
+                        collision_free_size(&[&anc_bytes, &our_bytes, &their_bytes], size as usize)
+                            .and_then(|star| {
+                                let mut star_opts = git2::MergeFileOptions::new();
+                                star_opts.marker_size(star);
+                                star_opts.style_diff3(style == "diff3");
+                                star_opts.style_zdiff3(style == "zdiff3");
+                                git2::merge_file(&anc_in, &our_in, &their_in, Some(&mut star_opts))
+                                    .ok()
+                                    .and_then(|star_result| {
+                                        let star_replay =
+                                            String::from_utf8_lossy(star_result.content())
+                                                .to_string();
+                                        // Marker lines are one line each at any
+                                        // size, so the line counts must agree —
+                                        // bail to heuristics if they somehow don't.
+                                        if star_replay.lines().count() != replay_line_count {
+                                            return None;
+                                        }
+                                        replay_hunks(&star_replay, star as usize, style != "merge")
+                                    })
+                            })
+                            .unwrap_or_default();
                     return (size, reported.to_string(), hunks);
                 }
             }
@@ -1265,8 +1288,11 @@ fn detect_conflict_emission(
 }
 
 /// A marker size that cannot collide with any content line: strictly longer
-/// than every leading `<`/`=`/`>`/`|` run in any input blob.
-fn collision_free_size(blobs: &[&[u8]], at_least: usize) -> u16 {
+/// than every leading `<`/`=`/`>`/`|` run in any input blob. None when no
+/// such size fits in u16 (merge_file's marker_size is a u16) — the caller
+/// then falls back to heuristics rather than using a size that could itself
+/// collide with content.
+fn collision_free_size(blobs: &[&[u8]], at_least: usize) -> Option<u16> {
     let mut max_run = at_least;
     for bytes in blobs {
         // Byte-level scan: merge_file works on raw bytes, so the run count
@@ -1280,7 +1306,12 @@ fn collision_free_size(blobs: &[&[u8]], at_least: usize) -> u16 {
             }
         }
     }
-    (max_run + 3).min(u16::MAX as usize) as u16
+    let size = max_run + 3;
+    if size > u16::MAX as usize {
+        None
+    } else {
+        Some(size as u16)
+    }
 }
 
 /// Extract hunk marker positions from a replay generated at a
@@ -1438,11 +1469,25 @@ pub async fn resolve_conflict_take_side(
 
     match entry {
         Some(e) if e.mode == 0o160000 => {
-            // Submodule (gitlink) pointer — there is no blob to write and
-            // the path is a directory in the worktree. Stage the chosen
-            // COMMIT pointer directly (like `git checkout --ours -- path`
-            // followed by `git add`); the submodule's own worktree is left
-            // for `git submodule update` to move.
+            // Submodule (gitlink) pointer — there is no blob to write. Stage
+            // the chosen COMMIT pointer directly (like `git checkout --ours`
+            // + `git add`). The submodule's own files come from a later
+            // `git submodule update`; here we only make the WORKTREE match
+            // what git does for a gitlink checkout — an empty directory at
+            // the path. Without this, a submodule↔file type conflict leaves
+            // the OTHER side's regular file (or a symlink) on disk while the
+            // index holds the gitlink, so `git status` reports the
+            // just-"resolved" path as dirty.
+            if let Ok(meta) = std::fs::symlink_metadata(&full_path) {
+                if !meta.file_type().is_dir() {
+                    std::fs::remove_file(&full_path)?;
+                    std::fs::create_dir(&full_path)?;
+                }
+                // An existing directory is left as-is (it may already be the
+                // submodule's populated worktree).
+            } else {
+                std::fs::create_dir(&full_path)?;
+            }
             let resolved = git2::IndexEntry {
                 // Clear the stage bits — this is the resolution entry.
                 flags: e.flags & !0x3000,
@@ -1464,9 +1509,12 @@ pub async fn resolve_conflict_take_side(
             // refused with an actionable message — never delete a tree
             // that may hold uncommitted submodule work.
             if let Ok(meta) = std::fs::symlink_metadata(&full_path) {
+                // The same branch is reached by a file↔directory (D/F)
+                // conflict with no submodule involved, so the message must
+                // not assume one.
                 if meta.file_type().is_dir() && std::fs::remove_dir(&full_path).is_err() {
                     return Err(LeviathanError::OperationFailed(format!(
-                        "'{}' is a submodule directory with files in it — move or remove it, then take this side again",
+                        "'{}' is a directory with files in it (the other side made this path a directory) — move or remove it, then take this side again",
                         file_path
                     )));
                 }
@@ -3288,8 +3336,13 @@ mod tests {
 
         // Collision-free size must exceed every marker-shaped run in blobs.
         let blob = b"content\n<<<<<<<<<<<<<<< quoted long run\n" as &[u8];
-        let star = collision_free_size(&[blob], 7);
+        let star = collision_free_size(&[blob], 7).expect("fits in u16");
         assert!(star as usize > 15);
+
+        // A run near u16::MAX has no collision-free size that fits in u16 —
+        // bail to None rather than clamp to a colliding size.
+        let huge = vec![b'<'; u16::MAX as usize];
+        assert!(collision_free_size(&[&huge], 7).is_none());
     }
 
     #[test]
@@ -3319,6 +3372,30 @@ mod tests {
         // nothing at that size.
         let out_of_order = "<<<<<<< HEAD\nours\n>>>>>>> f\n=======\n";
         assert!(detected_marker_sizes(out_of_order, 7).is_empty());
+    }
+
+    #[test]
+    fn test_detected_marker_sizes_always_retains_the_smallest_size() {
+        // 16 distinct LARGE complete conflicts fill the cap, then a real
+        // sub-7 conflict appears. The smallest (sub-7) size must survive
+        // the cap — dropping it would floor the structural fallback to 7
+        // and hide the real markers as content.
+        let mut content = String::new();
+        for n in 20..36usize {
+            content.push_str(&"<".repeat(n));
+            content.push('\n');
+            content.push_str(&"=".repeat(n));
+            content.push('\n');
+            content.push_str(&">".repeat(n));
+            content.push('\n');
+        }
+        // The real, small conflict, demonstrated LAST (after the cap filled).
+        content.push_str("<<<< HEAD\nours\n====\ntheirs\n>>>> f\n");
+        let sizes = detected_marker_sizes(&content, 1);
+        assert!(
+            sizes.contains(&4),
+            "the smallest demonstrated size must be retained past the cap; got {sizes:?}"
+        );
     }
 
     #[test]
@@ -3521,6 +3598,84 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_take_side_gitlink_materializes_dir_and_leaves_clean_worktree() {
+        // Taking the SUBMODULE side of a submodule↔file type conflict must
+        // leave the worktree consistent with the staged gitlink (git checks
+        // a gitlink out as an empty directory). Without materializing it,
+        // the OTHER side's regular file stays on disk and `git status`
+        // reports the just-"resolved" path as dirty.
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        let ptr = repo.create_commit("ptr", &[("a.txt", "1")]);
+        let git_repo = repo.repo();
+        std::fs::create_dir(repo.path.join("sub")).unwrap();
+        stage_gitlink(&git_repo, "sub", ptr);
+        repo.create_commit("Add submodule", &[]);
+
+        // Feature replaces the submodule with a regular file.
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        {
+            let mut index = git_repo.index().unwrap();
+            index.remove_path(Path::new("sub")).unwrap();
+            index.write().unwrap();
+        }
+        std::fs::remove_dir_all(repo.path.join("sub")).ok();
+        std::fs::write(repo.path.join("sub"), "vendored\n").unwrap();
+        repo.stage_file("sub");
+        repo.create_commit("Feature vendors sub", &[]);
+
+        repo.checkout_branch(&initial_branch);
+        let ptr2 = repo.create_commit("ptr2", &[("a.txt", "2")]);
+        stage_gitlink(&git_repo, "sub", ptr2);
+        repo.create_commit("Main moves submodule", &[]);
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // Force the workdir to hold the OTHER side's regular FILE (the exact
+        // shape that would be left behind if the gitlink arm ignored the
+        // worktree).
+        if std::fs::symlink_metadata(repo.path.join("sub"))
+            .map(|m| !m.file_type().is_file())
+            .unwrap_or(true)
+        {
+            let _ = std::fs::remove_dir_all(repo.path.join("sub"));
+            let _ = std::fs::remove_file(repo.path.join("sub"));
+            std::fs::write(repo.path.join("sub"), "vendored\n").unwrap();
+        }
+
+        resolve_conflict_take_side(repo.path_str(), "sub".to_string(), "ours".to_string())
+            .await
+            .expect("taking the gitlink side must succeed");
+
+        // The worktree path is now an (empty) directory, matching a gitlink
+        // checkout — not the leftover regular file.
+        let meta = std::fs::symlink_metadata(repo.path.join("sub")).unwrap();
+        assert!(meta.file_type().is_dir(), "gitlink materialized as a dir");
+
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        assert!(!index.has_conflicts());
+        let staged = index.get_path(Path::new("sub"), 0).expect("stage-0 entry");
+        assert_eq!(staged.mode, 0o160000, "staged as a gitlink");
+        assert_eq!(staged.id, ptr2, "ours' commit pointer");
+        // The path is no longer reported as a conflict/dirty typechange.
+        assert!(get_conflicts(repo.path_str())
+            .await
+            .unwrap()
+            .iter()
+            .all(|c| c.path != "sub"));
+    }
+
+    #[tokio::test]
     async fn test_take_side_refuses_to_delete_a_populated_submodule_worktree() {
         let repo = TestRepo::with_initial_commit();
         let initial_branch = repo.current_branch();
@@ -3568,7 +3723,7 @@ mod tests {
                 .await
                 .expect_err("must refuse rather than delete a populated tree");
         assert!(
-            err.to_string().contains("submodule directory"),
+            err.to_string().contains("is a directory with files in it"),
             "actionable message, not a raw OS error; got: {err}"
         );
         // The tree is untouched.

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -1252,41 +1252,41 @@ fn detect_conflict_emission(
         }
     }
 
-    // Structural fallback (hand-edited files, missing sides). When BOTH
-    // the attribute size and 7 show a complete conflict the bytes are
-    // genuinely undecidable — one size is the real marker, the other is
-    // quoted content (e.g. a README showing `<<<<<<<`) that coincidentally
-    // forms a complete conflict at its own size. Prefer the SMALLER size:
-    // the frontend parser matches markers of EXACTLY the reported size,
-    // while its orphan safety-net matches runs of `>=` that size. Reporting
-    // the smaller size means a real marker of the LARGER size is still caught
-    // by the safety net (which collapses to a clean whole-file conflict),
-    // whereas reporting the LARGER size lets a real SMALLER marker slip under
-    // both the exact-match parser and the `>=` net — leaking raw markers into
-    // the pane and letting Mark Resolved round-trip them to disk. When NEITHER
-    // matches, fall back to a size the content itself demonstrates (stale
-    // attribute).
-    // Choose the reported size. The frontend parses markers of EXACTLY this
-    // size, and its orphan safety-net matches runs of `>=` this size. Reporting
-    // a size LARGER than a real marker makes BOTH miss it — raw markers leak
-    // into the pane and round-trip to disk; reporting SMALLER is safe, because
-    // a real LARGER marker is still caught by the `>=` net (which collapses to
-    // a clean whole-file conflict). Every real marker forms a COMPLETE conflict
-    // structure, so its size is in `detected_all`; take the SMALLEST
-    // demonstrated size. This subsumes both the attribute size and 7 (each is
-    // in `detected_all` iff it has a complete structure) — crucially, it still
-    // recovers a real sub-7 size even when the current attribute has drifted
-    // back to the default 7 (e.g. .gitattributes' own conflict was resolved
-    // after git wrote the markers), the case a two-candidate attr-vs-7 check
-    // blind-spots. Exclude runs of 1-2 chars: git's practical minimum
-    // conflict-marker-size is 3, and a lone `<`/`=`/`>` content line forming a
-    // "complete" size-1 structure would otherwise make the whole file parse as
-    // markers. A quoted LARGER conflict block only yields a spurious,
-    // blob-validated conflict block the frontend already contains. When nothing
-    // >=3 is demonstrated, fall back to the attribute size (default 7).
+    // Structural fallback (hand-edited files, missing sides). Choose the
+    // reported size. The frontend parses markers of EXACTLY this size, and its
+    // orphan safety-net matches runs of `>=` this size. Reporting a size LARGER
+    // than a real marker makes BOTH miss it — raw markers leak into the pane and
+    // round-trip to disk; reporting SMALLER is safe, because a real LARGER
+    // marker is still caught by the `>=` net (which collapses to a clean
+    // whole-file conflict). So take the SMALLEST candidate:
+    //  - every DEMONSTRATED complete size (`detected_all`) — this recovers a
+    //    real sub-7 size even when the current attribute has drifted back to the
+    //    default 7 (.gitattributes' own conflict resolved after git wrote the
+    //    markers), which a two-candidate attr-vs-7 check blind-spots; and
+    //  - the EXPLICIT attribute size (`attr_size != 7`) — because this fallback
+    //    runs only for HAND-EDITED files, and a hand edit that breaks the real
+    //    conflict's structure (e.g. deletes its separator) removes its size from
+    //    `detected_all`, so without the attribute a real sub-7 size would be
+    //    floored UP to a larger quoted-but-complete block and leak. `attr_size`
+    //    is only a real signal when it names a non-default size; a bare 7 is
+    //    indistinguishable from "no attribute", so folding it would wrongly cap
+    //    a genuine raised size (e.g. 12) down to 7.
+    // Exclude runs of 1-2 chars: git's practical minimum conflict-marker-size is
+    // 3, and a lone `<`/`=`/`>` content line forming a "complete" size-1
+    // structure would otherwise make the whole file parse as markers. A quoted
+    // LARGER conflict block only yields a spurious, blob-validated conflict block
+    // the frontend already contains. When nothing >=3 remains, fall back to the
+    // attribute size (default 7).
+    // Residual (accepted): if the attribute ALSO drifted to the default 7 AND
+    // the real markers are sub-7 AND a hand edit broke their structure, no
+    // signal of the real size survives; the min still floors >=7 and sub-7
+    // markers leak. Closing it would need the frontend echo-net floor below 7,
+    // which the design avoids (3-6-char `===`/`>>>` content dividers would then
+    // false-positive).
     let size = detected_all
         .iter()
         .copied()
+        .chain((attr_size != 7).then_some(attr_size))
         .filter(|&n| n >= 3)
         .min()
         .unwrap_or(attr_size);
@@ -3575,6 +3575,54 @@ mod tests {
             .find(|c| c.path == "shared.txt")
             .expect("conflict should be listed");
         assert_eq!(txt.marker_size, 3);
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_fallback_uses_explicit_attr_when_real_conflict_hand_broken() {
+        // The structural fallback runs only for HAND-EDITED files, and a hand
+        // edit can break the real conflict's structure (delete its separator) so
+        // its size is NOT demonstrated-complete in the content. Here the real
+        // markers are size 5 (explicit conflict-marker-size=5) but hand-broken,
+        // and the file quotes a COMPLETE size-10 block. Without folding the
+        // explicit attribute, the fallback would floor UP to 10 and leak the real
+        // size-5 markers; folding attr_size (5) caps the reported size at 5.
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit(
+            "Add attrs and shared",
+            &[
+                (".gitattributes", "*.txt conflict-marker-size=5\n"),
+                ("shared.txt", "base"),
+            ],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // A quoted COMPLETE size-10 block + the REAL size-5 conflict with its
+        // separator hand-DELETED (so size 5 is not demonstrated-complete), plus a
+        // stray edit so no replay matches.
+        std::fs::write(
+            repo.path.join("shared.txt"),
+            "<<<<<<<<<< ex\nx\n==========\ny\n>>>>>>>>>> ex\nhand edit\n<<<<< HEAD\nmain content\nfeature content\n>>>>> feature\n",
+        )
+        .unwrap();
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert_eq!(txt.marker_size, 5);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -1190,9 +1190,11 @@ fn detect_conflict_emission(
 fn collision_free_size(blobs: &[&[u8]], at_least: usize) -> u16 {
     let mut max_run = at_least;
     for bytes in blobs {
-        for line in String::from_utf8_lossy(bytes).lines() {
-            for ch in ['<', '=', '>', '|'] {
-                let n = line.chars().take_while(|&c| c == ch).count();
+        // Byte-level scan: merge_file works on raw bytes, so the run count
+        // must too (a lossy string decode could in principle diverge).
+        for line in bytes.split(|&b| b == b'\n') {
+            for ch in *b"<=>|" {
+                let n = line.iter().take_while(|&&b| b == ch).count();
                 if n > max_run {
                     max_run = n;
                 }

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -1238,7 +1238,21 @@ fn detect_conflict_emission(
     } else if complete_7 {
         7
     } else {
-        detected_all.iter().copied().find(|&n| n >= 7).unwrap_or(7)
+        // Nothing complete at the attribute size or 7. Prefer a
+        // demonstrated 7+ size; failing that, a demonstrated SUB-7 size
+        // (largest first — long runs are least likely to be quoted
+        // content). Flooring to 7 here would be the dangerous direction:
+        // a stale sub-7 attribute (git honors conflict-marker-size=4) on
+        // a hand-edited file would then parse as ZERO conflicts and let
+        // Mark Resolved silently stage the raw markers, while a sub-7
+        // false positive merely shows a spurious conflict block that the
+        // frontend's blob-validated parsing already contains.
+        detected_all
+            .iter()
+            .copied()
+            .find(|&n| n >= 7)
+            .or_else(|| detected_all.iter().copied().max())
+            .unwrap_or(7)
     };
     let style = if diff3_within_first_conflict(&content, size as usize) {
         "diff3"
@@ -1443,6 +1457,20 @@ pub async fn resolve_conflict_take_side(
             // it, which would corrupt the link's TARGET file and stage the
             // pre-existing (wrong) link blob instead of the chosen side.
             remove_if_symlink(&full_path)?;
+            // A DIRECTORY here is the other side's submodule worktree
+            // (gitlink↔file/symlink type conflict) — fs::write/symlink on
+            // it fails with a raw EISDIR/EEXIST. An empty placeholder dir
+            // (uninitialized submodule) is removed; a populated one is
+            // refused with an actionable message — never delete a tree
+            // that may hold uncommitted submodule work.
+            if let Ok(meta) = std::fs::symlink_metadata(&full_path) {
+                if meta.file_type().is_dir() && std::fs::remove_dir(&full_path).is_err() {
+                    return Err(LeviathanError::OperationFailed(format!(
+                        "'{}' is a submodule directory with files in it — move or remove it, then take this side again",
+                        file_path
+                    )));
+                }
+            }
             if e.mode == 0o120000 {
                 // The chosen side IS a symlink — its blob content is the
                 // link target path; recreate the link rather than writing
@@ -3363,6 +3391,185 @@ mod tests {
         assert!(
             !txt.conflict_hunks.is_empty(),
             "replay-certified files get authoritative hunks"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_structural_fallback_recovers_sub7_size_on_hand_edited_files() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        // Markers were written at size 4 (git honors sub-7 attribute
+        // values) but the attribute has since gone back to the default,
+        // AND the user hand-edited the file so no replay can match. The
+        // structural fallback must still report the demonstrated size —
+        // flooring to 7 would parse the surviving size-4 hunk as ZERO
+        // conflicts and let Mark Resolved stage the raw markers silently.
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // What git's CLI wrote at conflict-marker-size=4 before the
+        // attribute was resolved away, then hand-edited (an extra line),
+        // so every replay candidate fails the exact-content match.
+        std::fs::write(
+            repo.path.join("shared.txt"),
+            "hand-added line\n<<<< HEAD\nmain content\n====\nfeature content\n>>>> feature\n",
+        )
+        .unwrap();
+
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert_eq!(
+            txt.marker_size, 4,
+            "the structural fallback must keep the content-demonstrated sub-7 size"
+        );
+        assert!(
+            txt.conflict_hunks.is_empty(),
+            "hand-edited files get heuristics, not authoritative hunks"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_take_side_writes_the_file_side_of_a_submodule_type_conflict() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        let ptr = repo.create_commit("ptr", &[("a.txt", "1")]);
+        let git_repo = repo.repo();
+        std::fs::create_dir(repo.path.join("sub")).unwrap();
+        stage_gitlink(&git_repo, "sub", ptr);
+        repo.create_commit("Add submodule", &[]);
+
+        // Feature replaces the submodule with a vendored regular FILE.
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        {
+            let mut index = git_repo.index().unwrap();
+            index.remove_path(Path::new("sub")).unwrap();
+            index.write().unwrap();
+        }
+        std::fs::remove_dir_all(repo.path.join("sub")).ok();
+        std::fs::write(repo.path.join("sub"), "vendored contents\n").unwrap();
+        repo.stage_file("sub");
+        repo.create_commit("Feature vendors sub", &[]);
+
+        // Main moves the submodule pointer.
+        repo.checkout_branch(&initial_branch);
+        let ptr2 = repo.create_commit("ptr2", &[("a.txt", "2")]);
+        stage_gitlink(&git_repo, "sub", ptr2);
+        repo.create_commit("Main moves submodule", &[]);
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        assert!(
+            conflicts.iter().any(|c| c.path == "sub" && c.is_submodule),
+            "gitlink<->file type conflict should be listed as a submodule conflict"
+        );
+        // Model an initialized submodule: its worktree DIRECTORY sits at
+        // the conflicted path (empty placeholder here). fs::write on it
+        // would fail with EISDIR.
+        if std::fs::symlink_metadata(repo.path.join("sub")).is_err() {
+            std::fs::create_dir(repo.path.join("sub")).unwrap();
+        } else if std::fs::symlink_metadata(repo.path.join("sub"))
+            .unwrap()
+            .file_type()
+            .is_file()
+        {
+            std::fs::remove_file(repo.path.join("sub")).unwrap();
+            std::fs::create_dir(repo.path.join("sub")).unwrap();
+        }
+
+        resolve_conflict_take_side(repo.path_str(), "sub".to_string(), "theirs".to_string())
+            .await
+            .expect("taking the FILE side over an empty submodule dir must succeed");
+
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("sub")).unwrap(),
+            "vendored contents\n"
+        );
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        assert!(!index.has_conflicts());
+        let staged = index.get_path(Path::new("sub"), 0).expect("stage-0 entry");
+        assert_eq!(staged.mode, 0o100644, "staged as a regular file");
+    }
+
+    #[tokio::test]
+    async fn test_take_side_refuses_to_delete_a_populated_submodule_worktree() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        let ptr = repo.create_commit("ptr", &[("a.txt", "1")]);
+        let git_repo = repo.repo();
+        std::fs::create_dir(repo.path.join("sub")).unwrap();
+        stage_gitlink(&git_repo, "sub", ptr);
+        repo.create_commit("Add submodule", &[]);
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        {
+            let mut index = git_repo.index().unwrap();
+            index.remove_path(Path::new("sub")).unwrap();
+            index.write().unwrap();
+        }
+        std::fs::remove_dir_all(repo.path.join("sub")).ok();
+        std::fs::write(repo.path.join("sub"), "vendored contents\n").unwrap();
+        repo.stage_file("sub");
+        repo.create_commit("Feature vendors sub", &[]);
+
+        repo.checkout_branch(&initial_branch);
+        let ptr2 = repo.create_commit("ptr2", &[("a.txt", "2")]);
+        stage_gitlink(&git_repo, "sub", ptr2);
+        repo.create_commit("Main moves submodule", &[]);
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // A POPULATED submodule worktree — possibly uncommitted work.
+        std::fs::remove_file(repo.path.join("sub")).ok();
+        std::fs::remove_dir_all(repo.path.join("sub")).ok();
+        std::fs::create_dir(repo.path.join("sub")).unwrap();
+        std::fs::write(repo.path.join("sub/work.txt"), "uncommitted\n").unwrap();
+
+        let err =
+            resolve_conflict_take_side(repo.path_str(), "sub".to_string(), "theirs".to_string())
+                .await
+                .expect_err("must refuse rather than delete a populated tree");
+        assert!(
+            err.to_string().contains("submodule directory"),
+            "actionable message, not a raw OS error; got: {err}"
+        );
+        // The tree is untouched.
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("sub/work.txt")).unwrap(),
+            "uncommitted\n"
         );
     }
 

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -992,11 +992,11 @@ fn has_complete_conflict(content: &str, size: usize) -> bool {
 /// size. Used when the conflict-marker-size attribute no longer matches
 /// what git wrote (it can change mid-operation via .gitattributes' own
 /// resolution). The 7+ floor avoids false positives on `< quoted` lines.
-fn detected_marker_sizes(content: &str) -> Vec<u32> {
+fn detected_marker_sizes(content: &str, min_size: usize) -> Vec<u32> {
     let mut sizes: Vec<u32> = Vec::new();
     for line in content.lines() {
         let n = line.chars().take_while(|&c| c == '<').count();
-        if n >= 7
+        if n >= min_size
             && n <= u16::MAX as usize
             && matches!(line.chars().nth(n), None | Some(' '))
             && !sizes.contains(&(n as u32))
@@ -1085,12 +1085,18 @@ fn detect_conflict_emission(
     // markers' feet, and trusting only the attribute would then report a
     // size the file does not use (the frontend would find zero conflicts
     // and let Mark Resolved stage the raw markers as resolved content).
-    let detected = detected_marker_sizes(&content);
+    // Git emits runs as small as 1, so the REPLAY candidates take every
+    // demonstrated size — a wrong size simply fails the replay match, so
+    // sub-7 candidates cannot cause false positives there. The structural
+    // fallback below stays at the 7+ floor: quoted `< text` / `= text`
+    // lines can coincidentally form complete sub-7 structures, and only
+    // the replay can certify those sizes safely.
+    let detected_all = detected_marker_sizes(&content, 1);
     let mut candidates: Vec<u32> = vec![attr_size];
     if attr_size != 7 {
         candidates.push(7);
     }
-    for &d in &detected {
+    for &d in &detected_all {
         if !candidates.contains(&d) {
             candidates.push(d);
         }
@@ -1173,7 +1179,7 @@ fn detect_conflict_emission(
     } else if complete_7 {
         7
     } else {
-        detected.first().copied().unwrap_or(7)
+        detected_all.iter().copied().find(|&n| n >= 7).unwrap_or(7)
     };
     let style = if diff3_within_first_conflict(&content, size as usize) {
         "diff3"
@@ -3128,14 +3134,76 @@ mod tests {
     #[test]
     fn test_detected_marker_sizes() {
         let raised = "ctx\n<<<<<<<<<<<< HEAD\nours\n============\ntheirs\n>>>>>>>>>>>> f\n";
-        assert_eq!(detected_marker_sizes(raised), vec![12]);
+        assert_eq!(detected_marker_sizes(raised, 7), vec![12]);
 
         let none = "just\nplain\ntext\n< quoted line\n";
-        assert!(detected_marker_sizes(none).is_empty());
+        assert!(detected_marker_sizes(none, 7).is_empty());
 
         // An incomplete start-shaped line demonstrates nothing.
         let incomplete = "<<<<<<< HEAD\nno separator or end\n";
-        assert!(detected_marker_sizes(incomplete).is_empty());
+        assert!(detected_marker_sizes(incomplete, 7).is_empty());
+
+        // Git emits runs as small as 1 — sub-7 sizes are demonstrable when
+        // the floor allows them (used for replay candidates only).
+        let tiny = "<<<< HEAD\nours\n====\ntheirs\n>>>> f\n";
+        assert_eq!(detected_marker_sizes(tiny, 1), vec![4]);
+        assert!(detected_marker_sizes(tiny, 7).is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_recovers_sub7_size_when_attribute_went_stale() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        // The file's markers were written at size 4 (git honors sub-7
+        // attribute values), but the attribute has since changed to 8 —
+        // e.g. by resolving .gitattributes' own conflict mid-operation.
+        // The replay must still certify the true size via the
+        // content-demonstrated candidates.
+        repo.create_commit(
+            "Add attrs and shared",
+            &[
+                (".gitattributes", "*.txt conflict-marker-size=8\n"),
+                ("shared.txt", "base"),
+            ],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // Rewrite the conflict as size-4 emission (what git wrote before
+        // the attribute changed).
+        let mut opts = git2::MergeFileOptions::new();
+        opts.marker_size(4);
+        replay_conflict_to_workdir(&repo, "shared.txt", &mut opts);
+        let written = std::fs::read_to_string(repo.path.join("shared.txt")).unwrap();
+        assert!(
+            written.lines().any(|l| l.starts_with("<<<< ")),
+            "precondition: size-4 markers on disk; got:\n{written}"
+        );
+
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert_eq!(
+            txt.marker_size, 4,
+            "the replay must certify the sub-7 size the content demonstrates"
+        );
+        assert!(
+            !txt.conflict_hunks.is_empty(),
+            "replay-certified files get authoritative hunks"
+        );
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -1249,14 +1249,23 @@ fn detect_conflict_emission(
 
     // Structural fallback (hand-edited files, missing sides). When BOTH
     // the attribute size and 7 show a complete conflict the bytes are
-    // genuinely undecidable — prefer 7: it is what this app's own merge
-    // engine (libgit2) always writes, and CLI-written files at the raised
-    // size are certified by the replay above before any user edit could
-    // break its equality. When NEITHER matches, fall back to a size the
-    // content itself demonstrates (stale attribute).
+    // genuinely undecidable — one size is the real marker, the other is
+    // quoted content (e.g. a README showing `<<<<<<<`) that coincidentally
+    // forms a complete conflict at its own size. Prefer the SMALLER size:
+    // the frontend parser matches markers of EXACTLY the reported size,
+    // while its orphan safety-net matches runs of `>=` that size. Reporting
+    // the smaller size means a real marker of the LARGER size is still caught
+    // by the safety net (which collapses to a clean whole-file conflict),
+    // whereas reporting the LARGER size lets a real SMALLER marker slip under
+    // both the exact-match parser and the `>=` net — leaking raw markers into
+    // the pane and letting Mark Resolved round-trip them to disk. When NEITHER
+    // matches, fall back to a size the content itself demonstrates (stale
+    // attribute).
     let complete_attr = attr_size != 7 && has_complete_conflict(&content, attr_size as usize);
     let complete_7 = has_complete_conflict(&content, 7);
-    let size = if complete_attr && !complete_7 {
+    let size = if complete_attr && complete_7 {
+        attr_size.min(7)
+    } else if complete_attr {
         attr_size
     } else if complete_7 {
         7
@@ -3472,6 +3481,56 @@ mod tests {
             .find(|c| c.path == "shared.txt")
             .expect("conflict should be listed");
         assert_eq!(txt.marker_size, 7);
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_undecidable_fallback_prefers_smaller_real_sub7_size() {
+        // Mirror of the prefers-default-size case, in the DANGEROUS direction:
+        // the real markers are a SUB-7 size (conflict-marker-size=3, honored by
+        // the git CLI) and the file ALSO quotes a standard 7-char conflict (a
+        // README/fixture showing markers). Both sizes look complete, so the
+        // structural fallback is undecidable — it must prefer the SMALLER (3).
+        // Reporting 7 would make the frontend's exact-match parser miss the
+        // real size-3 markers AND its `>=7` orphan safety-net miss them too,
+        // leaking raw markers into the pane and letting Mark Resolved stage
+        // them to disk as "resolved".
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit(
+            "Add attrs and shared",
+            &[
+                (".gitattributes", "*.txt conflict-marker-size=3\n"),
+                ("shared.txt", "base"),
+            ],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // Hand-edit: a QUOTED standard 7-char conflict block (plain content)
+        // plus the REAL size-3 conflict, with a stray edit so no replay matches
+        // and the structural fallback must decide.
+        std::fs::write(
+            repo.path.join("shared.txt"),
+            "<<<<<<< quoted\nq1\n=======\nq2\n>>>>>>> quoted\nedited by hand\n<<< HEAD\nmain content\n===\nfeature content\n>>> feature\n",
+        )
+        .unwrap();
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert_eq!(txt.marker_size, 3);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -1054,14 +1054,28 @@ fn detect_conflict_emission(
         candidates.push(7);
     }
 
-    if let (Some(anc), Some(our), Some(their)) = (ancestor, ours, theirs) {
+    // Replay from blob CONTENTS (not index entries): a missing ancestor —
+    // an add/add conflict — is merged against an empty base, exactly as git
+    // does, so those files still get replay verification instead of falling
+    // through to the ambiguous structural scan.
+    let blob = |e: Option<&git2::IndexEntry>| -> Option<Vec<u8>> {
+        e.and_then(|e| repo.find_blob(e.id).ok().map(|b| b.content().to_vec()))
+    };
+    let anc_bytes = blob(ancestor).unwrap_or_default();
+    if let (Some(our_bytes), Some(their_bytes)) = (blob(ours), blob(theirs)) {
+        let mut anc_in = git2::MergeFileInput::new();
+        anc_in.content(&anc_bytes);
+        let mut our_in = git2::MergeFileInput::new();
+        our_in.content(&our_bytes);
+        let mut their_in = git2::MergeFileInput::new();
+        their_in.content(&their_bytes);
         for &size in &candidates {
             for style in ["merge", "diff3", "zdiff3"] {
                 let mut opts = git2::MergeFileOptions::new();
                 opts.marker_size(size as u16);
                 opts.style_diff3(style == "diff3");
                 opts.style_zdiff3(style == "zdiff3");
-                let Ok(result) = repo.merge_file_from_index(anc, our, their, Some(&mut opts))
+                let Ok(result) = git2::merge_file(&anc_in, &our_in, &their_in, Some(&mut opts))
                 else {
                     continue;
                 };
@@ -1075,9 +1089,11 @@ fn detect_conflict_emission(
         }
     }
 
-    // Structural fallback. When BOTH sizes show a complete conflict the
-    // bytes are undecidable — follow the gitattributes-documented semantics
-    // (the replay above already resolved the common libgit2 case).
+    // Structural fallback (hand-edited files, missing sides). When BOTH
+    // sizes show a complete conflict the bytes are genuinely undecidable —
+    // prefer 7: it is what this app's own merge engine (libgit2) always
+    // writes, and CLI-written files at the raised size are certified by the
+    // replay above before any user edit could break its equality.
     let size = if attr_size == 7 {
         7
     } else {
@@ -1085,9 +1101,8 @@ fn detect_conflict_emission(
             has_complete_conflict(&content, attr_size as usize),
             has_complete_conflict(&content, 7),
         ) {
-            (true, _) => attr_size,
-            (false, true) => 7,
-            (false, false) => 7,
+            (true, false) => attr_size,
+            _ => 7,
         }
     };
     let style = if diff3_within_first_conflict(&content, size as usize) {
@@ -2718,6 +2733,127 @@ mod tests {
             txt.marker_size, 7,
             "the quoted sample must not defeat the replay verification"
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_add_add_conflict_replays_against_empty_base() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        // An add/add conflict has NO ancestor entry, so index-based replay
+        // is impossible — the empty-base replay must still certify the size.
+        // One side quotes a complete 12-char conflict (the docs case the
+        // attribute was raised for); the real markers are libgit2's 7.
+        let quoted = "docs:\n<<<<<<<<<<<< sample\none\n============\ntwo\n>>>>>>>>>>>> sample\n";
+        repo.create_commit(
+            "Add attrs",
+            &[(".gitattributes", "*.md conflict-marker-size=12\n")],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature adds doc", &[("new.md", quoted)]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main adds doc", &[("new.md", "unrelated text\n")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        let written = std::fs::read_to_string(repo.path.join("new.md")).unwrap();
+        assert!(
+            written.contains("<<<<<<< ") && written.contains("<<<<<<<<<<<< sample"),
+            "precondition: real 7-char markers AND the quoted 12-sample coexist; got:\n{written}"
+        );
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let md = conflicts
+            .iter()
+            .find(|c| c.path == "new.md")
+            .expect("add/add conflict should be listed");
+        assert!(md.ancestor.is_none(), "precondition: no ancestor entry");
+        assert_eq!(
+            md.marker_size, 7,
+            "empty-base replay must certify the real size for add/add conflicts"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_add_add_pipe_content_is_not_diff3() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        // Ours content contains a 7-pipe run (Markdown table art). With no
+        // ancestor entry the replay must still run (empty base) and report
+        // merge style — a diff3 misreport would make the frontend discard
+        // every ours line after the pipe run as a "base section".
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature adds", &[("new.txt", "THEIRS\n")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main adds", &[("new.txt", "a\n|||||||\nz\n")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "new.txt")
+            .expect("add/add conflict should be listed");
+        assert!(txt.ancestor.is_none(), "precondition: no ancestor entry");
+        assert_eq!(txt.marker_size, 7);
+        assert_eq!(
+            txt.conflict_style, "merge",
+            "pipe-run content must not misreport diff3 for add/add conflicts"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_undecidable_fallback_prefers_default_size() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit(
+            "Add attrs and shared",
+            &[
+                (".gitattributes", "*.txt conflict-marker-size=12\n"),
+                ("shared.txt", "base"),
+            ],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // Hand-edit the file so no replay matches, with COMPLETE conflict
+        // structures at BOTH sizes. Undecidable from bytes — the fallback
+        // must prefer 7 (this app's own engine) so the real markers written
+        // by libgit2 stay parseable rather than leaking as resolved text.
+        std::fs::write(
+            repo.path.join("shared.txt"),
+            "<<<<<<<<<<<< quoted\nq1\n============\nq2\n>>>>>>>>>>>> quoted\nedited by hand\n<<<<<<< HEAD\nmain content\n=======\nfeature content\n>>>>>>> feature\n",
+        )
+        .unwrap();
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert_eq!(txt.marker_size, 7);
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -900,34 +900,28 @@ pub async fn get_conflicts(path: String) -> Result<Vec<ConflictFile>> {
             .filter_map(|e| e.as_ref())
             .any(|e| repo.find_blob(e.id).map(|b| b.is_binary()).unwrap_or(false));
 
-        // The marker size git used when writing this file's conflict hunks.
-        // A raised size means 7-char marker-shaped lines are CONTENT, so the
-        // parser cannot guess — it needs the authoritative attribute value.
-        // BUT the attribute only describes what git's CLI writes: libgit2's
-        // own merge/checkout ignores conflict-marker-size and always emits
-        // 7-char markers, so a raised attribute is only trusted when the
-        // working file really contains a complete conflict at that size.
-        let attr_size = repo
-            .get_attr(
-                Path::new(&file_path),
-                "conflict-marker-size",
-                git2::AttrCheckFlags::default(),
+        // How this file's conflict hunks were actually written. The
+        // conflict-marker-size attribute and merge.conflictStyle config only
+        // describe what git's CLI writes — libgit2's own merge/checkout
+        // ignores both and always emits 7-char merge-style markers — so the
+        // emission must be verified against the working file, not assumed.
+        // Binary conflicts have no marker hunks to detect (and libgit2's
+        // binary merge result has no content to replay against) — report
+        // the defaults; the text merge editor never parses them anyway.
+        let (marker_size, conflict_style) = if is_binary {
+            (
+                crate::models::conflict::default_marker_size(),
+                crate::models::conflict::default_conflict_style(),
             )
-            .ok()
-            .flatten()
-            .and_then(|v| v.parse::<u32>().ok())
-            .filter(|&n| n >= 1)
-            .unwrap_or_else(crate::models::conflict::default_marker_size);
-        let marker_size = if attr_size == 7 {
-            7
         } else {
-            match std::fs::read_to_string(Path::new(&path).join(&file_path)) {
-                Ok(content) if has_complete_conflict(&content, attr_size as usize) => attr_size,
-                Ok(_) => 7,
-                // Unreadable working file (deleted side, binary) — the size
-                // is moot for parsing, report the attribute value.
-                Err(_) => attr_size,
-            }
+            detect_conflict_emission(
+                &repo,
+                Path::new(&path),
+                &file_path,
+                conflict.ancestor.as_ref(),
+                conflict.our.as_ref(),
+                conflict.their.as_ref(),
+            )
         };
 
         conflicts.push(ConflictFile {
@@ -937,6 +931,7 @@ pub async fn get_conflicts(path: String) -> Result<Vec<ConflictFile>> {
             theirs: get_entry(conflict.their),
             is_binary,
             marker_size,
+            conflict_style,
         });
     }
 
@@ -944,27 +939,163 @@ pub async fn get_conflicts(path: String) -> Result<Vec<ConflictFile>> {
     Ok(conflicts)
 }
 
+/// True when `line` is a marker run of `ch`: EXACTLY `size` characters
+/// followed by a space or end-of-line.
+fn is_marker_run(line: &str, ch: char, size: usize) -> bool {
+    let n = line.chars().take_while(|&c| c == ch).count();
+    n == size && matches!(line.chars().nth(n), None | Some(' '))
+}
+
+/// The `conflict-marker-size` gitattribute for a path, defaulting to 7.
+/// Parsed as u16: real sizes are tiny, and the cap also bounds the
+/// separator-string allocations downstream — a hostile
+/// `conflict-marker-size=4000000000` in a cloned repo's .gitattributes must
+/// not make the backend try to allocate gigabytes.
+fn attr_marker_size(repo: &git2::Repository, file_path: &str) -> u32 {
+    repo.get_attr(
+        Path::new(file_path),
+        "conflict-marker-size",
+        git2::AttrCheckFlags::default(),
+    )
+    .ok()
+    .flatten()
+    .and_then(|v| v.parse::<u16>().ok())
+    .map(u32::from)
+    .filter(|&n| n >= 1)
+    .unwrap_or_else(crate::models::conflict::default_marker_size)
+}
+
 /// True when `content` holds a complete conflict written at `size`: a start
 /// run, then a separator, then an end run — each exactly `size` marker
 /// characters followed by a space or end-of-line, in git's emission order.
-/// Used to verify that a raised conflict-marker-size attribute matches what
-/// was actually written (libgit2 ignores the attribute and emits 7).
+/// Fallback signal only — content that QUOTES a complete conflict (docs,
+/// fixtures) fools it, which is why detect_conflict_emission replays the
+/// merge first.
 fn has_complete_conflict(content: &str, size: usize) -> bool {
-    let run_is = |line: &str, ch: char| -> bool {
-        let n = line.chars().take_while(|&c| c == ch).count();
-        n == size && matches!(line.chars().nth(n), None | Some(' '))
-    };
     let sep: String = "=".repeat(size);
     let mut stage = 0u8; // 0 = want start, 1 = want separator, 2 = want end
     for line in content.lines() {
         match stage {
-            0 if run_is(line, '<') => stage = 1,
+            0 if is_marker_run(line, '<', size) => stage = 1,
             1 if line == sep => stage = 2,
-            2 if run_is(line, '>') => return true,
+            2 if is_marker_run(line, '>', size) => return true,
             _ => {}
         }
     }
     false
+}
+
+/// True when the FIRST complete conflict at `size` contains a base marker
+/// (`|||||||` run of the same size) between its start and separator —
+/// the structural signature of diff3 emission. Fallback signal only.
+fn diff3_within_first_conflict(content: &str, size: usize) -> bool {
+    let sep: String = "=".repeat(size);
+    let mut in_ours = false;
+    let mut saw_base = false;
+    for line in content.lines() {
+        if !in_ours {
+            if is_marker_run(line, '<', size) {
+                in_ours = true;
+            }
+        } else if line == sep {
+            return saw_base;
+        } else if is_marker_run(line, '|', size) {
+            saw_base = true;
+        }
+    }
+    false
+}
+
+/// Line-based comparison of the working file against a replayed merge,
+/// tolerant of the two things that legitimately differ between engines:
+/// marker LABELS (git's CLI writes branch names/commit subjects, libgit2
+/// writes index-entry paths) and CR line endings (checkout filters).
+/// Content lines must match exactly.
+fn matches_replay(workdir: &str, replay: &str, size: usize) -> bool {
+    let marker_kind = |line: &str| -> Option<char> {
+        ['<', '>', '|']
+            .into_iter()
+            .find(|&ch| is_marker_run(line, ch, size))
+    };
+    let a: Vec<&str> = workdir.lines().collect();
+    let b: Vec<&str> = replay.lines().collect();
+    a.len() == b.len()
+        && a.iter().zip(b.iter()).all(|(x, y)| {
+            x == y || matches!((marker_kind(x), marker_kind(y)), (Some(p), Some(q)) if p == q)
+        })
+}
+
+/// Determine the marker size and conflict style this file's hunks were
+/// ACTUALLY written with. The gitattribute/config only describe what git's
+/// CLI writes; libgit2 (the in-app merge engine) ignores both and always
+/// emits 7-char merge-style markers, and the same bytes can be a real
+/// conflict at one size and quoted content at another. So: replay the merge
+/// from the index blobs at each candidate size × style and accept a
+/// (label/CR tolerant) match as definitive; fall back to structural scans
+/// only when replay cannot decide (user-edited file, missing side).
+fn detect_conflict_emission(
+    repo: &git2::Repository,
+    repo_root: &Path,
+    file_path: &str,
+    ancestor: Option<&git2::IndexEntry>,
+    ours: Option<&git2::IndexEntry>,
+    theirs: Option<&git2::IndexEntry>,
+) -> (u32, String) {
+    let attr_size = attr_marker_size(repo, file_path);
+    let content = match std::fs::read_to_string(repo_root.join(file_path)) {
+        Ok(c) => c,
+        // Unreadable working file (deleted side, binary) — size and style
+        // are moot for parsing; report the attribute value.
+        Err(_) => return (attr_size, crate::models::conflict::default_conflict_style()),
+    };
+
+    let mut candidates: Vec<u32> = vec![attr_size];
+    if attr_size != 7 {
+        candidates.push(7);
+    }
+
+    if let (Some(anc), Some(our), Some(their)) = (ancestor, ours, theirs) {
+        for &size in &candidates {
+            for style in ["merge", "diff3", "zdiff3"] {
+                let mut opts = git2::MergeFileOptions::new();
+                opts.marker_size(size as u16);
+                opts.style_diff3(style == "diff3");
+                opts.style_zdiff3(style == "zdiff3");
+                let Ok(result) = repo.merge_file_from_index(anc, our, their, Some(&mut opts))
+                else {
+                    continue;
+                };
+                let replay = String::from_utf8_lossy(result.content());
+                if matches_replay(&content, &replay, size as usize) {
+                    // zdiff3 emits the same structure as diff3 to a parser.
+                    let reported = if style == "merge" { "merge" } else { "diff3" };
+                    return (size, reported.to_string());
+                }
+            }
+        }
+    }
+
+    // Structural fallback. When BOTH sizes show a complete conflict the
+    // bytes are undecidable — follow the gitattributes-documented semantics
+    // (the replay above already resolved the common libgit2 case).
+    let size = if attr_size == 7 {
+        7
+    } else {
+        match (
+            has_complete_conflict(&content, attr_size as usize),
+            has_complete_conflict(&content, 7),
+        ) {
+            (true, _) => attr_size,
+            (false, true) => 7,
+            (false, false) => 7,
+        }
+    };
+    let style = if diff3_within_first_conflict(&content, size as usize) {
+        "diff3"
+    } else {
+        "merge"
+    };
+    (size, style.to_string())
 }
 
 /// Get content of a blob by OID
@@ -2445,6 +2576,7 @@ mod tests {
             txt.marker_size, 7,
             "raised attribute must fall back to 7 when the file was written with 7-char markers"
         );
+        assert_eq!(txt.conflict_style, "merge");
         let md = conflicts
             .iter()
             .find(|c| c.path == "other.md")
@@ -2453,7 +2585,8 @@ mod tests {
 
         // Git's CLI (rebase/cherry-pick shell-outs, external git) DOES honor
         // the attribute. Simulate its emission: with real 12-char markers on
-        // disk the raised size must be reported.
+        // disk the raised size must be reported. (The extra content line is
+        // not in the blobs, so this exercises the structural fallback.)
         std::fs::write(
             repo.path.join("shared.txt"),
             "<<<<<<<<<<<< HEAD\nmain content\n<<<<<<< a 7-char sample in content\n============\nfeature content\n>>>>>>>>>>>> feature\n",
@@ -2468,6 +2601,205 @@ mod tests {
             txt.marker_size, 12,
             "raised attribute must be reported when the file really uses raised markers"
         );
+    }
+
+    /// Replays a merge of the conflicted index entries for `path` with the
+    /// given options and writes the result to the working directory —
+    /// simulating what a different engine (git's CLI) would have written.
+    fn replay_conflict_to_workdir(repo: &TestRepo, path: &str, opts: &mut git2::MergeFileOptions) {
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        let conflict = index
+            .conflicts()
+            .unwrap()
+            .flatten()
+            .find(|c| {
+                c.our
+                    .as_ref()
+                    .map(|e| String::from_utf8_lossy(&e.path) == path)
+                    .unwrap_or(false)
+            })
+            .expect("conflict should exist");
+        let result = git_repo
+            .merge_file_from_index(
+                conflict.ancestor.as_ref().unwrap(),
+                conflict.our.as_ref().unwrap(),
+                conflict.their.as_ref().unwrap(),
+                Some(opts),
+            )
+            .unwrap();
+        std::fs::write(repo.path.join(path), result.content()).unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_replay_detects_cli_written_raised_markers() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit(
+            "Add attrs and shared",
+            &[
+                (".gitattributes", "*.txt conflict-marker-size=12\n"),
+                ("shared.txt", "base"),
+            ],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // Rewrite the conflict exactly as git's CLI would: raised size, with
+        // labels DIFFERENT from libgit2's index-entry paths — the replay
+        // comparison must tolerate label differences.
+        let mut opts = git2::MergeFileOptions::new();
+        opts.marker_size(12);
+        opts.our_label("HEAD");
+        opts.their_label("feature");
+        replay_conflict_to_workdir(&repo, "shared.txt", &mut opts);
+
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("txt conflict should be listed");
+        assert_eq!(txt.marker_size, 12);
+        assert_eq!(txt.conflict_style, "merge");
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_quoted_raised_sample_does_not_fool_size_detection() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        // The OURS side's CONTENT quotes a complete 12-char conflict — the
+        // very kind of file conflict-marker-size gets raised for. A purely
+        // structural scan reports 12 here; only the merge replay can tell
+        // that libgit2 actually wrote the real markers at 7.
+        let quoted = "docs:\n<<<<<<<<<<<< sample\none\n============\ntwo\n>>>>>>>>>>>> sample\n";
+        repo.create_commit(
+            "Add attrs and shared",
+            &[
+                (".gitattributes", "*.txt conflict-marker-size=12\n"),
+                ("shared.txt", "base"),
+            ],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", quoted)]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        let written = std::fs::read_to_string(repo.path.join("shared.txt")).unwrap();
+        assert!(
+            written.contains("<<<<<<<<<<<< sample") && written.contains("<<<<<<< "),
+            "precondition: quoted 12-sample AND real 7-char markers coexist; got:\n{written}"
+        );
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("txt conflict should be listed");
+        assert_eq!(
+            txt.marker_size, 7,
+            "the quoted sample must not defeat the replay verification"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_hostile_marker_size_attribute_is_rejected() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        // A hostile/typo attribute value must not force a multi-gigabyte
+        // allocation — it is rejected at parse time and falls back to 7.
+        repo.create_commit(
+            "Add attrs and shared",
+            &[
+                (".gitattributes", "*.txt conflict-marker-size=4000000000\n"),
+                ("shared.txt", "base"),
+            ],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("txt conflict should be listed");
+        assert_eq!(txt.marker_size, 7);
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_reports_diff3_style() {
+        let repo = TestRepo::with_initial_commit();
+        setup_conflicting_branches(&repo);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // Rewrite the conflict as diff3 emission (merge.conflictStyle=diff3
+        // via git's CLI) — the style must be detected and reported so the
+        // frontend knows a ||||||| line is a base section, not ours content.
+        let mut opts = git2::MergeFileOptions::new();
+        opts.style_diff3(true);
+        replay_conflict_to_workdir(&repo, "shared.txt", &mut opts);
+        let written = std::fs::read_to_string(repo.path.join("shared.txt")).unwrap();
+        assert!(
+            written.contains("|||||||"),
+            "precondition: diff3 emission has a base marker; got:\n{written}"
+        );
+
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert_eq!(txt.marker_size, 7);
+        assert_eq!(txt.conflict_style, "diff3");
+    }
+
+    #[test]
+    fn test_diff3_within_first_conflict() {
+        let diff3 = "<<<<<<< HEAD\nours\n||||||| base\nbase\n=======\ntheirs\n>>>>>>> f\n";
+        assert!(diff3_within_first_conflict(diff3, 7));
+
+        let merge_style = "<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> f\n";
+        assert!(!diff3_within_first_conflict(merge_style, 7));
+
+        // A pipe run in the THEIRS section is content, not a diff3 signal.
+        let pipes_in_theirs = "<<<<<<< HEAD\nours\n=======\n||||||| x\ntheirs\n>>>>>>> f\n";
+        assert!(!diff3_within_first_conflict(pipes_in_theirs, 7));
     }
 
     #[test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -1430,9 +1430,13 @@ pub async fn resolve_conflict(
         // symlink_metadata, not exists(): exists() FOLLOWS symlinks, so a
         // dangling link reports false and would be left on disk while the
         // index stages its deletion — an untracked leftover that blocks
-        // later checkouts.
-        if std::fs::symlink_metadata(&full_path).is_ok() {
-            std::fs::remove_file(&full_path)?;
+        // later checkouts. A DIRECTORY here is a submodule worktree — git
+        // leaves it behind on `git rm` of a submodule, so never delete the
+        // tree (and remove_file would error on it anyway).
+        if let Ok(meta) = std::fs::symlink_metadata(&full_path) {
+            if !meta.file_type().is_dir() {
+                std::fs::remove_file(&full_path)?;
+            }
         }
         index.remove_path(Path::new(&file_path))?;
     } else {
@@ -1531,15 +1535,17 @@ pub async fn resolve_conflict_take_side(
             // the OTHER side's regular file (or a symlink) on disk while the
             // index holds the gitlink, so `git status` reports the
             // just-"resolved" path as dirty.
+            // create_dir_all, not create_dir: a NESTED gitlink (e.g.
+            // `vendor/sub`) may have no parent directory on disk yet.
             if let Ok(meta) = std::fs::symlink_metadata(&full_path) {
                 if !meta.file_type().is_dir() {
                     std::fs::remove_file(&full_path)?;
-                    std::fs::create_dir(&full_path)?;
+                    std::fs::create_dir_all(&full_path)?;
                 }
                 // An existing directory is left as-is (it may already be the
                 // submodule's populated worktree).
             } else {
-                std::fs::create_dir(&full_path)?;
+                std::fs::create_dir_all(&full_path)?;
             }
             let resolved = git2::IndexEntry {
                 // Clear the stage bits — this is the resolution entry.
@@ -1571,6 +1577,12 @@ pub async fn resolve_conflict_take_side(
                         file_path
                     )));
                 }
+            }
+            // A NESTED conflicted path (e.g. `vendor/pkg/file`) may have no
+            // parent directory on disk — create it so the write/symlink
+            // below gives a sensible result instead of a raw NotFound.
+            if let Some(parent) = full_path.parent() {
+                std::fs::create_dir_all(parent)?;
             }
             if e.mode == 0o120000 {
                 // The chosen side IS a symlink — its blob content is the
@@ -2834,6 +2846,106 @@ mod tests {
             .find(|s| s.path().ok() == Some("doomed.txt"))
             .expect("deletion should be staged");
         assert!(entry.status().contains(git2::Status::INDEX_DELETED));
+    }
+
+    #[tokio::test]
+    async fn test_take_side_gitlink_materializes_a_nested_missing_parent_dir() {
+        // A NESTED gitlink (`vendor/sub`) whose parent directory does not
+        // exist on disk. create_dir (non-recursive) would fail; the
+        // resolution must create the parent chain and succeed.
+        let repo = TestRepo::with_initial_commit();
+        let git_repo = repo.repo();
+        let ptr_ours = repo.create_commit("ptr ours", &[("a.txt", "2")]);
+        let ptr_theirs = repo.create_commit("ptr theirs", &[("a.txt", "3")]);
+
+        // Directly stage a 3-stage conflict for the nested gitlink path so
+        // the worktree genuinely has no `vendor/` directory.
+        let mut index = git_repo.index().unwrap();
+        for (stage, oid) in [(1u16, ptr_ours), (2u16, ptr_ours), (3u16, ptr_theirs)] {
+            let entry = git2::IndexEntry {
+                ctime: git2::IndexTime::new(0, 0),
+                mtime: git2::IndexTime::new(0, 0),
+                dev: 0,
+                ino: 0,
+                mode: 0o160000,
+                uid: 0,
+                gid: 0,
+                file_size: 0,
+                id: oid,
+                flags: stage << 12,
+                flags_extended: 0,
+                path: b"vendor/sub".to_vec(),
+            };
+            index.add(&entry).unwrap();
+        }
+        index.write().unwrap();
+        assert!(!repo.path.join("vendor").exists());
+
+        resolve_conflict_take_side(
+            repo.path_str(),
+            "vendor/sub".to_string(),
+            "ours".to_string(),
+        )
+        .await
+        .expect("nested gitlink resolution must create the parent dir");
+
+        let meta = std::fs::symlink_metadata(repo.path.join("vendor/sub")).unwrap();
+        assert!(meta.file_type().is_dir(), "gitlink materialized as a dir");
+        let git_repo = repo.repo();
+        let index = git_repo.index().unwrap();
+        assert!(!index.has_conflicts());
+        assert_eq!(
+            index.get_path(Path::new("vendor/sub"), 0).unwrap().mode,
+            0o160000
+        );
+    }
+
+    #[tokio::test]
+    async fn test_resolve_conflict_delete_leaves_a_submodule_directory_in_place() {
+        // resolve_conflict with delete_file on a path that is a DIRECTORY on
+        // disk (a submodule worktree) must stage the removal without erroring
+        // on remove_file, and must NOT delete the directory tree.
+        let repo = TestRepo::with_initial_commit();
+        let git_repo = repo.repo();
+        let ptr = repo.create_commit("ptr", &[("a.txt", "1")]);
+        let mut index = git_repo.index().unwrap();
+        let entry = git2::IndexEntry {
+            ctime: git2::IndexTime::new(0, 0),
+            mtime: git2::IndexTime::new(0, 0),
+            dev: 0,
+            ino: 0,
+            mode: 0o160000,
+            uid: 0,
+            gid: 0,
+            file_size: 0,
+            id: ptr,
+            flags: 0,
+            flags_extended: 0,
+            path: b"sub".to_vec(),
+        };
+        index.add(&entry).unwrap();
+        index.write().unwrap();
+        // A populated submodule worktree directory sits on disk.
+        std::fs::create_dir(repo.path.join("sub")).unwrap();
+        std::fs::write(repo.path.join("sub/work.txt"), "wip\n").unwrap();
+
+        resolve_conflict(
+            repo.path_str(),
+            "sub".to_string(),
+            String::new(),
+            Some(true),
+        )
+        .await
+        .expect("delete on a submodule dir must not error on remove_file");
+
+        // The directory (and its uncommitted work) is left on disk.
+        assert!(repo.path.join("sub/work.txt").exists());
+        let git_repo = repo.repo();
+        assert!(git_repo
+            .index()
+            .unwrap()
+            .get_path(Path::new("sub"), 0)
+            .is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -6,7 +6,7 @@ use tauri::command;
 use super::path_utils::validate_path_within_repo;
 use crate::error::{LeviathanError, Result};
 use crate::models::{
-    ConflictDetails, ConflictEntry, ConflictFile, ConflictMarker, ConflictMarkerFile,
+    ConflictDetails, ConflictEntry, ConflictFile, ConflictHunk, ConflictMarker, ConflictMarkerFile,
 };
 use crate::utils::create_command;
 
@@ -908,10 +908,11 @@ pub async fn get_conflicts(path: String) -> Result<Vec<ConflictFile>> {
         // Binary conflicts have no marker hunks to detect (and libgit2's
         // binary merge result has no content to replay against) — report
         // the defaults; the text merge editor never parses them anyway.
-        let (marker_size, conflict_style) = if is_binary {
+        let (marker_size, conflict_style, conflict_hunks) = if is_binary {
             (
                 crate::models::conflict::default_marker_size(),
                 crate::models::conflict::default_conflict_style(),
+                Vec::new(),
             )
         } else {
             detect_conflict_emission(
@@ -932,6 +933,7 @@ pub async fn get_conflicts(path: String) -> Result<Vec<ConflictFile>> {
             is_binary,
             marker_size,
             conflict_style,
+            conflict_hunks,
         });
     }
 
@@ -983,6 +985,28 @@ fn has_complete_conflict(content: &str, size: usize) -> bool {
         }
     }
     false
+}
+
+/// Marker sizes the file's content DEMONSTRATES: distinct start-run lengths
+/// (7+, space/EOL-terminated) that form a complete conflict at their own
+/// size. Used when the conflict-marker-size attribute no longer matches
+/// what git wrote (it can change mid-operation via .gitattributes' own
+/// resolution). The 7+ floor avoids false positives on `< quoted` lines.
+fn detected_marker_sizes(content: &str) -> Vec<u32> {
+    let mut sizes: Vec<u32> = Vec::new();
+    for line in content.lines() {
+        let n = line.chars().take_while(|&c| c == '<').count();
+        if n >= 7
+            && n <= u16::MAX as usize
+            && matches!(line.chars().nth(n), None | Some(' '))
+            && !sizes.contains(&(n as u32))
+            && has_complete_conflict(content, n)
+        {
+            sizes.push(n as u32);
+        }
+    }
+    sizes.sort_unstable();
+    sizes
 }
 
 /// True when the FIRST complete conflict at `size` contains a base marker
@@ -1040,18 +1064,36 @@ fn detect_conflict_emission(
     ancestor: Option<&git2::IndexEntry>,
     ours: Option<&git2::IndexEntry>,
     theirs: Option<&git2::IndexEntry>,
-) -> (u32, String) {
+) -> (u32, String, Vec<ConflictHunk>) {
     let attr_size = attr_marker_size(repo, file_path);
     let content = match std::fs::read_to_string(repo_root.join(file_path)) {
         Ok(c) => c,
         // Unreadable working file (deleted side, binary) — size and style
         // are moot for parsing; report the attribute value.
-        Err(_) => return (attr_size, crate::models::conflict::default_conflict_style()),
+        Err(_) => {
+            return (
+                attr_size,
+                crate::models::conflict::default_conflict_style(),
+                Vec::new(),
+            )
+        }
     };
 
+    // Sizes actually WRITTEN in the file. The attribute reflects the repo's
+    // configuration NOW, not when git wrote the markers — resolving
+    // .gitattributes' own conflict mid-operation can change it under the
+    // markers' feet, and trusting only the attribute would then report a
+    // size the file does not use (the frontend would find zero conflicts
+    // and let Mark Resolved stage the raw markers as resolved content).
+    let detected = detected_marker_sizes(&content);
     let mut candidates: Vec<u32> = vec![attr_size];
     if attr_size != 7 {
         candidates.push(7);
+    }
+    for &d in &detected {
+        if !candidates.contains(&d) {
+            candidates.push(d);
+        }
     }
 
     // Replay from blob CONTENTS (not index entries): a missing ancestor —
@@ -1083,34 +1125,125 @@ fn detect_conflict_emission(
                 if matches_replay(&content, &replay, size as usize) {
                     // zdiff3 emits the same structure as diff3 to a parser.
                     let reported = if style == "merge" { "merge" } else { "diff3" };
-                    return (size, reported.to_string());
+                    // The replay matched line-for-line, so marker positions
+                    // in the replay ARE positions in the working file. But
+                    // the replay's own content can quote marker-shaped
+                    // lines just like the file — re-replay at a size no
+                    // blob line collides with, where marker detection is
+                    // unambiguous, and hand the frontend AUTHORITATIVE
+                    // hunk positions instead of shape heuristics.
+                    let replay_line_count = replay.lines().count();
+                    let star =
+                        collision_free_size(&[&anc_bytes, &our_bytes, &their_bytes], size as usize);
+                    let mut star_opts = git2::MergeFileOptions::new();
+                    star_opts.marker_size(star);
+                    star_opts.style_diff3(style == "diff3");
+                    star_opts.style_zdiff3(style == "zdiff3");
+                    let hunks = git2::merge_file(&anc_in, &our_in, &their_in, Some(&mut star_opts))
+                        .ok()
+                        .and_then(|star_result| {
+                            let star_replay =
+                                String::from_utf8_lossy(star_result.content()).to_string();
+                            // Marker lines are one line each at any
+                            // size, so the line counts must agree —
+                            // bail to heuristics if they somehow don't.
+                            if star_replay.lines().count() != replay_line_count {
+                                return None;
+                            }
+                            replay_hunks(&star_replay, star as usize, style != "merge")
+                        })
+                        .unwrap_or_default();
+                    return (size, reported.to_string(), hunks);
                 }
             }
         }
     }
 
     // Structural fallback (hand-edited files, missing sides). When BOTH
-    // sizes show a complete conflict the bytes are genuinely undecidable —
-    // prefer 7: it is what this app's own merge engine (libgit2) always
-    // writes, and CLI-written files at the raised size are certified by the
-    // replay above before any user edit could break its equality.
-    let size = if attr_size == 7 {
+    // the attribute size and 7 show a complete conflict the bytes are
+    // genuinely undecidable — prefer 7: it is what this app's own merge
+    // engine (libgit2) always writes, and CLI-written files at the raised
+    // size are certified by the replay above before any user edit could
+    // break its equality. When NEITHER matches, fall back to a size the
+    // content itself demonstrates (stale attribute).
+    let complete_attr = attr_size != 7 && has_complete_conflict(&content, attr_size as usize);
+    let complete_7 = has_complete_conflict(&content, 7);
+    let size = if complete_attr && !complete_7 {
+        attr_size
+    } else if complete_7 {
         7
     } else {
-        match (
-            has_complete_conflict(&content, attr_size as usize),
-            has_complete_conflict(&content, 7),
-        ) {
-            (true, false) => attr_size,
-            _ => 7,
-        }
+        detected.first().copied().unwrap_or(7)
     };
     let style = if diff3_within_first_conflict(&content, size as usize) {
         "diff3"
     } else {
         "merge"
     };
-    (size, style.to_string())
+    // No replay match — the file was hand-edited; positions would be
+    // guesses, so the frontend's validated heuristics take over.
+    (size, style.to_string(), Vec::new())
+}
+
+/// A marker size that cannot collide with any content line: strictly longer
+/// than every leading `<`/`=`/`>`/`|` run in any input blob.
+fn collision_free_size(blobs: &[&[u8]], at_least: usize) -> u16 {
+    let mut max_run = at_least;
+    for bytes in blobs {
+        for line in String::from_utf8_lossy(bytes).lines() {
+            for ch in ['<', '=', '>', '|'] {
+                let n = line.chars().take_while(|&c| c == ch).count();
+                if n > max_run {
+                    max_run = n;
+                }
+            }
+        }
+    }
+    (max_run + 3).min(u16::MAX as usize) as u16
+}
+
+/// Extract hunk marker positions from a replay generated at a
+/// collision-free size — every marker-shaped line is a REAL marker there.
+/// Returns None on any malformed structure (never expected).
+fn replay_hunks(replay: &str, size: usize, has_base: bool) -> Option<Vec<ConflictHunk>> {
+    let sep: String = "=".repeat(size);
+    let mut hunks: Vec<ConflictHunk> = Vec::new();
+    let mut cur: Option<(u32, Option<u32>, Option<u32>)> = None; // (start, base, separator)
+    for (i, line) in replay.lines().enumerate() {
+        let i = i as u32;
+        match cur {
+            None => {
+                if is_marker_run(line, '<', size) {
+                    cur = Some((i, None, None));
+                }
+            }
+            Some((start, base, separator)) => {
+                if separator.is_none()
+                    && has_base
+                    && base.is_none()
+                    && is_marker_run(line, '|', size)
+                {
+                    cur = Some((start, Some(i), None));
+                } else if separator.is_none() && line == sep {
+                    cur = Some((start, base, Some(i)));
+                } else if let Some(sep_idx) = separator {
+                    if is_marker_run(line, '>', size) {
+                        hunks.push(ConflictHunk {
+                            start,
+                            separator: sep_idx,
+                            end: i,
+                            base,
+                        });
+                        cur = None;
+                    }
+                }
+            }
+        }
+    }
+    if cur.is_some() {
+        return None;
+    }
+    Some(hunks)
 }
 
 /// Get content of a blob by OID
@@ -1126,7 +1259,13 @@ pub async fn get_blob_content(path: String, oid: String) -> Result<String> {
         ));
     }
 
-    Ok(String::from_utf8_lossy(blob.content()).to_string())
+    // STRICT decoding, matching read_file_content: a lossy read would put
+    // U+FFFD substitutions on screen, and resolving from such a pane (Use
+    // Base on a legacy-encoded ancestor) would silently bake the corrupted
+    // text into the resolved file. The caller treats the error like any
+    // other unreadable side and offers verbatim (raw-bytes) resolution.
+    String::from_utf8(blob.content().to_vec())
+        .map_err(|_| LeviathanError::OperationFailed("File content is not valid UTF-8".to_string()))
 }
 
 /// Mark a file as resolved with the given content.
@@ -1206,10 +1345,13 @@ pub async fn resolve_conflict_take_side(
             #[cfg(unix)]
             {
                 use std::os::unix::fs::PermissionsExt;
-                // Preserve the executable bit recorded in the index entry
-                if e.mode == 0o100755 {
-                    std::fs::set_permissions(&full_path, std::fs::Permissions::from_mode(0o755))?;
-                }
+                // Apply the chosen side's mode in BOTH directions: fs::write
+                // keeps the existing file's permissions, so taking a
+                // non-executable side over an executable on-disk file must
+                // chmod DOWN too, or the resolved file is staged with the
+                // mode of the side the user rejected.
+                let mode = if e.mode == 0o100755 { 0o755 } else { 0o644 };
+                std::fs::set_permissions(&full_path, std::fs::Permissions::from_mode(mode))?;
             }
             index.add_path(Path::new(&file_path))?;
         }
@@ -2854,6 +2996,193 @@ mod tests {
             .find(|c| c.path == "shared.txt")
             .expect("conflict should be listed");
         assert_eq!(txt.marker_size, 7);
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_detects_size_when_attribute_went_stale() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        // NO conflict-marker-size attribute — but the file's markers were
+        // written at 12 (the attribute was dropped mid-operation, e.g. by
+        // resolving .gitattributes' own conflict). The size must be
+        // detected from the content, or the frontend would find zero
+        // conflicts and Mark Resolved would stage the raw markers.
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // Simulate CLI-written raised markers (with a hand edit so replay
+        // cannot match and the structural fallback must decide).
+        std::fs::write(
+            repo.path.join("shared.txt"),
+            "<<<<<<<<<<<< HEAD\nmain content\nhand edit\n============\nfeature content\n>>>>>>>>>>>> feature\n",
+        )
+        .unwrap();
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert_eq!(
+            txt.marker_size, 12,
+            "the written size must be detected from content when no size matches the attribute"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_reports_authoritative_hunk_positions() {
+        let repo = TestRepo::with_initial_commit();
+        setup_conflicting_branches(&repo);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        // Workdir: <<<<<<< ours / main content / ======= / feature content
+        // / >>>>>>> theirs — the replay matched, so positions are exact.
+        assert_eq!(txt.conflict_hunks.len(), 1);
+        let h = &txt.conflict_hunks[0];
+        assert_eq!((h.start, h.separator, h.end, h.base), (0, 2, 4, None));
+
+        // The positions must actually point at the marker lines on disk.
+        let written = std::fs::read_to_string(repo.path.join("shared.txt")).unwrap();
+        let lines: Vec<&str> = written.lines().collect();
+        assert!(lines[h.start as usize].starts_with("<<<<<<<"));
+        assert!(lines[h.separator as usize].starts_with("======="));
+        assert!(lines[h.end as usize].starts_with(">>>>>>>"));
+    }
+
+    #[tokio::test]
+    async fn test_hand_edited_file_reports_no_hunk_positions() {
+        let repo = TestRepo::with_initial_commit();
+        setup_conflicting_branches(&repo);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        // A hand edit breaks the replay match — positions would be guesses,
+        // so none may be reported (the frontend heuristics take over).
+        let mut content = std::fs::read_to_string(repo.path.join("shared.txt")).unwrap();
+        content.push_str("hand edit\n");
+        std::fs::write(repo.path.join("shared.txt"), content).unwrap();
+
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert!(txt.conflict_hunks.is_empty());
+    }
+
+    #[test]
+    fn test_replay_hunks_and_collision_free_size() {
+        let replay = "ctx\n<<<<<<<<<< ours\na\n==========\nb\n>>>>>>>>>> theirs\ntail\n";
+        let hunks = replay_hunks(replay, 10, false).unwrap();
+        assert_eq!(hunks.len(), 1);
+        assert_eq!(
+            (
+                hunks[0].start,
+                hunks[0].separator,
+                hunks[0].end,
+                hunks[0].base
+            ),
+            (1, 3, 5, None)
+        );
+
+        let diff3 = "<<<<<<<<<< o\na\n||||||||||\nbase\n==========\nb\n>>>>>>>>>> t\n";
+        let hunks = replay_hunks(diff3, 10, true).unwrap();
+        assert_eq!(hunks[0].base, Some(2));
+
+        // Collision-free size must exceed every marker-shaped run in blobs.
+        let blob = b"content\n<<<<<<<<<<<<<<< quoted long run\n" as &[u8];
+        let star = collision_free_size(&[blob], 7);
+        assert!(star as usize > 15);
+    }
+
+    #[test]
+    fn test_detected_marker_sizes() {
+        let raised = "ctx\n<<<<<<<<<<<< HEAD\nours\n============\ntheirs\n>>>>>>>>>>>> f\n";
+        assert_eq!(detected_marker_sizes(raised), vec![12]);
+
+        let none = "just\nplain\ntext\n< quoted line\n";
+        assert!(detected_marker_sizes(none).is_empty());
+
+        // An incomplete start-shaped line demonstrates nothing.
+        let incomplete = "<<<<<<< HEAD\nno separator or end\n";
+        assert!(detected_marker_sizes(incomplete).is_empty());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_take_side_applies_the_chosen_sides_mode_downward() {
+        use std::os::unix::fs::PermissionsExt;
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        // Base + theirs: non-executable. Ours: executable.
+        repo.create_commit("Add script", &[("script.sh", "#!/bin/sh\nbase\n")]);
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("script.sh", "#!/bin/sh\ntheirs\n")]);
+        repo.checkout_branch(&initial_branch);
+        let script = repo.path.join("script.sh");
+        std::fs::write(&script, "#!/bin/sh\nours\n").unwrap();
+        std::fs::set_permissions(&script, std::fs::Permissions::from_mode(0o755)).unwrap();
+        repo.stage_file("script.sh");
+        repo.create_commit("Main change makes executable", &[]);
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+        // The conflicted on-disk file carries ours' executable bit.
+        assert_ne!(
+            std::fs::metadata(&script).unwrap().permissions().mode() & 0o111,
+            0,
+            "precondition: conflicted file is executable"
+        );
+
+        // Taking THEIRS (non-executable) must chmod DOWN, not keep ours' bit.
+        resolve_conflict_take_side(
+            repo.path_str(),
+            "script.sh".to_string(),
+            "theirs".to_string(),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            std::fs::metadata(&script).unwrap().permissions().mode() & 0o111,
+            0,
+            "the resolved file must carry the CHOSEN side's mode"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -1395,6 +1395,37 @@ pub async fn resolve_conflict(
     let full_path = validate_path_within_repo(Path::new(&path), &file_path)?;
     let mut index = repo.index()?;
 
+    // Inspect this file's conflict entries once. Two invariants are enforced
+    // server-side rather than trusting the frontend's routing:
+    //  - a NON-UTF-8 filename cannot round-trip through the String API
+    //    (get_conflicts already lossy-encoded it), so building a path from
+    //    file_path here would target a DIFFERENT (U+FFFD-mangled) file —
+    //    silently creating a ghost and leaving the real file conflicted.
+    //  - a SYMLINK/SUBMODULE conflict must be resolved by choosing a side
+    //    (take-side), never by writing text content over it.
+    let mut special_mode = false;
+    for c in index.conflicts()?.filter_map(|r| r.ok()) {
+        for entry in [&c.our, &c.their, &c.ancestor].into_iter().flatten() {
+            if String::from_utf8_lossy(&entry.path) == file_path.as_str() {
+                if std::str::from_utf8(&entry.path).is_err() {
+                    return Err(LeviathanError::OperationFailed(format!(
+                        "'{}' has a non-UTF-8 name and can't be resolved in the app — resolve it with git in a terminal",
+                        file_path
+                    )));
+                }
+                if entry.mode == 0o120000 || entry.mode == 0o160000 {
+                    special_mode = true;
+                }
+            }
+        }
+    }
+    if special_mode && !delete_file.unwrap_or(false) {
+        return Err(LeviathanError::OperationFailed(format!(
+            "'{}' is a symlink or submodule conflict — choose a side instead of writing text",
+            file_path
+        )));
+    }
+
     if delete_file.unwrap_or(false) {
         // symlink_metadata, not exists(): exists() FOLLOWS symlinks, so a
         // dangling link reports false and would be left on disk while the
@@ -1409,6 +1440,12 @@ pub async fn resolve_conflict(
         // THROUGH an existing symlink — fs::write follows it and would
         // corrupt the link's target file (and stage the wrong blob).
         remove_if_symlink(&full_path)?;
+        // The parent directory can be missing (deleted out-of-band, or a
+        // file↔directory resolution) — create it so the write gives a
+        // sensible result instead of a raw NotFound.
+        if let Some(parent) = full_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
         std::fs::write(&full_path, &content)?;
         index.add_path(Path::new(&file_path))?;
     }
@@ -1455,6 +1492,22 @@ pub async fn resolve_conflict_take_side(
         .ok_or_else(|| {
             LeviathanError::OperationFailed(format!("No conflict found for '{}'", file_path))
         })?;
+
+    // A NON-UTF-8 filename cannot round-trip through the String API — the
+    // matched-by-lossy path here differs from the entry's real bytes, so
+    // every fs/index op below would target a DIFFERENT (mangled) path,
+    // silently creating a ghost file and leaving the real one conflicted.
+    // Refuse honestly instead.
+    if [&conflict.our, &conflict.their, &conflict.ancestor]
+        .into_iter()
+        .flatten()
+        .any(|e| std::str::from_utf8(&e.path).is_err())
+    {
+        return Err(LeviathanError::OperationFailed(format!(
+            "'{}' has a non-UTF-8 name and can't be resolved in the app — resolve it with git in a terminal",
+            file_path
+        )));
+    }
 
     let entry = match side.as_str() {
         "ours" => conflict.our,
@@ -2859,6 +2912,100 @@ mod tests {
         );
         assert!(!repo.path.join("shared.txt").exists());
         assert!(!repo.repo().index().unwrap().has_conflicts());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_resolve_conflict_rejects_writing_text_over_a_symlink() {
+        // resolve_conflict (the text pipeline) must refuse a symlink
+        // conflict server-side — writing text content would corrupt the
+        // link. The UI routes these to take-side; this enforces it.
+        use std::os::unix::fs::symlink;
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        let link = repo.path.join("link");
+        symlink("base-target", &link).unwrap();
+        repo.stage_file("link");
+        repo.create_commit("Add link", &[]);
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        std::fs::remove_file(&link).unwrap();
+        symlink("theirs-target", &link).unwrap();
+        repo.stage_file("link");
+        repo.create_commit("Feature retargets", &[]);
+        repo.checkout_branch(&initial_branch);
+        std::fs::remove_file(&link).unwrap();
+        symlink("ours-target", &link).unwrap();
+        repo.stage_file("link");
+        repo.create_commit("Main retargets", &[]);
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        let err = resolve_conflict(
+            repo.path_str(),
+            "link".to_string(),
+            "arbitrary text".to_string(),
+            None,
+        )
+        .await
+        .expect_err("must refuse to write text over a symlink conflict");
+        assert!(err.to_string().contains("symlink or submodule conflict"));
+        // The link is untouched and still conflicted.
+        let meta = std::fs::symlink_metadata(&link).unwrap();
+        assert!(meta.file_type().is_symlink());
+        assert!(repo.repo().index().unwrap().has_conflicts());
+    }
+
+    #[tokio::test]
+    async fn test_take_side_refuses_a_non_utf8_filename() {
+        // A non-UTF-8 filename cannot round-trip through the String API —
+        // the frontend already has a lossy name — so resolving would target
+        // a DIFFERENT (mangled) path. Refuse honestly instead of silently
+        // creating a ghost and leaving the real file conflicted.
+        let repo = TestRepo::with_initial_commit();
+        let git_repo = repo.repo();
+        let ours_oid = git_repo.blob(b"ours\n").unwrap();
+        let theirs_oid = git_repo.blob(b"theirs\n").unwrap();
+        // café.txt where é is the raw Latin-1 byte 0xE9 (not valid UTF-8).
+        let raw_path: &[u8] = b"caf\xe9.txt";
+
+        let mut index = git_repo.index().unwrap();
+        for (stage, oid) in [(2u16, ours_oid), (3u16, theirs_oid)] {
+            let entry = git2::IndexEntry {
+                ctime: git2::IndexTime::new(0, 0),
+                mtime: git2::IndexTime::new(0, 0),
+                dev: 0,
+                ino: 0,
+                mode: 0o100644,
+                uid: 0,
+                gid: 0,
+                file_size: 0,
+                id: oid,
+                flags: stage << 12,
+                flags_extended: 0,
+                path: raw_path.to_vec(),
+            };
+            index.add(&entry).unwrap();
+        }
+        index.write().unwrap();
+        assert!(git_repo.index().unwrap().has_conflicts());
+
+        // The frontend would send the LOSSY name (get_conflicts lossy-
+        // encoded it). take-side finds the entry by lossy match, then
+        // refuses because the entry's real bytes aren't UTF-8.
+        let lossy = String::from_utf8_lossy(raw_path).to_string();
+        let err = resolve_conflict_take_side(repo.path_str(), lossy, "ours".to_string())
+            .await
+            .expect_err("must refuse a non-UTF-8 filename rather than corrupt");
+        assert!(err.to_string().contains("non-UTF-8 name"));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -1036,6 +1036,7 @@ fn detected_marker_sizes(content: &str, min_size: usize) -> Vec<u32> {
     let mut stage: HashMap<usize, u8> = HashMap::new();
     let mut sizes: Vec<u32> = Vec::new();
     let mut min_complete: Option<u32> = None;
+    let mut min_complete_ge3: Option<u32> = None;
     for line in content.lines() {
         let (ch, exact) = match line.chars().next() {
             Some('<') => ('<', false),
@@ -1064,6 +1065,9 @@ fn detected_marker_sizes(content: &str, min_size: usize) -> Vec<u32> {
                 *s = 3;
                 let sz = n as u32;
                 min_complete = Some(min_complete.map_or(sz, |m| m.min(sz)));
+                if sz >= 3 {
+                    min_complete_ge3 = Some(min_complete_ge3.map_or(sz, |m| m.min(sz)));
+                }
                 if sizes.len() < MAX_DETECTED_SIZES {
                     sizes.push(sz);
                 }
@@ -1071,13 +1075,18 @@ fn detected_marker_sizes(content: &str, min_size: usize) -> Vec<u32> {
             _ => {}
         }
     }
-    // Always retain the smallest demonstrated complete size, even if the
-    // cap already filled with larger (possibly hostile/quoted) ones. A
-    // small real conflict size (git honors conflict-marker-size as low as
-    // 1) evicted from the list would make the structural fallback floor to
-    // 7, and the frontend would then parse the real sub-7 markers as plain
-    // content and stage them silently.
-    if let Some(m) = min_complete {
+    // Always retain the smallest demonstrated complete size, even if the cap
+    // already filled with larger (possibly hostile/quoted) ones. A small real
+    // conflict size (git honors conflict-marker-size as low as 1) evicted from
+    // the list would make the structural fallback floor to 7, and the frontend
+    // would then parse the real sub-7 markers as plain content and stage them
+    // silently. Retain the smallest complete size >= 3 SEPARATELY: the
+    // structural fallback filters to >= 3, so a sub-3 decoy occupying the
+    // global-min slot would be dropped there while a cap-evicted real size in
+    // [3,6] is not retained — floating the reported size above the real markers
+    // and leaking them. Retaining both closes that hole for at most one extra
+    // entry.
+    for m in [min_complete, min_complete_ge3].into_iter().flatten() {
         if !sizes.contains(&m) {
             sizes.push(m);
         }
@@ -1289,7 +1298,11 @@ fn detect_conflict_emission(
         .chain((attr_size != 7).then_some(attr_size))
         .filter(|&n| n >= 3)
         .min()
-        .unwrap_or(attr_size);
+        // Nothing >=3 survived. attr_size is only reached here when it is 7 or
+        // sub-3 (a 3-6 attr would have passed the filter above); reporting a
+        // sub-3 attr would make the frontend parse `<<`/`==`/`>>` in ordinary
+        // prose as markers. Fall back to the safe default (7).
+        .unwrap_or_else(crate::models::conflict::default_marker_size);
     let style = if diff3_within_first_conflict(&content, size as usize) {
         "diff3"
     } else {
@@ -3578,6 +3591,52 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_get_conflicts_fallback_never_reports_a_sub3_attribute_size() {
+        // conflict-marker-size=2 is legal (git honors sizes as low as 1), but
+        // reporting 2 would make the frontend parse ordinary `<<`/`==`/`>>`
+        // prose as markers. When nothing >=3 is demonstrated (here the file was
+        // hand-resolved to plain content with no markers left, yet the index is
+        // still conflicted), the fallback must report the safe default 7, never
+        // the sub-3 attribute size.
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit(
+            "Add attrs and shared",
+            &[
+                (".gitattributes", "*.txt conflict-marker-size=2\n"),
+                ("shared.txt", "base"),
+            ],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // Hand-resolved to plain content — no conflict markers remain, so no
+        // size is demonstrated and replay cannot match.
+        std::fs::write(
+            repo.path.join("shared.txt"),
+            "just ordinary prose\n<< not a marker, only two\nmore text\n",
+        )
+        .unwrap();
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert_eq!(txt.marker_size, 7);
+    }
+
+    #[tokio::test]
     async fn test_get_conflicts_fallback_uses_explicit_attr_when_real_conflict_hand_broken() {
         // The structural fallback runs only for HAND-EDITED files, and a hand
         // edit can break the real conflict's structure (delete its separator) so
@@ -3863,6 +3922,42 @@ mod tests {
         assert!(
             sizes.contains(&4),
             "the smallest demonstrated size must be retained past the cap; got {sizes:?}"
+        );
+    }
+
+    #[test]
+    fn test_detected_marker_sizes_retains_smallest_ge3_when_global_min_is_sub3() {
+        // A sub-3 decoy (size 2) is the GLOBAL smallest, so it occupies the
+        // "retain smallest" slot — but the structural fallback filters to >= 3,
+        // dropping it. Meanwhile a real size-5 conflict is cap-evicted. Without
+        // separately retaining the smallest complete size >= 3, the fallback
+        // would floor to 6 and leak the real size-5 markers.
+        let mut content = String::new();
+        // Sub-3 complete conflict → sets the global min to 2.
+        content.push_str("<<\na\n==\nb\n>>\n");
+        // 20 distinct decoys at sizes 6..=25 fill the 16-slot cap first.
+        for n in 6..=25usize {
+            content.push_str(&"<".repeat(n));
+            content.push('\n');
+            content.push_str("a\n");
+            content.push_str(&"=".repeat(n));
+            content.push('\n');
+            content.push_str("b\n");
+            content.push_str(&">".repeat(n));
+            content.push('\n');
+        }
+        // The REAL size-5 conflict, LAST — its slot push is cap-blocked.
+        content.push_str("<<<<<\nours\n=====\ntheirs\n>>>>>\n");
+
+        let sizes = detected_marker_sizes(&content, 1);
+        assert!(
+            sizes.contains(&5),
+            "the smallest complete size >=3 must be retained past the cap; got {sizes:?}"
+        );
+        let min_ge3 = sizes.iter().copied().filter(|&n| n >= 3).min().unwrap();
+        assert_eq!(
+            min_ge3, 5,
+            "the >=3 structural fallback would floor to {min_ge3}, leaking size-5 markers"
         );
     }
 

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -1477,14 +1477,19 @@ pub async fn resolve_conflict_take_side(
                 // a regular file containing the target as text.
                 #[cfg(unix)]
                 {
+                    use std::os::unix::ffi::OsStrExt;
                     // remove_if_symlink only cleared a symlink; in a
                     // file↔symlink type conflict the workdir holds a REGULAR
                     // file, and symlink() refuses to replace it (EEXIST).
                     if std::fs::symlink_metadata(&full_path).is_ok() {
                         std::fs::remove_file(&full_path)?;
                     }
+                    // A symlink target is an arbitrary byte string, not
+                    // necessarily UTF-8 — from_utf8_lossy would replace odd
+                    // bytes with U+FFFD and silently break the link. Write
+                    // the exact bytes git recorded.
                     std::os::unix::fs::symlink(
-                        String::from_utf8_lossy(blob.content()).as_ref(),
+                        std::ffi::OsStr::from_bytes(blob.content()),
                         &full_path,
                     )?;
                 }
@@ -3866,6 +3871,63 @@ mod tests {
         let index = git_repo.index().unwrap();
         assert!(!index.has_conflicts());
         assert!(index.get_path(Path::new("link"), 0).is_none());
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_take_side_preserves_non_utf8_symlink_targets() {
+        use std::os::unix::ffi::OsStrExt;
+        use std::os::unix::fs::symlink;
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        // A symlink target is an arbitrary byte string — not necessarily
+        // UTF-8. from_utf8_lossy would replace the odd bytes with U+FFFD
+        // and silently break the recreated link.
+        let odd_target: &[u8] = b"target-\xff\xfe-end";
+        let link = repo.path.join("link");
+        // Base points somewhere neutral; ours and theirs both retarget it
+        // differently, so the merge genuinely conflicts.
+        symlink("base-target", &link).unwrap();
+        repo.stage_file("link");
+        repo.create_commit("Add link", &[]);
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        std::fs::remove_file(&link).unwrap();
+        symlink(std::ffi::OsStr::from_bytes(odd_target), &link).unwrap();
+        // Re-stage so feature's tree records the odd-target link as theirs.
+        repo.stage_file("link");
+        repo.create_commit("Feature uses odd link", &[]);
+
+        repo.checkout_branch(&initial_branch);
+        std::fs::remove_file(&link).unwrap();
+        symlink("plain-target", &link).unwrap();
+        repo.stage_file("link");
+        repo.create_commit("Main retargets link", &[]);
+
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        resolve_conflict_take_side(repo.path_str(), "link".to_string(), "theirs".to_string())
+            .await
+            .unwrap();
+
+        // The recreated link's target is byte-identical — no U+FFFD.
+        let meta = std::fs::symlink_metadata(&link).unwrap();
+        assert!(meta.file_type().is_symlink());
+        let recreated = std::fs::read_link(&link).unwrap();
+        assert_eq!(
+            recreated.as_os_str().as_bytes(),
+            odd_target,
+            "the non-utf8 target must survive byte-for-byte"
+        );
     }
 
     #[cfg(unix)]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -992,7 +992,9 @@ fn attr_marker_size(repo: &git2::Repository, file_path: &str) -> u32 {
 /// characters followed by a space or end-of-line, in git's emission order.
 /// Fallback signal only — content that QUOTES a complete conflict (docs,
 /// fixtures) fools it, which is why detect_conflict_emission replays the
-/// merge first.
+/// merge first. Test oracle for the single-size completion semantics that
+/// `detected_marker_sizes` (the production path) computes across all sizes.
+#[cfg(test)]
 fn has_complete_conflict(content: &str, size: usize) -> bool {
     let sep: String = "=".repeat(size);
     let mut stage = 0u8; // 0 = want start, 1 = want separator, 2 = want end
@@ -1163,9 +1165,12 @@ fn detect_conflict_emission(
     // Git emits runs as small as 1, so the REPLAY candidates take every
     // demonstrated size — a wrong size simply fails the replay match, so
     // sub-7 candidates cannot cause false positives there. The structural
-    // fallback below stays at the 7+ floor: quoted `< text` / `= text`
-    // lines can coincidentally form complete sub-7 structures, and only
-    // the replay can certify those sizes safely.
+    // fallback below (when no replay matches) also uses these demonstrated
+    // sizes: a quoted `< text` / `= text` block that coincidentally forms a
+    // complete structure only makes the fallback prefer a size at which the
+    // frontend renders a spurious-but-blob-validated conflict block — the
+    // SAFE direction — whereas ignoring a real sub-7 size would leak its raw
+    // markers.
     let detected_all = detected_marker_sizes(&content, 1);
     let mut candidates: Vec<u32> = vec![attr_size];
     if attr_size != 7 {
@@ -1261,31 +1266,30 @@ fn detect_conflict_emission(
     // the pane and letting Mark Resolved round-trip them to disk. When NEITHER
     // matches, fall back to a size the content itself demonstrates (stale
     // attribute).
-    let complete_attr = attr_size != 7 && has_complete_conflict(&content, attr_size as usize);
-    let complete_7 = has_complete_conflict(&content, 7);
-    let size = if complete_attr && complete_7 {
-        attr_size.min(7)
-    } else if complete_attr {
-        attr_size
-    } else if complete_7 {
-        7
-    } else {
-        // Nothing complete at the attribute size or 7. Prefer a
-        // demonstrated 7+ size; failing that, a demonstrated SUB-7 size
-        // (largest first — long runs are least likely to be quoted
-        // content). Flooring to 7 here would be the dangerous direction:
-        // a stale sub-7 attribute (git honors conflict-marker-size=4) on
-        // a hand-edited file would then parse as ZERO conflicts and let
-        // Mark Resolved silently stage the raw markers, while a sub-7
-        // false positive merely shows a spurious conflict block that the
-        // frontend's blob-validated parsing already contains.
-        detected_all
-            .iter()
-            .copied()
-            .find(|&n| n >= 7)
-            .or_else(|| detected_all.iter().copied().max())
-            .unwrap_or(7)
-    };
+    // Choose the reported size. The frontend parses markers of EXACTLY this
+    // size, and its orphan safety-net matches runs of `>=` this size. Reporting
+    // a size LARGER than a real marker makes BOTH miss it — raw markers leak
+    // into the pane and round-trip to disk; reporting SMALLER is safe, because
+    // a real LARGER marker is still caught by the `>=` net (which collapses to
+    // a clean whole-file conflict). Every real marker forms a COMPLETE conflict
+    // structure, so its size is in `detected_all`; take the SMALLEST
+    // demonstrated size. This subsumes both the attribute size and 7 (each is
+    // in `detected_all` iff it has a complete structure) — crucially, it still
+    // recovers a real sub-7 size even when the current attribute has drifted
+    // back to the default 7 (e.g. .gitattributes' own conflict was resolved
+    // after git wrote the markers), the case a two-candidate attr-vs-7 check
+    // blind-spots. Exclude runs of 1-2 chars: git's practical minimum
+    // conflict-marker-size is 3, and a lone `<`/`=`/`>` content line forming a
+    // "complete" size-1 structure would otherwise make the whole file parse as
+    // markers. A quoted LARGER conflict block only yields a spurious,
+    // blob-validated conflict block the frontend already contains. When nothing
+    // >=3 is demonstrated, fall back to the attribute size (default 7).
+    let size = detected_all
+        .iter()
+        .copied()
+        .filter(|&n| n >= 3)
+        .min()
+        .unwrap_or(attr_size);
     let style = if diff3_within_first_conflict(&content, size as usize) {
         "diff3"
     } else {
@@ -3520,6 +3524,104 @@ mod tests {
         // Hand-edit: a QUOTED standard 7-char conflict block (plain content)
         // plus the REAL size-3 conflict, with a stray edit so no replay matches
         // and the structural fallback must decide.
+        std::fs::write(
+            repo.path.join("shared.txt"),
+            "<<<<<<< quoted\nq1\n=======\nq2\n>>>>>>> quoted\nedited by hand\n<<< HEAD\nmain content\n===\nfeature content\n>>> feature\n",
+        )
+        .unwrap();
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert_eq!(txt.marker_size, 3);
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_fallback_prefers_smallest_demonstrated_size() {
+        // NEITHER the attribute size nor 7 shows a complete conflict, but the
+        // content demonstrates two SUB-7 sizes: the REAL size-3 markers and a
+        // quoted size-5 block. The fallback must prefer the SMALLEST (3) —
+        // reporting 5 would make the exact-match parser miss the real size-3
+        // markers and the `>=min(7,5)=5` orphan net miss them too.
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // Real size-3 conflict + a quoted size-5 conflict, hand-edited so no
+        // replay matches. No conflict-marker-size attribute (attr defaults to
+        // 7); neither 7 nor any attribute size is complete.
+        std::fs::write(
+            repo.path.join("shared.txt"),
+            "context\n<<< ours\nmain content\n===\nfeature content\n>>> theirs\nhand edit\n<<<<< example\nfoo\n=====\nbar\n>>>>> example\n",
+        )
+        .unwrap();
+        let conflicts = get_conflicts(repo.path_str()).await.unwrap();
+        let txt = conflicts
+            .iter()
+            .find(|c| c.path == "shared.txt")
+            .expect("conflict should be listed");
+        assert_eq!(txt.marker_size, 3);
+    }
+
+    #[tokio::test]
+    async fn test_get_conflicts_recovers_sub7_size_when_attribute_reverted_to_default() {
+        // The attribute was conflict-marker-size=3 when git wrote the markers,
+        // then REVERTED to the default 7 (e.g. resolving .gitattributes' own
+        // conflict). attr_marker_size now returns 7, so a two-candidate
+        // attr-vs-7 check would be blind to the real size-3 markers — and a
+        // quoted 7-char block makes 7 look complete, so it would report 7 and
+        // leak the real size-3 markers. Taking the smallest DEMONSTRATED size
+        // recovers 3.
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit(
+            "Add attrs and shared",
+            &[
+                (".gitattributes", "*.txt conflict-marker-size=3\n"),
+                ("shared.txt", "base"),
+            ],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        let _ = merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await;
+
+        // Revert the attribute to default (remove the rule) and stage it, as
+        // resolving .gitattributes' own conflict via `git add` would — the
+        // lookup now falls through to the index and returns the default 7.
+        std::fs::write(repo.path.join(".gitattributes"), "").unwrap();
+        {
+            let repo_stage = git2::Repository::open(&repo.path).unwrap();
+            let mut idx = repo_stage.index().unwrap();
+            idx.add_path(Path::new(".gitattributes")).unwrap();
+            idx.write().unwrap();
+        }
+
+        // Quoted standard 7-char conflict block + stray edit (breaks replay),
+        // plus the REAL size-3 markers git actually wrote.
         std::fs::write(
             repo.path.join("shared.txt"),
             "<<<<<<< quoted\nq1\n=======\nq2\n>>>>>>> quoted\nedited by hand\n<<< HEAD\nmain content\n===\nfeature content\n>>> feature\n",

--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -567,8 +567,14 @@ pub async fn read_file_content(
             "File not found in index".to_string(),
         ))
     } else {
-        // Read from working directory
+        // Read from working directory. A MISSING file gets its own error
+        // code — callers must be able to tell "the file is gone" (e.g. a
+        // staged deletion) from "the file exists but could not be decoded"
+        // (legacy encoding), which are presented very differently.
         let full_path = validate_path_within_repo(Path::new(&repo_path), &file_path)?;
+        if !full_path.exists() {
+            return Err(crate::error::LeviathanError::FileNotFound(file_path));
+        }
         let content = std::fs::read_to_string(&full_path)?;
         Ok(content)
     }

--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -450,11 +450,14 @@ pub async fn discard_changes(path: String, paths: Vec<String>) -> Result<()> {
         repo.checkout_index(Some(&mut fresh_index), Some(&mut checkout_opts))?;
     }
 
-    // Delete untracked files
+    // Delete untracked files. symlink_metadata, not exists()/is_dir(): both
+    // FOLLOW symlinks, so a dangling link would be skipped (left on disk)
+    // and a link to a directory would be reported as a directory. The
+    // symlink itself is what must go — never its target.
     for file_path in untracked_paths {
         let full_path = repo_path.join(file_path);
-        if full_path.exists() {
-            if full_path.is_dir() {
+        if let Ok(meta) = std::fs::symlink_metadata(&full_path) {
+            if meta.file_type().is_dir() {
                 std::fs::remove_dir_all(&full_path)?;
             } else {
                 std::fs::remove_file(&full_path)?;

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -27,6 +27,12 @@ pub enum LeviathanError {
     #[error("Invalid path: {0}")]
     InvalidPath(String),
 
+    /// The requested file does not exist on disk. Distinct from other read
+    /// failures (permissions, invalid encoding) so callers can tell "the
+    /// file is GONE" from "the file exists but could not be decoded".
+    #[error("File not found: {0}")]
+    FileNotFound(String),
+
     #[error("Branch not found: {0}")]
     BranchNotFound(String),
 
@@ -100,6 +106,7 @@ impl From<LeviathanError> for ErrorResponse {
             LeviathanError::RepositoryNotFound(_) => "REPO_NOT_FOUND",
             LeviathanError::RepositoryNotOpen => "REPO_NOT_OPEN",
             LeviathanError::InvalidPath(_) => "INVALID_PATH",
+            LeviathanError::FileNotFound(_) => "FILE_NOT_FOUND",
             LeviathanError::BranchNotFound(_) => "BRANCH_NOT_FOUND",
             LeviathanError::CommitNotFound(_) => "COMMIT_NOT_FOUND",
             LeviathanError::TagNotFound(_) => "TAG_NOT_FOUND",
@@ -143,6 +150,7 @@ impl serde::Serialize for LeviathanError {
                 LeviathanError::RepositoryNotFound(_) => "REPO_NOT_FOUND",
                 LeviathanError::RepositoryNotOpen => "REPO_NOT_OPEN",
                 LeviathanError::InvalidPath(_) => "INVALID_PATH",
+                LeviathanError::FileNotFound(_) => "FILE_NOT_FOUND",
                 LeviathanError::BranchNotFound(_) => "BRANCH_NOT_FOUND",
                 LeviathanError::CommitNotFound(_) => "COMMIT_NOT_FOUND",
                 LeviathanError::TagNotFound(_) => "TAG_NOT_FOUND",

--- a/src-tauri/src/models/conflict.rs
+++ b/src-tauri/src/models/conflict.rs
@@ -19,6 +19,12 @@ pub struct ConflictFile {
     /// whole blobs (see resolve_conflict_take_side).
     #[serde(default)]
     pub is_binary: bool,
+    /// Whether any side is a submodule (gitlink) pointer. Submodule
+    /// conflicts have no blobs at all — their entry OIDs are COMMITS — so
+    /// neither the text editor nor the binary chooser's blob reads apply;
+    /// resolving one stages the chosen commit pointer directly.
+    #[serde(default)]
+    pub is_submodule: bool,
     /// Marker size the conflict hunks in this file were actually written
     /// with (git's default is 7; the conflict-marker-size gitattribute
     /// raises it). The backend verifies the attribute against the file's

--- a/src-tauri/src/models/conflict.rs
+++ b/src-tauri/src/models/conflict.rs
@@ -34,6 +34,28 @@ pub struct ConflictFile {
     /// to start with a pipe run.
     #[serde(default = "default_conflict_style")]
     pub conflict_style: String,
+    /// AUTHORITATIVE marker positions in the working file (0-based line
+    /// indices), derived from a collision-free re-replay when the merge
+    /// replay matched the file. When present the frontend parses by these
+    /// positions instead of shape heuristics — content that quotes marker
+    /// lines (even byte-identical to the real ones) can never confuse
+    /// them. Empty when the file was hand-edited (no replay match).
+    #[serde(default)]
+    pub conflict_hunks: Vec<ConflictHunk>,
+}
+
+/// One conflict hunk's marker line positions in the working file.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ConflictHunk {
+    /// `<<<<<<<` line index
+    pub start: u32,
+    /// `=======` line index
+    pub separator: u32,
+    /// `>>>>>>>` line index
+    pub end: u32,
+    /// `|||||||` line index for diff3-style emission
+    pub base: Option<u32>,
 }
 
 pub(crate) fn default_marker_size() -> u32 {

--- a/src-tauri/src/models/conflict.rs
+++ b/src-tauri/src/models/conflict.rs
@@ -19,6 +19,16 @@ pub struct ConflictFile {
     /// whole blobs (see resolve_conflict_take_side).
     #[serde(default)]
     pub is_binary: bool,
+    /// Effective `conflict-marker-size` gitattribute for this path (git's
+    /// default is 7). The frontend parser must use this exact size — the
+    /// same byte pattern is a real conflict at one size and plain content
+    /// at another, so it is not decidable from file contents alone.
+    #[serde(default = "default_marker_size")]
+    pub marker_size: u32,
+}
+
+pub(crate) fn default_marker_size() -> u32 {
+    7
 }
 
 /// Represents one side of a conflict

--- a/src-tauri/src/models/conflict.rs
+++ b/src-tauri/src/models/conflict.rs
@@ -19,16 +19,29 @@ pub struct ConflictFile {
     /// whole blobs (see resolve_conflict_take_side).
     #[serde(default)]
     pub is_binary: bool,
-    /// Effective `conflict-marker-size` gitattribute for this path (git's
-    /// default is 7). The frontend parser must use this exact size — the
-    /// same byte pattern is a real conflict at one size and plain content
-    /// at another, so it is not decidable from file contents alone.
+    /// Marker size the conflict hunks in this file were actually written
+    /// with (git's default is 7; the conflict-marker-size gitattribute
+    /// raises it). The backend verifies the attribute against the file's
+    /// real emission — the frontend parser must use this exact size, since
+    /// the same byte pattern is a real conflict at one size and plain
+    /// content at another.
     #[serde(default = "default_marker_size")]
     pub marker_size: u32,
+    /// Conflict style the hunks were written with: "merge" (default) or
+    /// "diff3" (has `|||||||` base sections; zdiff3 is reported as diff3 —
+    /// the emitted structure is the same to a parser). Without this the
+    /// frontend cannot tell a base section from ours content that happens
+    /// to start with a pipe run.
+    #[serde(default = "default_conflict_style")]
+    pub conflict_style: String,
 }
 
 pub(crate) fn default_marker_size() -> u32 {
     7
+}
+
+pub(crate) fn default_conflict_style() -> String {
+    "merge".to_string()
 }
 
 /// Represents one side of a conflict

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -945,6 +945,33 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('a conflict OPENING on a background-tabbed repo refreshes the pinned repo too', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        // The merge ran on repo A, but the user switched to B during its
+        // await — the conflict event still carries A's path, and A (not B)
+        // must be the repo that gets refreshed.
+        repositoryStore.getState().setActiveByPath('/repo/b');
+        await el.updateComplete;
+
+        (el as any).handleMergeConflictEvent(
+          new CustomEvent('merge-conflict', { detail: { repositoryPath: '/repo/a' } })
+        );
+        await el.updateComplete;
+
+        expect((el as any).staleRepoPaths.has('/repo/a')).to.be.true;
+        const dialog = el.shadowRoot!.querySelector(
+          'lv-conflict-resolution-dialog'
+        ) as HTMLElement & { repositoryPath: string };
+        expect(dialog.repositoryPath).to.equal('/repo/a');
+      } finally {
+        el.remove();
+      }
+    });
+
     it('completing on a background-tabbed repo refreshes the PINNED repo, not the active one', async () => {
       const el = createAppShell();
       document.body.appendChild(el);

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -912,6 +912,34 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('refuses to open for a repo whose tab was closed mid-operation', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        await el.updateComplete;
+
+        // The merge ran on repo A; the user closed A's tab during the
+        // await. A dialog pinned to a closed repo would float over the
+        // wrong screen with dead completion plumbing.
+        repositoryStore.getState().removeRepository('/repo/a');
+        await el.updateComplete;
+        (el as any).handleMergeConflictEvent(
+          new CustomEvent('merge-conflict', { detail: { repositoryPath: '/repo/a' } })
+        );
+        await el.updateComplete;
+
+        expect((el as any).showConflictDialog).to.be.false;
+        expect(el.shadowRoot!.querySelector('lv-conflict-resolution-dialog')).to.be.null;
+        const toasts = uiStore.getState().toasts;
+        expect(toasts.some((t) => t.type === 'warning' && t.message.includes('tab was closed')))
+          .to.be.true;
+      } finally {
+        el.remove();
+      }
+    });
+
     it('a second conflict event cannot hijack an open dialog', async () => {
       const el = createAppShell();
       document.body.appendChild(el);

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -879,4 +879,106 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
   });
+
+  describe('conflict dialog repo pinning', () => {
+    it('keeps operating on the repo it was opened for after a tab switch', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        // Stash-apply conflicts on repo A (clean state) open the dialog.
+        (el as any).openConflictDialogFromState();
+        await el.updateComplete;
+        const dialog = () =>
+          el.shadowRoot!.querySelector('lv-conflict-resolution-dialog') as HTMLElement & {
+            repositoryPath: string;
+          };
+        expect(dialog(), 'dialog should open').to.exist;
+        expect(dialog().repositoryPath).to.equal('/repo/a');
+
+        // Ctrl+Tab still works behind the full-screen dialog — the dialog
+        // must NOT retarget to repo B, or its abort/resolve commands would
+        // destroy repo B's unrelated work.
+        repositoryStore.getState().setActiveByPath('/repo/b');
+        await el.updateComplete;
+        expect(dialog(), 'dialog stays open').to.exist;
+        expect(dialog().repositoryPath).to.equal('/repo/a');
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('re-pins to the repo active at the NEXT open', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        (el as any).openConflictDialogFromState();
+        await el.updateComplete;
+        (el as any).closeConflictDialog();
+        repositoryStore.getState().setActiveByPath('/repo/b');
+        await el.updateComplete;
+
+        (el as any).openConflictDialogFromState();
+        await el.updateComplete;
+        const dialog = el.shadowRoot!.querySelector(
+          'lv-conflict-resolution-dialog'
+        ) as HTMLElement & { repositoryPath: string };
+        expect(dialog.repositoryPath).to.equal('/repo/b');
+      } finally {
+        el.remove();
+      }
+    });
+  });
+
+  describe('conflict operation derivation for external operations', () => {
+    for (const state of ['apply-mailbox', 'apply-mailbox-or-rebase', 'bisect'] as const) {
+      it(`refuses to open the dialog for an external ${state} operation`, async () => {
+        const el = createAppShell();
+        document.body.appendChild(el);
+        try {
+          const repo = { ...mockRepo('/repo/a', 'a'), state };
+          repositoryStore.getState().addRepository(repo, { activate: true });
+          await el.updateComplete;
+
+          // The dialog cannot drive am/bisect: Complete would not run their
+          // --continue and the inferred-stash Abort would discard the
+          // conflicted files while the operation stays wedged.
+          (el as any).openConflictDialogFromState();
+          await el.updateComplete;
+
+          expect((el as any).showConflictDialog).to.be.false;
+          expect(el.shadowRoot!.querySelector('lv-conflict-resolution-dialog')).to.be.null;
+          const toasts = uiStore.getState().toasts;
+          expect(toasts.some((t) => t.type === 'warning' && t.message.includes(state))).to.be
+            .true;
+        } finally {
+          el.remove();
+        }
+      });
+    }
+
+    it('still infers a stash conflict for a clean state', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        await el.updateComplete;
+        (el as any).openConflictDialogFromState();
+        await el.updateComplete;
+        expect((el as any).showConflictDialog).to.be.true;
+        expect((el as any).conflictOperationType).to.equal('stash');
+      } finally {
+        el.remove();
+      }
+    });
+  });
 });

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -945,6 +945,33 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('completing on a background-tabbed repo refreshes the PINNED repo, not the active one', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        (el as any).openConflictDialogFromState();
+        await el.updateComplete;
+
+        // User tabs to B, then completes the operation on pinned repo A.
+        repositoryStore.getState().setActiveByPath('/repo/b');
+        await el.updateComplete;
+        (el as any).handleConflictResolved();
+        await el.updateComplete;
+
+        // A is backgrounded — it must be marked stale (refreshed when
+        // re-activated) so its tab doesn't keep showing merge state.
+        expect((el as any).staleRepoPaths.has('/repo/a')).to.be.true;
+        expect((el as any).showConflictDialog).to.be.false;
+      } finally {
+        el.remove();
+      }
+    });
+
     it('re-pins to the repo active at the NEXT open', async () => {
       const el = createAppShell();
       document.body.appendChild(el);

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -912,6 +912,39 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('a second conflict event cannot hijack an open dialog', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        (el as any).openConflictDialogFromState();
+        await el.updateComplete;
+
+        // User Ctrl+Tabs to repo B behind the dialog, then a NEW merge
+        // conflict fires there. It must not retarget the open dialog's
+        // repo or operation — that would aim repo A's picks at repo B.
+        repositoryStore.getState().setActiveByPath('/repo/b');
+        await el.updateComplete;
+        (el as any).handleMergeConflictEvent(new CustomEvent('merge-conflict'));
+        await el.updateComplete;
+
+        const dialog = el.shadowRoot!.querySelector(
+          'lv-conflict-resolution-dialog'
+        ) as HTMLElement & { repositoryPath: string; operationType: string };
+        expect(dialog.repositoryPath).to.equal('/repo/a');
+        expect(dialog.operationType).to.equal('stash');
+        // The refusal is not silent.
+        const toasts = uiStore.getState().toasts;
+        expect(toasts.some((t) => t.message.includes('already in progress'))).to.be.true;
+      } finally {
+        el.remove();
+      }
+    });
+
     it('re-pins to the repo active at the NEXT open', async () => {
       const el = createAppShell();
       document.body.appendChild(el);

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1339,6 +1339,72 @@ describe('app-shell multi-repo behavior', () => {
     });
   });
 
+  describe('context-menu operation pinning', () => {
+    it('handleResetToCommit hard-resets the origin repo, not the tab switched to during the confirm', async () => {
+      // A hard reset discards uncommitted work — it must never run against a
+      // repo the user did not confirm. The confirm await yields; a mid-confirm
+      // tab switch rebinds activeRepository.
+      // No appendChild: the handler operates on @state + gitService (mocked)
+      // and does not need rendering; a full render cascade only adds noise.
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/a', 'a') };
+      (el as any).contextMenu = {
+        visible: true,
+        x: 0,
+        y: 0,
+        commit: { oid: 'deadbeef', summary: 'a commit', shortId: 'deadbee' },
+      };
+
+      let resolveConfirm: (v: unknown) => void = () => {};
+      mockResponses['plugin:dialog|message'] = () =>
+        new Promise((res) => {
+          resolveConfirm = res;
+        });
+
+      const promise = (el as any).handleResetToCommit('hard');
+      await new Promise((r) => setTimeout(r, 0));
+
+      // User switches to repo B while the confirm is up.
+      (el as any).activeRepository = { repository: mockRepo('/repo/b', 'b') };
+      resolveConfirm('Ok');
+      await promise;
+
+      const resetCall = invokeCallArgs.find((c) => c.command === 'reset');
+      expect(resetCall, 'reset was called').to.not.be.undefined;
+      expect(resetCall!.args.path).to.equal('/repo/a');
+    });
+
+    it('handleFixupCommit creates the fixup in the origin repo, not the tab switched to during the status check', async () => {
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/a', 'a') };
+      (el as any).contextMenu = {
+        visible: true,
+        x: 0,
+        y: 0,
+        commit: { oid: 'deadbeef', summary: 'a commit', shortId: 'deadbee' },
+      };
+
+      let resolveStatus: (v: unknown) => void = () => {};
+      mockResponses['get_status'] = () =>
+        new Promise((res) => {
+          resolveStatus = res;
+        });
+
+      const promise = (el as any).handleFixupCommit();
+      await new Promise((r) => setTimeout(r, 0));
+
+      // User switches tabs while the status check is in flight.
+      (el as any).activeRepository = { repository: mockRepo('/repo/b', 'b') };
+      resolveStatus([{ path: 'f.ts', isStaged: true }]);
+      await promise;
+
+      const commitCall = invokeCallArgs.find((c) => c.command === 'create_commit');
+      expect(commitCall, 'create_commit was called').to.not.be.undefined;
+      expect(commitCall!.args.path).to.equal('/repo/a');
+      expect((commitCall!.args.message as string)).to.contain('fixup!');
+    });
+  });
+
   describe('conflict operation derivation for external operations', () => {
     for (const state of ['apply-mailbox', 'apply-mailbox-or-rebase', 'bisect'] as const) {
       it(`refuses to open the dialog for an external ${state} operation`, async () => {

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1169,6 +1169,70 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('ref-menu Checkout and graph Checkout both refresh via the PINNED path (sibling consistency)', async () => {
+      for (const handler of ['handleRefCheckout', 'handleCheckoutBranchFromGraph'] as const) {
+        const el = createAppShell();
+        document.body.appendChild(el);
+        try {
+          mockResponses['checkout_with_autostash'] = () => ({ success: true });
+          (el as any).activeRepository = { repository: mockRepo('/repo/a', 'a') };
+          (el as any).refContextMenu = { visible: true, refName: 'feature' };
+          const pinnedCalls: Array<string | null> = [];
+          (el as any).refreshConflictDialogRepo = (p: string | null) => pinnedCalls.push(p);
+          let plainRefreshCalled = false;
+          (el as any).handleRefresh = () => { plainRefreshCalled = true; };
+
+          await (el as any)[handler](
+            new CustomEvent('x', { detail: { branchName: 'feature' } })
+          );
+
+          expect(pinnedCalls, `${handler} routes through the pinned refresh`).to.deep.equal(['/repo/a']);
+          expect(plainRefreshCalled, `${handler} avoids the unpinned refresh`).to.be.false;
+        } finally {
+          el.remove();
+        }
+      }
+    });
+
+    it('closing the pinned tab cancels an open cherry-pick or interactive-rebase dialog', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/b');
+        await el.updateComplete;
+
+        // Fake the two dialogs as open and pinned to repo A. The @query
+        // fields are read-only getters, so shadow them on the instance.
+        let cpClosed = false;
+        let rbClosed = false;
+        Object.defineProperty(el, 'cherryPickDialog', {
+          configurable: true,
+          value: {
+            pinnedRepositoryPathIfOpen: '/repo/a',
+            close: () => { cpClosed = true; },
+          },
+        });
+        Object.defineProperty(el, 'interactiveRebaseDialog', {
+          configurable: true,
+          value: {
+            pinnedRepositoryPathIfOpen: '/repo/a',
+            close: () => { rbClosed = true; },
+          },
+        });
+
+        // Close repo A's tab — the store subscription must dismiss both.
+        repositoryStore.getState().removeRepository('/repo/a');
+        await el.updateComplete;
+
+        expect(cpClosed, 'cherry-pick dialog closed').to.be.true;
+        expect(rbClosed, 'rebase dialog closed').to.be.true;
+      } finally {
+        el.remove();
+      }
+    });
+
     it('a rebase-complete event bubbling from a nested dialog reaches the host pinned refresh', async () => {
       // Interactive rebase is dispatched by the branch-list's OWN embedded
       // dialog too, not just the app-shell one — the host-level listener

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1405,6 +1405,84 @@ describe('app-shell multi-repo behavior', () => {
     });
   });
 
+  describe('reword pinning', () => {
+    it('handleRewordCommit does not open the rebase dialog if the user switched repos during the history await', async () => {
+      // The interactive-rebase dialog pins to the LIVE active-repo prop at
+      // open(); opening it after a mid-await tab switch would configure a
+      // reword of repo A's commit against repo B. The handler must cancel.
+      repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
+      repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/a', 'a') };
+      (el as any).contextMenu = {
+        visible: true,
+        x: 0,
+        y: 0,
+        commit: { oid: 'commitA', summary: 'a commit', shortId: 'commitA' },
+      };
+
+      // Shadow the @query dialog getter with a spy.
+      let opened = false;
+      Object.defineProperty(el, 'interactiveRebaseDialog', {
+        configurable: true,
+        value: {
+          open: () => {
+            opened = true;
+          },
+        },
+      });
+
+      let resolveHistory: (v: unknown) => void = () => {};
+      mockResponses['get_commit_history'] = () =>
+        new Promise((res) => {
+          resolveHistory = res;
+        });
+
+      const promise = (el as any).handleRewordCommit();
+      await new Promise((r) => setTimeout(r, 0));
+
+      // User switches to repo B while the history IPC is in flight.
+      (el as any).activeRepository = { repository: mockRepo('/repo/b', 'b') };
+      // History resolves; commit is non-HEAD (different oid) → else branch.
+      resolveHistory([{ oid: 'headOfA' }]);
+      await promise;
+
+      expect(opened, 'rebase dialog must NOT open against the switched-to repo').to.be.false;
+      const warn = uiStore.getState().toasts.find((t) => t.type === 'warning');
+      expect(warn, 'a warning toast explains the cancellation').to.not.be.undefined;
+    });
+
+    it('handleRewordCommit opens the rebase dialog when the repo did not change', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
+
+      const el = createAppShell();
+      (el as any).activeRepository = { repository: mockRepo('/repo/a', 'a') };
+      (el as any).contextMenu = {
+        visible: true,
+        x: 0,
+        y: 0,
+        commit: { oid: 'commitA', summary: 'a commit', shortId: 'commitA' },
+      };
+
+      let opened = false;
+      Object.defineProperty(el, 'interactiveRebaseDialog', {
+        configurable: true,
+        value: {
+          open: () => {
+            opened = true;
+          },
+        },
+      });
+
+      mockResponses['get_commit_history'] = () => [{ oid: 'headOfA' }];
+
+      await (el as any).handleRewordCommit();
+
+      expect(opened, 'rebase dialog opens for a non-HEAD commit on the same repo').to.be.true;
+    });
+  });
+
   describe('conflict operation derivation for external operations', () => {
     for (const state of ['apply-mailbox', 'apply-mailbox-or-rebase', 'bisect'] as const) {
       it(`refuses to open the dialog for an external ${state} operation`, async () => {

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1103,6 +1103,28 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('gitflow-operation on a background-tabbed repo refreshes the PINNED repo, not the active one', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        (el as any).handleGitflowEvent(
+          new CustomEvent('gitflow-operation', {
+            detail: { type: 'finish-feature', name: 'login', repositoryPath: '/repo/b' },
+          })
+        );
+        await el.updateComplete;
+
+        expect((el as any).staleRepoPaths.has('/repo/b'), 'pinned repo marked stale').to.be.true;
+      } finally {
+        el.remove();
+      }
+    });
+
     it('rebase-complete on a background-tabbed repo refreshes the PINNED repo, not the active one', async () => {
       const el = createAppShell();
       document.body.appendChild(el);

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1076,6 +1076,55 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('cherry-pick-complete on a background-tabbed repo refreshes the PINNED repo, not the active one', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        // The pick ran on B; the user has tabbed back to A by completion.
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        (el as any).handleCherryPickComplete(
+          new CustomEvent('cherry-pick-complete', {
+            detail: {
+              sourceCommit: { oid: 'abcdef1234567890' },
+              noCommit: false,
+              repositoryPath: '/repo/b',
+            },
+          })
+        );
+        await el.updateComplete;
+
+        expect((el as any).staleRepoPaths.has('/repo/b'), 'pinned repo marked stale').to.be.true;
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('rebase-complete on a background-tabbed repo refreshes the PINNED repo, not the active one', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        (el as any).handleRebaseComplete(
+          new CustomEvent('rebase-complete', {
+            detail: { repositoryPath: '/repo/b' },
+          })
+        );
+        await el.updateComplete;
+
+        expect((el as any).staleRepoPaths.has('/repo/b'), 'pinned repo marked stale').to.be.true;
+      } finally {
+        el.remove();
+      }
+    });
+
     it('re-pins to the repo active at the NEXT open', async () => {
       const el = createAppShell();
       document.body.appendChild(el);

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1103,6 +1103,34 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('a window repository-refresh carrying repoPath pins to that repo (sidebar success paths)', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/b');
+        await el.updateComplete;
+
+        const pinnedCalls: Array<string | null> = [];
+        (el as any).refreshConflictDialogRepo = (p: string | null) => pinnedCalls.push(p);
+        let plainRefreshCalled = false;
+        (el as any).handleRefresh = () => { plainRefreshCalled = true; };
+
+        // A stash/tag/branch success on backgrounded repo A forwards its
+        // repo path through the window refresh.
+        window.dispatchEvent(
+          new CustomEvent('repository-refresh', { detail: { repoPath: '/repo/a' } })
+        );
+        await el.updateComplete;
+
+        expect(pinnedCalls, 'pinned to the originating repo').to.deep.equal(['/repo/a']);
+        expect(plainRefreshCalled, 'not the unpinned active-tab refresh').to.be.false;
+      } finally {
+        el.remove();
+      }
+    });
+
     it('gitflow-operation on a background-tabbed repo refreshes the PINNED repo, not the active one', async () => {
       const el = createAppShell();
       document.body.appendChild(el);

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1125,6 +1125,79 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('a successful pull refreshes via the PINNED path, not the unconditional active-tab refresh', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        mockResponses['pull'] = () => null; // success (invokeCommand wraps)
+        (el as any).activeRepository = { repository: mockRepo('/repo/a', 'a') };
+        // Spy: the fix routes the success path through refreshConflictDialogRepo
+        // with the captured repo path, not the unpinned handleRefresh().
+        const pinnedCalls: Array<string | null> = [];
+        (el as any).refreshConflictDialogRepo = (p: string | null) => pinnedCalls.push(p);
+        let plainRefreshCalled = false;
+        (el as any).handleRefresh = () => { plainRefreshCalled = true; };
+
+        await (el as any).handlePull();
+
+        expect(pinnedCalls, 'success routes through the pinned refresh').to.deep.equal(['/repo/a']);
+        expect(plainRefreshCalled, 'the unpinned handleRefresh is not used').to.be.false;
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('a successful branch checkout refreshes via the PINNED path', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        mockResponses['checkout_with_autostash'] = () => ({ success: true });
+        (el as any).activeRepository = { repository: mockRepo('/repo/a', 'a') };
+        const pinnedCalls: Array<string | null> = [];
+        (el as any).refreshConflictDialogRepo = (p: string | null) => pinnedCalls.push(p);
+        let plainRefreshCalled = false;
+        (el as any).handleRefresh = () => { plainRefreshCalled = true; };
+
+        await (el as any).handleCheckoutBranch(
+          new CustomEvent('checkout-branch', { detail: { branch: 'feature' } })
+        );
+
+        expect(pinnedCalls).to.deep.equal(['/repo/a']);
+        expect(plainRefreshCalled).to.be.false;
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('a rebase-complete event bubbling from a nested dialog reaches the host pinned refresh', async () => {
+      // Interactive rebase is dispatched by the branch-list's OWN embedded
+      // dialog too, not just the app-shell one — the host-level listener
+      // must catch either.
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        // Dispatch from a descendant so it bubbles to the host listener.
+        const child = el.shadowRoot!.querySelector('*') ?? el;
+        child.dispatchEvent(
+          new CustomEvent('rebase-complete', {
+            detail: { repositoryPath: '/repo/b' },
+            bubbles: true,
+            composed: true,
+          })
+        );
+        await el.updateComplete;
+
+        expect((el as any).staleRepoPaths.has('/repo/b')).to.be.true;
+      } finally {
+        el.remove();
+      }
+    });
+
     it('rebase-complete on a background-tabbed repo refreshes the PINNED repo, not the active one', async () => {
       const el = createAppShell();
       document.body.appendChild(el);

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -940,6 +940,55 @@ describe('app-shell multi-repo behavior', () => {
       }
     });
 
+    it('closing the pinned repo tab while the dialog is OPEN closes it with a warning', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        (el as any).openConflictDialogFromState();
+        await el.updateComplete;
+        expect((el as any).showConflictDialog).to.be.true;
+
+        // The user clicks the × on repo A's tab with the dialog up. The
+        // dialog must not stay floating over whatever renders next.
+        repositoryStore.getState().removeRepository('/repo/a');
+        await el.updateComplete;
+
+        expect((el as any).showConflictDialog).to.be.false;
+        expect(el.shadowRoot!.querySelector('lv-conflict-resolution-dialog')).to.be.null;
+        const toasts = uiStore.getState().toasts;
+        expect(
+          toasts.some((t) => t.type === 'warning' && t.message.includes('reopen it'))
+        ).to.be.true;
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('closing an UNRELATED tab leaves the dialog alone', async () => {
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        repositoryStore.getState().setActiveByPath('/repo/a');
+        await el.updateComplete;
+
+        (el as any).openConflictDialogFromState();
+        await el.updateComplete;
+        repositoryStore.getState().removeRepository('/repo/b');
+        await el.updateComplete;
+
+        expect((el as any).showConflictDialog).to.be.true;
+      } finally {
+        el.remove();
+      }
+    });
+
     it('a second conflict event cannot hijack an open dialog', async () => {
       const el = createAppShell();
       document.body.appendChild(el);

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -974,6 +974,20 @@ export class AppShell extends LitElement {
     // dialog whose Complete/Abort target a repo with no operation at all.
     const repoPath = repoPathOverride ?? this.activeRepository?.repository.path;
     if (!repoPath) return;
+    // The tab may have been CLOSED during the operation's await — a dialog
+    // pinned to a closed repo would float over the empty screen with a
+    // post-close refresh that no-ops. The repo on disk still holds the
+    // in-progress operation; re-opening the tab surfaces it again.
+    if (
+      repoPath !== this.activeRepository?.repository.path &&
+      !repositoryStore.getState().openRepositories.some((r) => r.repository.path === repoPath)
+    ) {
+      showToast(
+        'Conflicts were detected in a repository whose tab was closed — reopen it to resolve them',
+        'warning',
+      );
+      return;
+    }
     if (this.showConflictDialog) {
       showToast(
         'A conflict resolution is already in progress — finish or close it first',

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1599,7 +1599,7 @@ export class AppShell extends LitElement {
     });
 
     if (result.success) {
-      this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
       showToast(`Merged ${refName}`, 'success');
     } else if (result.error?.code === 'MERGE_CONFLICT') {
       this.conflictOperationType = 'merge';
@@ -1630,7 +1630,7 @@ export class AppShell extends LitElement {
     });
 
     if (result.success) {
-      this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
       showToast(`Rebased onto ${refName}`, 'success');
     } else if (result.error?.code === 'REBASE_CONFLICT') {
       this.conflictOperationType = 'rebase';
@@ -1652,16 +1652,19 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
 
     const branchName = this.refContextMenu.refName;
+    // Captured before the delete await: the delete and its refresh must target
+    // the repo it was invoked on, even if the user switches tabs mid-operation.
+    const repoPath = this.activeRepository.repository.path;
     this.refContextMenu = { ...this.refContextMenu, visible: false };
 
     const result = await gitService.deleteBranch(
-      this.activeRepository.repository.path,
+      repoPath,
       branchName,
       false
     );
 
     if (result.success) {
-      this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
       showToast(`Deleted branch ${branchName}`, 'success');
     } else {
       log.error('Delete branch failed:', result.error);
@@ -1673,15 +1676,18 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
 
     const tagName = this.refContextMenu.refName;
+    // Captured before the delete await: the delete and its refresh must target
+    // the repo it was invoked on, even if the user switches tabs mid-operation.
+    const repoPath = this.activeRepository.repository.path;
     this.refContextMenu = { ...this.refContextMenu, visible: false };
 
     const result = await gitService.deleteTag({
-      path: this.activeRepository.repository.path,
+      path: repoPath,
       name: tagName,
     });
 
     if (result.success) {
-      this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
       showToast(`Deleted tag ${tagName}`, 'success');
     } else {
       log.error('Delete tag failed:', result.error);
@@ -1693,15 +1699,18 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
 
     const tagName = this.refContextMenu.refName;
+    // Captured before the (slow, network) push await: the push and its refresh
+    // must target the repo it was invoked on, even if the user switches tabs.
+    const repoPath = this.activeRepository.repository.path;
     this.refContextMenu = { ...this.refContextMenu, visible: false };
 
     const result = await gitService.pushTag({
-      path: this.activeRepository.repository.path,
+      path: repoPath,
       name: tagName,
     });
 
     if (result.success) {
-      await this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
       showToast(`Pushed tag ${tagName}`, 'success');
     } else {
       log.error('Push tag failed:', result.error);
@@ -1831,6 +1840,11 @@ export class AppShell extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the confirm await: the revert commit must be created in
+    // the repo it was invoked on, even if the user switches tabs (rebinding
+    // activeRepository) while the confirm is up.
+    const repoPath = this.activeRepository.repository.path;
+
     // A merge commit has no single "the change" to undo; git requires an
     // explicit mainline parent (`git revert -m`). Default to the first parent
     // (the branch the merge landed on), which is what reverting a merge almost
@@ -1845,7 +1859,6 @@ export class AppShell extends LitElement {
     );
     if (!confirmed) return;
 
-    const repoPath = this.activeRepository!.repository.path;
     const result = await import('./services/git.service.ts').then((m) =>
       m.revert({
         path: repoPath,
@@ -1855,7 +1868,7 @@ export class AppShell extends LitElement {
     );
 
     if (result.success) {
-      await this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
       showToast(`Reverted ${commit.oid.substring(0, 7)}`, 'success');
     } else if (result.error?.code === 'REVERT_CONFLICT') {
       // Show conflict resolution dialog
@@ -1903,7 +1916,9 @@ export class AppShell extends LitElement {
 
     if (result.success) {
       showToast(`Aborted ${state}`, 'success');
-      this.handleRefresh();
+      // `path` was captured before the abort await — pin the refresh to it so a
+      // mid-abort tab switch doesn't refresh the wrong repo.
+      this.refreshConflictDialogRepo(path);
     } else {
       log.error('Abort failed:', result.error);
       showToast(result.error?.message || 'Abort failed', 'error');
@@ -1919,9 +1934,12 @@ export class AppShell extends LitElement {
     const branchName = e.detail?.branchName;
     if (!branchName || !this.activeRepository) return;
 
-    gitService.deleteBranch(this.activeRepository.repository.path, branchName, true).then(async (result) => {
+    // Captured before the delete: the force-delete and its refresh must target
+    // the repo it was invoked on, even if the user switches tabs mid-operation.
+    const repoPath = this.activeRepository.repository.path;
+    gitService.deleteBranch(repoPath, branchName, true).then(async (result) => {
       if (result.success) {
-        await this.handleRefresh();
+        this.refreshConflictDialogRepo(repoPath);
         showToast(`Force deleted branch ${branchName}`, 'success');
       } else {
         showToast(result.error?.message || 'Force delete failed', 'error');
@@ -2028,6 +2046,11 @@ export class AppShell extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the confirm await: a hard reset discards uncommitted work
+    // and must target the repo it was invoked on, even if the user switches
+    // tabs (rebinding activeRepository) while the confirm is up.
+    const repoPath = this.activeRepository.repository.path;
+
     // Confirm reset based on mode
     if (mode === 'hard') {
       const confirmed = await showConfirm(
@@ -2053,14 +2076,14 @@ export class AppShell extends LitElement {
 
     const result = await import('./services/git.service.ts').then((m) =>
       m.reset({
-        path: this.activeRepository!.repository.path,
+        path: repoPath,
         targetRef: commit.oid,
         mode,
       })
     );
 
     if (result.success) {
-      await this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
     } else {
       log.error('Reset failed:', result.error);
       showErrorWithSuggestion(result.error?.message || '', 'Reset failed');
@@ -2094,8 +2117,13 @@ export class AppShell extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured once, before the status await: the fixup commit must be created
+    // in the repo it was invoked on, not whichever tab is active if the user
+    // switches during the (yielding) status check.
+    const repoPath = this.activeRepository.repository.path;
+
     // Check if there are staged changes
-    const statusResult = await gitService.getStatus(this.activeRepository.repository.path);
+    const statusResult = await gitService.getStatus(repoPath);
     if (!statusResult.success || !statusResult.data) {
       showToast('Failed to check status', 'error');
       return;
@@ -2108,13 +2136,13 @@ export class AppShell extends LitElement {
     }
 
     // Create fixup commit
-    const result = await gitService.createCommit(this.activeRepository.repository.path, {
+    const result = await gitService.createCommit(repoPath, {
       message: `fixup! ${commit.summary}`,
     });
 
     if (result.success) {
       showToast(`Created fixup commit for ${commit.shortId}`, 'success');
-      await this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
       window.dispatchEvent(new CustomEvent('status-refresh'));
     } else {
       showErrorWithSuggestion(result.error?.message || '', 'Failed to create fixup commit');
@@ -2131,8 +2159,13 @@ export class AppShell extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured once, before the status await: the squash commit must be created
+    // in the repo it was invoked on, not whichever tab is active if the user
+    // switches during the (yielding) status check.
+    const repoPath = this.activeRepository.repository.path;
+
     // Check if there are staged changes
-    const statusResult = await gitService.getStatus(this.activeRepository.repository.path);
+    const statusResult = await gitService.getStatus(repoPath);
     if (!statusResult.success || !statusResult.data) {
       showToast('Failed to check status', 'error');
       return;
@@ -2145,13 +2178,13 @@ export class AppShell extends LitElement {
     }
 
     // Create squash commit
-    const result = await gitService.createCommit(this.activeRepository.repository.path, {
+    const result = await gitService.createCommit(repoPath, {
       message: `squash! ${commit.summary}`,
     });
 
     if (result.success) {
       showToast(`Created squash commit for ${commit.shortId}`, 'success');
-      await this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
       window.dispatchEvent(new CustomEvent('status-refresh'));
     } else {
       showErrorWithSuggestion(result.error?.message || '', 'Failed to create squash commit');
@@ -2695,11 +2728,15 @@ export class AppShell extends LitElement {
         category: 'action',
         icon: 'undo',
         action: this.requiresRepository(async () => {
+          // Captured BEFORE the prompt/AI/confirm awaits (all yield): the
+          // reflog reset must run on the repo it was invoked on, even if the
+          // user switches tabs while any of those dialogs/calls are pending.
+          const repoPath = this.activeRepository!.repository.path;
           const query = await showPrompt('Smart Undo (AI)', 'Describe what you want to undo (e.g., "before the rebase", "undo last 3 commits"):');
           if (!query) return;
 
           const result = await import('./services/ai.service.ts').then(m =>
-            m.findReflogEntry(this.activeRepository!.repository.path, query)
+            m.findReflogEntry(repoPath, query)
           );
 
           if (result.success && result.data) {
@@ -2707,11 +2744,11 @@ export class AppShell extends LitElement {
             const confirmed = await showConfirm('Smart Undo', `${match.description}\n\nReset to HEAD@{${match.index}}? (soft reset — changes preserved as staged)`);
             if (confirmed) {
               const resetResult = await import('./services/git.service.ts').then(m =>
-                m.resetToReflog(this.activeRepository!.repository.path, match.index, 'soft')
+                m.resetToReflog(repoPath, match.index, 'soft')
               );
               if (resetResult.success) {
                 showToast('Undo successful', 'success');
-                await this.handleRefresh();
+                this.refreshConflictDialogRepo(repoPath);
               } else {
                 showToast(resetResult.error?.message ?? 'Undo failed', 'error');
               }
@@ -3173,10 +3210,13 @@ export class AppShell extends LitElement {
     // must inspect result.success — a catch-only path always reported success and
     // the backend emits remote-operation-completed only on success, so failures
     // were fully silent.
-    const result = await gitService.fetch({ path: this.activeRepository.repository.path });
+    // Pinned: fetch is a slow network op; if the user switches tabs while it
+    // runs, the refresh must target the repo that fetched, not the active tab.
+    const repoPath = this.activeRepository.repository.path;
+    const result = await gitService.fetch({ path: repoPath });
     if (result.success) {
       progressService.completeOperation(opId);
-      this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
     } else {
       progressService.failOperation(opId);
       showToast(result.error?.message ?? 'Fetch failed', 'error');
@@ -3221,10 +3261,13 @@ export class AppShell extends LitElement {
     // must inspect result.success — a catch-only path always reported success and
     // the backend emits remote-operation-completed only on success, so failures
     // were fully silent.
-    const result = await gitService.push({ path: this.activeRepository.repository.path });
+    // Pinned: push is a slow network op; if the user switches tabs while it
+    // runs, the refresh must target the repo that pushed, not the active tab.
+    const repoPath = this.activeRepository.repository.path;
+    const result = await gitService.push({ path: repoPath });
     if (result.success) {
       progressService.completeOperation(opId);
-      this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
     } else {
       progressService.failOperation(opId);
       showToast(result.error?.message ?? 'Push failed', 'error');
@@ -3237,7 +3280,10 @@ export class AppShell extends LitElement {
 
   private async handleCreateStash(): Promise<void> {
     if (!this.activeRepository) return;
-    const result = await gitService.createStash({ path: this.activeRepository.repository.path });
+    // Pinned: if the user switches tabs while the stash is being created, the
+    // refresh must target the repo that was stashed, not the active tab.
+    const repoPath = this.activeRepository.repository.path;
+    const result = await gitService.createStash({ path: repoPath });
     if (result.success) {
       if (result.data === null) {
         // Clean working tree: nothing to stash — informational, not an error.
@@ -3245,7 +3291,7 @@ export class AppShell extends LitElement {
         return;
       }
       showToast('Stash created', 'success');
-      this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
     } else {
       showToast(result.error?.message ?? 'Failed to create stash', 'error');
     }

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -917,6 +917,9 @@ export class AppShell extends LitElement {
       // A conflicted git-flow finish carries the context to complete the finish.
       this.conflictGitflowFinish = customEvent.detail?.gitflowFinish ?? null;
       this.conflictInitialFilePath = customEvent.detail?.filePath ?? null;
+      // An explicit operation always knows its source — clear any uncertainty
+      // left over from a previous state-inferred stash flow.
+      this.conflictStashSourceCertain = true;
       this.showConflictDialog = true;
     } else {
       // No operation context (the diff view's "Open Merge Editor" button, a

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -725,9 +725,17 @@ export class AppShell extends LitElement {
   // here, otherwise dispatching it from inside handleRefresh would re-trigger
   // handleWindowRefresh in an unbounded loop.
   private handleWindowRefresh = (e: Event): void => {
-    const detail = (e as CustomEvent).detail as { source?: string } | undefined;
+    const detail = (e as CustomEvent).detail as { source?: string; repoPath?: string } | undefined;
     if (detail?.source === 'app-shell') return;
-    this.handleRefresh();
+    // When the refresh names the repo the operation ran on (a sidebar
+    // stash/tag/branch success), pin to it — a plain handleRefresh would
+    // refresh whichever tab is active if the user switched mid-operation,
+    // leaving the originating repo stale until the file watcher notices.
+    if (detail?.repoPath) {
+      this.refreshConflictDialogRepo(detail.repoPath);
+    } else {
+      this.handleRefresh();
+    }
   };
 
   // Cycle the active repository tab by offset (wraps around both ends)

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1075,6 +1075,24 @@ export class AppShell extends LitElement {
         );
       }
 
+      // Same for the cherry-pick / interactive-rebase dialogs: they pin to
+      // their repo at open() and stay open across tab switches, so closing
+      // the pinned tab must dismiss them too — otherwise they float over
+      // another repo and their next click would run against a repository
+      // that is no longer in the tab bar.
+      const repoOpen = (path: string | null): boolean =>
+        !!path && state.openRepositories.some((r) => r.repository.path === path);
+      const cpPinned = this.cherryPickDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (cpPinned && !repoOpen(cpPinned)) {
+        this.cherryPickDialog?.close();
+        showToast('The repository tab was closed — cherry-pick cancelled', 'warning');
+      }
+      const rbPinned = this.interactiveRebaseDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (rbPinned && !repoOpen(rbPinned)) {
+        this.interactiveRebaseDialog?.close();
+        showToast('The repository tab was closed — interactive rebase cancelled', 'warning');
+      }
+
       // The open diff binds a click-time StatusEntry snapshot. Re-derive it
       // from every status refresh so a file that became conflicted since the
       // click (e.g. a merge run in an external terminal) hits the diff view's
@@ -1527,7 +1545,9 @@ export class AppShell extends LitElement {
 
     if (result.success && result.data?.success) {
       this.handleAutoStashToast(result.data, refName, repoPath);
-      this.handleRefresh();
+      // Pinned refresh, matching the sibling command-palette checkout: the
+      // checkout ran on repoPath, which may be backgrounded by completion.
+      this.refreshConflictDialogRepo(repoPath);
     } else {
       log.error('Checkout failed:', result.data?.message || result.error);
       showErrorWithSuggestion(result.data?.message || result.error?.message || '', 'Checkout failed');
@@ -2262,7 +2282,8 @@ export class AppShell extends LitElement {
 
     if (result.success && result.data?.success) {
       this.handleAutoStashToast(result.data, branchName, repoPath);
-      this.handleRefresh();
+      // Pinned refresh, matching the sibling checkout handlers.
+      this.refreshConflictDialogRepo(repoPath);
     } else {
       log.error('Failed to checkout branch:', result.data?.message || result.error);
       showErrorWithSuggestion(result.data?.message || result.error?.message || '', 'Failed to checkout branch');

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -901,16 +901,20 @@ export class AppShell extends LitElement {
     }>;
     if (customEvent.detail?.operationType) {
       this.conflictOperationType = customEvent.detail.operationType;
+      // Thread stash-completion semantics so the dialog drops the correct entry
+      // (and only when the failed operation had pop semantics).
+      this.conflictStashIndex = customEvent.detail?.stashIndex ?? 0;
+      this.conflictDropStashOnComplete = customEvent.detail?.dropStashOnComplete ?? true;
+      // A squash finish that conflicted must complete as a squash, not a merge commit.
+      this.conflictSquashMerge = customEvent.detail?.squash ?? false;
+      // A conflicted git-flow finish carries the context to complete the finish.
+      this.conflictGitflowFinish = customEvent.detail?.gitflowFinish ?? null;
+      this.showConflictDialog = true;
+    } else {
+      // No context provided (e.g. the diff view's "Open Merge Editor" button):
+      // derive the operation from repository state instead.
+      this.openConflictDialogFromState();
     }
-    // Thread stash-completion semantics so the dialog drops the correct entry
-    // (and only when the failed operation had pop semantics).
-    this.conflictStashIndex = customEvent.detail?.stashIndex ?? 0;
-    this.conflictDropStashOnComplete = customEvent.detail?.dropStashOnComplete ?? true;
-    // A squash finish that conflicted must complete as a squash, not a merge commit.
-    this.conflictSquashMerge = customEvent.detail?.squash ?? false;
-    // A conflicted git-flow finish carries the context to complete the finish.
-    this.conflictGitflowFinish = customEvent.detail?.gitflowFinish ?? null;
-    this.showConflictDialog = true;
     this.handleRefresh();
   };
 
@@ -1395,9 +1399,8 @@ export class AppShell extends LitElement {
       // Auto-stash is pop semantics: the conflicted auto-stash sits at index 0 and
       // must be dropped once its changes are applied and resolved.
       this.conflictOperationType = 'stash';
-      this.conflictStashIndex = 0;
+      this.resetConflictDetailState();
       this.conflictDropStashOnComplete = true;
-      this.conflictSquashMerge = false;
       this.showConflictDialog = true;
       this.handleRefresh();
     } else if (data.stashed && data.stashApplied) {
@@ -1565,22 +1568,45 @@ export class AppShell extends LitElement {
     return ['cherrypick', 'merge', 'rebase', 'rebase-interactive', 'rebase-merge', 'revert'].includes(state);
   }
 
-  private handleOpenConflictDialog(): void {
+  /** True when the working tree has unmerged (conflicted) files. */
+  private get hasConflictedFiles(): boolean {
+    return (this.activeRepository?.status ?? []).some((f) => f.isConflicted);
+  }
+
+  /**
+   * Derive which operation the current index conflicts belong to from the
+   * repository state. A clean state with conflicted files means a stash apply
+   * conflicted — the only conflict source that leaves no in-progress state.
+   */
+  private deriveConflictOperationType(): 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash' {
+    const state = this.activeRepository?.repository.state ?? 'clean';
+    if (state === 'cherrypick') return 'cherry-pick';
+    if (state === 'rebase' || state === 'rebase-interactive' || state === 'rebase-merge') return 'rebase';
+    if (state === 'revert') return 'revert';
+    if (state === 'merge') return 'merge';
+    return 'stash';
+  }
+
+  /**
+   * Open the conflict dialog with the operation derived from repository state.
+   * Used when the trigger carries no operation context (banner button, diff
+   * view redirect, conflicted-file click).
+   */
+  private openConflictDialogFromState(): void {
     if (!this.activeRepository) return;
 
-    const state = this.activeRepository.repository.state;
-    if (state === 'cherrypick') {
-      this.conflictOperationType = 'cherry-pick';
-    } else if (state === 'merge') {
-      this.conflictOperationType = 'merge';
-    } else if (state === 'rebase' || state === 'rebase-interactive' || state === 'rebase-merge') {
-      this.conflictOperationType = 'rebase';
-    } else if (state === 'revert') {
-      this.conflictOperationType = 'revert';
-    }
-
+    this.conflictOperationType = this.deriveConflictOperationType();
     this.resetConflictDetailState();
+    // A state-derived stash conflict has unknown pop semantics — never drop a
+    // stash entry we can't identify. Completing keeps the stash (safe).
+    if (this.conflictOperationType === 'stash') {
+      this.conflictDropStashOnComplete = false;
+    }
     this.showConflictDialog = true;
+  }
+
+  private handleOpenConflictDialog(): void {
+    this.openConflictDialogFromState();
   }
 
   private async handleRevertCommit(): Promise<void> {
@@ -2041,6 +2067,12 @@ export class AppShell extends LitElement {
   }
 
   private handleFileSelected(e: CustomEvent<{ file: StatusEntry; isPartiallyStaged?: boolean }>): void {
+    // A conflicted file is resolved in the merge editor, never shown as a raw
+    // diff — its working-tree content is git's conflict-marker text.
+    if (e.detail.file.isConflicted) {
+      this.openConflictDialogFromState();
+      return;
+    }
     // Close blame if open
     this.showBlame = false;
     this.blameFile = null;
@@ -3153,7 +3185,7 @@ export class AppShell extends LitElement {
               ` : ''}
 
               <main id="main-content" class="center-panel" tabindex="-1">
-                ${this.activeRepository.repository.state !== 'clean'
+                ${this.activeRepository.repository.state !== 'clean' || this.hasConflictedFiles
                   ? html`
                       <div class="operation-banner ${this.activeRepository.repository.state}">
                         <span class="operation-icon">
@@ -3171,19 +3203,25 @@ export class AppShell extends LitElement {
                             this.activeRepository.repository.state === 'rebase-merge' ? 'Rebase in progress' :
                             this.activeRepository.repository.state === 'revert' ? 'Revert in progress' :
                             this.activeRepository.repository.state === 'bisect' ? 'Bisect in progress' :
+                            this.activeRepository.repository.state === 'clean' ? 'Stash conflicts need resolution' :
                             `Operation in progress: ${this.activeRepository.repository.state}`}
                         </span>
                         <div class="operation-banner-actions">
-                          ${this.canResolveConflicts(this.activeRepository.repository.state)
+                          ${this.canResolveConflicts(this.activeRepository.repository.state) ||
+                          (this.activeRepository.repository.state === 'clean' && this.hasConflictedFiles)
                             ? html`
                                 <button class="operation-btn operation-btn-primary" @click=${this.handleOpenConflictDialog}>
                                   Resolve Conflicts
                                 </button>
                               `
                             : ''}
-                          <button class="operation-abort-btn" @click=${this.handleAbortOperation}>
-                            Abort
-                          </button>
+                          ${this.activeRepository.repository.state !== 'clean'
+                            ? html`
+                                <button class="operation-abort-btn" @click=${this.handleAbortOperation}>
+                                  Abort
+                                </button>
+                              `
+                            : ''}
                         </div>
                       </div>
                     `

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2125,13 +2125,32 @@ export class AppShell extends LitElement {
   }
 
   private handleConflictResolved(): void {
+    const pinnedPath = this.conflictDialogConfig?.repoPath ?? null;
     this.closeConflictDialog();
-    this.handleRefresh();
+    this.refreshConflictDialogRepo(pinnedPath);
   }
 
   private handleConflictAborted(): void {
+    const pinnedPath = this.conflictDialogConfig?.repoPath ?? null;
     this.closeConflictDialog();
-    this.handleRefresh();
+    this.refreshConflictDialogRepo(pinnedPath);
+  }
+
+  /**
+   * The dialog operated on the repo it was PINNED to. If the user switched
+   * tabs while it was up, refreshing the ACTIVE repo would leave the
+   * operated-on repo showing a stale merge state (state/status/graph) until
+   * some unrelated event refreshed it. Refresh the pinned repo instead:
+   * live when it is still active, via the stale-on-activate path (plus a
+   * badge hydration so its tab clears promptly) when it is backgrounded.
+   */
+  private refreshConflictDialogRepo(pinnedPath: string | null): void {
+    if (!pinnedPath || pinnedPath === this.activeRepository?.repository.path) {
+      this.handleRefresh();
+      return;
+    }
+    this.staleRepoPaths.add(pinnedPath);
+    this.scheduleBadgeHydration(pinnedPath);
   }
 
   private handleResizeStart(e: MouseEvent, type: 'left' | 'right'): void {

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -539,6 +539,9 @@ export class AppShell extends LitElement {
   // When a git-flow finish conflicts, the finish context so the dialog can COMPLETE
   // the finish (tag / merge develop / delete branch) after the conflict is resolved.
   @state() private conflictGitflowFinish: GitflowFinishContext | null = null;
+  // The file the user clicked to enter the conflict flow — the dialog opens
+  // preselected on it instead of always starting at the first conflict.
+  @state() private conflictInitialFilePath: string | null = null;
 
   // Command palette
   @state() private showCommandPalette = false;
@@ -898,6 +901,7 @@ export class AppShell extends LitElement {
       dropStashOnComplete?: boolean;
       squash?: boolean;
       gitflowFinish?: GitflowFinishContext;
+      filePath?: string;
     }>;
     if (customEvent.detail?.operationType) {
       this.conflictOperationType = customEvent.detail.operationType;
@@ -909,11 +913,13 @@ export class AppShell extends LitElement {
       this.conflictSquashMerge = customEvent.detail?.squash ?? false;
       // A conflicted git-flow finish carries the context to complete the finish.
       this.conflictGitflowFinish = customEvent.detail?.gitflowFinish ?? null;
+      this.conflictInitialFilePath = customEvent.detail?.filePath ?? null;
       this.showConflictDialog = true;
     } else {
-      // No context provided (e.g. the diff view's "Open Merge Editor" button):
-      // derive the operation from repository state instead.
-      this.openConflictDialogFromState();
+      // No operation context (the diff view's "Open Merge Editor" button, a
+      // conflicted-file stage click): derive the operation from repository
+      // state, keeping the clicked file preselected when one was given.
+      this.openConflictDialogFromState(customEvent.detail?.filePath);
     }
     this.handleRefresh();
   };
@@ -934,6 +940,7 @@ export class AppShell extends LitElement {
     this.conflictDropStashOnComplete = true;
     this.conflictSquashMerge = false;
     this.conflictGitflowFinish = null;
+    this.conflictInitialFilePath = null;
   }
 
   // Handle gitflow events (init, feature/release/hotfix operations) to trigger refresh
@@ -961,6 +968,27 @@ export class AppShell extends LitElement {
       const newActiveRepo = state.getActiveRepository();
       const repoChanged = this.activeRepository?.repository.path !== newActiveRepo?.repository.path;
       this.activeRepository = newActiveRepo;
+
+      // The open diff binds a click-time StatusEntry snapshot. Re-derive it
+      // from every status refresh so a file that became conflicted since the
+      // click (e.g. a merge run in an external terminal) hits the diff view's
+      // isConflicted guards instead of rendering raw marker text — and stays
+      // in sync in the other direction once it's resolved.
+      if (this.diffFile && !repoChanged && newActiveRepo) {
+        const fresh =
+          newActiveRepo.status.find(
+            (f) => f.path === this.diffFile!.path && f.isStaged === this.diffFile!.isStaged
+          ) ?? newActiveRepo.status.find((f) => f.path === this.diffFile!.path);
+        // Only swap on a real transition — reassigning every refresh would
+        // needlessly reload the visible diff.
+        if (
+          fresh &&
+          (fresh.isConflicted !== this.diffFile.isConflicted ||
+            fresh.status !== this.diffFile.status)
+        ) {
+          this.diffFile = fresh;
+        }
+      }
 
       // Start/stop per-repo services as tabs open and close. Every OPEN repo
       // gets a watcher (not just the active one) so background repos don't go
@@ -1592,7 +1620,7 @@ export class AppShell extends LitElement {
    * Used when the trigger carries no operation context (banner button, diff
    * view redirect, conflicted-file click).
    */
-  private openConflictDialogFromState(): void {
+  private openConflictDialogFromState(initialFilePath?: string): void {
     if (!this.activeRepository) return;
 
     this.conflictOperationType = this.deriveConflictOperationType();
@@ -1602,6 +1630,7 @@ export class AppShell extends LitElement {
     if (this.conflictOperationType === 'stash') {
       this.conflictDropStashOnComplete = false;
     }
+    this.conflictInitialFilePath = initialFilePath ?? null;
     this.showConflictDialog = true;
   }
 
@@ -2068,9 +2097,10 @@ export class AppShell extends LitElement {
 
   private handleFileSelected(e: CustomEvent<{ file: StatusEntry; isPartiallyStaged?: boolean }>): void {
     // A conflicted file is resolved in the merge editor, never shown as a raw
-    // diff — its working-tree content is git's conflict-marker text.
+    // diff — its working-tree content is git's conflict-marker text. Open the
+    // dialog on the file that was actually clicked.
     if (e.detail.file.isConflicted) {
-      this.openConflictDialogFromState();
+      this.openConflictDialogFromState(e.detail.file.path);
       return;
     }
     // Close blame if open
@@ -3373,6 +3403,7 @@ export class AppShell extends LitElement {
               open
               repositoryPath=${this.activeRepository.repository.path}
               operationType=${this.conflictOperationType}
+              .initialFilePath=${this.conflictInitialFilePath}
               .stashIndex=${this.conflictStashIndex}
               .dropStashOnComplete=${this.conflictDropStashOnComplete}
               .squashMerge=${this.conflictSquashMerge}

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -947,7 +947,7 @@ export class AppShell extends LitElement {
       // state, keeping the clicked file preselected when one was given.
       this.openConflictDialogFromState(customEvent.detail?.filePath);
     }
-    this.handleRefresh();
+    this.refreshConflictDialogRepo(customEvent.detail?.repositoryPath ?? null);
   };
 
   // Handle merge-conflict events from branch list (e.g., sidebar merge resulting in conflicts)
@@ -956,7 +956,7 @@ export class AppShell extends LitElement {
     this.conflictOperationType = 'merge';
     this.resetConflictDetailState();
     this.openConflictDialogPinned(detail?.repositoryPath);
-    this.handleRefresh();
+    this.refreshConflictDialogRepo(detail?.repositoryPath ?? null);
   };
 
   /**
@@ -1506,7 +1506,7 @@ export class AppShell extends LitElement {
       this.resetConflictDetailState();
       this.conflictDropStashOnComplete = true;
       this.openConflictDialogPinned(repoPath);
-      this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
     } else if (data.stashed && data.stashApplied) {
       showToast(data.message, data.message.includes('staged status was not preserved') ? 'warning' : 'info');
     } else if (data.stashed && !data.stashApplied) {
@@ -1535,6 +1535,7 @@ export class AppShell extends LitElement {
       this.conflictOperationType = 'merge';
       this.resetConflictDetailState();
       this.openConflictDialogPinned(repoPath);
+      this.refreshConflictDialogRepo(repoPath);
       notifyWarning(
         'Merge Conflict',
         `Conflicts detected while merging ${refName}. Please resolve conflicts to continue.`,
@@ -1565,6 +1566,7 @@ export class AppShell extends LitElement {
       this.conflictOperationType = 'rebase';
       this.resetConflictDetailState();
       this.openConflictDialogPinned(repoPath);
+      this.refreshConflictDialogRepo(repoPath);
       notifyWarning(
         'Rebase Conflict',
         `Conflicts detected while rebasing onto ${refName}. Please resolve conflicts to continue.`,
@@ -1669,7 +1671,7 @@ export class AppShell extends LitElement {
       'Conflicts detected during cherry-pick. Please resolve conflicts to continue.',
       !settingsStore.getState().showNativeNotifications
     );
-    this.handleRefresh();
+    this.refreshConflictDialogRepo(detail?.repositoryPath ?? null);
   }
 
   private canResolveConflicts(state: string): boolean {
@@ -1778,6 +1780,7 @@ export class AppShell extends LitElement {
       this.conflictOperationType = 'revert';
       this.resetConflictDetailState();
       this.openConflictDialogPinned(repoPath);
+      this.refreshConflictDialogRepo(repoPath);
       notifyWarning(
         'Revert Conflict',
         `Conflicts detected while reverting ${commit.oid.substring(0, 7)}. Please resolve conflicts to continue.`,
@@ -2137,12 +2140,15 @@ export class AppShell extends LitElement {
   }
 
   /**
-   * The dialog operated on the repo it was PINNED to. If the user switched
-   * tabs while it was up, refreshing the ACTIVE repo would leave the
-   * operated-on repo showing a stale merge state (state/status/graph) until
-   * some unrelated event refreshed it. Refresh the pinned repo instead:
-   * live when it is still active, via the stale-on-activate path (plus a
-   * badge hydration so its tab clears promptly) when it is backgrounded.
+   * Refresh the repo a conflict dialog operates/operated ON — used both
+   * when a conflict opens the dialog and when Complete/Abort closes it.
+   * The user can switch tabs during the triggering operation's await (and
+   * behind the open dialog), so refreshing the ACTIVE repo could leave the
+   * operated-on repo showing a stale merge state (state/status/graph)
+   * until some unrelated event refreshed it. Refresh the pinned repo
+   * instead: live when it is still active, via the stale-on-activate path
+   * (plus a badge hydration so its tab updates promptly) when it is
+   * backgrounded.
    */
   private refreshConflictDialogRepo(pinnedPath: string | null): void {
     if (!pinnedPath || pinnedPath === this.activeRepository?.repository.path) {
@@ -3109,13 +3115,13 @@ export class AppShell extends LitElement {
       this.conflictOperationType = 'merge';
       this.resetConflictDetailState();
       this.openConflictDialogPinned(repoPath);
-      this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
     } else if (result.error?.code === 'REBASE_CONFLICT') {
       progressService.failOperation(opId);
       this.conflictOperationType = 'rebase';
       this.resetConflictDetailState();
       this.openConflictDialogPinned(repoPath);
-      this.handleRefresh();
+      this.refreshConflictDialogRepo(repoPath);
     } else {
       progressService.failOperation(opId);
       showToast(result.error?.message ?? 'Pull failed', 'error');

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -530,13 +530,24 @@ export class AppShell extends LitElement {
   // Conflict resolution dialog
   @state() private showConflictDialog = false;
   /**
-   * Repository the conflict dialog was opened FOR. The dialog must keep
-   * operating on that repository even if the user switches repo tabs while
-   * it is up (Ctrl+Tab still works behind the full-screen dialog) — binding
-   * the live active-repo path would aim its abort/resolve/stage commands at
-   * whichever repo happens to be active, destroying unrelated work.
+   * The open dialog's inputs, SNAPSHOTTED at open time. The dialog must
+   * keep operating on the repository and operation it was opened for even
+   * if the user switches repo tabs (Ctrl+Tab still works behind the
+   * full-screen dialog) or another conflicting operation fires while it is
+   * up — live-binding the loose fields below would let a second conflict
+   * source retarget an in-flight resolution's repo/operation, aiming its
+   * abort/resolve/stage commands at the wrong repository.
    */
-  @state() private conflictDialogRepoPath: string | null = null;
+  @state() private conflictDialogConfig: {
+    repoPath: string;
+    operationType: 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash';
+    initialFilePath: string | null;
+    stashSourceCertain: boolean;
+    stashIndex: number;
+    dropStashOnComplete: boolean;
+    squashMerge: boolean;
+    gitflowFinish: GitflowFinishContext | null;
+  } | null = null;
   @state() private conflictOperationType: 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash' = 'merge';
   // Stash-completion semantics for the conflict dialog (which entry to drop and
   // whether to drop it at all — pop drops, plain apply keeps).
@@ -913,6 +924,7 @@ export class AppShell extends LitElement {
       squash?: boolean;
       gitflowFinish?: GitflowFinishContext;
       filePath?: string;
+      repositoryPath?: string;
     }>;
     if (customEvent.detail?.operationType) {
       this.conflictOperationType = customEvent.detail.operationType;
@@ -928,7 +940,7 @@ export class AppShell extends LitElement {
       // An explicit operation always knows its source — clear any uncertainty
       // left over from a previous state-inferred stash flow.
       this.conflictStashSourceCertain = true;
-      this.openConflictDialogPinned();
+      this.openConflictDialogPinned(customEvent.detail?.repositoryPath);
     } else {
       // No operation context (the diff view's "Open Merge Editor" button, a
       // conflicted-file stage click): derive the operation from repository
@@ -939,22 +951,52 @@ export class AppShell extends LitElement {
   };
 
   // Handle merge-conflict events from branch list (e.g., sidebar merge resulting in conflicts)
-  private handleMergeConflictEvent = (): void => {
+  private handleMergeConflictEvent = (e?: Event): void => {
+    const detail = (e as CustomEvent<{ repositoryPath?: string }> | undefined)?.detail;
     this.conflictOperationType = 'merge';
     this.resetConflictDetailState();
-    this.openConflictDialogPinned();
+    this.openConflictDialogPinned(detail?.repositoryPath);
     this.handleRefresh();
   };
 
-  /** Open the conflict dialog pinned to the repository that is active NOW. */
-  private openConflictDialogPinned(): void {
-    this.conflictDialogRepoPath = this.activeRepository?.repository.path ?? null;
+  /**
+   * Open the conflict dialog with the staged conflict* fields snapshotted
+   * and pinned to the repository that is active NOW. Refuses to retarget an
+   * ALREADY-OPEN dialog: a new conflicting operation on another repo (or
+   * even this one) must not hijack an in-flight resolution's repo,
+   * operation type, or completion semantics.
+   */
+  private openConflictDialogPinned(repoPathOverride?: string): void {
+    // The conflicting operation ran on a repo path captured BEFORE its
+    // await — pass that path in. Falling back to the active repo is only
+    // safe for synchronous open paths; after an await the user may have
+    // switched tabs, and pinning the now-active repo would trap them in a
+    // dialog whose Complete/Abort target a repo with no operation at all.
+    const repoPath = repoPathOverride ?? this.activeRepository?.repository.path;
+    if (!repoPath) return;
+    if (this.showConflictDialog) {
+      showToast(
+        'A conflict resolution is already in progress — finish or close it first',
+        'warning',
+      );
+      return;
+    }
+    this.conflictDialogConfig = {
+      repoPath,
+      operationType: this.conflictOperationType,
+      initialFilePath: this.conflictInitialFilePath,
+      stashSourceCertain: this.conflictStashSourceCertain,
+      stashIndex: this.conflictStashIndex,
+      dropStashOnComplete: this.conflictDropStashOnComplete,
+      squashMerge: this.conflictSquashMerge,
+      gitflowFinish: this.conflictGitflowFinish,
+    };
     this.showConflictDialog = true;
   }
 
   private closeConflictDialog(): void {
     this.showConflictDialog = false;
-    this.conflictDialogRepoPath = null;
+    this.conflictDialogConfig = null;
   }
 
   // Reset the conflict-dialog completion semantics to defaults so a value set by a
@@ -1436,15 +1478,13 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
 
     const refName = this.refContextMenu.refName;
+    const repoPath = this.activeRepository.repository.path;
     this.refContextMenu = { ...this.refContextMenu, visible: false };
 
-    const result = await gitService.checkoutWithAutoStash(
-      this.activeRepository.repository.path,
-      refName
-    );
+    const result = await gitService.checkoutWithAutoStash(repoPath, refName);
 
     if (result.success && result.data?.success) {
-      this.handleAutoStashToast(result.data, refName);
+      this.handleAutoStashToast(result.data, refName, repoPath);
       this.handleRefresh();
     } else {
       log.error('Checkout failed:', result.data?.message || result.error);
@@ -1452,7 +1492,11 @@ export class AppShell extends LitElement {
     }
   }
 
-  private handleAutoStashToast(data: gitService.CheckoutWithStashResult, refName: string): void {
+  private handleAutoStashToast(
+    data: gitService.CheckoutWithStashResult,
+    refName: string,
+    repoPath: string,
+  ): void {
     if (data.stashed && data.stashConflict) {
       showToast(`Switched to ${refName} — stash conflicts need resolution`, 'warning');
       // Open the conflict dialog so the user can resolve the failed stash pop.
@@ -1461,7 +1505,7 @@ export class AppShell extends LitElement {
       this.conflictOperationType = 'stash';
       this.resetConflictDetailState();
       this.conflictDropStashOnComplete = true;
-      this.openConflictDialogPinned();
+      this.openConflictDialogPinned(repoPath);
       this.handleRefresh();
     } else if (data.stashed && data.stashApplied) {
       showToast(data.message, data.message.includes('staged status was not preserved') ? 'warning' : 'info');
@@ -1474,10 +1518,13 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
 
     const refName = this.refContextMenu.refName;
+    // The user can switch repo tabs while the operation runs — the dialog
+    // must pin to the repo the operation ran ON, not the one active later.
+    const repoPath = this.activeRepository.repository.path;
     this.refContextMenu = { ...this.refContextMenu, visible: false };
 
     const result = await gitService.merge({
-      path: this.activeRepository.repository.path,
+      path: repoPath,
       sourceRef: refName,
     });
 
@@ -1487,7 +1534,7 @@ export class AppShell extends LitElement {
     } else if (result.error?.code === 'MERGE_CONFLICT') {
       this.conflictOperationType = 'merge';
       this.resetConflictDetailState();
-      this.openConflictDialogPinned();
+      this.openConflictDialogPinned(repoPath);
       notifyWarning(
         'Merge Conflict',
         `Conflicts detected while merging ${refName}. Please resolve conflicts to continue.`,
@@ -1503,10 +1550,11 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
 
     const refName = this.refContextMenu.refName;
+    const repoPath = this.activeRepository.repository.path;
     this.refContextMenu = { ...this.refContextMenu, visible: false };
 
     const result = await gitService.rebase({
-      path: this.activeRepository.repository.path,
+      path: repoPath,
       onto: refName,
     });
 
@@ -1516,7 +1564,7 @@ export class AppShell extends LitElement {
     } else if (result.error?.code === 'REBASE_CONFLICT') {
       this.conflictOperationType = 'rebase';
       this.resetConflictDetailState();
-      this.openConflictDialogPinned();
+      this.openConflictDialogPinned(repoPath);
       notifyWarning(
         'Rebase Conflict',
         `Conflicts detected while rebasing onto ${refName}. Please resolve conflicts to continue.`,
@@ -1610,11 +1658,12 @@ export class AppShell extends LitElement {
     this.handleRefresh();
   }
 
-  private handleCherryPickConflict(): void {
+  private handleCherryPickConflict(e: Event): void {
+    const detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
     // Show conflict resolution dialog
     this.conflictOperationType = 'cherry-pick';
     this.resetConflictDetailState();
-    this.openConflictDialogPinned();
+    this.openConflictDialogPinned(detail?.repositoryPath);
     notifyWarning(
       'Cherry-pick Conflict',
       'Conflicts detected during cherry-pick. Please resolve conflicts to continue.',
@@ -1712,9 +1761,10 @@ export class AppShell extends LitElement {
     );
     if (!confirmed) return;
 
+    const repoPath = this.activeRepository!.repository.path;
     const result = await import('./services/git.service.ts').then((m) =>
       m.revert({
-        path: this.activeRepository!.repository.path,
+        path: repoPath,
         commitOid: commit.oid,
         mainline: isMergeCommit ? 1 : undefined,
       })
@@ -1727,7 +1777,7 @@ export class AppShell extends LitElement {
       // Show conflict resolution dialog
       this.conflictOperationType = 'revert';
       this.resetConflictDetailState();
-      this.openConflictDialogPinned();
+      this.openConflictDialogPinned(repoPath);
       notifyWarning(
         'Revert Conflict',
         `Conflicts detected while reverting ${commit.oid.substring(0, 7)}. Please resolve conflicts to continue.`,
@@ -2128,10 +2178,11 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
 
     const branchName = e.detail.branchName;
-    const result = await gitService.checkoutWithAutoStash(this.activeRepository.repository.path, branchName);
+    const repoPath = this.activeRepository.repository.path;
+    const result = await gitService.checkoutWithAutoStash(repoPath, branchName);
 
     if (result.success && result.data?.success) {
-      this.handleAutoStashToast(result.data, branchName);
+      this.handleAutoStashToast(result.data, branchName, repoPath);
       this.handleRefresh();
     } else {
       log.error('Failed to checkout branch:', result.data?.message || result.error);
@@ -3026,10 +3077,11 @@ export class AppShell extends LitElement {
 
   private async handlePull(): Promise<void> {
     if (!this.activeRepository) return;
+    const repoPath = this.activeRepository.repository.path;
     const opId = progressService.startOperation('pull', 'Pulling from remote...');
     // gitService.pull returns a CommandResult (invokeCommand never throws), so we
     // must inspect result.success — the old catch-only path always reported success.
-    const result = await gitService.pull({ path: this.activeRepository.repository.path });
+    const result = await gitService.pull({ path: repoPath });
     if (result.success) {
       progressService.completeOperation(opId);
       this.handleRefresh();
@@ -3037,13 +3089,13 @@ export class AppShell extends LitElement {
       progressService.failOperation(opId);
       this.conflictOperationType = 'merge';
       this.resetConflictDetailState();
-      this.openConflictDialogPinned();
+      this.openConflictDialogPinned(repoPath);
       this.handleRefresh();
     } else if (result.error?.code === 'REBASE_CONFLICT') {
       progressService.failOperation(opId);
       this.conflictOperationType = 'rebase';
       this.resetConflictDetailState();
-      this.openConflictDialogPinned();
+      this.openConflictDialogPinned(repoPath);
       this.handleRefresh();
     } else {
       progressService.failOperation(opId);
@@ -3115,10 +3167,11 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
 
     const branch = e.detail.branch;
-    const result = await gitService.checkoutWithAutoStash(this.activeRepository.repository.path, branch);
+    const repoPath = this.activeRepository.repository.path;
+    const result = await gitService.checkoutWithAutoStash(repoPath, branch);
 
     if (result.success && result.data?.success) {
-      this.handleAutoStashToast(result.data, branch);
+      this.handleAutoStashToast(result.data, branch, repoPath);
       this.handleRefresh();
     } else {
       log.error('Failed to checkout branch:', result.data?.message || result.error);
@@ -3451,18 +3504,18 @@ export class AppShell extends LitElement {
           `
         : ''}
 
-      ${this.showConflictDialog && this.activeRepository
+      ${this.showConflictDialog && this.conflictDialogConfig
         ? html`
             <lv-conflict-resolution-dialog
               open
-              repositoryPath=${this.conflictDialogRepoPath ?? this.activeRepository.repository.path}
-              operationType=${this.conflictOperationType}
-              .initialFilePath=${this.conflictInitialFilePath}
-              .stashSourceCertain=${this.conflictStashSourceCertain}
-              .stashIndex=${this.conflictStashIndex}
-              .dropStashOnComplete=${this.conflictDropStashOnComplete}
-              .squashMerge=${this.conflictSquashMerge}
-              .gitflowFinish=${this.conflictGitflowFinish}
+              repositoryPath=${this.conflictDialogConfig.repoPath}
+              operationType=${this.conflictDialogConfig.operationType}
+              .initialFilePath=${this.conflictDialogConfig.initialFilePath}
+              .stashSourceCertain=${this.conflictDialogConfig.stashSourceCertain}
+              .stashIndex=${this.conflictDialogConfig.stashIndex}
+              .dropStashOnComplete=${this.conflictDialogConfig.dropStashOnComplete}
+              .squashMerge=${this.conflictDialogConfig.squashMerge}
+              .gitflowFinish=${this.conflictDialogConfig.gitflowFinish}
               @operation-completed=${this.handleConflictResolved}
               @operation-aborted=${this.handleConflictAborted}
             ></lv-conflict-resolution-dialog>

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1198,6 +1198,9 @@ export class AppShell extends LitElement {
     this.addEventListener('merge-conflict', this.handleMergeConflictEvent);
     this.addEventListener('gitflow-initialized', this.handleGitflowEvent);
     this.addEventListener('gitflow-operation', this.handleGitflowEvent);
+    // Host-level so the branch-list's own rebase dialog reaches it too, not
+    // just the app-shell dialog.
+    this.addEventListener('rebase-complete', this.handleRebaseComplete);
     this.addEventListener('show-commit', this.handleShowCommitEvent);
     window.addEventListener('settings-changed', this.handleSettingsChanged);
 
@@ -1321,6 +1324,7 @@ export class AppShell extends LitElement {
     this.removeEventListener('merge-conflict', this.handleMergeConflictEvent);
     this.removeEventListener('gitflow-initialized', this.handleGitflowEvent);
     this.removeEventListener('gitflow-operation', this.handleGitflowEvent);
+    this.removeEventListener('rebase-complete', this.handleRebaseComplete);
     this.removeEventListener('show-commit', this.handleShowCommitEvent);
     window.removeEventListener('settings-changed', this.handleSettingsChanged);
     gitService.cleanupRemoteOperationListeners();
@@ -1700,12 +1704,15 @@ export class AppShell extends LitElement {
     this.refreshConflictDialogRepo(repositoryPath ?? null);
   }
 
-  private handleRebaseComplete(e: Event): void {
+  // Arrow + host-level listener (not an inline binding on one dialog):
+  // interactive rebase is dispatched by BOTH the app-shell dialog and the
+  // branch-list's own embedded dialog, and a bubbling host listener catches
+  // either. The pinned refresh targets the repo the rebase ran on, which
+  // may no longer be the active tab.
+  private handleRebaseComplete = (e: Event): void => {
     const detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
-    // Same pinned refresh as cherry-pick-complete: the rebase ran on the
-    // originating repo, which may no longer be the active tab.
     this.refreshConflictDialogRepo(detail?.repositoryPath ?? null);
-  }
+  };
 
   private handleCherryPickConflict(e: Event): void {
     const detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
@@ -3156,7 +3163,10 @@ export class AppShell extends LitElement {
     const result = await gitService.pull({ path: repoPath });
     if (result.success) {
       progressService.completeOperation(opId);
-      this.handleRefresh();
+      // Pinned: a ref-only pull emits no working-tree watcher event, so a
+      // pull that completed on a now-backgrounded repo must be refreshed
+      // (or marked stale) by path, not via the active tab.
+      this.refreshConflictDialogRepo(repoPath);
     } else if (result.error?.code === 'MERGE_CONFLICT') {
       progressService.failOperation(opId);
       this.conflictOperationType = 'merge';
@@ -3244,7 +3254,9 @@ export class AppShell extends LitElement {
 
     if (result.success && result.data?.success) {
       this.handleAutoStashToast(result.data, branch, repoPath);
-      this.handleRefresh();
+      // Pinned: the checkout ran on repoPath, which may be backgrounded by
+      // the time it completes — refresh by path, not via the active tab.
+      this.refreshConflictDialogRepo(repoPath);
     } else {
       log.error('Failed to checkout branch:', result.data?.message || result.error);
       showErrorWithSuggestion(result.data?.message || result.error?.message || '', 'Failed to checkout branch');
@@ -4018,7 +4030,6 @@ export class AppShell extends LitElement {
         <lv-interactive-rebase-dialog
           id="app-rebase-dialog"
           .repositoryPath=${this.activeRepository.repository.path}
-          @rebase-complete=${this.handleRebaseComplete}
         ></lv-interactive-rebase-dialog>
       ` : ''}
 

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -3249,7 +3249,7 @@ export class AppShell extends LitElement {
                             this.activeRepository.repository.state === 'rebase-merge' ? 'Rebase in progress' :
                             this.activeRepository.repository.state === 'revert' ? 'Revert in progress' :
                             this.activeRepository.repository.state === 'bisect' ? 'Bisect in progress' :
-                            this.activeRepository.repository.state === 'clean' ? 'Stash conflicts need resolution' :
+                            this.activeRepository.repository.state === 'clean' ? 'Conflicts need resolution' :
                             `Operation in progress: ${this.activeRepository.repository.state}`}
                         </span>
                         <div class="operation-banner-actions">

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1100,6 +1100,21 @@ export class AppShell extends LitElement {
         this.interactiveRebaseDialog?.close();
         showToast('The repository tab was closed — interactive rebase cancelled', 'warning');
       }
+      // Same for the create-tag / create-branch dialogs: they pin to their repo
+      // at open() and stay open across tab switches, so closing the pinned tab
+      // must dismiss them — otherwise a successful create (create-branch even
+      // moves HEAD via checkout) would silently mutate a repo no longer in the
+      // tab bar, invisible in the visible one.
+      const ctPinned = this.createTagDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (ctPinned && !repoOpen(ctPinned)) {
+        this.createTagDialog?.close();
+        showToast('The repository tab was closed — tag creation cancelled', 'warning');
+      }
+      const cbPinned = this.createBranchDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (cbPinned && !repoOpen(cbPinned)) {
+        this.createBranchDialog?.close();
+        showToast('The repository tab was closed — branch creation cancelled', 'warning');
+      }
 
       // The open diff binds a click-time StatusEntry snapshot. Re-derive it
       // from every status refresh so a file that became conflicted since the

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -529,6 +529,14 @@ export class AppShell extends LitElement {
 
   // Conflict resolution dialog
   @state() private showConflictDialog = false;
+  /**
+   * Repository the conflict dialog was opened FOR. The dialog must keep
+   * operating on that repository even if the user switches repo tabs while
+   * it is up (Ctrl+Tab still works behind the full-screen dialog) — binding
+   * the live active-repo path would aim its abort/resolve/stage commands at
+   * whichever repo happens to be active, destroying unrelated work.
+   */
+  @state() private conflictDialogRepoPath: string | null = null;
   @state() private conflictOperationType: 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash' = 'merge';
   // Stash-completion semantics for the conflict dialog (which entry to drop and
   // whether to drop it at all — pop drops, plain apply keeps).
@@ -920,7 +928,7 @@ export class AppShell extends LitElement {
       // An explicit operation always knows its source — clear any uncertainty
       // left over from a previous state-inferred stash flow.
       this.conflictStashSourceCertain = true;
-      this.showConflictDialog = true;
+      this.openConflictDialogPinned();
     } else {
       // No operation context (the diff view's "Open Merge Editor" button, a
       // conflicted-file stage click): derive the operation from repository
@@ -934,9 +942,20 @@ export class AppShell extends LitElement {
   private handleMergeConflictEvent = (): void => {
     this.conflictOperationType = 'merge';
     this.resetConflictDetailState();
-    this.showConflictDialog = true;
+    this.openConflictDialogPinned();
     this.handleRefresh();
   };
+
+  /** Open the conflict dialog pinned to the repository that is active NOW. */
+  private openConflictDialogPinned(): void {
+    this.conflictDialogRepoPath = this.activeRepository?.repository.path ?? null;
+    this.showConflictDialog = true;
+  }
+
+  private closeConflictDialog(): void {
+    this.showConflictDialog = false;
+    this.conflictDialogRepoPath = null;
+  }
 
   // Reset the conflict-dialog completion semantics to defaults so a value set by a
   // prior operation (e.g. squash=true from a git-flow squash finish, or a non-zero
@@ -1442,7 +1461,7 @@ export class AppShell extends LitElement {
       this.conflictOperationType = 'stash';
       this.resetConflictDetailState();
       this.conflictDropStashOnComplete = true;
-      this.showConflictDialog = true;
+      this.openConflictDialogPinned();
       this.handleRefresh();
     } else if (data.stashed && data.stashApplied) {
       showToast(data.message, data.message.includes('staged status was not preserved') ? 'warning' : 'info');
@@ -1468,7 +1487,7 @@ export class AppShell extends LitElement {
     } else if (result.error?.code === 'MERGE_CONFLICT') {
       this.conflictOperationType = 'merge';
       this.resetConflictDetailState();
-      this.showConflictDialog = true;
+      this.openConflictDialogPinned();
       notifyWarning(
         'Merge Conflict',
         `Conflicts detected while merging ${refName}. Please resolve conflicts to continue.`,
@@ -1497,7 +1516,7 @@ export class AppShell extends LitElement {
     } else if (result.error?.code === 'REBASE_CONFLICT') {
       this.conflictOperationType = 'rebase';
       this.resetConflictDetailState();
-      this.showConflictDialog = true;
+      this.openConflictDialogPinned();
       notifyWarning(
         'Rebase Conflict',
         `Conflicts detected while rebasing onto ${refName}. Please resolve conflicts to continue.`,
@@ -1595,7 +1614,7 @@ export class AppShell extends LitElement {
     // Show conflict resolution dialog
     this.conflictOperationType = 'cherry-pick';
     this.resetConflictDetailState();
-    this.showConflictDialog = true;
+    this.openConflictDialogPinned();
     notifyWarning(
       'Cherry-pick Conflict',
       'Conflicts detected during cherry-pick. Please resolve conflicts to continue.',
@@ -1616,16 +1635,27 @@ export class AppShell extends LitElement {
 
   /**
    * Derive which operation the current index conflicts belong to from the
-   * repository state. A clean state with conflicted files means a stash apply
-   * conflicted — the only conflict source that leaves no in-progress state.
+   * repository state. A CLEAN state with conflicted files means a stash
+   * apply conflicted — the only conflict source that leaves no in-progress
+   * state. Returns null for states this dialog cannot drive (an external
+   * `git am` / `git bisect`): its Complete does not run their --continue
+   * and its stash-flavored Abort would discard the conflicted files while
+   * leaving the operation wedged mid-flight.
    */
-  private deriveConflictOperationType(): 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash' {
+  private deriveConflictOperationType():
+    | 'merge'
+    | 'rebase'
+    | 'cherry-pick'
+    | 'revert'
+    | 'stash'
+    | null {
     const state = this.activeRepository?.repository.state ?? 'clean';
     if (state === 'cherrypick') return 'cherry-pick';
     if (state === 'rebase' || state === 'rebase-interactive' || state === 'rebase-merge') return 'rebase';
     if (state === 'revert') return 'revert';
     if (state === 'merge') return 'merge';
-    return 'stash';
+    if (state === 'clean') return 'stash';
+    return null;
   }
 
   /**
@@ -1636,7 +1666,15 @@ export class AppShell extends LitElement {
   private openConflictDialogFromState(initialFilePath?: string): void {
     if (!this.activeRepository) return;
 
-    this.conflictOperationType = this.deriveConflictOperationType();
+    const operationType = this.deriveConflictOperationType();
+    if (operationType === null) {
+      showToast(
+        `Conflicts from an external ${this.activeRepository.repository.state} operation — resolve them with git in a terminal`,
+        'warning',
+      );
+      return;
+    }
+    this.conflictOperationType = operationType;
     this.resetConflictDetailState();
     // A state-derived stash conflict has unknown pop semantics — never drop a
     // stash entry we can't identify (completing keeps the stash), and the
@@ -1647,7 +1685,7 @@ export class AppShell extends LitElement {
       this.conflictStashSourceCertain = false;
     }
     this.conflictInitialFilePath = initialFilePath ?? null;
-    this.showConflictDialog = true;
+    this.openConflictDialogPinned();
   }
 
   private handleOpenConflictDialog(): void {
@@ -1689,7 +1727,7 @@ export class AppShell extends LitElement {
       // Show conflict resolution dialog
       this.conflictOperationType = 'revert';
       this.resetConflictDetailState();
-      this.showConflictDialog = true;
+      this.openConflictDialogPinned();
       notifyWarning(
         'Revert Conflict',
         `Conflicts detected while reverting ${commit.oid.substring(0, 7)}. Please resolve conflicts to continue.`,
@@ -2037,12 +2075,12 @@ export class AppShell extends LitElement {
   }
 
   private handleConflictResolved(): void {
-    this.showConflictDialog = false;
+    this.closeConflictDialog();
     this.handleRefresh();
   }
 
   private handleConflictAborted(): void {
-    this.showConflictDialog = false;
+    this.closeConflictDialog();
     this.handleRefresh();
   }
 
@@ -2999,13 +3037,13 @@ export class AppShell extends LitElement {
       progressService.failOperation(opId);
       this.conflictOperationType = 'merge';
       this.resetConflictDetailState();
-      this.showConflictDialog = true;
+      this.openConflictDialogPinned();
       this.handleRefresh();
     } else if (result.error?.code === 'REBASE_CONFLICT') {
       progressService.failOperation(opId);
       this.conflictOperationType = 'rebase';
       this.resetConflictDetailState();
-      this.showConflictDialog = true;
+      this.openConflictDialogPinned();
       this.handleRefresh();
     } else {
       progressService.failOperation(opId);
@@ -3417,7 +3455,7 @@ export class AppShell extends LitElement {
         ? html`
             <lv-conflict-resolution-dialog
               open
-              repositoryPath=${this.activeRepository.repository.path}
+              repositoryPath=${this.conflictDialogRepoPath ?? this.activeRepository.repository.path}
               operationType=${this.conflictOperationType}
               .initialFilePath=${this.conflictInitialFilePath}
               .stashSourceCertain=${this.conflictStashSourceCertain}

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2202,13 +2202,25 @@ export class AppShell extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the history await: the reword targets THIS repo's commit.
+    const repoPath = this.activeRepository.repository.path;
+
     // Check if this is HEAD commit by comparing with the first commit in history.
     // Note: This works for the common case of a branch checkout. In detached HEAD state,
     // the first commit in history is still HEAD, so this approach remains valid.
     const historyResult = await gitService.getCommitHistory({
-      path: this.activeRepository.repository.path,
+      path: repoPath,
       limit: 1,
     });
+
+    // The interactive-rebase dialog and the commit panel both bind to the LIVE
+    // active repo. If the user switched tabs during the history await, opening
+    // either would configure a reword of THIS repo's commit against another
+    // repo (rewriting the wrong history, or dead-ending on a missing commit).
+    if (this.activeRepository?.repository.path !== repoPath) {
+      showToast('Repository changed — reword cancelled', 'warning');
+      return;
+    }
 
     const isHead = historyResult.success && historyResult.data &&
       historyResult.data.length > 0 && historyResult.data[0].oid === commit.oid;

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1684,14 +1684,23 @@ export class AppShell extends LitElement {
   }
 
   private handleCherryPickComplete(e: CustomEvent): void {
-    const { sourceCommit, noCommit } = e.detail;
-    this.graphCanvas?.refresh?.();
+    const { sourceCommit, noCommit, repositoryPath } = e.detail;
     if (noCommit) {
       showToast(`Staged changes from ${sourceCommit.oid.substring(0, 7)}`, 'success');
     } else {
       showToast(`Cherry-picked ${sourceCommit.oid.substring(0, 7)}`, 'success');
     }
-    this.handleRefresh();
+    // Pinned refresh: after a mid-operation tab switch the cherry-pick
+    // completed on the ORIGINATING repo — refreshing the active tab would
+    // leave that repo's graph and state stale until the file watcher fires.
+    this.refreshConflictDialogRepo(repositoryPath ?? null);
+  }
+
+  private handleRebaseComplete(e: Event): void {
+    const detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    // Same pinned refresh as cherry-pick-complete: the rebase ran on the
+    // originating repo, which may no longer be the active tab.
+    this.refreshConflictDialogRepo(detail?.repositoryPath ?? null);
   }
 
   private handleCherryPickConflict(e: Event): void {
@@ -4005,7 +4014,7 @@ export class AppShell extends LitElement {
         <lv-interactive-rebase-dialog
           id="app-rebase-dialog"
           .repositoryPath=${this.activeRepository.repository.path}
-          @rebase-complete=${() => this.handleRefresh()}
+          @rebase-complete=${this.handleRebaseComplete}
         ></lv-interactive-rebase-dialog>
       ` : ''}
 

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -4102,11 +4102,13 @@ export class AppShell extends LitElement {
       ${this.activeRepository ? html`
         <lv-create-tag-dialog
           .repositoryPath=${this.activeRepository.repository.path}
-          @tag-created=${() => this.handleRefresh()}
+          @tag-created=${(e: CustomEvent<{ repositoryPath?: string }>) =>
+            this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null)}
         ></lv-create-tag-dialog>
         <lv-create-branch-dialog
           .repositoryPath=${this.activeRepository.repository.path}
-          @branch-created=${() => this.handleRefresh()}
+          @branch-created=${(e: CustomEvent<{ repositoryPath?: string }>) =>
+            this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null)}
         ></lv-create-branch-dialog>
         <lv-cherry-pick-dialog
           .repositoryPath=${this.activeRepository.repository.path}

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1051,6 +1051,26 @@ export class AppShell extends LitElement {
       const repoChanged = this.activeRepository?.repository.path !== newActiveRepo?.repository.path;
       this.activeRepository = newActiveRepo;
 
+      // Closing the pinned repo's TAB while its conflict dialog is up
+      // would leave the dialog floating over whatever renders next, with
+      // dead completion plumbing (the open-time guard only covers closes
+      // during the triggering operation's await). Close it with an
+      // explanation — the operation itself persists on disk and resurfaces
+      // when the repo is reopened.
+      if (
+        this.showConflictDialog &&
+        this.conflictDialogConfig &&
+        !state.openRepositories.some(
+          (r) => r.repository.path === this.conflictDialogConfig!.repoPath,
+        )
+      ) {
+        this.closeConflictDialog();
+        showToast(
+          'The repository tab was closed — reopen it to continue resolving its conflicts',
+          'warning',
+        );
+      }
+
       // The open diff binds a click-time StatusEntry snapshot. Re-derive it
       // from every status refresh so a file that became conflicted since the
       // click (e.g. a merge run in an external terminal) hits the diff view's

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1026,8 +1026,12 @@ export class AppShell extends LitElement {
   }
 
   // Handle gitflow events (init, feature/release/hotfix operations) to trigger refresh
-  private handleGitflowEvent = (): void => {
-    this.handleRefresh();
+  private handleGitflowEvent = (e: Event): void => {
+    // Pinned refresh, like every other operation completion: the gitflow
+    // command ran on the repo the panel showed at click time, which may be
+    // backgrounded by the time it finishes.
+    const detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    this.refreshConflictDialogRepo(detail?.repositoryPath ?? null);
   };
 
   // Handle show-commit events (e.g., from reflog dialog "Show in graph")

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -542,6 +542,9 @@ export class AppShell extends LitElement {
   // The file the user clicked to enter the conflict flow — the dialog opens
   // preselected on it instead of always starting at the first conflict.
   @state() private conflictInitialFilePath: string | null = null;
+  // False when 'stash' was only inferred from a clean repo state — the dialog
+  // must not promise the changes are safe in a stash that may not exist.
+  @state() private conflictStashSourceCertain = true;
 
   // Command palette
   @state() private showCommandPalette = false;
@@ -941,6 +944,7 @@ export class AppShell extends LitElement {
     this.conflictSquashMerge = false;
     this.conflictGitflowFinish = null;
     this.conflictInitialFilePath = null;
+    this.conflictStashSourceCertain = true;
   }
 
   // Handle gitflow events (init, feature/release/hotfix operations) to trigger refresh
@@ -987,6 +991,12 @@ export class AppShell extends LitElement {
             fresh.status !== this.diffFile.status)
         ) {
           this.diffFile = fresh;
+        } else if (!fresh && this.diffFile.isConflicted) {
+          // A conflicted file that left the status entirely was resolved and
+          // committed (e.g. Complete Merge) — close the diff rather than
+          // showing a permanently stale "has merge conflicts" interstitial.
+          this.diffFile = null;
+          this.showDiff = false;
         }
       }
 
@@ -1626,9 +1636,12 @@ export class AppShell extends LitElement {
     this.conflictOperationType = this.deriveConflictOperationType();
     this.resetConflictDetailState();
     // A state-derived stash conflict has unknown pop semantics — never drop a
-    // stash entry we can't identify. Completing keeps the stash (safe).
+    // stash entry we can't identify (completing keeps the stash), and the
+    // source is only inferred (checkout -m / apply -3 look identical), so the
+    // dialog must not promise the changes are safe in a stash.
     if (this.conflictOperationType === 'stash') {
       this.conflictDropStashOnComplete = false;
+      this.conflictStashSourceCertain = false;
     }
     this.conflictInitialFilePath = initialFilePath ?? null;
     this.showConflictDialog = true;
@@ -3404,6 +3417,7 @@ export class AppShell extends LitElement {
               repositoryPath=${this.activeRepository.repository.path}
               operationType=${this.conflictOperationType}
               .initialFilePath=${this.conflictInitialFilePath}
+              .stashSourceCertain=${this.conflictStashSourceCertain}
               .stashIndex=${this.conflictStashIndex}
               .dropStashOnComplete=${this.conflictDropStashOnComplete}
               .squashMerge=${this.conflictSquashMerge}

--- a/src/components/__tests__/lv-file-status.test.ts
+++ b/src/components/__tests__/lv-file-status.test.ts
@@ -961,5 +961,46 @@ describe('lv-file-status', () => {
 
       expect(findCommands('get_status').length).to.equal(1);
     });
+
+    it('discards against the origin repo even if the user switches tabs during the confirm', async () => {
+      // Discard is irreversible. The confirm is an OS dialog wrapper whose
+      // await can yield; a tab switch during it rebinds this.repositoryPath.
+      // The discard must still run against the repo it was invoked on — else
+      // it silently destroys the WRONG repo's uncommitted work.
+      openRepoInStore(REPO_PATH);
+      const el = await renderFileStatus();
+
+      let resolveConfirm!: (v: unknown) => void;
+      mockInvoke = async (command: string) => {
+        if (command === 'plugin:dialog|message') {
+          return new Promise((resolve) => {
+            resolveConfirm = resolve;
+          });
+        }
+        if (command === 'get_status') return mockStatusEntries;
+        return null;
+      };
+
+      clearHistory();
+      const file = {
+        path: 'src/utils/helper.ts',
+        status: 'modified',
+        isStaged: false,
+        isConflicted: false,
+      };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const promise = (el as any).handleDiscardFile(file, new Event('click'));
+
+      // The confirm is now in flight; the user switches tabs.
+      await new Promise((r) => setTimeout(r, 10));
+      el.repositoryPath = '/other/repo';
+
+      resolveConfirm('Ok');
+      await promise;
+
+      const discard = findCommands('discard_changes')[0];
+      expect(discard, 'discard_changes was called').to.not.be.undefined;
+      expect((discard.args as { path: string }).path).to.equal(REPO_PATH);
+    });
   });
 });

--- a/src/components/__tests__/lv-gitflow-panel.test.ts
+++ b/src/components/__tests__/lv-gitflow-panel.test.ts
@@ -369,6 +369,50 @@ describe('lv-gitflow-panel', () => {
   });
 
   // ── Start operations ───────────────────────────────────────────────────
+  describe('load race safety', () => {
+    it('a slow load for the previous repo cannot overwrite the current repo panel', async () => {
+      // The Finish buttons bind directly to the active items; a stale load
+      // for repo A landing after the user switched to repo B would show A's
+      // branches under B's tab and could finish/delete the wrong branch.
+      let releaseA: ((v: unknown) => void) | null = null;
+      mockInvoke = async (command: string, args?: unknown) => {
+        const path = (args as { path?: string })?.path;
+        if (command === 'get_gitflow_config') {
+          if (path === '/repo/A') return new Promise((res) => { releaseA = res; });
+          return DEFAULT_CONFIG;
+        }
+        if (command === 'get_branches') {
+          return path === '/repo/A'
+            ? [makeBranch({ name: 'feature/A-only', shorthand: 'feature/A-only', isHead: false })]
+            : [makeBranch({ name: 'feature/B-only', shorthand: 'feature/B-only', isHead: false })];
+        }
+        return null;
+      };
+
+      const el = await fixture<LvGitflowPanel>(
+        html`<lv-gitflow-panel .repositoryPath=${'/repo/A'}></lv-gitflow-panel>`
+      );
+      // A's config load is deferred (in flight). Switch to B, which resolves.
+      el.repositoryPath = '/repo/B';
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 60));
+      await el.updateComplete;
+
+      const internal = el as unknown as { activeFeatures: Array<{ name: string }> };
+      expect(internal.activeFeatures.map((f) => f.name)).to.deep.equal(['B-only']);
+
+      // A's slow response finally lands — it must be discarded, not applied.
+      releaseA!(DEFAULT_CONFIG);
+      await new Promise((r) => setTimeout(r, 60));
+      await el.updateComplete;
+
+      expect(
+        internal.activeFeatures.map((f) => f.name),
+        "the stale repo's items must not overwrite the current panel",
+      ).to.deep.equal(['B-only']);
+    });
+  });
+
   describe('start operations', () => {
     it('calls gitflow_start_feature when New Feature action button is clicked', async () => {
       setupMocks({ branches: emptyBranches });

--- a/src/components/__tests__/lv-gitflow-panel.test.ts
+++ b/src/components/__tests__/lv-gitflow-panel.test.ts
@@ -351,8 +351,10 @@ describe('lv-gitflow-panel', () => {
 
       const el = await renderPanel();
 
-      let eventFired = false;
-      el.addEventListener('gitflow-initialized', () => { eventFired = true; });
+      let eventDetail: unknown = null;
+      el.addEventListener('gitflow-initialized', ((e: CustomEvent) => {
+        eventDetail = e.detail;
+      }) as EventListener);
 
       const initBtn = el.shadowRoot!.querySelector('.btn-primary') as HTMLButtonElement;
       initBtn.click();
@@ -360,7 +362,9 @@ describe('lv-gitflow-panel', () => {
       await new Promise((r) => setTimeout(r, 150));
       await el.updateComplete;
 
-      expect(eventFired).to.be.true;
+      // Carries the pre-await repo capture so the host's refresh pins to
+      // the repo the init ran on.
+      expect(eventDetail).to.deep.equal({ repositoryPath: REPO_PATH });
     });
   });
 
@@ -473,7 +477,13 @@ describe('lv-gitflow-panel', () => {
         await new Promise((r) => setTimeout(r, 150));
         await el.updateComplete;
 
-        expect(eventDetail).to.deep.equal({ type: 'start-feature', name: 'new-feat' });
+        // repositoryPath is the PRE-AWAIT capture — the host's refresh must
+        // target the repo the start ran on, not the tab active at completion.
+        expect(eventDetail).to.deep.equal({
+          type: 'start-feature',
+          name: 'new-feat',
+          repositoryPath: REPO_PATH,
+        });
       } finally {
         cleanupMockPrompt();
       }
@@ -571,7 +581,13 @@ describe('lv-gitflow-panel', () => {
       await new Promise((r) => setTimeout(r, 150));
       await el.updateComplete;
 
-      expect(eventDetail).to.deep.equal({ type: 'finish-feature', name: 'login' });
+      // repositoryPath is the PRE-AWAIT capture — same pinning as the
+      // conflict-path events.
+      expect(eventDetail).to.deep.equal({
+        type: 'finish-feature',
+        name: 'login',
+        repositoryPath: REPO_PATH,
+      });
     });
 
     it('does NOT call finish release when prompt is cancelled', async () => {

--- a/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
@@ -558,6 +558,57 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
       expect(deletedNames).to.include('feature/wip');
     });
 
+    it('deletes + prunes the repo it was opened for, not the tab switched to while open', async () => {
+      // The dialog pins its repo at open(); repositoryPath is bound live to the
+      // active tab. Switching tabs while the (irreversible) cleanup dialog is
+      // open must not redirect the force-deletes / remote prune to another repo.
+      const el = await renderAndOpen([mergedSafe]);
+
+      // User switches to another repo while the dialog is open.
+      el.repositoryPath = '/other/repo';
+      await el.updateComplete;
+
+      let detail: { repositoryPath?: string } | null = null;
+      el.addEventListener('cleanup-complete', (e) => {
+        detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+      });
+
+      clearHistory();
+      const deleteBtn = el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement;
+      deleteBtn.click();
+      await new Promise((r) => setTimeout(r, 200));
+      await el.updateComplete;
+
+      const deleteCalls = findCommands('delete_branch');
+      expect(deleteCalls.length).to.be.greaterThan(0);
+      deleteCalls.forEach((c) =>
+        expect((c.args as { path: string }).path).to.equal(REPO_PATH),
+      );
+      const pruneCalls = findCommands('prune_remote_tracking_branches');
+      pruneCalls.forEach((c) =>
+        expect((c.args as { path: string }).path).to.equal(REPO_PATH),
+      );
+      expect(detail, 'cleanup-complete dispatched').to.not.be.null;
+      expect(detail!.repositoryPath).to.equal(REPO_PATH);
+    });
+
+    it('exposes its pinned repo only while open, for host self-close', async () => {
+      mockInvoke = async (command: string) => {
+        if (command === 'get_cleanup_candidates') return [];
+        return null;
+      };
+      const el = await fixture<LvBranchCleanupDialog>(
+        html`<lv-branch-cleanup-dialog .repositoryPath=${REPO_PATH}></lv-branch-cleanup-dialog>`,
+      );
+      await el.updateComplete;
+      expect(el.pinnedRepositoryPathIfOpen, 'null before open').to.be.null;
+      el.open();
+      await settle(el);
+      expect(el.pinnedRepositoryPathIfOpen, 'pinned while open').to.equal(REPO_PATH);
+      el.close();
+      expect(el.pinnedRepositoryPathIfOpen, 'null after close').to.be.null;
+    });
+
     it('cleanup-complete event dispatched after successful deletion', async () => {
       const el = await renderAndOpen([mergedSafe]);
 

--- a/src/components/dialogs/__tests__/lv-cherry-pick-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-cherry-pick-dialog.test.ts
@@ -124,4 +124,29 @@ describe('lv-cherry-pick-dialog', () => {
     expect(lastInvokedCommand).to.equal('cherry_pick');
     expect(lastInvokedArgs?.mainline).to.equal(undefined);
   });
+
+  it('cherry-pick-complete carries the repo the pick ran on (pinned pre-await)', async () => {
+    // The success refresh must target the ORIGINATING repo — after a
+    // mid-operation tab switch, refreshing the active tab would leave the
+    // picked-onto repo's graph and state stale.
+    const el = await fixture<LvCherryPickDialog>(
+      html`<lv-cherry-pick-dialog .repositoryPath=${'/test/repo'}></lv-cherry-pick-dialog>`,
+    );
+    el.open(makeCommit(['p1']));
+    await el.updateComplete;
+
+    let detail: { repositoryPath?: string } | undefined;
+    el.addEventListener('cherry-pick-complete', (e) => {
+      detail = (e as CustomEvent).detail;
+    });
+
+    const btn = Array.from(el.shadowRoot!.querySelectorAll('button')).find((b) =>
+      /cherry-pick/i.test(b.textContent ?? ''),
+    ) as HTMLButtonElement;
+    btn.click();
+    await new Promise((r) => setTimeout(r, 50));
+    await el.updateComplete;
+
+    expect(detail?.repositoryPath).to.equal('/test/repo');
+  });
 });

--- a/src/components/dialogs/__tests__/lv-cherry-pick-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-cherry-pick-dialog.test.ts
@@ -149,4 +149,35 @@ describe('lv-cherry-pick-dialog', () => {
 
     expect(detail?.repositoryPath).to.equal('/test/repo');
   });
+
+  it('pins to the repo present at open(), surviving a repositoryPath rebind (tab switch)', async () => {
+    // The dialog is long-lived (open → review → later Execute click). A
+    // Ctrl+Tab while it sits open rebinds the reactive prop; the pick must
+    // still run on the repo shown when it opened.
+    const el = await fixture<LvCherryPickDialog>(
+      html`<lv-cherry-pick-dialog .repositoryPath=${'/repo/A'}></lv-cherry-pick-dialog>`,
+    );
+    el.open(makeCommit(['p1']));
+    await el.updateComplete;
+
+    // Simulate the active-repo tab switching while the dialog stays open.
+    el.repositoryPath = '/repo/B';
+    await el.updateComplete;
+
+    let detail: { repositoryPath?: string } | undefined;
+    el.addEventListener('cherry-pick-complete', (e) => {
+      detail = (e as CustomEvent).detail;
+    });
+
+    const btn = Array.from(el.shadowRoot!.querySelectorAll('button')).find((b) =>
+      /cherry-pick/i.test(b.textContent ?? ''),
+    ) as HTMLButtonElement;
+    btn.click();
+    await new Promise((r) => setTimeout(r, 50));
+    await el.updateComplete;
+
+    expect(lastInvokedCommand).to.equal('cherry_pick');
+    expect(lastInvokedArgs?.path, 'runs on the pinned repo, not the rebound one').to.equal('/repo/A');
+    expect(detail?.repositoryPath).to.equal('/repo/A');
+  });
 });

--- a/src/components/dialogs/__tests__/lv-cherry-pick-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-cherry-pick-dialog.test.ts
@@ -180,4 +180,30 @@ describe('lv-cherry-pick-dialog', () => {
     expect(lastInvokedArgs?.path, 'runs on the pinned repo, not the rebound one').to.equal('/repo/A');
     expect(detail?.repositoryPath).to.equal('/repo/A');
   });
+
+  it('shows the branch captured at open, not the rebound one after a tab switch', async () => {
+    // The "Cherry-pick onto" label must match the repo the operation
+    // actually targets — the live currentBranch prop rebinds on a tab
+    // switch and would otherwise advertise the wrong target branch.
+    const el = await fixture<LvCherryPickDialog>(
+      html`<lv-cherry-pick-dialog
+        .repositoryPath=${'/repo/A'}
+        .currentBranch=${'main'}
+      ></lv-cherry-pick-dialog>`,
+    );
+    el.open(makeCommit(['p1']));
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('.target-branch')?.textContent).to.contain('main');
+
+    // Tab switch rebinds both props.
+    el.repositoryPath = '/repo/B';
+    el.currentBranch = 'develop';
+    await el.updateComplete;
+
+    expect(
+      el.shadowRoot!.querySelector('.target-branch')?.textContent,
+      'label stays pinned to the branch shown at open',
+    ).to.contain('main');
+    expect(el.shadowRoot!.querySelector('.target-branch')?.textContent).to.not.contain('develop');
+  });
 });

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -700,6 +700,69 @@ describe('lv-conflict-resolution-dialog', () => {
       expect(continueBtn.disabled).to.be.false;
     });
 
+    it('Complete confirms when the editor holds unsaved rework', async () => {
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        resolvedFiles: Set<string>;
+        conflicts: ConflictFile[];
+        handleContinue: () => Promise<void>;
+      };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+
+      // The selected file was Mark-Resolved earlier, then reworked: an
+      // unsaved pick sits on screen. Complete must not silently commit the
+      // older on-disk content.
+      const editor = el.shadowRoot!.querySelector('lv-merge-editor')!;
+      const editorInternal = editor as unknown as {
+        segments: Array<Record<string, unknown>>;
+        userTouched: boolean;
+      };
+      editorInternal.segments = [
+        {
+          id: 1,
+          type: 'resolved',
+          lines: ['rework'],
+          oursLines: [],
+          theirsLines: [],
+          oursLabel: '',
+          theirsLabel: '',
+          origin: 'ours',
+          fromConflict: true,
+        },
+      ];
+      editorInternal.userTouched = true;
+
+      let confirmAnswer: unknown = false;
+      let confirmCalls = 0;
+      let completedFired = false;
+      el.addEventListener('operation-completed', () => {
+        completedFired = true;
+      });
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return confirmAnswer;
+        }
+        return baseMock(command, args);
+      };
+
+      // Declined: nothing commits, the dialog stays open with the rework.
+      await internal.handleContinue.call(el);
+      expect(confirmCalls).to.equal(1);
+      expect(completedFired).to.be.false;
+
+      // Accepted: the continue proceeds normally.
+      confirmAnswer = 'Ok';
+      await internal.handleContinue.call(el);
+      expect(completedFired).to.be.true;
+    });
+
     it('dispatches operation-completed on successful continue', async () => {
       const el = await renderDialog();
       el.open = true;
@@ -1122,6 +1185,45 @@ describe('lv-conflict-resolution-dialog', () => {
       fire('resolve-finished');
       await el.updateComplete;
       expect(abortBtn.disabled).to.be.false;
+    });
+
+    it('file navigation is blocked while a resolve write is in flight', async () => {
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      // Navigating away mid-write and back lets a SECOND write start against
+      // the same file — two overlapping writes, last-to-land wins silently.
+      const editor = el.shadowRoot!.querySelector('lv-merge-editor')!;
+      editor.dispatchEvent(
+        new CustomEvent('resolve-started', { bubbles: true, composed: true })
+      );
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        selectedIndex: number;
+        handleFileSelect: (i: number) => Promise<void>;
+        handleNext: () => Promise<void>;
+      };
+      expect(internal.selectedIndex).to.equal(0);
+      await internal.handleFileSelect.call(el, 1);
+      expect(internal.selectedIndex, 'file-list click must be inert mid-write').to.equal(0);
+      await internal.handleNext.call(el);
+      expect(internal.selectedIndex, 'Next must be inert mid-write').to.equal(0);
+
+      const nextBtn = Array.from(el.shadowRoot!.querySelectorAll('.nav-btn')).find(
+        (b) => b.textContent?.includes('Next')
+      ) as HTMLButtonElement;
+      expect(nextBtn.disabled, 'Next renders disabled mid-write').to.be.true;
+
+      editor.dispatchEvent(
+        new CustomEvent('resolve-finished', { bubbles: true, composed: true })
+      );
+      await el.updateComplete;
+      await internal.handleNext.call(el);
+      expect(internal.selectedIndex, 'navigation works again after the write').to.equal(1);
     });
 
     it('a double-click on External during the confirm window launches one tool session', async () => {

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -1561,6 +1561,60 @@ describe('lv-conflict-resolution-dialog', () => {
       ).to.equal(0);
     });
 
+    it('a late identity capture from a PREVIOUS dialog session cannot cross over', async () => {
+      // Session 1 opens for stashIndex=1 and its getStashes hangs; the
+      // dialog closes and reopens (session 2, stashIndex=0). When session
+      // 1's response finally lands it must be discarded — pairing its list
+      // with session 2's index would capture the wrong entry's identity.
+      let releaseFirst: ((v: unknown) => void) | null = null;
+      let call = 0;
+      const stale = [
+        { index: 0, message: 'other', oid: 'oid-wrong' },
+        { index: 1, message: 'first session target', oid: 'oid-session1' },
+      ];
+      const fresh = [{ index: 0, message: 'second session target', oid: 'oid-session2' }];
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_stashes') {
+          call++;
+          if (call === 1) {
+            return new Promise((res) => {
+              releaseFirst = () => res(stale);
+            });
+          }
+          return fresh;
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderDialog('stash');
+      (el as unknown as { stashIndex: number }).stashIndex = 1;
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 50));
+
+      // Close and reopen for a different stash.
+      (el as unknown as { close: () => void }).close.call(el);
+      await el.updateComplete;
+      (el as unknown as { stashIndex: number }).stashIndex = 0;
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 50));
+
+      // Session 2's capture landed.
+      expect(
+        (el as unknown as { stashOidToDrop: string | null }).stashOidToDrop
+      ).to.equal('oid-session2');
+
+      // Session 1's response arrives late — it must not overwrite.
+      releaseFirst!(stale);
+      await new Promise(r => setTimeout(r, 20));
+      expect(
+        (el as unknown as { stashOidToDrop: string | null }).stashOidToDrop,
+        "a stale session's list must not pair with the new session's index"
+      ).to.equal('oid-session2');
+    });
+
     it('skips the drop with a warning when the stash entry vanished mid-dialog', async () => {
       let stashList: Array<{ index: number; message: string; oid: string }> = [
         { index: 0, message: 'the conflicted stash', oid: 'oid-target' },

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -868,6 +868,38 @@ describe('lv-conflict-resolution-dialog', () => {
       release!();
       await completing;
     });
+
+    it('blocks Abort and Complete while the external merge tool is open', async () => {
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        launchingExternalTool: string | null;
+        showAbortConfirm: boolean;
+        handleAbort: () => void;
+      };
+      // Simulate an external tool session in flight (launchMergeTool blocks
+      // until the tool exits).
+      internal.launchingExternalTool = 'src/main.ts';
+      await el.updateComplete;
+
+      const abortBtn = el.shadowRoot!.querySelector(
+        '.footer-actions .btn-danger'
+      ) as HTMLButtonElement;
+      const continueBtn = el.shadowRoot!.querySelector(
+        '.footer-actions .btn-primary'
+      ) as HTMLButtonElement;
+      expect(abortBtn.disabled).to.be.true;
+      expect(continueBtn.disabled).to.be.true;
+
+      // Aborting under an open tool would let its later save re-dirty the
+      // just-aborted working tree.
+      internal.handleAbort.call(el);
+      expect(internal.showAbortConfirm).to.be.false;
+    });
   });
 
   // ── Merge completion ─────────────────────────────────────────────────────

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -398,6 +398,39 @@ describe('lv-conflict-resolution-dialog', () => {
       expect(internal.selectedIndex, 'must stop at the first file').to.equal(0);
       expect(internal.selectedConflict).to.not.be.null;
     });
+
+    it('file-select re-validates the index after the confirm await against a shrunken list', async () => {
+      // A runContinue reload can replace/shrink this.conflicts while the
+      // leave confirm is up; the stacked select must not point past the new
+      // array and collapse the editor to "Select a file".
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        selectedIndex: number;
+        conflicts: ConflictFile[];
+        handleFileSelect: (i: number) => Promise<void>;
+        confirmLeaveInProgress: () => Promise<boolean>;
+        selectedConflict: ConflictFile | null;
+      };
+      internal.selectedIndex = 0;
+      let release!: (v: boolean) => void;
+      internal.confirmLeaveInProgress = () =>
+        new Promise<boolean>((res) => { release = res; });
+
+      // Select the last file (index 2 of 3); the confirm is pending.
+      const pending = internal.handleFileSelect.call(el, 2);
+      // A reload shrinks the list to one file while the confirm is up.
+      internal.conflicts = internal.conflicts.slice(0, 1);
+      release(true);
+      await pending;
+
+      expect(internal.selectedIndex, 'stale index must be rejected').to.equal(0);
+      expect(internal.selectedConflict, 'selection stays valid').to.not.be.null;
+    });
   });
 
   // ── Pinned repository visibility ─────────────────────────────────────────
@@ -1632,6 +1665,34 @@ describe('lv-conflict-resolution-dialog', () => {
       const errorToast = uiStore.getState().toasts.find(t => t.type === 'error');
       expect(errorToast, 'error toast shown').to.not.be.undefined;
     });
+
+    it('closes the dialog (not a dead-end) when the operation was concluded outside the app', async () => {
+      // The user ran `git merge --abort` in a terminal, so the backend abort
+      // reports the operation no longer exists. Escape is suppressed and
+      // Complete may be disabled, so the dialog must recognize this and
+      // close rather than trap the user.
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+
+      mockInvoke = async (command: string) => {
+        if (command === 'abort_merge')
+          throw { code: 'COMMAND_ERROR', message: 'There is no merge to abort (MERGE_HEAD missing).' };
+        if (command === 'get_conflicts') return TEST_CONFLICTS;
+        return null;
+      };
+
+      let abortedFired = false;
+      el.addEventListener('operation-aborted', () => { abortedFired = true; });
+
+      await (el as unknown as { handleAbortConfirm: () => Promise<void> }).handleAbortConfirm.bind(el)();
+
+      expect(abortedFired, 'operation-aborted dispatched so the host cleans up').to.be.true;
+      expect(el.open, 'dialog closed instead of trapping the user').to.be.false;
+      const warn = uiStore.getState().toasts.find(t => t.type === 'warning');
+      expect(warn?.message).to.contain('concluded outside the app');
+    });
   });
 
   // ── External merge tool verification ───────────────────────────────────────
@@ -1984,6 +2045,42 @@ describe('lv-conflict-resolution-dialog', () => {
         TEST_CONFLICTS.map(c => c.path),
       );
       expect(invokeHistory.some(h => h.command === 'discard_changes'), 'files restored').to.be.true;
+    });
+
+    it('stash abort restores files ALREADY resolved this session, not just still-conflicted ones', async () => {
+      // A file resolved in-session (Mark Resolved → staged, or take-side
+      // deletion) is no longer index-conflicted, so the refetch alone would
+      // EXCLUDE it. Abort must restore the UNION so it doesn't leave that
+      // resolution staged while claiming everything was reverted.
+      const el = await renderDialog('stash');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+
+      const internal = el as unknown as { conflicts: ConflictFile[] };
+      // Two files were originally conflicted...
+      const originalPaths = internal.conflicts.map((c) => c.path);
+      expect(originalPaths.length).to.be.greaterThan(1);
+
+      // ...but the refetch reports only ONE still conflicted (the other was
+      // resolved in-session and is now staged).
+      const stillConflicted = originalPaths[0];
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_conflicts') return [{ path: stillConflicted }];
+        return baseMock(command, args);
+      };
+
+      invokeHistory.length = 0;
+      await (el as unknown as { handleAbortConfirm: () => Promise<void> }).handleAbortConfirm.bind(el)();
+
+      const unstageCall = invokeHistory.find((h) => h.command === 'unstage_files');
+      expect(unstageCall, 'unstage called').to.exist;
+      const paths = (unstageCall!.args as { paths: string[] }).paths;
+      // The UNION: every originally-conflicted path, including the resolved one.
+      for (const p of originalPaths) {
+        expect(paths, `resolved file ${p} must be restored`).to.include(p);
+      }
     });
   });
 

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -824,6 +824,50 @@ describe('lv-conflict-resolution-dialog', () => {
 
       expect(dropCalls).to.equal(1);
     });
+
+    it('blocks Abort while Complete is running (and vice versa)', async () => {
+      const el = await renderDialog('stash');
+      el.dropStashOnComplete = true;
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        resolvedFiles: Set<string>;
+        conflicts: ConflictFile[];
+        showAbortConfirm: boolean;
+        handleContinue: () => Promise<void>;
+        handleAbort: () => void;
+      };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+      await el.updateComplete;
+
+      let release: (() => void) | null = null;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_conflicts') return TEST_CONFLICTS;
+        if (command === 'drop_stash') {
+          await new Promise<void>(r => { release = r; });
+          return null;
+        }
+        return null;
+      };
+
+      const completing = internal.handleContinue.call(el);
+      await el.updateComplete;
+
+      // While Complete awaits the backend, Abort must be inert — aborting now
+      // would revert the files AND lose the stash entry, with a false toast.
+      const abortBtn = el.shadowRoot!.querySelector(
+        '.footer-actions .btn-danger'
+      ) as HTMLButtonElement;
+      expect(abortBtn.disabled).to.be.true;
+      internal.handleAbort.call(el);
+      expect(internal.showAbortConfirm).to.be.false;
+
+      release!();
+      await completing;
+    });
   });
 
   // ── Merge completion ─────────────────────────────────────────────────────

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -431,6 +431,71 @@ describe('lv-conflict-resolution-dialog', () => {
       expect(internal.selectedIndex).to.equal(2);
     });
 
+    it('does not yank selection when a mid-flight resolution lands for another file', async () => {
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        selectedIndex: number;
+        resolvedFiles: Set<string>;
+      };
+      // User clicked Mark Resolved on main.ts (index 0), then switched to
+      // utils.ts (index 1) and is working there when the call completes.
+      internal.selectedIndex = 1;
+
+      const handleConflictResolved = (el as unknown as {
+        handleConflictResolved: (e: CustomEvent) => void;
+      }).handleConflictResolved.bind(el);
+
+      handleConflictResolved(
+        new CustomEvent('conflict-resolved', {
+          detail: { file: makeConflict('src/main.ts') },
+        })
+      );
+
+      // main.ts is marked resolved but the selection stays on the file the
+      // user is actively editing.
+      expect(internal.resolvedFiles.has('src/main.ts')).to.be.true;
+      expect(internal.selectedIndex).to.equal(1);
+    });
+
+    it('refreshes the embedded editor when the external tool resolves the selected file', async () => {
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        selectedIndex: number;
+        conflicts: ConflictFile[];
+        resolvedFiles: Set<string>;
+        handleOpenExternalTool: (path: string) => Promise<void>;
+      };
+      const before = internal.conflicts[0];
+      expect(internal.selectedIndex).to.equal(0);
+
+      mockInvoke = async (command: string) => {
+        if (command === 'launch_merge_tool') return { success: true };
+        // After the tool, the file is no longer conflicted.
+        if (command === 'get_conflicts') return TEST_CONFLICTS.slice(1);
+        return null;
+      };
+
+      await internal.handleOpenExternalTool.call(el, 'src/main.ts');
+      await el.updateComplete;
+
+      // The conflict object identity changed (forcing the editor to reload
+      // the tool's output instead of a stale parse), the file is resolved,
+      // and selection advanced off it.
+      expect(internal.conflicts[0]).to.not.equal(before);
+      expect(internal.resolvedFiles.has('src/main.ts')).to.be.true;
+      expect(internal.selectedIndex).to.equal(1);
+    });
+
     it('wraps around to earlier unresolved files after resolving the last one', async () => {
       const el = await renderDialog();
       el.open = true;

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -430,6 +430,34 @@ describe('lv-conflict-resolution-dialog', () => {
       // Should advance to index 2 (src/app.ts), skipping resolved src/utils.ts
       expect(internal.selectedIndex).to.equal(2);
     });
+
+    it('wraps around to earlier unresolved files after resolving the last one', async () => {
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        selectedIndex: number;
+        resolvedFiles: Set<string>;
+      };
+      // User skipped ahead and resolved the LAST file first; the earlier
+      // files (index 0, 1) are still unresolved and must be reachable.
+      internal.selectedIndex = 2;
+
+      const handleConflictResolved = (el as unknown as {
+        handleConflictResolved: (e: CustomEvent) => void;
+      }).handleConflictResolved.bind(el);
+
+      handleConflictResolved(
+        new CustomEvent('conflict-resolved', {
+          detail: { file: makeConflict('src/app.ts') },
+        })
+      );
+
+      expect(internal.selectedIndex).to.equal(0);
+    });
   });
 
   // ── Abort flow ─────────────────────────────────────────────────────────
@@ -664,15 +692,47 @@ describe('lv-conflict-resolution-dialog', () => {
     });
   });
 
-  // ── Show/close methods ─────────────────────────────────────────────────
-  describe('show/close', () => {
-    it('sets open to true and resets state on show()', async () => {
+  // ── Open/close behavior ─────────────────────────────────────────────────
+  describe('open/close', () => {
+    it('resets state and loads conflicts once when opened', async () => {
       const el = await renderDialog();
+      invokeHistory.length = 0;
 
-      await el.show();
+      el.open = true;
+      await el.updateComplete;
       await new Promise(r => setTimeout(r, 100));
 
       expect(el.open).to.be.true;
+      const internal = el as unknown as { selectedIndex: number };
+      expect(internal.selectedIndex).to.equal(0);
+      // The open transition must trigger exactly one conflicts load — a
+      // second load would race the first.
+      const loads = invokeHistory.filter(h => h.command === 'get_conflicts');
+      expect(loads.length).to.equal(1);
+    });
+
+    it('preselects the file the user clicked to enter the flow', async () => {
+      const el = await renderDialog();
+      el.initialFilePath = 'src/app.ts';
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as { selectedIndex: number };
+      // TEST_CONFLICTS order: main.ts (0), utils.ts (1), app.ts (2)
+      expect(internal.selectedIndex).to.equal(2);
+      const selected = el.shadowRoot!.querySelector('.file-item.selected');
+      expect(selected!.textContent).to.include('app.ts');
+    });
+
+    it('falls back to the first conflict when the clicked file is not conflicted', async () => {
+      const el = await renderDialog();
+      el.initialFilePath = 'src/not-conflicted.ts';
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+
       const internal = el as unknown as { selectedIndex: number };
       expect(internal.selectedIndex).to.equal(0);
     });

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -900,6 +900,43 @@ describe('lv-conflict-resolution-dialog', () => {
       internal.handleAbort.call(el);
       expect(internal.showAbortConfirm).to.be.false;
     });
+
+    it("blocks Abort and Complete while the EDITOR's external tool is open", async () => {
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      // The embedded merge editor announces its tool session with an event.
+      const editor = el.shadowRoot!.querySelector('lv-merge-editor')!;
+      editor.dispatchEvent(
+        new CustomEvent('external-tool-started', { bubbles: true, composed: true })
+      );
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        showAbortConfirm: boolean;
+        handleAbort: () => void;
+      };
+      const abortBtn = el.shadowRoot!.querySelector(
+        '.footer-actions .btn-danger'
+      ) as HTMLButtonElement;
+      const continueBtn = el.shadowRoot!.querySelector(
+        '.footer-actions .btn-primary'
+      ) as HTMLButtonElement;
+      expect(abortBtn.disabled).to.be.true;
+      expect(continueBtn.disabled).to.be.true;
+      internal.handleAbort.call(el);
+      expect(internal.showAbortConfirm).to.be.false;
+
+      // The lock releases when the tool session ends.
+      editor.dispatchEvent(
+        new CustomEvent('external-tool-finished', { bubbles: true, composed: true })
+      );
+      await el.updateComplete;
+      expect(abortBtn.disabled).to.be.false;
+    });
   });
 
   // ── Merge completion ─────────────────────────────────────────────────────

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -496,6 +496,51 @@ describe('lv-conflict-resolution-dialog', () => {
       expect(internal.selectedIndex).to.equal(1);
     });
 
+    it('confirms before a file switch that would discard in-progress picks', async () => {
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        selectedIndex: number;
+        handleFileSelect: (index: number) => Promise<void>;
+      };
+      // Give the embedded editor unsaved in-memory picks.
+      const editor = el.shadowRoot!.querySelector('lv-merge-editor') as unknown as {
+        segments: Array<Record<string, unknown>>;
+        updateComplete: Promise<boolean>;
+      };
+      editor.segments = [
+        { id: 1, type: 'resolved', lines: ['picked'], oursLines: ['a'], theirsLines: ['b'], oursLabel: '', theirsLabel: '', origin: 'ours', fromConflict: true },
+      ];
+      await editor.updateComplete;
+
+      // Confirm declined → the switch is cancelled and the picks survive.
+      let confirmCalls = 0;
+      const prevMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return false;
+        }
+        return prevMock(command, args);
+      };
+      await internal.handleFileSelect.call(el, 2);
+      expect(confirmCalls).to.be.greaterThan(0);
+      expect(internal.selectedIndex).to.equal(0);
+
+      // Confirm accepted → the switch proceeds. (The plugin maps the native
+      // dialog's button label: 'Ok' means confirmed.)
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') return 'Ok';
+        return prevMock(command, args);
+      };
+      await internal.handleFileSelect.call(el, 2);
+      expect(internal.selectedIndex).to.equal(2);
+    });
+
     it('wraps around to earlier unresolved files after resolving the last one', async () => {
       const el = await renderDialog();
       el.open = true;

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -982,6 +982,8 @@ describe('lv-conflict-resolution-dialog', () => {
       let dropCalls = 0;
       mockInvoke = async (command: string) => {
         if (command === 'get_conflicts') return TEST_CONFLICTS;
+        if (command === 'get_stashes')
+          return [{ index: 0, message: 'popped', oid: 'oid-drop-me' }];
         if (command === 'drop_stash') {
           dropCalls++;
           // Slow backend call — the second click arrives while this awaits.
@@ -990,6 +992,8 @@ describe('lv-conflict-resolution-dialog', () => {
         }
         return null;
       };
+      // Identity captured at open (drops are identity-verified, never blind).
+      (el as unknown as { stashOidToDrop: string | null }).stashOidToDrop = 'oid-drop-me';
 
       // Double-click: both invocations start before the first completes. A
       // second dropStash would delete an UNRELATED entry after indices shift.
@@ -1021,15 +1025,23 @@ describe('lv-conflict-resolution-dialog', () => {
       let release: (() => void) | null = null;
       mockInvoke = async (command: string) => {
         if (command === 'get_conflicts') return TEST_CONFLICTS;
+        if (command === 'get_stashes')
+          return [{ index: 0, message: 'popped', oid: 'oid-drop-me' }];
         if (command === 'drop_stash') {
           await new Promise<void>(r => { release = r; });
           return null;
         }
         return null;
       };
+      (el as unknown as { stashOidToDrop: string | null }).stashOidToDrop = 'oid-drop-me';
 
       const completing = internal.handleContinue.call(el);
       await el.updateComplete;
+      // The identity verification awaits getStashes before dropping — poll
+      // until the drop call is actually in flight.
+      for (let i = 0; i < 50 && !release; i++) {
+        await new Promise(r => setTimeout(r, 10));
+      }
 
       // While Complete awaits the backend, Abort must be inert — aborting now
       // would revert the files AND lose the stash entry, with a false toast.
@@ -1505,6 +1517,12 @@ describe('lv-conflict-resolution-dialog', () => {
     });
 
     it('drops the stash and completes on continue', async () => {
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_stashes')
+          return [{ index: 0, message: 'popped', oid: 'oid-popped' }];
+        return baseMock(command, args);
+      };
       const el = await renderDialog('stash');
       el.open = true;
       await el.updateComplete;
@@ -1649,7 +1667,49 @@ describe('lv-conflict-resolution-dialog', () => {
       ).to.be.false;
       expect(completedFired, 'the resolution itself still completes').to.be.true;
       const warn = uiStore.getState().toasts.find(t => t.type === 'warning');
-      expect(warn?.message).to.include('left in place');
+      expect(warn?.message).to.include('left in the stash list');
+    });
+
+    it('an unverifiable identity NEVER falls back to a blind index drop', async () => {
+      // The open-time capture failed (get_stashes errored); meanwhile an
+      // external `git stash push` put unrelated WIP at index 0. A blind
+      // index drop would permanently delete that WIP.
+      let allowStashList = false;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_stashes') {
+          if (!allowStashList) throw new Error('transient failure');
+          return [{ index: 0, message: 'unrelated WIP', oid: 'oid-wip' }];
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderDialog('stash');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      allowStashList = true;
+
+      const internal = el as unknown as {
+        resolvedFiles: Set<string>;
+        conflicts: ConflictFile[];
+        handleContinue: () => Promise<void>;
+      };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+      let completedFired = false;
+      el.addEventListener('operation-completed', () => {
+        completedFired = true;
+      });
+      clearToasts();
+      invokeHistory.length = 0;
+      await internal.handleContinue.call(el);
+
+      expect(
+        invokeHistory.some(h => h.command === 'drop_stash'),
+        'no identity, no drop — never a blind index'
+      ).to.be.false;
+      expect(completedFired).to.be.true;
+      const warn = uiStore.getState().toasts.find(t => t.type === 'warning');
+      expect(warn?.message).to.include('left in the stash list');
     });
 
     it('aborts a stash conflict by restoring ONLY the conflicted files (no hard reset, stash kept)', async () => {
@@ -1735,6 +1795,18 @@ describe('lv-conflict-resolution-dialog', () => {
     beforeEach(() => clearToasts());
 
     it('drops stash@{stashIndex} when dropStashOnComplete is true', async () => {
+      // Four entries; the popped one is index 3. Its identity is captured
+      // at open and the drop is verified against it.
+      const stashList = [0, 1, 2, 3].map((i) => ({
+        index: i,
+        message: `stash ${i}`,
+        oid: `oid-${i}`,
+      }));
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_stashes') return stashList;
+        return baseMock(command, args);
+      };
       const el = await renderDialog('stash');
       el.stashIndex = 3;
       el.dropStashOnComplete = true;

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -1142,6 +1142,49 @@ describe('lv-conflict-resolution-dialog', () => {
       expect(dropCalls).to.equal(1);
     });
 
+    it('a double-click on Complete with unsaved rework shows only ONE confirm', async () => {
+      // The Complete claim is taken BEFORE the unsaved-rework confirm await,
+      // so a fast second click is swallowed by the entry guard rather than
+      // stacking a second confirm dialog.
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        resolvedFiles: Set<string>;
+        conflicts: ConflictFile[];
+        handleContinue: () => Promise<void>;
+      };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+      await el.updateComplete;
+
+      const editor = el.shadowRoot!.querySelector('lv-merge-editor') as unknown as {
+        hasUnsavedResolutions: () => boolean;
+      };
+      expect(editor, 'the embedded editor is present').to.exist;
+      editor.hasUnsavedResolutions = () => true;
+
+      let confirmCalls = 0;
+      let releaseConfirm: (() => void) | null = null;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_conflicts') return TEST_CONFLICTS;
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return new Promise((res) => { releaseConfirm = () => res(false); });
+        }
+        return { success: true };
+      };
+
+      const first = internal.handleContinue.call(el);
+      const second = internal.handleContinue.call(el);
+      await new Promise(r => setTimeout(r, 30));
+      expect(confirmCalls, 'only one confirm may be shown').to.equal(1);
+      releaseConfirm!();
+      await Promise.all([first, second]);
+    });
+
     it('blocks Abort while Complete is running (and vice versa)', async () => {
       const el = await renderDialog('stash');
       el.dropStashOnComplete = true;

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -1079,6 +1079,118 @@ describe('lv-conflict-resolution-dialog', () => {
       expect(abortBtn.disabled).to.be.false;
     });
 
+    it('overlapping resolve writes keep the guards held until the LAST one finishes', async () => {
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      // Two writes can be in flight at once by design: a file switch resets
+      // the editor's own flag so the new file can resolve while the old
+      // file's write drains. Each write dispatches its own started/finished
+      // pair — the first finish must NOT unlock Abort/Complete.
+      const editor = el.shadowRoot!.querySelector('lv-merge-editor')!;
+      const fire = (name: string) =>
+        editor.dispatchEvent(new CustomEvent(name, { bubbles: true, composed: true }));
+      fire('resolve-started');
+      fire('resolve-started');
+      fire('resolve-finished');
+      await el.updateComplete;
+
+      const abortBtn = el.shadowRoot!.querySelector(
+        '.footer-actions .btn-danger'
+      ) as HTMLButtonElement;
+      expect(
+        abortBtn.disabled,
+        'the first finish must not unlock while a second write is in flight'
+      ).to.be.true;
+      const internal = el as unknown as { showAbortConfirm: boolean; handleAbort: () => void };
+      internal.handleAbort.call(el);
+      expect(internal.showAbortConfirm).to.be.false;
+
+      fire('resolve-finished');
+      await el.updateComplete;
+      expect(abortBtn.disabled).to.be.false;
+
+      // A stray extra finish must not underflow into a negative depth that
+      // a later started could no-op against.
+      fire('resolve-finished');
+      fire('resolve-started');
+      await el.updateComplete;
+      expect(abortBtn.disabled, 'depth must floor at zero').to.be.true;
+      fire('resolve-finished');
+      await el.updateComplete;
+      expect(abortBtn.disabled).to.be.false;
+    });
+
+    it('a double-click on External during the confirm window launches one tool session', async () => {
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      let confirmCalls = 0;
+      let launchCalls = 0;
+      let releaseConfirm: (() => void) | null = null;
+      let confirmMessage = '';
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          confirmMessage = String((args as { message?: unknown })?.message ?? '');
+          return new Promise(res => {
+            releaseConfirm = () => res('Ok');
+          });
+        }
+        if (command === 'launch_merge_tool') {
+          launchCalls++;
+          return { success: true };
+        }
+        if (command === 'get_conflicts') return TEST_CONFLICTS;
+        return null;
+      };
+
+      // The selected file has unsaved picks, so launching on it confirms.
+      const editor = el.shadowRoot!.querySelector('lv-merge-editor')!;
+      const editorInternal = editor as unknown as {
+        segments: Array<Record<string, unknown>>;
+        userTouched: boolean;
+      };
+      editorInternal.segments = [
+        {
+          id: 1,
+          type: 'resolved',
+          lines: ['x'],
+          oursLines: [],
+          theirsLines: [],
+          oursLabel: '',
+          theirsLabel: '',
+          origin: 'ours',
+          fromConflict: true,
+        },
+      ];
+      editorInternal.userTouched = true;
+
+      const internal = el as unknown as {
+        selectedConflict: ConflictFile | null;
+        handleOpenExternalTool: (path: string) => Promise<void>;
+      };
+      const selectedPath = internal.selectedConflict!.path;
+      const first = internal.handleOpenExternalTool.call(el, selectedPath);
+      const second = internal.handleOpenExternalTool.call(el, selectedPath);
+      await new Promise(r => setTimeout(r, 30));
+      expect(confirmCalls, 'only one confirm may be shown').to.equal(1);
+      expect(
+        confirmMessage,
+        'the confirm must use tool wording, not the file-switch copy'
+      ).to.include('external tool works on the file as saved on disk');
+      releaseConfirm!();
+      await Promise.all([first, second]);
+      await new Promise(r => setTimeout(r, 30));
+      expect(launchCalls, 'only one tool session may launch').to.equal(1);
+    });
+
     it('the two tool launchers are mutually exclusive in both directions', async () => {
       const el = await renderDialog('merge');
       el.open = true;

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -726,6 +726,40 @@ describe('lv-conflict-resolution-dialog', () => {
       expect(selected!.textContent).to.include('app.ts');
     });
 
+    it('uses honest non-stash wording when the stash source is only inferred', async () => {
+      const el = await renderDialog('stash');
+      el.stashSourceCertain = false;
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      // Open the abort confirm and check its message doesn't promise the
+      // changes are safe in a stash entry that may not exist.
+      const abortBtn = el.shadowRoot!.querySelector('.footer-actions .btn-danger') as HTMLElement;
+      abortBtn.click();
+      await el.updateComplete;
+
+      const msg = el.shadowRoot!.querySelector('.confirm-message')!;
+      expect(msg.textContent).to.include('not saved anywhere else');
+      expect(msg.textContent).to.not.include('remains in the stash list');
+    });
+
+    it('keeps the reassuring stash wording when the stash source is known', async () => {
+      const el = await renderDialog('stash');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const abortBtn = el.shadowRoot!.querySelector('.footer-actions .btn-danger') as HTMLElement;
+      abortBtn.click();
+      await el.updateComplete;
+
+      const msg = el.shadowRoot!.querySelector('.confirm-message')!;
+      expect(msg.textContent).to.include('remains in the stash list');
+    });
+
     it('falls back to the first conflict when the clicked file is not conflicted', async () => {
       const el = await renderDialog();
       el.initialFilePath = 'src/not-conflicted.ts';

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -1920,6 +1920,35 @@ describe('lv-conflict-resolution-dialog', () => {
       const infoToast = uiStore.getState().toasts.find(t => t.type === 'info');
       expect(infoToast, 'info toast shown').to.not.be.undefined;
     });
+
+    it('stash abort re-fetches the real conflict paths even when the client list is empty (load in flight)', async () => {
+      // The conflict load can still be in flight (empty this.conflicts,
+      // loadFailed false) when the user hits Abort. Trusting the empty
+      // client list would no-op and falsely report success while the tree
+      // stays conflicted — the abort must re-fetch the authoritative list.
+      const el = await renderDialog('stash');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+
+      // Simulate an in-flight load: the index IS conflicted but the client
+      // list has not populated yet.
+      const internal = el as unknown as { conflicts: ConflictFile[]; loadFailed: boolean };
+      internal.conflicts = [];
+      internal.loadFailed = false;
+      await el.updateComplete;
+
+      invokeHistory.length = 0;
+      await (el as unknown as { handleAbortConfirm: () => Promise<void> }).handleAbortConfirm.bind(el)();
+
+      // The abort re-fetched and restored the REAL paths, not no-opped.
+      const unstageCall = invokeHistory.find(h => h.command === 'unstage_files');
+      expect(unstageCall, 'unstage_files called for the re-fetched paths').to.exist;
+      expect((unstageCall!.args as Record<string, unknown>).paths).to.deep.equal(
+        TEST_CONFLICTS.map(c => c.path),
+      );
+      expect(invokeHistory.some(h => h.command === 'discard_changes'), 'files restored').to.be.true;
+    });
   });
 
   // ── Stash: empty conflict list must NOT drop (never-applied changes) ────────

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -1050,6 +1050,35 @@ describe('lv-conflict-resolution-dialog', () => {
       expect(abortBtn.disabled).to.be.false;
     });
 
+    it("footer buttons disable while the editor's resolve write is in flight", async () => {
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const editor = el.shadowRoot!.querySelector('lv-merge-editor')!;
+      editor.dispatchEvent(
+        new CustomEvent('resolve-started', { bubbles: true, composed: true })
+      );
+      await el.updateComplete;
+
+      const abortBtn = el.shadowRoot!.querySelector(
+        '.footer-actions .btn-danger'
+      ) as HTMLButtonElement;
+      const continueBtn = el.shadowRoot!.querySelector(
+        '.footer-actions .btn-primary'
+      ) as HTMLButtonElement;
+      expect(abortBtn.disabled).to.be.true;
+      expect(continueBtn.disabled).to.be.true;
+
+      editor.dispatchEvent(
+        new CustomEvent('resolve-finished', { bubbles: true, composed: true })
+      );
+      await el.updateComplete;
+      expect(abortBtn.disabled).to.be.false;
+    });
+
     it('the two tool launchers are mutually exclusive in both directions', async () => {
       const el = await renderDialog('merge');
       el.open = true;

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -190,10 +190,23 @@ describe('lv-conflict-resolution-dialog', () => {
       await el.updateComplete;
 
       const fileNames = el.shadowRoot!.querySelectorAll('.file-name');
-      const names = Array.from(fileNames).map(n => n.textContent!.trim());
-      expect(names).to.include('main.ts');
-      expect(names).to.include('utils.ts');
-      expect(names).to.include('app.ts');
+      const names = Array.from(fileNames).map(n => n.textContent!.replace(/\s+/g, ' ').trim());
+      expect(names.some(n => n.startsWith('main.ts'))).to.be.true;
+      expect(names.some(n => n.startsWith('utils.ts'))).to.be.true;
+      expect(names.some(n => n.startsWith('app.ts'))).to.be.true;
+    });
+
+    it('shows the directory hint for files in subdirectories', async () => {
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const dirs = Array.from(el.shadowRoot!.querySelectorAll('.file-dir')).map(
+        n => n.textContent!.trim()
+      );
+      expect(dirs).to.include('src');
     });
 
     it('marks first file as selected by default', async () => {

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -510,11 +510,13 @@ describe('lv-conflict-resolution-dialog', () => {
       // Give the embedded editor unsaved in-memory picks.
       const editor = el.shadowRoot!.querySelector('lv-merge-editor') as unknown as {
         segments: Array<Record<string, unknown>>;
+        userTouched: boolean;
         updateComplete: Promise<boolean>;
       };
       editor.segments = [
         { id: 1, type: 'resolved', lines: ['picked'], oursLines: ['a'], theirsLines: ['b'], oursLabel: '', theirsLabel: '', origin: 'ours', fromConflict: true },
       ];
+      editor.userTouched = true;
       await editor.updateComplete;
 
       // Confirm declined → the switch is cancelled and the picks survive.

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -1526,6 +1526,78 @@ describe('lv-conflict-resolution-dialog', () => {
       expect(el.open).to.be.false;
     });
 
+    it('drops the stash by IDENTITY when the list shifted while the dialog was open', async () => {
+      // An external `git stash drop` in a terminal mid-resolution shifts
+      // the indices — dropping blindly by the open-time index would delete
+      // an UNRELATED stash.
+      let stashList = [
+        { index: 0, message: 'the conflicted stash', oid: 'oid-target' },
+        { index: 1, message: 'other', oid: 'oid-other' },
+      ];
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_stashes') return stashList;
+        return baseMock(command, args);
+      };
+
+      const el = await renderDialog('stash');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+
+      // The external drop removes an entry ABOVE ours: our stash is now index 0.
+      stashList = [{ index: 0, message: 'the conflicted stash', oid: 'oid-target' }];
+
+      const internal = el as unknown as { resolvedFiles: Set<string>; conflicts: ConflictFile[] };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+      invokeHistory.length = 0;
+      await (el as unknown as { handleContinue: () => Promise<void> }).handleContinue.bind(el)();
+
+      const dropCall = invokeHistory.find(h => h.command === 'drop_stash');
+      expect(dropCall, 'drop_stash called').to.exist;
+      expect(
+        (dropCall!.args as Record<string, unknown>).index,
+        'dropped at the RE-LOCATED index'
+      ).to.equal(0);
+    });
+
+    it('skips the drop with a warning when the stash entry vanished mid-dialog', async () => {
+      let stashList: Array<{ index: number; message: string; oid: string }> = [
+        { index: 0, message: 'the conflicted stash', oid: 'oid-target' },
+      ];
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_stashes') return stashList;
+        return baseMock(command, args);
+      };
+
+      const el = await renderDialog('stash');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+
+      // The entry is gone entirely (dropped externally).
+      stashList = [];
+
+      const internal = el as unknown as { resolvedFiles: Set<string>; conflicts: ConflictFile[] };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+      let completedFired = false;
+      el.addEventListener('operation-completed', () => {
+        completedFired = true;
+      });
+      clearToasts();
+      invokeHistory.length = 0;
+      await (el as unknown as { handleContinue: () => Promise<void> }).handleContinue.bind(el)();
+
+      expect(
+        invokeHistory.some(h => h.command === 'drop_stash'),
+        'nothing may be dropped'
+      ).to.be.false;
+      expect(completedFired, 'the resolution itself still completes').to.be.true;
+      const warn = uiStore.getState().toasts.find(t => t.type === 'warning');
+      expect(warn?.message).to.include('left in place');
+    });
+
     it('aborts a stash conflict by restoring ONLY the conflicted files (no hard reset, stash kept)', async () => {
       const el = await renderDialog('stash');
       el.open = true;

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -1851,6 +1851,42 @@ describe('lv-conflict-resolution-dialog', () => {
       expect(warn?.message).to.include('left in the stash list');
     });
 
+    it('a FAILED drop_stash still completes the operation (the apply already succeeded)', async () => {
+      // The conflict resolution and stash APPLY succeeded; only removing the
+      // redundant stash entry failed. That must NOT dead-end the dialog —
+      // it should warn but complete, or the pinned repo never refreshes.
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_stashes')
+          return [{ index: 0, message: 'the conflicted stash', oid: 'oid-target' }];
+        if (command === 'drop_stash')
+          return Promise.reject({ code: 'IO_ERROR', message: 'disk error' });
+        return baseMock(command, args);
+      };
+
+      const el = await renderDialog('stash');
+      el.dropStashOnComplete = true;
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+
+      (el as unknown as { stashOidToDrop: string | null }).stashOidToDrop = 'oid-target';
+      const internal = el as unknown as { resolvedFiles: Set<string>; conflicts: ConflictFile[] };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+      let completedFired = false;
+      el.addEventListener('operation-completed', () => {
+        completedFired = true;
+      });
+      clearToasts();
+      invokeHistory.length = 0;
+      await (el as unknown as { handleContinue: () => Promise<void> }).handleContinue.bind(el)();
+
+      expect(invokeHistory.some(h => h.command === 'drop_stash'), 'drop was attempted').to.be.true;
+      expect(completedFired, 'the operation still completes so the repo refreshes').to.be.true;
+      const warn = uiStore.getState().toasts.find(t => t.type === 'warning');
+      expect(warn?.message, 'warns the stash was left behind').to.include('left in the stash list');
+    });
+
     it('an unverifiable identity NEVER falls back to a blind index drop', async () => {
       // The open-time capture failed (get_stashes errored); meanwhile an
       // external `git stash push` put unrelated WIP at index 0. A blind

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -340,6 +340,144 @@ describe('lv-conflict-resolution-dialog', () => {
       internal.handlePrevious();
       expect(internal.selectedIndex).to.equal(0);
     });
+
+    it('stacked Next calls behind one confirm cannot push the selection out of bounds', async () => {
+      // Alt+ArrowDown auto-repeat stacks several handleNext calls behind a
+      // single unsaved-work confirm; each read the same stale index. Without
+      // the post-await bound re-check they drive selectedIndex past the last
+      // file and Prev/Next go permanently inert.
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        selectedIndex: number;
+        handleNext: () => Promise<void>;
+        confirmLeaveInProgress: () => Promise<boolean>;
+        selectedConflict: ConflictFile | null;
+      };
+      internal.selectedIndex = 1; // one below the last file (index 2 of 3)
+      const release: Array<(v: boolean) => void> = [];
+      internal.confirmLeaveInProgress = () =>
+        new Promise<boolean>((res) => release.push(res));
+
+      const p1 = internal.handleNext.call(el);
+      const p2 = internal.handleNext.call(el);
+      release.forEach((r) => r(true));
+      await Promise.all([p1, p2]);
+
+      expect(internal.selectedIndex, 'must stop at the last file').to.equal(2);
+      expect(internal.selectedConflict, 'selection must stay valid').to.not.be.null;
+    });
+
+    it('stacked Previous calls behind one confirm cannot go below index 0', async () => {
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        selectedIndex: number;
+        handlePrevious: () => Promise<void>;
+        confirmLeaveInProgress: () => Promise<boolean>;
+        selectedConflict: ConflictFile | null;
+      };
+      internal.selectedIndex = 1;
+      const release: Array<(v: boolean) => void> = [];
+      internal.confirmLeaveInProgress = () =>
+        new Promise<boolean>((res) => release.push(res));
+
+      const p1 = internal.handlePrevious.call(el);
+      const p2 = internal.handlePrevious.call(el);
+      release.forEach((r) => r(true));
+      await Promise.all([p1, p2]);
+
+      expect(internal.selectedIndex, 'must stop at the first file').to.equal(0);
+      expect(internal.selectedConflict).to.not.be.null;
+    });
+  });
+
+  // ── Pinned repository visibility ─────────────────────────────────────────
+  describe('pinned repository visibility', () => {
+    it('names the repository it operates on in the header subtitle', async () => {
+      // The dialog stays pinned to the repo the operation started on even
+      // when another tab is active — without naming it, the user cannot
+      // tell whose merge Complete/Abort will hit.
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const subtitle = el.shadowRoot!.querySelector('.header-subtitle');
+      expect(subtitle?.textContent).to.include('· repo');
+    });
+  });
+
+  // ── Fresh conflict metadata adoption ─────────────────────────────────────
+  describe('fresh conflict metadata adoption', () => {
+    it('adopts the fresh ConflictFile when the editor tool session ends', async () => {
+      // The external tool can change what get_conflicts reports for the
+      // file (markerSize, hunks); keeping the stale object would misparse
+      // the tool's output on the next load.
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const editor = el.shadowRoot!.querySelector('lv-merge-editor')!;
+      const fresh = { ...makeConflict('src/main.ts'), markerSize: 12 };
+      editor.dispatchEvent(
+        new CustomEvent('external-tool-finished', {
+          detail: { filePath: 'src/main.ts', freshConflicts: [fresh] },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        conflicts: ConflictFile[];
+        editorToolActive: boolean;
+      };
+      expect(internal.editorToolActive).to.be.false;
+      expect(internal.conflicts[0].markerSize).to.equal(12);
+    });
+
+    it('the dialog launcher adopts the re-fetched ConflictFile for a still-conflicted file', async () => {
+      setupDefaultMocks();
+      const freshEntry = { ...makeConflict('src/main.ts'), markerSize: 9 };
+      let conflictsCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'launch_merge_tool') return { success: true, message: null };
+        if (command === 'get_conflicts') {
+          conflictsCalls++;
+          // First call: dialog open. Later calls: post-tool re-check.
+          return conflictsCalls === 1 ? TEST_CONFLICTS : [freshEntry];
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderDialog();
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        conflicts: ConflictFile[];
+        handleOpenExternalTool: (path: string) => Promise<void>;
+      };
+      await internal.handleOpenExternalTool.call(el, 'src/main.ts');
+      await el.updateComplete;
+
+      expect(internal.conflicts[0].markerSize, 'fresh metadata adopted').to.equal(9);
+      clearToasts();
+    });
   });
 
   // ── Conflict resolution tracking ───────────────────────────────────────

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -1002,6 +1002,39 @@ describe('lv-conflict-resolution-dialog', () => {
       await el.updateComplete;
       expect(abortBtn.disabled).to.be.false;
     });
+
+    it('the two tool launchers are mutually exclusive in both directions', async () => {
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        launchingExternalTool: string | null;
+        editorToolActive: boolean;
+        hasMergeTool: boolean;
+      };
+      internal.hasMergeTool = true;
+
+      // Dialog tool session open → the editor's launcher must be locked.
+      internal.launchingExternalTool = 'src/main.ts';
+      await el.updateComplete;
+      const editor = el.shadowRoot!.querySelector('lv-merge-editor') as HTMLElement & {
+        externalToolLocked: boolean;
+      };
+      expect(editor.externalToolLocked).to.be.true;
+      internal.launchingExternalTool = null;
+
+      // Editor tool session open → the dialog's file-list launchers must
+      // render disabled, matching their handler guard.
+      internal.editorToolActive = true;
+      await el.updateComplete;
+      const fileToolBtns = el.shadowRoot!.querySelectorAll('.file-item button');
+      for (const btn of Array.from(fileToolBtns)) {
+        expect((btn as HTMLButtonElement).disabled).to.be.true;
+      }
+    });
   });
 
   // ── Merge completion ─────────────────────────────────────────────────────

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -786,6 +786,46 @@ describe('lv-conflict-resolution-dialog', () => {
     });
   });
 
+  // ── Continue re-entry guard ──────────────────────────────────────────────
+  describe('continue re-entry guard', () => {
+    it('a double-click on Complete drops the stash only once', async () => {
+      const el = await renderDialog('stash');
+      el.dropStashOnComplete = true;
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        resolvedFiles: Set<string>;
+        conflicts: ConflictFile[];
+        handleContinue: () => Promise<void>;
+      };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+      await el.updateComplete;
+
+      let dropCalls = 0;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_conflicts') return TEST_CONFLICTS;
+        if (command === 'drop_stash') {
+          dropCalls++;
+          // Slow backend call — the second click arrives while this awaits.
+          await new Promise(r => setTimeout(r, 30));
+          return null;
+        }
+        return null;
+      };
+
+      // Double-click: both invocations start before the first completes. A
+      // second dropStash would delete an UNRELATED entry after indices shift.
+      const first = internal.handleContinue.call(el);
+      const second = internal.handleContinue.call(el);
+      await Promise.all([first, second]);
+
+      expect(dropCalls).to.equal(1);
+    });
+  });
+
   // ── Merge completion ─────────────────────────────────────────────────────
   describe('merge completion', () => {
     beforeEach(() => clearToasts());

--- a/src/components/dialogs/__tests__/lv-create-dialogs-pinning.test.ts
+++ b/src/components/dialogs/__tests__/lv-create-dialogs-pinning.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Multi-repo pinning tests for the create-tag and create-branch dialogs.
+ *
+ * Both dialogs' `repositoryPath` property is bound live to the active tab in
+ * app-shell. If the user opens the dialog on repo A and switches tabs to repo B
+ * while the modal is open, Create must still target repo A (the repo the dialog
+ * was opened for), and the created event must carry A so the host pins its
+ * refresh there — not silently mutate/refresh B.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeCalls: Array<{ command: string; args?: unknown }> = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeCalls.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { LvCreateTagDialog } from '../lv-create-tag-dialog.ts';
+import type { LvCreateBranchDialog } from '../lv-create-branch-dialog.ts';
+import '../lv-create-tag-dialog.ts';
+import '../lv-create-branch-dialog.ts';
+
+const REPO_A = '/repo/a';
+const REPO_B = '/repo/b';
+
+describe('create-tag / create-branch dialog pinning', () => {
+  beforeEach(() => {
+    invokeCalls.length = 0;
+    mockInvoke = () => Promise.resolve(null);
+  });
+
+  it('create-tag targets the repo it was opened for after a mid-dialog tab switch', async () => {
+    const el = await fixture<LvCreateTagDialog>(
+      html`<lv-create-tag-dialog .repositoryPath=${REPO_A}></lv-create-tag-dialog>`,
+    );
+    await el.updateComplete;
+
+    let detail: { repositoryPath?: string } | null = null;
+    el.addEventListener('tag-created', (e) => {
+      detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    });
+
+    // Open the dialog on repo A, then switch the (live) prop to repo B.
+    el.open();
+    await el.updateComplete;
+    el.repositoryPath = REPO_B;
+    await el.updateComplete;
+
+    // Fill in a non-annotated tag and create.
+    const internal = el as unknown as {
+      name: string;
+      isAnnotated: boolean;
+      handleCreate: () => Promise<void>;
+    };
+    internal.name = 'v1.0.0';
+    internal.isAnnotated = false;
+    invokeCalls.length = 0;
+    await internal.handleCreate();
+
+    const call = invokeCalls.find((c) => c.command === 'create_tag');
+    expect(call, 'create_tag called').to.not.be.undefined;
+    expect((call!.args as { path: string }).path).to.equal(REPO_A);
+    expect(detail, 'tag-created dispatched').to.not.be.null;
+    expect(detail!.repositoryPath).to.equal(REPO_A);
+  });
+
+  it('create-branch targets the repo it was opened for after a mid-dialog tab switch', async () => {
+    const el = await fixture<LvCreateBranchDialog>(
+      html`<lv-create-branch-dialog .repositoryPath=${REPO_A}></lv-create-branch-dialog>`,
+    );
+    await el.updateComplete;
+
+    let detail: { repositoryPath?: string } | null = null;
+    el.addEventListener('branch-created', (e) => {
+      detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    });
+
+    el.open();
+    await el.updateComplete;
+    el.repositoryPath = REPO_B;
+    await el.updateComplete;
+
+    const internal = el as unknown as {
+      branchName: string;
+      handleCreate: () => Promise<void>;
+    };
+    internal.branchName = 'feature/x';
+    invokeCalls.length = 0;
+    await internal.handleCreate();
+
+    const call = invokeCalls.find((c) => c.command === 'create_branch');
+    expect(call, 'create_branch called').to.not.be.undefined;
+    expect((call!.args as { path: string }).path).to.equal(REPO_A);
+    expect(detail, 'branch-created dispatched').to.not.be.null;
+    expect(detail!.repositoryPath).to.equal(REPO_A);
+  });
+});

--- a/src/components/dialogs/__tests__/lv-create-dialogs-pinning.test.ts
+++ b/src/components/dialogs/__tests__/lv-create-dialogs-pinning.test.ts
@@ -74,6 +74,20 @@ describe('create-tag / create-branch dialog pinning', () => {
     expect(detail!.repositoryPath).to.equal(REPO_A);
   });
 
+  it('create-tag exposes its pinned repo only while open, for host self-close', async () => {
+    const el = await fixture<LvCreateTagDialog>(
+      html`<lv-create-tag-dialog .repositoryPath=${REPO_A}></lv-create-tag-dialog>`,
+    );
+    await el.updateComplete;
+
+    expect(el.pinnedRepositoryPathIfOpen, 'null before open').to.be.null;
+    el.open();
+    await el.updateComplete;
+    expect(el.pinnedRepositoryPathIfOpen, 'pinned repo while open').to.equal(REPO_A);
+    el.close();
+    expect(el.pinnedRepositoryPathIfOpen, 'null after close').to.be.null;
+  });
+
   it('create-branch targets the repo it was opened for after a mid-dialog tab switch', async () => {
     const el = await fixture<LvCreateBranchDialog>(
       html`<lv-create-branch-dialog .repositoryPath=${REPO_A}></lv-create-branch-dialog>`,
@@ -103,5 +117,19 @@ describe('create-tag / create-branch dialog pinning', () => {
     expect((call!.args as { path: string }).path).to.equal(REPO_A);
     expect(detail, 'branch-created dispatched').to.not.be.null;
     expect(detail!.repositoryPath).to.equal(REPO_A);
+  });
+
+  it('create-branch exposes its pinned repo only while open, for host self-close', async () => {
+    const el = await fixture<LvCreateBranchDialog>(
+      html`<lv-create-branch-dialog .repositoryPath=${REPO_A}></lv-create-branch-dialog>`,
+    );
+    await el.updateComplete;
+
+    expect(el.pinnedRepositoryPathIfOpen, 'null before open').to.be.null;
+    el.open();
+    await el.updateComplete;
+    expect(el.pinnedRepositoryPathIfOpen, 'pinned repo while open').to.equal(REPO_A);
+    el.close();
+    expect(el.pinnedRepositoryPathIfOpen, 'null after close').to.be.null;
   });
 });

--- a/src/components/dialogs/__tests__/lv-interactive-rebase-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-interactive-rebase-dialog.test.ts
@@ -530,6 +530,26 @@ describe('lv-interactive-rebase-dialog (fixture)', () => {
       expect(eventFired).to.be.true;
     });
 
+    it('rebase-complete carries the repo the rebase ran on (pinned pre-await)', async () => {
+      // The success refresh must target the ORIGINATING repo — after a
+      // mid-operation tab switch, refreshing the active tab would leave
+      // the rebased repo's graph and state stale.
+      const el = await createDialog();
+      await openAndWait(el);
+
+      let detail: { repositoryPath?: string } | undefined;
+      el.addEventListener('rebase-complete', (e) => {
+        detail = (e as CustomEvent).detail;
+      });
+
+      const executeBtn = el.shadowRoot!.querySelector('.btn-primary') as HTMLButtonElement;
+      executeBtn.click();
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      expect(detail?.repositoryPath).to.equal(REPO_PATH);
+    });
+
     it('error message shown when execute fails', async () => {
       mockInvoke = async (command: string) => {
         switch (command) {

--- a/src/components/dialogs/__tests__/lv-interactive-rebase-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-interactive-rebase-dialog.test.ts
@@ -530,6 +530,38 @@ describe('lv-interactive-rebase-dialog (fixture)', () => {
       expect(eventFired).to.be.true;
     });
 
+    it('pins to the repo present at open(), surviving a repositoryPath rebind (tab switch)', async () => {
+      // Long-lived dialog: open → reorder → later Execute. A Ctrl+Tab
+      // while it sits open rebinds the reactive prop; the HISTORY-REWRITING
+      // rebase must still run on the repo shown at open, and its todo was
+      // loaded from that repo.
+      const el = await createDialog();
+      await openAndWait(el);
+      clearHistory();
+
+      // Simulate the active-repo tab switching while the dialog stays open.
+      el.repositoryPath = '/repo/OTHER';
+      await el.updateComplete;
+
+      let detail: { repositoryPath?: string } | undefined;
+      el.addEventListener('rebase-complete', (e) => {
+        detail = (e as CustomEvent).detail;
+      });
+
+      const executeBtn = el.shadowRoot!.querySelector('.btn-primary') as HTMLButtonElement;
+      executeBtn.click();
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const execCalls = findCommands('execute_interactive_rebase');
+      expect(execCalls.length).to.equal(1);
+      expect(
+        (execCalls[0].args as { path: string }).path,
+        'rewrites the pinned repo, not the rebound one',
+      ).to.equal(REPO_PATH);
+      expect(detail?.repositoryPath).to.equal(REPO_PATH);
+    });
+
     it('rebase-complete carries the repo the rebase ran on (pinned pre-await)', async () => {
       // The success refresh must target the ORIGINATING repo — after a
       // mid-operation tab switch, refreshing the active tab would leave

--- a/src/components/dialogs/lv-branch-cleanup-dialog.ts
+++ b/src/components/dialogs/lv-branch-cleanup-dialog.ts
@@ -281,6 +281,20 @@ export class LvBranchCleanupDialog extends LitElement {
 
   @property({ type: String }) repositoryPath = '';
 
+  /** The repo this dialog was opened for, captured at open(). repositoryPath is
+   * bound live to the active tab, so a tab switch while the modal is open would
+   * otherwise make the irreversible force-deletes / remote prune target the
+   * wrong repo. */
+  private pinnedRepoPath = '';
+  private isOpen = false;
+
+  /** The pinned repo while the dialog is open, else null — lets the host
+   * self-close the dialog when that repo's tab is closed (a Delete on a closed
+   * repo would otherwise force-delete branches in a repo not in the tab bar). */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.isOpen ? this.pinnedRepoPath : null;
+  }
+
   @state() private loading = true;
   @state() private mergedBranches: CleanupBranch[] = [];
   @state() private staleBranches: CleanupBranch[] = [];
@@ -294,11 +308,14 @@ export class LvBranchCleanupDialog extends LitElement {
 
   public async open(): Promise<void> {
     this.reset();
+    this.pinnedRepoPath = this.repositoryPath;
+    this.isOpen = true;
     this.modal.open = true;
     await this.loadCleanupData();
   }
 
   public close(): void {
+    this.isOpen = false;
     this.modal.open = false;
   }
 
@@ -319,7 +336,7 @@ export class LvBranchCleanupDialog extends LitElement {
     try {
       const { staleBranchDays } = settingsStore.getState();
       const result = await gitService.getCleanupCandidates(
-        this.repositoryPath,
+        this.pinnedRepoPath,
         staleBranchDays,
       );
 
@@ -548,10 +565,15 @@ export class LvBranchCleanupDialog extends LitElement {
     let deleted = 0;
     let failed = 0;
 
+    // Pinned at open(): these irreversible force-deletes and the remote prune
+    // must target the repo the cleanup was invoked on, even if the user
+    // switches tabs during the confirm or across the delete loop's awaits
+    // (which rebinds the live repositoryPath prop).
+    const repoPath = this.pinnedRepoPath;
     for (const cb of toDelete) {
       // Use force delete for warning/danger branches (not fully merged)
       const force = cb.risk === 'warning' || cb.risk === 'danger';
-      const result = await gitService.deleteBranch(this.repositoryPath, cb.branch.name, force);
+      const result = await gitService.deleteBranch(repoPath, cb.branch.name, force);
       if (result.success) {
         deleted++;
       } else {
@@ -563,7 +585,7 @@ export class LvBranchCleanupDialog extends LitElement {
     // Prune remote tracking branches if requested
     if (this.pruneRemotes) {
       try {
-        await gitService.pruneRemoteTrackingBranches(this.repositoryPath);
+        await gitService.pruneRemoteTrackingBranches(repoPath);
       } catch (err) {
         console.error('Failed to prune remote tracking branches:', err);
         showToast(`Failed to prune remote branches: ${err instanceof Error ? err.message : String(err)}`, 'error');
@@ -582,6 +604,7 @@ export class LvBranchCleanupDialog extends LitElement {
 
       this.dispatchEvent(
         new CustomEvent('cleanup-complete', {
+          detail: { repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }),
@@ -593,6 +616,7 @@ export class LvBranchCleanupDialog extends LitElement {
   }
 
   private handleModalClose(): void {
+    this.isOpen = false;
     if (!this.deleting) {
       this.reset();
     }

--- a/src/components/dialogs/lv-cherry-pick-dialog.ts
+++ b/src/components/dialogs/lv-cherry-pick-dialog.ts
@@ -205,10 +205,16 @@ export class LvCherryPickDialog extends LitElement {
   @state() private isExecuting = false;
   @state() private error = '';
   @state() private isOpen = false;
+  /** Repo captured at open. This is a long-lived dialog (open → review →
+   * a separate later click to execute); the reactive `repositoryPath`
+   * prop rebinds the instant the user Ctrl+Tabs to another repo, so every
+   * internal op must use THIS pinned value, not the live prop. */
+  private pinnedRepoPath = '';
 
   public open(commit: Commit): void {
     this.reset();
     this.commit = commit;
+    this.pinnedRepoPath = this.repositoryPath;
     this.isOpen = true;
   }
 
@@ -245,9 +251,9 @@ export class LvCherryPickDialog extends LitElement {
     this.isExecuting = true;
     this.error = '';
 
-    // Captured BEFORE the await: the conflict event must carry the repo the
-    // cherry-pick actually ran on, even if the prop is rebound mid-flight.
-    const repoPath = this.repositoryPath;
+    // The repo pinned at open — NOT the live prop, which rebinds on a
+    // tab switch while this dialog sits open.
+    const repoPath = this.pinnedRepoPath;
     try {
       const result = await cherryPick({
         path: repoPath,

--- a/src/components/dialogs/lv-cherry-pick-dialog.ts
+++ b/src/components/dialogs/lv-cherry-pick-dialog.ts
@@ -264,6 +264,10 @@ export class LvCherryPickDialog extends LitElement {
             commit: result.data,
             sourceCommit: this.commit,
             noCommit: this.noCommit,
+            // Same pinning as the conflict sibling: the refresh must target
+            // the repo the cherry-pick ran on, not whichever tab is active
+            // by the time it completes.
+            repositoryPath: repoPath,
           },
           bubbles: true,
           composed: true,

--- a/src/components/dialogs/lv-cherry-pick-dialog.ts
+++ b/src/components/dialogs/lv-cherry-pick-dialog.ts
@@ -267,8 +267,12 @@ export class LvCherryPickDialog extends LitElement {
         }));
         this.close();
       } else {
-        // Check if it's a conflict
-        if (result.error?.message?.includes('conflict')) {
+        // Check if it's a conflict — match the structured code like every
+        // other entry point, with the message match as a fallback.
+        if (
+          result.error?.code === 'CHERRY_PICK_CONFLICT' ||
+          result.error?.message?.toLowerCase().includes('conflict')
+        ) {
           this.dispatchEvent(new CustomEvent('cherry-pick-conflict', {
             detail: {
               sourceCommit: this.commit,

--- a/src/components/dialogs/lv-cherry-pick-dialog.ts
+++ b/src/components/dialogs/lv-cherry-pick-dialog.ts
@@ -210,11 +210,17 @@ export class LvCherryPickDialog extends LitElement {
    * prop rebinds the instant the user Ctrl+Tabs to another repo, so every
    * internal op must use THIS pinned value, not the live prop. */
   private pinnedRepoPath = '';
+  /** Target branch captured at open — the reactive `currentBranch` prop
+   * also rebinds on a tab switch, so the "Cherry-pick onto" LABEL must show
+   * the pinned branch, or it would advertise the wrong target the operation
+   * won't actually use. */
+  @state() private pinnedCurrentBranch = '';
 
   public open(commit: Commit): void {
     this.reset();
     this.commit = commit;
     this.pinnedRepoPath = this.repositoryPath;
+    this.pinnedCurrentBranch = this.currentBranch;
     this.isOpen = true;
   }
 
@@ -367,7 +373,7 @@ export class LvCherryPickDialog extends LitElement {
           <!-- Target Info -->
           <div class="target-info">
             <span class="target-label">Cherry-pick onto:</span>
-            <span class="target-branch">${this.currentBranch || 'current branch'}</span>
+            <span class="target-branch">${this.pinnedCurrentBranch || 'current branch'}</span>
           </div>
 
           <!-- Options -->

--- a/src/components/dialogs/lv-cherry-pick-dialog.ts
+++ b/src/components/dialogs/lv-cherry-pick-dialog.ts
@@ -245,9 +245,12 @@ export class LvCherryPickDialog extends LitElement {
     this.isExecuting = true;
     this.error = '';
 
+    // Captured BEFORE the await: the conflict event must carry the repo the
+    // cherry-pick actually ran on, even if the prop is rebound mid-flight.
+    const repoPath = this.repositoryPath;
     try {
       const result = await cherryPick({
-        path: this.repositoryPath,
+        path: repoPath,
         commitOid: this.commit.oid,
         noCommit: this.noCommit || undefined,
         // A merge commit needs an explicit mainline parent (like
@@ -277,6 +280,7 @@ export class LvCherryPickDialog extends LitElement {
             detail: {
               sourceCommit: this.commit,
               error: result.error,
+              repositoryPath: repoPath,
             },
             bubbles: true,
             composed: true,

--- a/src/components/dialogs/lv-cherry-pick-dialog.ts
+++ b/src/components/dialogs/lv-cherry-pick-dialog.ts
@@ -222,6 +222,12 @@ export class LvCherryPickDialog extends LitElement {
     this.isOpen = false;
   }
 
+  /** The repo this dialog is pinned to while open, or null when closed.
+   * The host uses it to close the dialog if that repo's tab is closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.isOpen ? this.pinnedRepoPath : null;
+  }
+
   private reset(): void {
     this.commit = null;
     this.noCommit = false;

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -396,8 +396,15 @@ export class LvConflictResolutionDialog extends LitElement {
   @state() private continuing = false;
   /** True while the EMBEDDED merge editor has an external tool session open. */
   @state() private editorToolActive = false;
-  /** True while the embedded editor's resolve/take-side write is in flight. */
-  @state() private editorResolving = false;
+  /**
+   * Number of the embedded editor's resolve/take-side writes in flight. A
+   * COUNT, not a boolean: switching files mid-write deliberately lets a new
+   * resolve start while the old one finishes, and each write dispatches its
+   * own started/finished pair — folding them into a boolean would unlock
+   * Abort/Complete/External on the FIRST finish while a write is still
+   * running.
+   */
+  @state() private editorResolveDepth = 0;
   @state() private showAbortConfirm = false;
   @state() private hasMergeTool = false;
   @state() private launchingExternalTool: string | null = null;
@@ -423,7 +430,7 @@ export class LvConflictResolutionDialog extends LitElement {
       this.aborting = false;
       this.continuing = false;
       this.editorToolActive = false;
-      this.editorResolving = false;
+      this.editorResolveDepth = 0;
       this.showAbortConfirm = false;
       this.mergeCommitted = false;
       // Seed from the finish context: a first-run release/hotfix whose master
@@ -457,7 +464,7 @@ export class LvConflictResolutionDialog extends LitElement {
     this.aborting = false;
     this.continuing = false;
     this.editorToolActive = false;
-    this.editorResolving = false;
+    this.editorResolveDepth = 0;
     this.showAbortConfirm = false;
     this.mergeCommitted = false;
     this.priorFinishCommitLanded = false;
@@ -551,17 +558,35 @@ export class LvConflictResolutionDialog extends LitElement {
       this.aborting ||
       this.continuing ||
       this.editorToolActive ||
-      this.editorResolving
+      this.editorResolveDepth > 0
     ) {
       return;
     }
-    // Launching on the SELECTED file replaces the editor's unsaved picks with
-    // the tool's output on reload — same confirm as a file switch.
-    if (this.selectedConflict?.path === conflictPath && !(await this.confirmLeaveInProgress())) {
-      return;
+    // Claim the launch BEFORE any await: the confirm below yields to the
+    // event loop, and a second click landing in that window would pass the
+    // entry guard again — two tool sessions editing the same file.
+    this.launchingExternalTool = conflictPath;
+    // Launching on the SELECTED file replaces the editor's unsaved picks
+    // with the tool's output on reload — confirm with tool wording (the
+    // file-switch copy would wrongly suggest Mark Resolved keeps the picks
+    // safe from the tool's result).
+    if (this.selectedConflict?.path === conflictPath) {
+      const editor = this.shadowRoot?.querySelector('lv-merge-editor') as LvMergeEditor | null;
+      if (editor?.hasUnsavedResolutions()) {
+        let proceed = false;
+        try {
+          proceed = await showConfirm(
+            'Discard in-progress resolution?',
+            'The external tool works on the file as saved on disk — your unsaved picks here will be replaced by its result.',
+            'warning',
+          );
+        } finally {
+          if (!proceed) this.launchingExternalTool = null;
+        }
+        if (!proceed) return;
+      }
     }
 
-    this.launchingExternalTool = conflictPath;
     try {
       const result = await gitService.launchMergeTool(this.repositoryPath, conflictPath);
       if (result.success && result.data?.success) {
@@ -676,7 +701,7 @@ export class LvConflictResolutionDialog extends LitElement {
       this.continuing ||
       this.launchingExternalTool !== null ||
       this.editorToolActive ||
-      this.editorResolving
+      this.editorResolveDepth > 0
     ) {
       return;
     }
@@ -723,7 +748,7 @@ export class LvConflictResolutionDialog extends LitElement {
       this.continuing ||
       this.launchingExternalTool !== null ||
       this.editorToolActive ||
-      this.editorResolving
+      this.editorResolveDepth > 0
     ) {
       return;
     }
@@ -865,7 +890,7 @@ export class LvConflictResolutionDialog extends LitElement {
       this.aborting ||
       this.launchingExternalTool !== null ||
       this.editorToolActive ||
-      this.editorResolving
+      this.editorResolveDepth > 0
     ) {
       return;
     }
@@ -1211,7 +1236,7 @@ export class LvConflictResolutionDialog extends LitElement {
                           this.aborting ||
                           this.continuing ||
                           this.editorToolActive ||
-                          this.editorResolving}
+                          this.editorResolveDepth > 0}
                           title="Open in external merge tool"
                         >
                           ${this.launchingExternalTool === conflict.path ? '...' : 'External'}
@@ -1235,8 +1260,12 @@ export class LvConflictResolutionDialog extends LitElement {
                     @conflict-resolved=${this.handleConflictResolved}
                     @external-tool-started=${() => { this.editorToolActive = true; }}
                     @external-tool-finished=${() => { this.editorToolActive = false; }}
-                    @resolve-started=${() => { this.editorResolving = true; }}
-                    @resolve-finished=${() => { this.editorResolving = false; }}
+                    @resolve-started=${() => {
+                      this.editorResolveDepth++;
+                    }}
+                    @resolve-finished=${() => {
+                      this.editorResolveDepth = Math.max(0, this.editorResolveDepth - 1);
+                    }}
                   ></lv-merge-editor>
                 `
               : html`
@@ -1276,7 +1305,7 @@ export class LvConflictResolutionDialog extends LitElement {
                 this.aborting ||
                 this.launchingExternalTool !== null ||
                 this.editorToolActive ||
-                this.editorResolving}
+                this.editorResolveDepth > 0}
             >
               Abort ${this.getOperationTitle()}
             </button>
@@ -1287,7 +1316,7 @@ export class LvConflictResolutionDialog extends LitElement {
                 this.aborting ||
                 this.launchingExternalTool !== null ||
                 this.editorToolActive ||
-                this.editorResolving ||
+                this.editorResolveDepth > 0 ||
                 this.loadFailed ||
                 this.resolvedCount < this.totalCount ||
                 (this.operationType === 'stash' && this.conflicts.length === 0)}

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -339,6 +339,13 @@ export class LvConflictResolutionDialog extends LitElement {
   @property({ type: String }) operationType: 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash' = 'merge';
   /** The file the user clicked to get here — preselected over the first conflict. */
   @property({ attribute: false }) initialFilePath: string | null = null;
+  /**
+   * False when 'stash' was merely INFERRED from a clean repository state
+   * (external `git stash apply`/`checkout -m`/`apply -3` — indistinguishable).
+   * Messaging must then not promise the changes are safe in a stash entry
+   * that may not exist.
+   */
+  @property({ type: Boolean }) stashSourceCertain = true;
   /** For 'stash' completion: which stash entry to drop once conflicts are resolved. */
   @property({ type: Number }) stashIndex = 0;
   /**
@@ -691,8 +698,10 @@ export class LvConflictResolutionDialog extends LitElement {
           if (result.success) {
             showToast(
               restoredCount === 0
-                ? 'Nothing needed restoring — your changes remain in the stash'
-                : 'Conflicted files restored — your changes remain in the stash',
+                ? 'Nothing needed restoring'
+                : this.stashSourceCertain
+                  ? 'Conflicted files restored — your changes remain in the stash'
+                  : 'Conflicted files restored to their committed (HEAD) state',
               'info',
             );
           }
@@ -737,8 +746,10 @@ export class LvConflictResolutionDialog extends LitElement {
    */
   private handleStashNotApplied(): void {
     showToast(
-      'The stash was not applied — your changes are still in the stash',
-      'warning',
+      this.stashSourceCertain
+        ? 'The stash was not applied — your changes are still in the stash'
+        : 'No conflicted files remain — nothing to resolve',
+      this.stashSourceCertain ? 'warning' : 'info',
     );
     this.dispatchEvent(
       new CustomEvent('operation-aborted', {
@@ -1157,7 +1168,9 @@ export class LvConflictResolutionDialog extends LitElement {
                   <div class="confirm-title">Abort ${this.getOperationTitle()}?</div>
                   <div class="confirm-message">
                     ${this.operationType === 'stash'
-                      ? 'The conflicted files will be reverted to their committed (HEAD) state, discarding the applied stash changes in those files. Any unrelated uncommitted changes are kept, and the stash entry itself remains in the stash list.'
+                      ? this.stashSourceCertain
+                        ? 'The conflicted files will be reverted to their committed (HEAD) state, discarding the applied stash changes in those files. Any unrelated uncommitted changes are kept, and the stash entry itself remains in the stash list.'
+                        : 'The conflicted files will be reverted to their committed (HEAD) state, discarding those changes. If they did not come from a stash apply, they are not saved anywhere else — this cannot be undone.'
                       : 'All resolved changes will be lost. This cannot be undone.'}
                   </div>
                   <div class="confirm-actions">

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -391,6 +391,7 @@ export class LvConflictResolutionDialog extends LitElement {
    */
   private priorFinishCommitLanded = false;
   @state() private aborting = false;
+  @state() private continuing = false;
   @state() private showAbortConfirm = false;
   @state() private hasMergeTool = false;
   @state() private launchingExternalTool: string | null = null;
@@ -761,7 +762,19 @@ export class LvConflictResolutionDialog extends LitElement {
   }
 
   private async handleContinue(): Promise<void> {
-    if (!this.repositoryPath) return;
+    // Re-entry guard: a double-click during the awaited backend call must not
+    // run the flow twice — a duplicate dropStash would delete an UNRELATED
+    // stash entry after the indices shift.
+    if (!this.repositoryPath || this.continuing) return;
+    this.continuing = true;
+    try {
+      await this.runContinue();
+    } finally {
+      this.continuing = false;
+    }
+  }
+
+  private async runContinue(): Promise<void> {
 
     // A failed load leaves us with no conflict data even though the index IS
     // conflicted. Never proceed (or drop the stash) in that state — keep the
@@ -1148,7 +1161,8 @@ export class LvConflictResolutionDialog extends LitElement {
             <button
               class="btn btn-primary"
               @click=${this.handleContinue}
-              ?disabled=${this.loadFailed ||
+              ?disabled=${this.continuing ||
+                this.loadFailed ||
                 this.resolvedCount < this.totalCount ||
                 (this.operationType === 'stash' && this.conflicts.length === 0)}
             >

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -644,22 +644,40 @@ export class LvConflictResolutionDialog extends LitElement {
     );
   }
 
+  /**
+   * Navigating away mid-write lets the user come BACK and start a second
+   * write against the same file — two overlapping writes, last one wins.
+   * The file-list rows and keyboard shortcuts have no disabled affordance
+   * (unlike the Prev/Next buttons), so the refusal must not be silent.
+   */
+  private navBlockedByResolve(): boolean {
+    if (this.editorResolveDepth === 0) return false;
+    showToast('Wait for the current resolve to finish', 'info');
+    return true;
+  }
+
   private async handleFileSelect(index: number): Promise<void> {
     if (index === this.selectedIndex) return;
+    if (this.navBlockedByResolve()) return;
     if (!(await this.confirmLeaveInProgress())) return;
+    if (this.editorResolveDepth > 0) return;
     this.selectedIndex = index;
   }
 
   private async handlePrevious(): Promise<void> {
     if (this.selectedIndex > 0) {
+      if (this.navBlockedByResolve()) return;
       if (!(await this.confirmLeaveInProgress())) return;
+      if (this.editorResolveDepth > 0) return;
       this.selectedIndex--;
     }
   }
 
   private async handleNext(): Promise<void> {
     if (this.selectedIndex < this.conflicts.length - 1) {
+      if (this.navBlockedByResolve()) return;
       if (!(await this.confirmLeaveInProgress())) return;
+      if (this.editorResolveDepth > 0) return;
       this.selectedIndex++;
     }
   }
@@ -893,6 +911,30 @@ export class LvConflictResolutionDialog extends LitElement {
       this.editorResolveDepth > 0
     ) {
       return;
+    }
+    // The editor can hold visible rework that was never Mark-Resolved: a
+    // reopened block (Reset), fresh picks, or a mid-typing edit draft. All
+    // files still COUNT as resolved (their last Mark Resolved is on disk),
+    // so Complete would silently commit that older content — a mere file
+    // switch confirms in this state, and completing is far more final.
+    const editor = this.shadowRoot?.querySelector('lv-merge-editor') as LvMergeEditor | null;
+    if (editor?.hasUnsavedResolutions()) {
+      const proceed = await showConfirm(
+        'Complete without the latest changes?',
+        'This file has picks or edits that were not saved with Mark Resolved — completing uses the last saved content and discards them.',
+        'warning',
+      );
+      if (!proceed) return;
+      // Re-check the exclusion guards after the confirm's await.
+      if (
+        this.continuing ||
+        this.aborting ||
+        this.launchingExternalTool !== null ||
+        this.editorToolActive ||
+        this.editorResolveDepth > 0
+      ) {
+        return;
+      }
     }
     this.continuing = true;
     try {
@@ -1181,7 +1223,7 @@ export class LvConflictResolutionDialog extends LitElement {
               <button
                 class="nav-btn"
                 @click=${this.handlePrevious}
-                ?disabled=${this.selectedIndex === 0}
+                ?disabled=${this.selectedIndex === 0 || this.editorResolveDepth > 0}
                 title="Previous file (Alt+Up)"
               >
                 ← Prev
@@ -1189,7 +1231,8 @@ export class LvConflictResolutionDialog extends LitElement {
               <button
                 class="nav-btn"
                 @click=${this.handleNext}
-                ?disabled=${this.selectedIndex >= this.conflicts.length - 1}
+                ?disabled=${this.selectedIndex >= this.conflicts.length - 1 ||
+                this.editorResolveDepth > 0}
                 title="Next file (Alt+Down)"
               >
                 Next →

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -628,10 +628,14 @@ export class LvConflictResolutionDialog extends LitElement {
         // The embedded editor is bound to this file's ConflictFile object and
         // only reloads on identity change — refresh it so it shows the tool's
         // output instead of a stale parse that Mark Resolved would write back
-        // OVER the merge the user just crafted in the tool.
+        // OVER the merge the user just crafted in the tool. Adopt the FRESH
+        // entry when the file is still conflicted: the tool may have changed
+        // what get_conflicts reports (markerSize, conflictStyle, hunks), and
+        // re-parsing with the stale metadata would misread its output.
         const wasSelected = this.selectedConflict?.path === conflictPath;
+        const fresh = conflictsResult.data?.find((c) => c.path === conflictPath);
         this.conflicts = this.conflicts.map((c) =>
-          c.path === conflictPath ? { ...c } : c
+          c.path === conflictPath ? (fresh ?? { ...c }) : c
         );
         if (stillConflicted) {
           showToast('File still has conflicts', 'warning');
@@ -682,6 +686,23 @@ export class LvConflictResolutionDialog extends LitElement {
     return true;
   }
 
+  /** The editor's own external-tool session ended. Adopt the fresh
+   * ConflictFile the editor re-fetched: the tool may have changed what
+   * get_conflicts reports (markerSize, conflictStyle, hunks), and keeping
+   * the stale object would misparse the tool's output on the next load. */
+  private handleEditorToolFinished(e: Event): void {
+    this.editorToolActive = false;
+    const detail = (e as CustomEvent<{
+      filePath?: string;
+      freshConflicts?: ConflictFile[] | null;
+    }>).detail;
+    const filePath = detail?.filePath;
+    const fresh = detail?.freshConflicts?.find((c) => c.path === filePath);
+    if (filePath && fresh) {
+      this.conflicts = this.conflicts.map((c) => (c.path === filePath ? fresh : c));
+    }
+  }
+
   private async handleFileSelect(index: number): Promise<void> {
     if (index === this.selectedIndex) return;
     if (this.navBlockedByResolve()) return;
@@ -695,6 +716,11 @@ export class LvConflictResolutionDialog extends LitElement {
       if (this.navBlockedByResolve()) return;
       if (!(await this.confirmLeaveInProgress())) return;
       if (this.editorResolveDepth > 0) return;
+      // Re-check the bound after the await: Alt+ArrowUp auto-repeat stacks
+      // several of these behind one confirm, and each read the same stale
+      // index — decrementing twice would drive the selection to -1 and
+      // leave Prev/Next permanently inert.
+      if (this.selectedIndex <= 0) return;
       this.selectedIndex--;
     }
   }
@@ -704,6 +730,9 @@ export class LvConflictResolutionDialog extends LitElement {
       if (this.navBlockedByResolve()) return;
       if (!(await this.confirmLeaveInProgress())) return;
       if (this.editorResolveDepth > 0) return;
+      // Same post-await bound re-check as handlePrevious — stacked calls
+      // must not push the index past the last file.
+      if (this.selectedIndex >= this.conflicts.length - 1) return;
       this.selectedIndex++;
     }
   }
@@ -1255,6 +1284,15 @@ export class LvConflictResolutionDialog extends LitElement {
     }
   }
 
+  /** The pinned repo's name. The dialog stays bound to the repo the
+   * operation started on even when another tab is active — without naming
+   * it, a user who switched tabs mid-operation has no way to tell whose
+   * merge Complete/Abort will hit. */
+  private get repositoryName(): string {
+    const path = this.repositoryPath ?? '';
+    return path.split(/[\\/]/).filter(Boolean).pop() ?? '';
+  }
+
   render() {
     if (!this.open) return nothing;
 
@@ -1267,7 +1305,7 @@ export class LvConflictResolutionDialog extends LitElement {
               Resolve ${this.getOperationTitle()} Conflicts
             </div>
             <div class="header-subtitle">
-              ${this.resolvedCount} of ${this.totalCount} file${this.totalCount === 1 ? '' : 's'} resolved
+              ${this.resolvedCount} of ${this.totalCount} file${this.totalCount === 1 ? '' : 's'} resolved${this.repositoryName ? ` · ${this.repositoryName}` : ''}
             </div>
           </div>
           <div class="header-actions">
@@ -1354,7 +1392,7 @@ export class LvConflictResolutionDialog extends LitElement {
                     this.launchingExternalTool !== null}
                     @conflict-resolved=${this.handleConflictResolved}
                     @external-tool-started=${() => { this.editorToolActive = true; }}
-                    @external-tool-finished=${() => { this.editorToolActive = false; }}
+                    @external-tool-finished=${this.handleEditorToolFinished}
                     @resolve-started=${() => {
                       this.editorResolveDepth++;
                     }}

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -1275,7 +1275,8 @@ export class LvConflictResolutionDialog extends LitElement {
               ?disabled=${this.continuing ||
                 this.aborting ||
                 this.launchingExternalTool !== null ||
-                this.editorToolActive}
+                this.editorToolActive ||
+                this.editorResolving}
             >
               Abort ${this.getOperationTitle()}
             </button>
@@ -1286,6 +1287,7 @@ export class LvConflictResolutionDialog extends LitElement {
                 this.aborting ||
                 this.launchingExternalTool !== null ||
                 this.editorToolActive ||
+                this.editorResolving ||
                 this.loadFailed ||
                 this.resolvedCount < this.totalCount ||
                 (this.operationType === 'stash' && this.conflicts.length === 0)}

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -396,6 +396,8 @@ export class LvConflictResolutionDialog extends LitElement {
   @state() private continuing = false;
   /** True while the EMBEDDED merge editor has an external tool session open. */
   @state() private editorToolActive = false;
+  /** True while the embedded editor's resolve/take-side write is in flight. */
+  @state() private editorResolving = false;
   @state() private showAbortConfirm = false;
   @state() private hasMergeTool = false;
   @state() private launchingExternalTool: string | null = null;
@@ -421,6 +423,7 @@ export class LvConflictResolutionDialog extends LitElement {
       this.aborting = false;
       this.continuing = false;
       this.editorToolActive = false;
+      this.editorResolving = false;
       this.showAbortConfirm = false;
       this.mergeCommitted = false;
       // Seed from the finish context: a first-run release/hotfix whose master
@@ -454,6 +457,7 @@ export class LvConflictResolutionDialog extends LitElement {
     this.aborting = false;
     this.continuing = false;
     this.editorToolActive = false;
+    this.editorResolving = false;
     this.showAbortConfirm = false;
     this.mergeCommitted = false;
     this.priorFinishCommitLanded = false;
@@ -546,8 +550,14 @@ export class LvConflictResolutionDialog extends LitElement {
       this.launchingExternalTool !== null ||
       this.aborting ||
       this.continuing ||
-      this.editorToolActive
+      this.editorToolActive ||
+      this.editorResolving
     ) {
+      return;
+    }
+    // Launching on the SELECTED file replaces the editor's unsaved picks with
+    // the tool's output on reload — same confirm as a file switch.
+    if (this.selectedConflict?.path === conflictPath && !(await this.confirmLeaveInProgress())) {
       return;
     }
 
@@ -665,7 +675,8 @@ export class LvConflictResolutionDialog extends LitElement {
       this.aborting ||
       this.continuing ||
       this.launchingExternalTool !== null ||
-      this.editorToolActive
+      this.editorToolActive ||
+      this.editorResolving
     ) {
       return;
     }
@@ -711,7 +722,8 @@ export class LvConflictResolutionDialog extends LitElement {
       this.aborting ||
       this.continuing ||
       this.launchingExternalTool !== null ||
-      this.editorToolActive
+      this.editorToolActive ||
+      this.editorResolving
     ) {
       return;
     }
@@ -852,7 +864,8 @@ export class LvConflictResolutionDialog extends LitElement {
       this.continuing ||
       this.aborting ||
       this.launchingExternalTool !== null ||
-      this.editorToolActive
+      this.editorToolActive ||
+      this.editorResolving
     ) {
       return;
     }
@@ -1197,7 +1210,8 @@ export class LvConflictResolutionDialog extends LitElement {
                           ?disabled=${this.launchingExternalTool !== null ||
                           this.aborting ||
                           this.continuing ||
-                          this.editorToolActive}
+                          this.editorToolActive ||
+                          this.editorResolving}
                           title="Open in external merge tool"
                         >
                           ${this.launchingExternalTool === conflict.path ? '...' : 'External'}
@@ -1221,6 +1235,8 @@ export class LvConflictResolutionDialog extends LitElement {
                     @conflict-resolved=${this.handleConflictResolved}
                     @external-tool-started=${() => { this.editorToolActive = true; }}
                     @external-tool-finished=${() => { this.editorToolActive = false; }}
+                    @resolve-started=${() => { this.editorResolving = true; }}
+                    @resolve-finished=${() => { this.editorResolving = false; }}
                   ></lv-merge-editor>
                 `
               : html`

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -439,8 +439,23 @@ export class LvConflictResolutionDialog extends LitElement {
       // (not just the dialog-internal re-run).
       this.priorFinishCommitLanded = this.gitflowFinish?.priorFinishCommitLanded ?? false;
       this.loadConflicts();
+      // Capture the to-be-dropped stash entry's IDENTITY at open. Complete
+      // may run much later, and an external `git stash drop` in a terminal
+      // meanwhile shifts the indices — dropping blindly by the open-time
+      // index could then delete an UNRELATED stash.
+      this.stashOidToDrop = null;
+      if (this.operationType === 'stash' && this.dropStashOnComplete) {
+        void gitService.getStashes(this.repositoryPath).then((result) => {
+          if (this.open && result.success) {
+            this.stashOidToDrop = result.data?.[this.stashIndex]?.oid ?? null;
+          }
+        });
+      }
     }
   }
+
+  /** OID of the stash entry Complete must drop, captured at dialog open. */
+  private stashOidToDrop: string | null = null;
 
   private handleKeyDown = (e: KeyboardEvent): void => {
     if (!this.open) return;
@@ -468,6 +483,7 @@ export class LvConflictResolutionDialog extends LitElement {
     this.showAbortConfirm = false;
     this.mergeCommitted = false;
     this.priorFinishCommitLanded = false;
+    this.stashOidToDrop = null;
   }
 
   /** Re-run the conflict load after a failure, resetting resolution progress. */
@@ -1060,18 +1076,48 @@ export class LvConflictResolutionDialog extends LitElement {
             return;
           }
           break;
-        case 'stash':
+        case 'stash': {
           // All conflicts resolved. Drop the stash only for pop semantics
           // (dropAfter/pop/auto-stash) — a plain apply must keep the stash entry.
           if (this.dropStashOnComplete) {
-            result = await gitService.dropStash({ path: this.repositoryPath, index: this.stashIndex });
-            if (!result.success) {
-              console.error('Failed to drop stash:', result.error);
-              showToast(result.error?.message ?? 'Failed to drop stash', 'error');
-              return;
+            // Re-locate the entry by the identity captured at open — an
+            // external `git stash drop` while the dialog was up shifts the
+            // indices, and a blind index drop could delete an unrelated
+            // stash. Skipping the drop (with a warning) is always safer
+            // than dropping the wrong entry.
+            let dropIndex: number | null = this.stashIndex;
+            if (this.stashOidToDrop) {
+              const stashes = await gitService.getStashes(this.repositoryPath);
+              if (!stashes.success || !stashes.data) {
+                showToast(
+                  'Could not verify the stash entry — it was left in the stash list',
+                  'warning',
+                );
+                dropIndex = null;
+              } else {
+                const found = stashes.data.findIndex((s) => s.oid === this.stashOidToDrop);
+                if (found < 0) {
+                  showToast(
+                    'The stash list changed while resolving — the entry was left in place',
+                    'warning',
+                  );
+                  dropIndex = null;
+                } else {
+                  dropIndex = found;
+                }
+              }
+            }
+            if (dropIndex !== null) {
+              result = await gitService.dropStash({ path: this.repositoryPath, index: dropIndex });
+              if (!result.success) {
+                console.error('Failed to drop stash:', result.error);
+                showToast(result.error?.message ?? 'Failed to drop stash', 'error');
+                return;
+              }
             }
           }
           break;
+        }
       }
 
       this.dispatchEvent(

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -392,6 +392,8 @@ export class LvConflictResolutionDialog extends LitElement {
   private priorFinishCommitLanded = false;
   @state() private aborting = false;
   @state() private continuing = false;
+  /** True while the EMBEDDED merge editor has an external tool session open. */
+  @state() private editorToolActive = false;
   @state() private showAbortConfirm = false;
   @state() private hasMergeTool = false;
   @state() private launchingExternalTool: string | null = null;
@@ -598,7 +600,14 @@ export class LvConflictResolutionDialog extends LitElement {
     // while a stash-drop Complete is in flight would revert the files AND
     // lose the stash entry; aborting under an open external tool would let
     // its later save re-dirty the just-aborted working tree.
-    if (this.aborting || this.continuing || this.launchingExternalTool !== null) return;
+    if (
+      this.aborting ||
+      this.continuing ||
+      this.launchingExternalTool !== null ||
+      this.editorToolActive
+    ) {
+      return;
+    }
     // Once the merge commit has landed (only the follow-up git-flow finish
     // step failed), there is nothing to abort — exit directly WITHOUT the
     // "all resolved changes will be lost" confirm, which would be false here
@@ -640,7 +649,8 @@ export class LvConflictResolutionDialog extends LitElement {
       !this.repositoryPath ||
       this.aborting ||
       this.continuing ||
-      this.launchingExternalTool !== null
+      this.launchingExternalTool !== null ||
+      this.editorToolActive
     ) {
       return;
     }
@@ -780,7 +790,8 @@ export class LvConflictResolutionDialog extends LitElement {
       !this.repositoryPath ||
       this.continuing ||
       this.aborting ||
-      this.launchingExternalTool !== null
+      this.launchingExternalTool !== null ||
+      this.editorToolActive
     ) {
       return;
     }
@@ -1140,7 +1151,10 @@ export class LvConflictResolutionDialog extends LitElement {
                     .repositoryPath=${this.repositoryPath}
                     .conflictFile=${this.selectedConflict}
                     .operationType=${this.operationType}
+                    .externalToolLocked=${this.continuing || this.aborting}
                     @conflict-resolved=${this.handleConflictResolved}
+                    @external-tool-started=${() => { this.editorToolActive = true; }}
+                    @external-tool-finished=${() => { this.editorToolActive = false; }}
                   ></lv-merge-editor>
                 `
               : html`
@@ -1176,7 +1190,10 @@ export class LvConflictResolutionDialog extends LitElement {
             <button
               class="btn btn-danger"
               @click=${this.handleAbort}
-              ?disabled=${this.continuing || this.aborting || this.launchingExternalTool !== null}
+              ?disabled=${this.continuing ||
+                this.aborting ||
+                this.launchingExternalTool !== null ||
+                this.editorToolActive}
             >
               Abort ${this.getOperationTitle()}
             </button>
@@ -1186,6 +1203,7 @@ export class LvConflictResolutionDialog extends LitElement {
               ?disabled=${this.continuing ||
                 this.aborting ||
                 this.launchingExternalTool !== null ||
+                this.editorToolActive ||
                 this.loadFailed ||
                 this.resolvedCount < this.totalCount ||
                 (this.operationType === 'stash' && this.conflicts.length === 0)}

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -1090,32 +1090,28 @@ export class LvConflictResolutionDialog extends LitElement {
           // All conflicts resolved. Drop the stash only for pop semantics
           // (dropAfter/pop/auto-stash) — a plain apply must keep the stash entry.
           if (this.dropStashOnComplete) {
-            // Re-locate the entry by the identity captured at open — an
-            // external `git stash drop` while the dialog was up shifts the
-            // indices, and a blind index drop could delete an unrelated
-            // stash. Skipping the drop (with a warning) is always safer
-            // than dropping the wrong entry.
-            let dropIndex: number | null = this.stashIndex;
-            if (this.stashOidToDrop) {
+            // Drop ONLY via the identity captured at OPEN — never by a
+            // blind index, not even as a fallback. The list can shift
+            // under the dialog (an external `git stash push` puts new WIP
+            // at index 0), so any index read after open — including a
+            // "fresh capture" at Complete time — can name the wrong entry.
+            // Skipping the drop (with a warning) is always safer than
+            // dropping the wrong one.
+            let dropIndex: number | null = null;
+            if (this.stashOidToDrop !== null) {
               const stashes = await gitService.getStashes(this.repositoryPath);
-              if (!stashes.success || !stashes.data) {
-                showToast(
-                  'Could not verify the stash entry — it was left in the stash list',
-                  'warning',
-                );
-                dropIndex = null;
-              } else {
+              if (stashes.success && stashes.data) {
                 const found = stashes.data.findIndex((s) => s.oid === this.stashOidToDrop);
-                if (found < 0) {
-                  showToast(
-                    'The stash list changed while resolving — the entry was left in place',
-                    'warning',
-                  );
-                  dropIndex = null;
-                } else {
+                if (found >= 0) {
                   dropIndex = found;
                 }
               }
+            }
+            if (dropIndex === null) {
+              showToast(
+                'Could not verify the stash entry — it was left in the stash list',
+                'warning',
+              );
             }
             if (dropIndex !== null) {
               result = await gitService.dropStash({ path: this.repositoryPath, index: dropIndex });

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -594,7 +594,9 @@ export class LvConflictResolutionDialog extends LitElement {
   }
 
   private handleAbort(): void {
-    if (this.aborting) return;
+    // Mutually exclusive with Complete: aborting while a stash-drop Complete
+    // is in flight would revert the files AND lose the stash entry.
+    if (this.aborting || this.continuing) return;
     // Once the merge commit has landed (only the follow-up git-flow finish
     // step failed), there is nothing to abort — exit directly WITHOUT the
     // "all resolved changes will be lost" confirm, which would be false here
@@ -632,7 +634,7 @@ export class LvConflictResolutionDialog extends LitElement {
   }
 
   private async handleAbortConfirm(): Promise<void> {
-    if (!this.repositoryPath || this.aborting) return;
+    if (!this.repositoryPath || this.aborting || this.continuing) return;
 
     // Safety net: if the merge was committed after the confirm opened, exit
     // without a no-op abort_merge. handleAbort normally routes here before the
@@ -764,8 +766,8 @@ export class LvConflictResolutionDialog extends LitElement {
   private async handleContinue(): Promise<void> {
     // Re-entry guard: a double-click during the awaited backend call must not
     // run the flow twice — a duplicate dropStash would delete an UNRELATED
-    // stash entry after the indices shift.
-    if (!this.repositoryPath || this.continuing) return;
+    // stash entry after the indices shift. Also mutually exclusive with Abort.
+    if (!this.repositoryPath || this.continuing || this.aborting) return;
     this.continuing = true;
     try {
       await this.runContinue();
@@ -1155,13 +1157,18 @@ export class LvConflictResolutionDialog extends LitElement {
               : 'No file selected'}
           </div>
           <div class="footer-actions">
-            <button class="btn btn-danger" @click=${this.handleAbort}>
+            <button
+              class="btn btn-danger"
+              @click=${this.handleAbort}
+              ?disabled=${this.continuing || this.aborting}
+            >
               Abort ${this.getOperationTitle()}
             </button>
             <button
               class="btn btn-primary"
               @click=${this.handleContinue}
               ?disabled=${this.continuing ||
+                this.aborting ||
                 this.loadFailed ||
                 this.resolvedCount < this.totalCount ||
                 (this.operationType === 'stash' && this.conflicts.length === 0)}

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -1152,9 +1152,18 @@ export class LvConflictResolutionDialog extends LitElement {
             if (dropIndex !== null) {
               result = await gitService.dropStash({ path: this.repositoryPath, index: dropIndex });
               if (!result.success) {
+                // The conflict resolution and the stash APPLY already
+                // succeeded — only removing the (now-redundant) stash entry
+                // failed. That entry lingering is recoverable, so this is
+                // NOT an operation failure: warn, but still complete like
+                // the unverifiable-identity branch above, or the pinned
+                // repo would never get refreshed and the dialog would
+                // dead-end on an already-applied stash.
                 console.error('Failed to drop stash:', result.error);
-                showToast(result.error?.message ?? 'Failed to drop stash', 'error');
-                return;
+                showToast(
+                  `${result.error?.message ?? 'Failed to drop stash'} — it was left in the stash list`,
+                  'warning',
+                );
               }
             }
           }

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -594,9 +594,11 @@ export class LvConflictResolutionDialog extends LitElement {
   }
 
   private handleAbort(): void {
-    // Mutually exclusive with Complete: aborting while a stash-drop Complete
-    // is in flight would revert the files AND lose the stash entry.
-    if (this.aborting || this.continuing) return;
+    // Mutually exclusive with Complete and the external merge tool: aborting
+    // while a stash-drop Complete is in flight would revert the files AND
+    // lose the stash entry; aborting under an open external tool would let
+    // its later save re-dirty the just-aborted working tree.
+    if (this.aborting || this.continuing || this.launchingExternalTool !== null) return;
     // Once the merge commit has landed (only the follow-up git-flow finish
     // step failed), there is nothing to abort — exit directly WITHOUT the
     // "all resolved changes will be lost" confirm, which would be false here
@@ -634,7 +636,14 @@ export class LvConflictResolutionDialog extends LitElement {
   }
 
   private async handleAbortConfirm(): Promise<void> {
-    if (!this.repositoryPath || this.aborting || this.continuing) return;
+    if (
+      !this.repositoryPath ||
+      this.aborting ||
+      this.continuing ||
+      this.launchingExternalTool !== null
+    ) {
+      return;
+    }
 
     // Safety net: if the merge was committed after the confirm opened, exit
     // without a no-op abort_merge. handleAbort normally routes here before the
@@ -767,7 +776,14 @@ export class LvConflictResolutionDialog extends LitElement {
     // Re-entry guard: a double-click during the awaited backend call must not
     // run the flow twice — a duplicate dropStash would delete an UNRELATED
     // stash entry after the indices shift. Also mutually exclusive with Abort.
-    if (!this.repositoryPath || this.continuing || this.aborting) return;
+    if (
+      !this.repositoryPath ||
+      this.continuing ||
+      this.aborting ||
+      this.launchingExternalTool !== null
+    ) {
+      return;
+    }
     this.continuing = true;
     try {
       await this.runContinue();
@@ -1106,7 +1122,7 @@ export class LvConflictResolutionDialog extends LitElement {
                           class="btn btn-sm"
                           style="margin-left: auto; padding: 2px 6px; font-size: 11px;"
                           @click=${(e: Event) => { e.stopPropagation(); this.handleOpenExternalTool(conflict.path); }}
-                          ?disabled=${this.launchingExternalTool === conflict.path}
+                          ?disabled=${this.launchingExternalTool !== null || this.aborting || this.continuing}
                           title="Open in external merge tool"
                         >
                           ${this.launchingExternalTool === conflict.path ? '...' : 'External'}
@@ -1160,7 +1176,7 @@ export class LvConflictResolutionDialog extends LitElement {
             <button
               class="btn btn-danger"
               @click=${this.handleAbort}
-              ?disabled=${this.continuing || this.aborting}
+              ?disabled=${this.continuing || this.aborting || this.launchingExternalTool !== null}
             >
               Abort ${this.getOperationTitle()}
             </button>
@@ -1169,6 +1185,7 @@ export class LvConflictResolutionDialog extends LitElement {
               @click=${this.handleContinue}
               ?disabled=${this.continuing ||
                 this.aborting ||
+                this.launchingExternalTool !== null ||
                 this.loadFailed ||
                 this.resolvedCount < this.totalCount ||
                 (this.operationType === 'stash' && this.conflicts.length === 0)}

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -708,6 +708,12 @@ export class LvConflictResolutionDialog extends LitElement {
     if (this.navBlockedByResolve()) return;
     if (!(await this.confirmLeaveInProgress())) return;
     if (this.editorResolveDepth > 0) return;
+    // Re-validate the index after the confirm await, like handlePrevious/
+    // handleNext: a runContinue reload (rebase --continue reporting fresh
+    // conflicts) can replace/shrink this.conflicts while the confirm is up,
+    // so a stale index would point past the new array and collapse the
+    // editor to "Select a file" with conflicts still unresolved.
+    if (index < 0 || index >= this.conflicts.length) return;
     this.selectedIndex = index;
   }
 
@@ -877,7 +883,21 @@ export class LvConflictResolutionDialog extends LitElement {
             this.aborting = false;
             return;
           }
-          const conflictPaths = refetch.data.map((c) => c.path);
+          // Restore the UNION of the still-conflicted paths AND the files
+          // that were originally conflicted when the dialog opened. A file
+          // the user already resolved in this session (Mark Resolved →
+          // staged, or take-side deletion) is no longer index-conflicted, so
+          // the refetch alone would EXCLUDE it — Abort would leave that
+          // resolution staged while claiming everything was reverted. The
+          // refetch remains the safety net for an empty/in-flight client
+          // list; the union re-adds the resolved files (their stash changes
+          // stay safe in the retained stash entry).
+          const conflictPaths = Array.from(
+            new Set([
+              ...refetch.data.map((c) => c.path),
+              ...this.conflicts.map((c) => c.path),
+            ]),
+          );
           if (conflictPaths.length === 0) {
             result = { success: true } as CommandResult<void>;
           } else {
@@ -919,6 +939,20 @@ export class LvConflictResolutionDialog extends LitElement {
           })
         );
         this.close();
+      } else if (this.abortFailedBecauseNoOperation(result.error?.message)) {
+        // The user concluded the operation outside the app (`git merge
+        // --abort` / `git commit` in a terminal), so there's nothing left
+        // to abort. Escape is suppressed and Complete may be disabled, so
+        // without this the full-screen dialog is inescapable. Treat it as
+        // concluded and close.
+        showToast(
+          `This ${this.getOperationTitle().toLowerCase()} was already concluded outside the app`,
+          'warning',
+        );
+        this.dispatchEvent(
+          new CustomEvent('operation-aborted', { bubbles: true, composed: true })
+        );
+        this.close();
       } else {
         console.error('Failed to abort:', result.error);
         showToast(result.error?.message ?? `Failed to abort ${this.getOperationTitle()}`, 'error');
@@ -929,6 +963,24 @@ export class LvConflictResolutionDialog extends LitElement {
       showToast(`Failed to abort ${this.getOperationTitle()}`, 'error');
       this.aborting = false; // Allow retry
     }
+  }
+
+  /** True when an abort failed because the operation no longer exists in the
+   * repo — the user concluded it outside the app. Detected from the
+   * backend/git2 "no ... to abort / not in progress" wording. */
+  private abortFailedBecauseNoOperation(message?: string): boolean {
+    const m = (message ?? '').toLowerCase();
+    return (
+      m.includes('no merge to abort') ||
+      m.includes('merge_head') ||
+      m.includes('no rebase') ||
+      m.includes('no cherry') ||
+      m.includes('cherry_pick_head') ||
+      m.includes('no revert') ||
+      m.includes('revert_head') ||
+      m.includes('not in progress') ||
+      m.includes('nothing to abort')
+    );
   }
 
   /**

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -860,23 +860,24 @@ export class LvConflictResolutionDialog extends LitElement {
           // them (clears the conflict index entries, resetting to HEAD) then discard
           // their working-tree changes (restores HEAD content). The stash entry is
           // never touched, so the stashed changes remain recoverable.
-          // When the conflict LOAD failed, the local list is empty but the index
-          // is genuinely conflicted — re-fetch so Abort restores the real paths
-          // instead of no-opping with a false success message.
+          // ALWAYS re-fetch the authoritative conflict list from the index
+          // rather than trusting the client-side `this.conflicts`. That list
+          // is empty both when the load FAILED and while it is still
+          // IN FLIGHT (per-file replay detection can take seconds) — in
+          // either case restoring from it would no-op and report a false
+          // "nothing needed restoring" success while the tree stays fully
+          // conflicted.
           let restoredCount = 0;
-          let conflictPaths = this.conflicts.map((c) => c.path);
-          if (this.loadFailed) {
-            const refetch = await gitService.getConflicts(this.repositoryPath);
-            if (!refetch.success || !refetch.data) {
-              showToast(
-                refetch.error?.message ?? 'Could not read conflicts — nothing was restored',
-                'error',
-              );
-              this.aborting = false;
-              return;
-            }
-            conflictPaths = refetch.data.map((c) => c.path);
+          const refetch = await gitService.getConflicts(this.repositoryPath);
+          if (!refetch.success || !refetch.data) {
+            showToast(
+              refetch.error?.message ?? 'Could not read conflicts — nothing was restored',
+              'error',
+            );
+            this.aborting = false;
+            return;
           }
+          const conflictPaths = refetch.data.map((c) => c.path);
           if (conflictPaths.length === 0) {
             result = { success: true } as CommandResult<void>;
           } else {

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -442,12 +442,19 @@ export class LvConflictResolutionDialog extends LitElement {
       // Capture the to-be-dropped stash entry's IDENTITY at open. Complete
       // may run much later, and an external `git stash drop` in a terminal
       // meanwhile shifts the indices — dropping blindly by the open-time
-      // index could then delete an UNRELATED stash.
+      // index could then delete an UNRELATED stash. The index AND a session
+      // epoch are captured with the request: the dialog can close and
+      // reopen for a different stash before this resolves, and a late
+      // first-session response must not pair its list with the SECOND
+      // session's index.
       this.stashOidToDrop = null;
+      this.stashCaptureEpoch++;
       if (this.operationType === 'stash' && this.dropStashOnComplete) {
+        const idx = this.stashIndex;
+        const epoch = this.stashCaptureEpoch;
         void gitService.getStashes(this.repositoryPath).then((result) => {
-          if (this.open && result.success) {
-            this.stashOidToDrop = result.data?.[this.stashIndex]?.oid ?? null;
+          if (this.open && epoch === this.stashCaptureEpoch && result.success) {
+            this.stashOidToDrop = result.data?.[idx]?.oid ?? null;
           }
         });
       }
@@ -456,6 +463,8 @@ export class LvConflictResolutionDialog extends LitElement {
 
   /** OID of the stash entry Complete must drop, captured at dialog open. */
   private stashOidToDrop: string | null = null;
+  /** Bumped per open/close so a stale identity capture can't cross sessions. */
+  private stashCaptureEpoch = 0;
 
   private handleKeyDown = (e: KeyboardEvent): void => {
     if (!this.open) return;
@@ -484,6 +493,7 @@ export class LvConflictResolutionDialog extends LitElement {
     this.mergeCommitted = false;
     this.priorFinishCommitLanded = false;
     this.stashOidToDrop = null;
+    this.stashCaptureEpoch++;
   }
 
   /** Re-run the conflict load after a failure, resetting resolution progress. */

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -559,12 +559,23 @@ export class LvConflictResolutionDialog extends LitElement {
         const stillConflicted =
           conflictsResult.success &&
           (conflictsResult.data ?? []).some((c) => c.path === conflictPath);
+        // The embedded editor is bound to this file's ConflictFile object and
+        // only reloads on identity change — refresh it so it shows the tool's
+        // output instead of a stale parse that Mark Resolved would write back
+        // OVER the merge the user just crafted in the tool.
+        const wasSelected = this.selectedConflict?.path === conflictPath;
+        this.conflicts = this.conflicts.map((c) =>
+          c.path === conflictPath ? { ...c } : c
+        );
         if (stillConflicted) {
           showToast('File still has conflicts', 'warning');
         } else {
           this.resolvedFiles = new Set([...this.resolvedFiles, conflictPath]);
           this.requestUpdate();
           showToast('Merge tool completed', 'success');
+          if (wasSelected) {
+            this.advanceToNextUnresolved();
+          }
         }
       } else {
         showToast(result.data?.message ?? result.error?.message ?? 'Merge tool failed', 'error');
@@ -592,13 +603,9 @@ export class LvConflictResolutionDialog extends LitElement {
     }
   }
 
-  private handleConflictResolved(e: CustomEvent): void {
-    const { file } = e.detail as { file: ConflictFile };
-    this.resolvedFiles = new Set([...this.resolvedFiles, file.path]);
-    this.requestUpdate();
-
-    // Move to the next unresolved file, wrapping around so files skipped
-    // earlier in the list are still reachable.
+  /** Move selection to the next unresolved file, wrapping around so files
+   * skipped earlier in the list are still reachable. */
+  private advanceToNextUnresolved(): void {
     const total = this.conflicts.length;
     for (let offset = 1; offset < total; offset++) {
       const i = (this.selectedIndex + offset) % total;
@@ -607,6 +614,20 @@ export class LvConflictResolutionDialog extends LitElement {
         return;
       }
     }
+  }
+
+  private handleConflictResolved(e: CustomEvent): void {
+    const { file } = e.detail as { file: ConflictFile };
+    // A resolve call can land AFTER the user has moved on to another file —
+    // only auto-advance when the resolved file is still the selected one, or
+    // the completion would yank them off the file they're actively working on
+    // (losing its in-memory picks on the way back).
+    const wasSelected = this.conflicts[this.selectedIndex]?.path === file.path;
+    this.resolvedFiles = new Set([...this.resolvedFiles, file.path]);
+    this.requestUpdate();
+    if (!wasSelected) return;
+
+    this.advanceToNextUnresolved();
   }
 
   private handleAbort(): void {

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -8,6 +8,8 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
+import { showConfirm } from '../../services/dialog.service.ts';
+import type { LvMergeEditor } from '../panels/lv-merge-editor.ts';
 import type { ConflictFile } from '../../types/git.types.ts';
 import type { CommandResult } from '../../types/api.types.ts';
 import '../panels/lv-merge-editor.ts';
@@ -556,8 +558,11 @@ export class LvConflictResolutionDialog extends LitElement {
         // The tool's exit code alone isn't authoritative — re-check the index to
         // confirm the file is no longer conflicted before marking it resolved.
         const conflictsResult = await gitService.getConflicts(this.repositoryPath);
+        // A FAILED re-check must count as still conflicted — treating it as
+        // resolved would enable Complete (and a stash drop) on a file that
+        // may still hold marker text.
         const stillConflicted =
-          conflictsResult.success &&
+          !conflictsResult.success ||
           (conflictsResult.data ?? []).some((c) => c.path === conflictPath);
         // The embedded editor is bound to this file's ConflictFile object and
         // only reloads on identity change — refresh it so it shows the tool's
@@ -587,18 +592,39 @@ export class LvConflictResolutionDialog extends LitElement {
     }
   }
 
-  private handleFileSelect(index: number): void {
+  /**
+   * The editor's picks live only in memory until Mark Resolved — navigating
+   * away re-parses the file from disk and silently discards them. Confirm
+   * before a user-driven switch when in-progress work would be lost.
+   * (Auto-advance after a resolution goes straight to selectedIndex — the
+   * resolved file's work IS on disk by then.)
+   */
+  private async confirmLeaveInProgress(): Promise<boolean> {
+    const editor = this.shadowRoot?.querySelector('lv-merge-editor') as LvMergeEditor | null;
+    if (!editor?.hasUnsavedResolutions()) return true;
+    return showConfirm(
+      'Discard in-progress resolution?',
+      'This file has conflict resolutions that are not saved yet — switching files discards them. Use Mark Resolved to keep them.',
+      'warning',
+    );
+  }
+
+  private async handleFileSelect(index: number): Promise<void> {
+    if (index === this.selectedIndex) return;
+    if (!(await this.confirmLeaveInProgress())) return;
     this.selectedIndex = index;
   }
 
-  private handlePrevious(): void {
+  private async handlePrevious(): Promise<void> {
     if (this.selectedIndex > 0) {
+      if (!(await this.confirmLeaveInProgress())) return;
       this.selectedIndex--;
     }
   }
 
-  private handleNext(): void {
+  private async handleNext(): Promise<void> {
     if (this.selectedIndex < this.conflicts.length - 1) {
+      if (!(await this.confirmLeaveInProgress())) return;
       this.selectedIndex++;
     }
   }

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -1168,7 +1168,10 @@ export class LvConflictResolutionDialog extends LitElement {
                           class="btn btn-sm"
                           style="margin-left: auto; padding: 2px 6px; font-size: 11px;"
                           @click=${(e: Event) => { e.stopPropagation(); this.handleOpenExternalTool(conflict.path); }}
-                          ?disabled=${this.launchingExternalTool !== null || this.aborting || this.continuing}
+                          ?disabled=${this.launchingExternalTool !== null ||
+                          this.aborting ||
+                          this.continuing ||
+                          this.editorToolActive}
                           title="Open in external merge tool"
                         >
                           ${this.launchingExternalTool === conflict.path ? '...' : 'External'}
@@ -1186,7 +1189,9 @@ export class LvConflictResolutionDialog extends LitElement {
                     .repositoryPath=${this.repositoryPath}
                     .conflictFile=${this.selectedConflict}
                     .operationType=${this.operationType}
-                    .externalToolLocked=${this.continuing || this.aborting}
+                    .externalToolLocked=${this.continuing ||
+                    this.aborting ||
+                    this.launchingExternalTool !== null}
                     @conflict-resolved=${this.handleConflictResolved}
                     @external-tool-started=${() => { this.editorToolActive = true; }}
                     @external-tool-finished=${() => { this.editorToolActive = false; }}

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -337,6 +337,8 @@ export class LvConflictResolutionDialog extends LitElement {
   @property({ type: Boolean, reflect: true }) open = false;
   @property({ type: String }) repositoryPath = '';
   @property({ type: String }) operationType: 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash' = 'merge';
+  /** The file the user clicked to get here — preselected over the first conflict. */
+  @property({ attribute: false }) initialFilePath: string | null = null;
   /** For 'stash' completion: which stash entry to drop once conflicts are resolved. */
   @property({ type: Number }) stashIndex = 0;
   /**
@@ -431,13 +433,6 @@ export class LvConflictResolutionDialog extends LitElement {
     }
   };
 
-  show(): void {
-    // updated() reacts to the open transition: it resets per-run state
-    // (including the committed-merge markers) and loads the conflicts.
-    // Doing any of that here would run it twice and race the loads.
-    this.open = true;
-  }
-
   private close(): void {
     this.open = false;
     this.conflicts = [];
@@ -464,6 +459,14 @@ export class LvConflictResolutionDialog extends LitElement {
       if (result.success && result.data) {
         this.conflicts = result.data;
         this.loadFailed = false;
+        // Open on the file the user clicked, when it's one of the conflicts.
+        // (Continue-with-new-conflicts paths reset the index to 0 afterwards.)
+        if (this.initialFilePath) {
+          const initialIndex = this.conflicts.findIndex((c) => c.path === this.initialFilePath);
+          if (initialIndex >= 0) {
+            this.selectedIndex = initialIndex;
+          }
+        }
       } else {
         console.error('Failed to load conflicts:', result.error);
         showToast('Failed to load conflicts', 'error');

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -967,32 +967,38 @@ export class LvConflictResolutionDialog extends LitElement {
     ) {
       return;
     }
-    // The editor can hold visible rework that was never Mark-Resolved: a
-    // reopened block (Reset), fresh picks, or a mid-typing edit draft. All
-    // files still COUNT as resolved (their last Mark Resolved is on disk),
-    // so Complete would silently commit that older content — a mere file
-    // switch confirms in this state, and completing is far more final.
-    const editor = this.shadowRoot?.querySelector('lv-merge-editor') as LvMergeEditor | null;
-    if (editor?.hasUnsavedResolutions()) {
-      const proceed = await showConfirm(
-        'Complete without the latest changes?',
-        'This file has picks or edits that were not saved with Mark Resolved — completing uses the last saved content and discards them.',
-        'warning',
-      );
-      if (!proceed) return;
-      // Re-check the exclusion guards after the confirm's await.
-      if (
-        this.continuing ||
-        this.aborting ||
-        this.launchingExternalTool !== null ||
-        this.editorToolActive ||
-        this.editorResolveDepth > 0
-      ) {
-        return;
-      }
-    }
+    // Claim BEFORE any await so a fast double-click is swallowed by the
+    // entry guard above rather than stacking a second confirm/continue —
+    // the same claim-before-confirm pattern as the external-tool launcher.
+    // The Complete AND Abort buttons' disabled bindings both reflect
+    // `continuing`, so claiming here also inerts Abort for the confirm
+    // window.
     this.continuing = true;
     try {
+      // The editor can hold visible rework that was never Mark-Resolved: a
+      // reopened block (Reset), fresh picks, or a mid-typing edit draft. All
+      // files still COUNT as resolved (their last Mark Resolved is on disk),
+      // so Complete would silently commit that older content — a mere file
+      // switch confirms in this state, and completing is far more final.
+      const editor = this.shadowRoot?.querySelector('lv-merge-editor') as LvMergeEditor | null;
+      if (editor?.hasUnsavedResolutions()) {
+        const proceed = await showConfirm(
+          'Complete without the latest changes?',
+          'This file has picks or edits that were not saved with Mark Resolved — completing uses the last saved content and discards them.',
+          'warning',
+        );
+        if (!proceed) return;
+        // Re-check the OTHER exclusion guards after the confirm's await (a
+        // tool session or abort may have started). `continuing` is ours.
+        if (
+          this.aborting ||
+          this.launchingExternalTool !== null ||
+          this.editorToolActive ||
+          this.editorResolveDepth > 0
+        ) {
+          return;
+        }
+      }
       await this.runContinue();
     } finally {
       this.continuing = false;

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -417,6 +417,8 @@ export class LvConflictResolutionDialog extends LitElement {
       this.resolvedFiles = new Set();
       this.selectedIndex = 0;
       this.aborting = false;
+      this.continuing = false;
+      this.editorToolActive = false;
       this.showAbortConfirm = false;
       this.mergeCommitted = false;
       // Seed from the finish context: a first-run release/hotfix whose master
@@ -448,6 +450,8 @@ export class LvConflictResolutionDialog extends LitElement {
     this.conflicts = [];
     this.resolvedFiles = new Set();
     this.aborting = false;
+    this.continuing = false;
+    this.editorToolActive = false;
     this.showAbortConfirm = false;
     this.mergeCommitted = false;
     this.priorFinishCommitLanded = false;
@@ -533,7 +537,17 @@ export class LvConflictResolutionDialog extends LitElement {
   }
 
   private async handleOpenExternalTool(conflictPath: string): Promise<void> {
-    if (!this.repositoryPath) return;
+    // Re-entrancy + mutual exclusion: one tool session at a time, and never
+    // under a running abort/complete.
+    if (
+      !this.repositoryPath ||
+      this.launchingExternalTool !== null ||
+      this.aborting ||
+      this.continuing ||
+      this.editorToolActive
+    ) {
+      return;
+    }
 
     this.launchingExternalTool = conflictPath;
     try {

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -4,13 +4,12 @@
  */
 
 import { LitElement, html, css, nothing } from 'lit';
-import { customElement, property, state, query } from 'lit/decorators.js';
+import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import type { ConflictFile } from '../../types/git.types.ts';
 import type { CommandResult } from '../../types/api.types.ts';
-import type { LvMergeEditor } from '../panels/lv-merge-editor.ts';
 import '../panels/lv-merge-editor.ts';
 
 /**
@@ -173,6 +172,15 @@ export class LvConflictResolutionDialog extends LitElement {
         overflow: hidden;
         text-overflow: ellipsis;
         white-space: nowrap;
+      }
+
+      /* Directory hint so same-named files in different folders are distinguishable */
+      .file-dir {
+        display: block;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
 
       .editor-container {
@@ -379,8 +387,6 @@ export class LvConflictResolutionDialog extends LitElement {
   @state() private launchingExternalTool: string | null = null;
   @state() private detectedMergeTool: string | null = null;
 
-  @query('lv-merge-editor') private mergeEditor?: LvMergeEditor;
-
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
     document.addEventListener('keydown', this.handleKeyDown);
@@ -425,11 +431,11 @@ export class LvConflictResolutionDialog extends LitElement {
     }
   };
 
-  async show(): Promise<void> {
+  show(): void {
+    // updated() reacts to the open transition: it resets per-run state
+    // (including the committed-merge markers) and loads the conflicts.
+    // Doing any of that here would run it twice and race the loads.
     this.open = true;
-    this.resolvedFiles = new Set();
-    this.selectedIndex = 0;
-    await this.loadConflicts();
   }
 
   private close(): void {
@@ -564,12 +570,15 @@ export class LvConflictResolutionDialog extends LitElement {
     this.resolvedFiles = new Set([...this.resolvedFiles, file.path]);
     this.requestUpdate();
 
-    // Move to next unresolved file
-    const nextUnresolved = this.conflicts.findIndex(
-      (c, i) => i > this.selectedIndex && !this.resolvedFiles.has(c.path)
-    );
-    if (nextUnresolved !== -1) {
-      this.selectedIndex = nextUnresolved;
+    // Move to the next unresolved file, wrapping around so files skipped
+    // earlier in the list are still reachable.
+    const total = this.conflicts.length;
+    for (let offset = 1; offset < total; offset++) {
+      const i = (this.selectedIndex + offset) % total;
+      if (!this.resolvedFiles.has(this.conflicts[i].path)) {
+        this.selectedIndex = i;
+        return;
+      }
     }
   }
 
@@ -651,6 +660,7 @@ export class LvConflictResolutionDialog extends LitElement {
           // When the conflict LOAD failed, the local list is empty but the index
           // is genuinely conflicted — re-fetch so Abort restores the real paths
           // instead of no-opping with a false success message.
+          let restoredCount = 0;
           let conflictPaths = this.conflicts.map((c) => c.path);
           if (this.loadFailed) {
             const refetch = await gitService.getConflicts(this.repositoryPath);
@@ -673,18 +683,21 @@ export class LvConflictResolutionDialog extends LitElement {
             result = unstageResult.success
               ? await gitService.discardChanges(this.repositoryPath, conflictPaths)
               : unstageResult;
+            if (result.success) restoredCount = conflictPaths.length;
+          }
+          if (result.success) {
+            showToast(
+              restoredCount === 0
+                ? 'Nothing needed restoring — your changes remain in the stash'
+                : 'Conflicted files restored — your changes remain in the stash',
+              'info',
+            );
           }
           break;
         }
       }
 
       if (result.success) {
-        if (this.operationType === 'stash') {
-          showToast(
-            'Conflicted files restored — your changes remain in the stash',
-            'info',
-          );
-        }
         if (this.operationType === 'merge' && this.priorFinishCommitLanded) {
           // Only the in-progress develop merge was rolled back — the master
           // merge and version tag from this finish are already committed.
@@ -1005,7 +1018,7 @@ export class LvConflictResolutionDialog extends LitElement {
               Resolve ${this.getOperationTitle()} Conflicts
             </div>
             <div class="header-subtitle">
-              ${this.resolvedCount} of ${this.totalCount} conflicts resolved
+              ${this.resolvedCount} of ${this.totalCount} file${this.totalCount === 1 ? '' : 's'} resolved
             </div>
           </div>
           <div class="header-actions">
@@ -1055,6 +1068,9 @@ export class LvConflictResolutionDialog extends LitElement {
                       </span>
                       <span class="file-name" title=${conflict.path}>
                         ${conflict.path.split('/').pop()}
+                        ${conflict.path.includes('/')
+                          ? html`<span class="file-dir">${conflict.path.slice(0, conflict.path.lastIndexOf('/'))}</span>`
+                          : nothing}
                       </span>
                       ${this.hasMergeTool && !this.resolvedFiles.has(conflict.path) ? html`
                         <button
@@ -1078,6 +1094,7 @@ export class LvConflictResolutionDialog extends LitElement {
                   <lv-merge-editor
                     .repositoryPath=${this.repositoryPath}
                     .conflictFile=${this.selectedConflict}
+                    .operationType=${this.operationType}
                     @conflict-resolved=${this.handleConflictResolved}
                   ></lv-merge-editor>
                 `

--- a/src/components/dialogs/lv-create-branch-dialog.ts
+++ b/src/components/dialogs/lv-create-branch-dialog.ts
@@ -130,6 +130,15 @@ export class LvCreateBranchDialog extends LitElement {
    * `repositoryPath` property is bound live to the active tab, so a tab switch
    * while the modal is open would otherwise make Create target the wrong repo. */
   private pinnedRepoPath = '';
+  private isOpen = false;
+
+  /** The pinned repo while the dialog is open, else null — lets the host
+   * self-close the dialog when that repo's tab is closed (a successful create
+   * + checkout on a closed repo would otherwise be a silent, invisible
+   * mutation). */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.isOpen ? this.pinnedRepoPath : null;
+  }
 
   @state() private branchName = '';
   @state() private checkoutAfterCreate = true;
@@ -142,6 +151,7 @@ export class LvCreateBranchDialog extends LitElement {
   public open(startPoint?: string): void {
     this.reset();
     this.pinnedRepoPath = this.repositoryPath;
+    this.isOpen = true;
     if (startPoint) {
       this.startPoint = startPoint;
     }
@@ -151,6 +161,7 @@ export class LvCreateBranchDialog extends LitElement {
   }
 
   public close(): void {
+    this.isOpen = false;
     this.modal.open = false;
   }
 
@@ -225,6 +236,7 @@ export class LvCreateBranchDialog extends LitElement {
   }
 
   private handleModalClose(): void {
+    this.isOpen = false;
     if (!this.isCreating) {
       this.reset();
     }

--- a/src/components/dialogs/lv-create-branch-dialog.ts
+++ b/src/components/dialogs/lv-create-branch-dialog.ts
@@ -126,6 +126,11 @@ export class LvCreateBranchDialog extends LitElement {
   @property({ type: String }) repositoryPath = '';
   @property({ type: String }) startPoint = '';
 
+  /** The repo this dialog was opened for, captured at open(). The
+   * `repositoryPath` property is bound live to the active tab, so a tab switch
+   * while the modal is open would otherwise make Create target the wrong repo. */
+  private pinnedRepoPath = '';
+
   @state() private branchName = '';
   @state() private checkoutAfterCreate = true;
   @state() private isCreating = false;
@@ -136,6 +141,7 @@ export class LvCreateBranchDialog extends LitElement {
 
   public open(startPoint?: string): void {
     this.reset();
+    this.pinnedRepoPath = this.repositoryPath;
     if (startPoint) {
       this.startPoint = startPoint;
     }
@@ -184,7 +190,8 @@ export class LvCreateBranchDialog extends LitElement {
     this.error = '';
 
     try {
-      const result = await createBranch(this.repositoryPath, {
+      const repoPath = this.pinnedRepoPath;
+      const result = await createBranch(repoPath, {
         name,
         startPoint: this.startPoint || undefined,
         checkout: this.checkoutAfterCreate,
@@ -192,7 +199,11 @@ export class LvCreateBranchDialog extends LitElement {
 
       if (result.success) {
         this.dispatchEvent(new CustomEvent('branch-created', {
-          detail: { branch: result.data, checkedOut: this.checkoutAfterCreate },
+          detail: {
+            branch: result.data,
+            checkedOut: this.checkoutAfterCreate,
+            repositoryPath: repoPath,
+          },
           bubbles: true,
           composed: true,
         }));

--- a/src/components/dialogs/lv-create-tag-dialog.ts
+++ b/src/components/dialogs/lv-create-tag-dialog.ts
@@ -182,6 +182,11 @@ export class LvCreateTagDialog extends LitElement {
 
   @property({ type: String }) repositoryPath = '';
 
+  /** The repo this dialog was opened for, captured at open(). The
+   * `repositoryPath` property is bound live to the active tab, so a tab switch
+   * while the modal is open would otherwise make Create target the wrong repo. */
+  private pinnedRepoPath = '';
+
   @state() private name = '';
   @state() private targetRef = '';
   @state() private message = '';
@@ -194,6 +199,7 @@ export class LvCreateTagDialog extends LitElement {
 
   public open(targetRef?: string): void {
     this.reset();
+    this.pinnedRepoPath = this.repositoryPath;
     if (targetRef) {
       this.targetRef = targetRef;
     }
@@ -264,8 +270,9 @@ export class LvCreateTagDialog extends LitElement {
     this.error = '';
 
     try {
+      const repoPath = this.pinnedRepoPath;
       const result = await createTag({
-        path: this.repositoryPath,
+        path: repoPath,
         name: tagName,
         target: this.targetRef || undefined,
         message: this.isAnnotated ? this.message.trim() : undefined,
@@ -273,7 +280,7 @@ export class LvCreateTagDialog extends LitElement {
 
       if (result.success) {
         this.dispatchEvent(new CustomEvent('tag-created', {
-          detail: { tag: result.data },
+          detail: { tag: result.data, repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));

--- a/src/components/dialogs/lv-create-tag-dialog.ts
+++ b/src/components/dialogs/lv-create-tag-dialog.ts
@@ -186,6 +186,14 @@ export class LvCreateTagDialog extends LitElement {
    * `repositoryPath` property is bound live to the active tab, so a tab switch
    * while the modal is open would otherwise make Create target the wrong repo. */
   private pinnedRepoPath = '';
+  private isOpen = false;
+
+  /** The pinned repo while the dialog is open, else null — lets the host
+   * self-close the dialog when that repo's tab is closed (a successful create
+   * on a closed repo would otherwise be a silent, invisible mutation). */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.isOpen ? this.pinnedRepoPath : null;
+  }
 
   @state() private name = '';
   @state() private targetRef = '';
@@ -200,6 +208,7 @@ export class LvCreateTagDialog extends LitElement {
   public open(targetRef?: string): void {
     this.reset();
     this.pinnedRepoPath = this.repositoryPath;
+    this.isOpen = true;
     if (targetRef) {
       this.targetRef = targetRef;
     }
@@ -209,6 +218,7 @@ export class LvCreateTagDialog extends LitElement {
   }
 
   public close(): void {
+    this.isOpen = false;
     this.modal.open = false;
   }
 
@@ -303,6 +313,7 @@ export class LvCreateTagDialog extends LitElement {
   }
 
   private handleModalClose(): void {
+    this.isOpen = false;
     if (!this.isCreating) {
       this.reset();
     }

--- a/src/components/dialogs/lv-interactive-rebase-dialog.ts
+++ b/src/components/dialogs/lv-interactive-rebase-dialog.ts
@@ -836,6 +836,10 @@ export class LvInteractiveRebaseDialog extends LitElement {
 
       if (result.success) {
         this.dispatchEvent(new CustomEvent('rebase-complete', {
+          // Same pinning as the conflict sibling below: the refresh must
+          // target the repo the rebase ran on, not whichever tab is active
+          // by the time it completes.
+          detail: { repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));

--- a/src/components/dialogs/lv-interactive-rebase-dialog.ts
+++ b/src/components/dialogs/lv-interactive-rebase-dialog.ts
@@ -531,6 +531,12 @@ export class LvInteractiveRebaseDialog extends LitElement {
     this.modal.open = false;
   }
 
+  /** The repo this dialog is pinned to while open, or null when closed.
+   * The host uses it to close the dialog if that repo's tab is closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.modal?.open ? this.pinnedRepoPath : null;
+  }
+
   private reset(): void {
     this.onto = '';
     this.commits = [];

--- a/src/components/dialogs/lv-interactive-rebase-dialog.ts
+++ b/src/components/dialogs/lv-interactive-rebase-dialog.ts
@@ -482,6 +482,13 @@ export class LvInteractiveRebaseDialog extends LitElement {
   @state() private draggedIndex: number | null = null;
   @state() private dropTargetIndex: number | null = null;
   @state() private showPreview = true;
+  /** Repo captured at open. This dialog is long-lived (open → reorder →
+   * a separate Execute click); the reactive `repositoryPath` prop rebinds
+   * the moment the user Ctrl+Tabs to another repo, so loadCommits AND the
+   * history-rewriting execute must use THIS pinned value, never the live
+   * prop — executing an interactive rebase against the wrong repo would
+   * rewrite the wrong history. */
+  private pinnedRepoPath = '';
 
   @query('lv-modal') private modal!: LvModal;
 
@@ -507,6 +514,7 @@ export class LvInteractiveRebaseDialog extends LitElement {
   public async open(onto: string, options?: { rewordCommitOid?: string }): Promise<void> {
     this.reset();
     this.onto = onto;
+    this.pinnedRepoPath = this.repositoryPath;
     this.modal.open = true;
     await this.loadCommits();
 
@@ -536,13 +544,13 @@ export class LvInteractiveRebaseDialog extends LitElement {
   }
 
   private async loadCommits(): Promise<void> {
-    if (!this.repositoryPath || !this.onto) return;
+    if (!this.pinnedRepoPath || !this.onto) return;
 
     this.loading = true;
     this.error = '';
 
     try {
-      const result = await gitService.getRebaseCommits(this.repositoryPath, this.onto);
+      const result = await gitService.getRebaseCommits(this.pinnedRepoPath, this.onto);
 
       if (result.success) {
         this.commits = (result.data || []).map(c => ({
@@ -829,9 +837,10 @@ export class LvInteractiveRebaseDialog extends LitElement {
 
       const todo = todoLines.join('\n');
 
-      // Captured BEFORE the await: the conflict event must carry the repo
-      // the rebase actually ran on, even if the prop is rebound mid-flight.
-      const repoPath = this.repositoryPath;
+      // The repo pinned at open — NOT the live prop, which rebinds on a
+      // tab switch while this dialog sits open. Executing against the
+      // wrong repo would rewrite the wrong history.
+      const repoPath = this.pinnedRepoPath;
       const result = await gitService.executeInteractiveRebase(repoPath, this.onto, todo);
 
       if (result.success) {

--- a/src/components/dialogs/lv-interactive-rebase-dialog.ts
+++ b/src/components/dialogs/lv-interactive-rebase-dialog.ts
@@ -829,11 +829,10 @@ export class LvInteractiveRebaseDialog extends LitElement {
 
       const todo = todoLines.join('\n');
 
-      const result = await gitService.executeInteractiveRebase(
-        this.repositoryPath,
-        this.onto,
-        todo
-      );
+      // Captured BEFORE the await: the conflict event must carry the repo
+      // the rebase actually ran on, even if the prop is rebound mid-flight.
+      const repoPath = this.repositoryPath;
+      const result = await gitService.executeInteractiveRebase(repoPath, this.onto, todo);
 
       if (result.success) {
         this.dispatchEvent(new CustomEvent('rebase-complete', {
@@ -847,7 +846,7 @@ export class LvInteractiveRebaseDialog extends LitElement {
           this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
             bubbles: true,
             composed: true,
-            detail: { operationType: 'rebase' },
+            detail: { operationType: 'rebase', repositoryPath: repoPath },
           }));
           showToast('Rebase paused — resolve conflicts to continue', 'warning');
         } else {

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -463,9 +463,9 @@ describe('lv-diff-view', () => {
     });
   });
 
-  // ── Conflict markers ──────────────────────────────────────────────────
-  describe('conflict markers', () => {
-    it('shows conflict banner for conflicted files', async () => {
+  // ── Conflicted files ──────────────────────────────────────────────────
+  describe('conflicted files', () => {
+    it('shows the merge-editor redirect instead of a diff', async () => {
       const diff = makeDiffFile({ status: 'conflicted' });
       setupDefaultMocks({ diff, fileContent: CONFLICT_CONTENT });
 
@@ -473,11 +473,15 @@ describe('lv-diff-view', () => {
         file: makeStatusEntry({ isConflicted: true, status: 'conflicted' }),
       });
 
-      const conflictBanner = el.shadowRoot!.querySelector('.conflict-banner');
-      expect(conflictBanner).to.not.be.null;
+      const redirect = el.shadowRoot!.querySelector('.conflict-redirect');
+      expect(redirect).to.not.be.null;
+      expect(redirect!.textContent).to.include('merge conflicts');
+      // No diff body and no edit affordance for conflicted files.
+      expect(el.shadowRoot!.querySelector('.diff-content')).to.be.null;
+      expect(el.shadowRoot!.querySelector('.edit-btn')).to.be.null;
     });
 
-    it('shows correct conflict count in banner', async () => {
+    it('never renders raw conflict markers', async () => {
       const diff = makeDiffFile({ status: 'conflicted' });
       setupDefaultMocks({ diff, fileContent: CONFLICT_CONTENT });
 
@@ -485,93 +489,49 @@ describe('lv-diff-view', () => {
         file: makeStatusEntry({ isConflicted: true, status: 'conflicted' }),
       });
 
-      const conflictInfo = el.shadowRoot!.querySelector('.conflict-info');
-      expect(conflictInfo).to.not.be.null;
-      expect(conflictInfo!.textContent).to.include('1 conflict');
+      const text = el.shadowRoot!.textContent ?? '';
+      for (const marker of ['<<<<<<<', '=======', '>>>>>>>']) {
+        expect(text, `UI must never contain "${marker}"`).to.not.include(marker);
+      }
     });
 
-    it('does not show conflict banner for non-conflicted files', async () => {
+    it('does not load the marker-laden diff at all', async () => {
+      const diff = makeDiffFile({ status: 'conflicted' });
+      setupDefaultMocks({ diff, fileContent: CONFLICT_CONTENT });
+
+      clearHistory();
+      await renderDiffView({
+        file: makeStatusEntry({ isConflicted: true, status: 'conflicted' }),
+      });
+
+      expect(findCommands('get_file_diff').length).to.equal(0);
+    });
+
+    it('dispatches open-conflict-dialog when Open Merge Editor is clicked', async () => {
+      const diff = makeDiffFile({ status: 'conflicted' });
+      setupDefaultMocks({ diff, fileContent: CONFLICT_CONTENT });
+
+      const el = await renderDiffView({
+        file: makeStatusEntry({ isConflicted: true, status: 'conflicted' }),
+      });
+
+      let dispatched = false;
+      el.addEventListener('open-conflict-dialog', () => {
+        dispatched = true;
+      });
+
+      const btn = el.shadowRoot!.querySelector('.conflict-redirect-btn') as HTMLElement;
+      expect(btn).to.not.be.null;
+      btn.click();
+
+      expect(dispatched).to.be.true;
+    });
+
+    it('does not show the redirect for non-conflicted files', async () => {
       setupDefaultMocks();
       const el = await renderDiffView();
 
-      const conflictBanner = el.shadowRoot!.querySelector('.conflict-banner');
-      expect(conflictBanner).to.be.null;
-    });
-  });
-
-  // ── Conflict resolution ──────────────────────────────────────────────
-  describe('conflict resolution', () => {
-    it('shows Accept All Ours and Accept All Theirs buttons in conflict banner', async () => {
-      const diff = makeDiffFile({ status: 'conflicted' });
-      setupDefaultMocks({ diff, fileContent: CONFLICT_CONTENT });
-
-      const el = await renderDiffView({
-        file: makeStatusEntry({ isConflicted: true, status: 'conflicted' }),
-      });
-
-      const conflictActions = el.shadowRoot!.querySelector('.conflict-actions');
-      expect(conflictActions).to.not.be.null;
-
-      const buttons = conflictActions!.querySelectorAll('.conflict-btn');
-      expect(buttons.length).to.equal(2);
-
-      const btnTexts = Array.from(buttons).map((b) => b.textContent?.trim());
-      expect(btnTexts).to.include('Accept All Ours');
-      expect(btnTexts).to.include('Accept All Theirs');
-    });
-
-    it('calls write_file_content when Accept All Ours is clicked', async () => {
-      const diff = makeDiffFile({ status: 'conflicted' });
-      setupDefaultMocks({ diff, fileContent: CONFLICT_CONTENT });
-
-      const el = await renderDiffView({
-        file: makeStatusEntry({ isConflicted: true, status: 'conflicted' }),
-      });
-
-      clearHistory();
-
-      // Click Accept All Ours
-      const buttons = el.shadowRoot!.querySelectorAll('.conflict-btn');
-      const oursBtn = Array.from(buttons).find(
-        (btn) => btn.textContent?.trim() === 'Accept All Ours'
-      ) as HTMLElement;
-      expect(oursBtn).to.not.be.undefined;
-      oursBtn.click();
-
-      await new Promise((r) => setTimeout(r, 200));
-      await el.updateComplete;
-
-      // Should have called read_file_content then write_file_content
-      const readCalls = findCommands('read_file_content');
-      expect(readCalls.length).to.be.greaterThan(0);
-
-      const writeCalls = findCommands('write_file_content');
-      expect(writeCalls.length).to.be.greaterThan(0);
-    });
-
-    it('calls write_file_content when Accept All Theirs is clicked', async () => {
-      const diff = makeDiffFile({ status: 'conflicted' });
-      setupDefaultMocks({ diff, fileContent: CONFLICT_CONTENT });
-
-      const el = await renderDiffView({
-        file: makeStatusEntry({ isConflicted: true, status: 'conflicted' }),
-      });
-
-      clearHistory();
-
-      // Click Accept All Theirs
-      const buttons = el.shadowRoot!.querySelectorAll('.conflict-btn');
-      const theirsBtn = Array.from(buttons).find(
-        (btn) => btn.textContent?.trim() === 'Accept All Theirs'
-      ) as HTMLElement;
-      expect(theirsBtn).to.not.be.undefined;
-      theirsBtn.click();
-
-      await new Promise((r) => setTimeout(r, 200));
-      await el.updateComplete;
-
-      const writeCalls = findCommands('write_file_content');
-      expect(writeCalls.length).to.be.greaterThan(0);
+      expect(el.shadowRoot!.querySelector('.conflict-redirect')).to.be.null;
     });
   });
 

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -271,6 +271,57 @@ describe('lv-merge-editor', () => {
       expect(segments[0].theirsLines).to.deep.equal(['theirs']);
     });
 
+    it('diff3: a bare ||||||| line in OURS content cannot truncate the ours hunk', async () => {
+      // merge.conflictStyle=diff3: the ours hunk itself contains a bare
+      // 7-pipe line. Cutting ours at the FIRST base-marker-shaped line
+      // would silently drop everything after it (the truncated prefix
+      // still validates!) — base candidates must be tried longest-first.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'base-line';
+          if (blobArgs?.oid === 'ours-oid') return 'ours-A\n|||||||\nours-B';
+          if (blobArgs?.oid === 'theirs-oid') return 'theirs-line';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            '<<<<<<< HEAD',
+            'ours-A',
+            '|||||||',
+            'ours-B',
+            '||||||| c5ca07f',
+            'base-line',
+            '=======',
+            'theirs-line',
+            '>>>>>>> feature',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderEditor();
+      const internal = el as unknown as EditorInternal;
+      internal.conflictFile = { ...makeConflictFile('src/test.ts'), conflictStyle: 'diff3' };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && (internal.segments.length > 0 || internal.loadFailed)) break;
+      }
+      await el.updateComplete;
+
+      const conflicts = internal.segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines, 'the full ours hunk survives').to.deep.equal([
+        'ours-A',
+        '|||||||',
+        'ours-B',
+      ]);
+      expect(conflicts[0].theirsLines).to.deep.equal(['theirs-line']);
+    });
+
     it('keeps a ||||||| line as ours CONTENT in default merge-style conflicts', async () => {
       const el = await renderEditor();
       // The default style has no base sections (and libgit2 never writes
@@ -3079,11 +3130,12 @@ describe('lv-merge-editor', () => {
       ).to.be.false;
     });
 
-    it('a take-side DELETION reloads the on-screen file into the guarded state', async () => {
+    it('a take-side DELETION lands in the terminal deleted state, not an error', async () => {
       // Modify/delete conflict, LAST file (no auto-advance): after "Use
       // Theirs (delete file)" the stale parse must not stay on screen with
-      // Mark Resolved enabled — clicking it would fs::write the old
-      // content back, silently resurrecting the deletion the user staged.
+      // Mark Resolved enabled (one click would fs::write the old content
+      // back), and it must NOT reload into the read-failure error whose
+      // Retry/verbatim buttons would resurrect the staged deletion.
       setupDefaultMocks();
       let deleted = false;
       const baseMock = mockInvoke;
@@ -3097,21 +3149,68 @@ describe('lv-merge-editor', () => {
         }
         return baseMock(command, args);
       };
+      // Theirs DELETED the file in this conflict.
+      const el = await renderEditor();
+      const internal = el as unknown as EditorInternal;
+      internal.conflictFile = { ...makeConflictFile('src/test.ts'), theirs: null };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && (internal.segments.length > 0 || internal.loadFailed)) break;
+      }
+      await el.updateComplete;
+
+      await (
+        el as unknown as { handleTakeSide: (s: string) => Promise<void> }
+      ).handleTakeSide.call(el, 'theirs');
+      await el.updateComplete;
+
+      expect(internalOf(el).loadFailed, 'no false error state').to.be.false;
+      expect(shadowText(el)).to.include('deleted by the resolution');
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled, 'Mark Resolved cannot resurrect the file').to.be.true;
+      // No resurrect buttons anywhere.
+      const verbatimBtns = Array.from(el.shadowRoot!.querySelectorAll('button')).filter(
+        (b) => b.textContent?.includes('verbatim') || b.textContent?.trim() === 'Retry'
+      );
+      expect(verbatimBtns.length).to.equal(0);
+    });
+
+    it('a take-side that KEEPS the file reloads the fresh content', async () => {
+      setupDefaultMocks();
+      let taken = false;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'resolve_conflict_take_side') {
+          taken = true;
+          return { success: true };
+        }
+        if (command === 'read_file_content' && taken) {
+          return 'line1\nline2-theirs\nline3';
+        }
+        return baseMock(command, args);
+      };
       const el = await renderLoadedEditor('src/test.ts');
       await (
         el as unknown as { handleTakeSide: (s: string) => Promise<void> }
       ).handleTakeSide.call(el, 'theirs');
       for (let i = 0; i < 100; i++) {
         await new Promise((r) => setTimeout(r, 20));
-        if (!internalOf(el).loading) break;
+        if (!internalOf(el).loading && internalOf(el).segments.length > 0) break;
       }
       await el.updateComplete;
 
-      expect(internalOf(el).loadFailed, 'the stale parse is gone').to.be.true;
-      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
-        (b) => b.textContent?.trim() === 'Mark Resolved'
-      ) as HTMLButtonElement;
-      expect(markBtn.disabled, 'Mark Resolved cannot resurrect the file').to.be.true;
+      const internal = internalOf(el);
+      expect(internal.loadFailed).to.be.false;
+      // The stale conflicted parse is gone; the taken content shows.
+      expect(internal.segments.filter((s) => s.type === 'conflict').length).to.equal(0);
+      expect(internal.segments.flatMap((s) => s.lines)).to.deep.equal([
+        'line1',
+        'line2-theirs',
+        'line3',
+      ]);
     });
 
     it('reload without unsaved picks does not ask', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -816,6 +816,106 @@ describe('lv-merge-editor', () => {
       expect(resolvedText).to.deep.equal(['ctx', '>>>>>>> feature', 'tail']);
     });
 
+    it('a quoted start marker directly ABOVE the real conflict stays content', async () => {
+      // git emits the quoted `<<<<<<< A` (common context) directly above
+      // the real hunk. Opening the region there swallows the real start
+      // marker into the body — nothing validates and the shape-only
+      // fallback would leak `<<<<<<< HEAD` as ours content. The parser
+      // must reconsider the quoted line as content and rescan.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid')
+            return '<<<<<<< A\nx0\n=======\ny\n>>>>>>> B';
+          if (blobArgs?.oid === 'ours-oid')
+            return '<<<<<<< A\nx1\n=======\ny\n>>>>>>> B';
+          if (blobArgs?.oid === 'theirs-oid')
+            return '<<<<<<< A\nx2\n=======\ny\n>>>>>>> B';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            '<<<<<<< A',
+            '<<<<<<< HEAD',
+            'x1',
+            '=======',
+            'x2',
+            '>>>>>>> theirs',
+            '=======',
+            'y',
+            '>>>>>>> B',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('docs/example.md');
+      const segments = internalOf(el).segments;
+      const conflicts = segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['x1']);
+      expect(conflicts[0].theirsLines).to.deep.equal(['x2']);
+      const resolvedText = segments
+        .filter((s) => s.type === 'resolved')
+        .flatMap((s) => s.lines);
+      expect(resolvedText, 'quoted markers stay content; real markers are consumed').to.deep.equal(
+        ['<<<<<<< A', '=======', 'y', '>>>>>>> B']
+      );
+    });
+
+    it('a quoted start marker INSIDE theirs does not blind the close checks', async () => {
+      // The theirs hunk contains marker-fragment content (like this very
+      // test file). The trailing window after an early close candidate must
+      // look PAST quoted start-shaped lines, or the orphaned real end below
+      // them goes unseen and the file splinters into phantom blocks.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'X\ntail';
+          if (blobArgs?.oid === 'ours-oid') return 'O1\ntail';
+          if (blobArgs?.oid === 'theirs-oid')
+            return 'T1\n>>>>>>> QE\nT2\n<<<<<<< QS\nT3\ntail';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            '<<<<<<< HEAD',
+            'O1',
+            '=======',
+            'T1',
+            '>>>>>>> QE',
+            'T2',
+            '<<<<<<< QS',
+            'T3',
+            '>>>>>>> theirs',
+            'tail',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/parser.test.ts');
+      const segments = internalOf(el).segments;
+      const conflicts = segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['O1']);
+      expect(conflicts[0].theirsLines).to.deep.equal([
+        'T1',
+        '>>>>>>> QE',
+        'T2',
+        '<<<<<<< QS',
+        'T3',
+      ]);
+      const resolvedText = segments
+        .filter((s) => s.type === 'resolved')
+        .flatMap((s) => s.lines);
+      expect(resolvedText).to.deep.equal(['tail']);
+    });
+
     it('keeps an unterminated conflict as a conflict block', async () => {
       const el = await renderEditor();
       const segments = internalOf(el).parseSegments(
@@ -2942,6 +3042,41 @@ describe('lv-merge-editor', () => {
         el.hasUnsavedResolutions(),
         'the write supersedes the in-memory picks'
       ).to.be.false;
+    });
+
+    it('a take-side DELETION reloads the on-screen file into the guarded state', async () => {
+      // Modify/delete conflict, LAST file (no auto-advance): after "Use
+      // Theirs (delete file)" the stale parse must not stay on screen with
+      // Mark Resolved enabled — clicking it would fs::write the old
+      // content back, silently resurrecting the deletion the user staged.
+      setupDefaultMocks();
+      let deleted = false;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'resolve_conflict_take_side') {
+          deleted = true;
+          return { success: true };
+        }
+        if (command === 'read_file_content' && deleted) {
+          throw new Error('file deleted');
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor('src/test.ts');
+      await (
+        el as unknown as { handleTakeSide: (s: string) => Promise<void> }
+      ).handleTakeSide.call(el, 'theirs');
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internalOf(el).loading) break;
+      }
+      await el.updateComplete;
+
+      expect(internalOf(el).loadFailed, 'the stale parse is gone').to.be.true;
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled, 'Mark Resolved cannot resurrect the file').to.be.true;
     });
 
     it('reload without unsaved picks does not ask', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -345,6 +345,35 @@ describe('lv-merge-editor', () => {
       expect(segments[0].type).to.equal('resolved');
     });
 
+    it('a long marker example in docs cannot swallow a real conflict below it', async () => {
+      const el = await renderEditor();
+      // Docs text shows an 8-char marker sample; a REAL 7-char conflict
+      // follows, then a setext-style 8-equals underline. The sample line
+      // must stay content and the real conflict must parse — otherwise the
+      // real markers would render as pickable content and be written back.
+      const segments = internalOf(el).parseSegments(
+        [
+          'Conflict docs',
+          '<<<<<<<< (a raised-size marker looks like this)',
+          'some prose',
+          '<<<<<<< HEAD',
+          'real ours line',
+          '=======',
+          'real theirs line',
+          '>>>>>>> feature',
+          'Overview',
+          '========',
+          'tail content',
+        ].join('\n')
+      );
+      const conflicts = segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['real ours line']);
+      expect(conflicts[0].theirsLines).to.deep.equal(['real theirs line']);
+      // The docs sample line stayed ordinary content.
+      expect(segments[0].lines).to.include('<<<<<<<< (a raised-size marker looks like this)');
+    });
+
     it('parses raised conflict-marker-size markers (gitattribute)', async () => {
       const el = await renderEditor();
       const m = (ch: string) => ch.repeat(32);

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -105,6 +105,19 @@ function setupDefaultMocks(): void {
         return { resolvedContent: 'ai-resolved', explanation: 'merged by ai' };
       case 'resolve_conflict':
         return { success: true };
+      case 'get_conflicts':
+        // Binary/submodule loads re-check the index to detect an
+        // already-resolved re-selection. By default the loaded file IS
+        // still conflicted (first load), so echo back the standard paths;
+        // re-selection tests override this to [] to exercise the terminal
+        // state.
+        return [
+          { path: 'src/test.ts' },
+          { path: 'image.png' },
+          { path: 'link' },
+          { path: 'thing' },
+          { path: 'sub' },
+        ];
       default:
         return null;
     }
@@ -1247,6 +1260,35 @@ describe('lv-merge-editor', () => {
       expect(call, 'take-side resolves blob-verbatim').to.not.be.undefined;
       expect((call!.args as { side: string }).side).to.equal('ours');
       expect(resolvedFired).to.be.true;
+    });
+
+    it('a verbatim take from the read-failure state lands terminal, not forever-Retry', async () => {
+      // The verbatim buttons appear only in the load-failure state. On the
+      // last file, taking a side succeeds but a reload would re-fail the
+      // same undecodable blob — the editor must show a terminal notice, not
+      // re-render the error with a Retry that loops and buttons that error.
+      setupDefaultMocks();
+      workdirContent = () => Promise.reject(new Error('invalid utf-8'));
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'resolve_conflict_take_side') return { success: true };
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      expect(internalOf(el).loadFailed).to.be.true;
+
+      const takeOurs = Array.from(el.shadowRoot!.querySelectorAll('.output-error button')).find(
+        (b) => b.textContent?.includes('verbatim') && b.classList.contains('btn-ours'),
+      ) as HTMLButtonElement;
+      takeOurs.click();
+      await new Promise((r) => setTimeout(r, 40));
+      await el.updateComplete;
+
+      expect(shadowText(el)).to.include('Resolved — the chosen version was staged');
+      expect(
+        el.shadowRoot!.querySelector('.output-error'),
+        'no forever-Retry error state',
+      ).to.be.null;
     });
 
     it('verbatim take-side is offered PER SIDE — a failed ours blob hides only ours', async () => {
@@ -2943,6 +2985,33 @@ describe('lv-merge-editor', () => {
       expect(invokeHistory.some(h => h.command === 'resolve_conflict')).to.be.false;
       expect(resolvedFired).to.be.true;
     });
+
+    it('re-selecting an already-resolved binary file shows a terminal state, not a live chooser', async () => {
+      // After resolution the file is no longer in the index conflict list;
+      // re-rendering the chooser with live buttons would let a second click
+      // error "No conflict found".
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        // The file is NOT in the conflict list anymore (already resolved).
+        if (command === 'get_conflicts') return [];
+        if (command === 'get_blob_content') throw { code: 'IO_ERROR', message: 'binary' };
+        return baseMock(command, args);
+      };
+      const el = await renderEditor();
+      const internal = el as unknown as { conflictFile: ConflictFile; loading: boolean };
+      internal.conflictFile = { ...makeConflictFile('image.png'), isBinary: true };
+      await el.updateComplete;
+      for (let i = 0; i < 50; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading) break;
+      }
+      await el.updateComplete;
+
+      expect(shadowText(el)).to.include('Resolved — the chosen version was staged');
+      expect(el.shadowRoot!.querySelector('.btn-ours'), 'no live chooser buttons').to.be.null;
+      expect(el.shadowRoot!.querySelector('.btn-theirs')).to.be.null;
+    });
   });
 
   // ── Deleted-side (modify/delete) conflicts ────────────────────────────────
@@ -3842,7 +3911,8 @@ describe('lv-merge-editor', () => {
       await new Promise((r) => setTimeout(r, 50));
       await el.updateComplete;
 
-      expect(shadowText(el)).to.include('Resolved — the chosen version was staged');
+      // Submodule-specific terminal message (staged commit + submodule update).
+      expect(shadowText(el)).to.include('Resolved — the chosen commit is staged');
       expect(el.shadowRoot!.querySelector('.btn-ours'), 'no re-clickable chooser').to.be.null;
       expect(el.shadowRoot!.querySelector('.btn-theirs')).to.be.null;
     });

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -3655,6 +3655,73 @@ describe('lv-merge-editor', () => {
       expectNoMarkers(el);
     });
 
+    it('a nested START marker swept into a conflict pane never renders raw', async () => {
+      // ours blob = ['line2-ours'], theirs blob = ['line2-theirs']. A nested
+      // <<<<<<< inside the body makes the split fall back and pull the start
+      // marker into a pane. The safety net must present the whole file as
+      // one clean conflict, never a pane containing '<<<<<<<'.
+      setupDefaultMocks();
+      workdirContent = [
+        'line1',
+        '<<<<<<< HEAD',
+        'line2-ours',
+        '=======',
+        'line2-theirs',
+        '<<<<<<< HEAD',
+        'extraline',
+        '>>>>>>> feature',
+        'line3',
+      ].join('\n');
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
+
+      const conflicts = internal.segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      // No pane contains a raw start marker.
+      for (const c of conflicts) {
+        expect(c.oursLines.some((l) => l.startsWith('<<<<<<<'))).to.be.false;
+        expect(c.theirsLines.some((l) => l.startsWith('<<<<<<<'))).to.be.false;
+      }
+      expectNoMarkers(el);
+    });
+
+    it('markers added OUTSIDE a hunk-parsed range (after Reload) never render raw', async () => {
+      // The backend hunk positions are fetched once at open and not
+      // refreshed by Reload. An externally-added marker block outside the
+      // original hunk range would be swept into a resolved segment — the
+      // safety net now covers the position-based path too.
+      setupDefaultMocks();
+      workdirContent = [
+        'line1',
+        '<<<<<<< HEAD',
+        'line2-ours',
+        '=======',
+        'line2-theirs',
+        '>>>>>>> feature',
+        'line3',
+        // Externally pasted leftover markers, OUTSIDE the reported hunk.
+        '<<<<<<< OTHER',
+        'stray',
+        '>>>>>>> OTHER',
+      ].join('\n');
+      const el = await renderEditor();
+      const internal = internalOf(el);
+      // Authoritative hunk positions for the ORIGINAL conflict only (lines
+      // 1/3/5, 0-based), as fetched at open — they still validate.
+      internal.conflictFile = {
+        ...makeConflictFile('src/test.ts'),
+        conflictHunks: [{ start: 1, separator: 3, end: 5 }],
+      };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && (internal.segments.length > 0 || internal.loadFailed)) break;
+      }
+      await el.updateComplete;
+
+      expectNoMarkers(el);
+    });
+
     it('a deleted separator PLUS an edited body line still keeps the orphan marker out of the panes', async () => {
       // The hand edit removed the separator AND changed a line, so no
       // blob-validated split exists. The orphan end marker must still act

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -760,6 +760,44 @@ describe('lv-merge-editor', () => {
       // All ours lines are additions, none miscolored as changed.
       expect(el.shadowRoot!.querySelectorAll('#panel-ours .code-addition').length).to.equal(2);
       expect(el.shadowRoot!.querySelectorAll('#panel-ours .line-changed').length).to.equal(0);
+
+      // There is no ancestor version — offering "Use Base" would stage an
+      // empty file as a "common ancestor" that never existed.
+      const useBase = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions .btn')).find(
+        (b) => b.textContent?.trim() === 'Use Base'
+      );
+      expect(useBase).to.be.undefined;
+    });
+  });
+
+  // ── Side blob read failures ──────────────────────────────────────────
+  describe('side blob read failures', () => {
+    it('routes a failed read of an existing side to the Retry state', async () => {
+      setupDefaultMocks();
+      mockInvoke = (async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          // The ours blob EXISTS but its read fails — this must not
+          // masquerade as an empty file (Use Ours would truncate it).
+          if (blobArgs?.oid === 'ours-oid') return Promise.reject(new Error('read failed'));
+          if (blobArgs?.oid === 'base-oid') return 'line1\nline2\nline3';
+          if (blobArgs?.oid === 'theirs-oid') return 'line1\nline2-theirs\nline3';
+          return '';
+        }
+        if (command === 'read_file_content') return DEFAULT_WORKDIR_CONTENT;
+        if (command === 'get_merge_tool_config') return null;
+        if (command === 'is_ai_available') return false;
+        return null;
+      }) as MockInvoke;
+
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
+      expect(internal.loadFailed).to.be.true;
+      expect(shadowText(el)).to.include('Could not read the merged file');
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled).to.be.true;
     });
   });
 

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -124,8 +124,12 @@ async function renderLoadedEditor(path = 'src/test.ts'): Promise<LvMergeEditor> 
   const internal = el as unknown as EditorInternal;
   internal.conflictFile = makeConflictFile(path);
   await el.updateComplete;
-  // loadContents runs from updated(); wait for it to settle.
-  await new Promise((r) => setTimeout(r, 50));
+  // loadContents runs from updated(); poll until it settles (the first load
+  // also initializes the syntax highlighter, which can take a while).
+  for (let i = 0; i < 100; i++) {
+    await new Promise((r) => setTimeout(r, 20));
+    if (!internal.loading && (internal.segments.length > 0 || internal.loadFailed)) break;
+  }
   await el.updateComplete;
   return el;
 }

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -916,6 +916,41 @@ describe('lv-merge-editor', () => {
       expect(resolvedText).to.deep.equal(['tail']);
     });
 
+    it('an unterminated conflict stays a block even when its start text is quoted elsewhere', async () => {
+      // The ours blob quotes '<<<<<<< HEAD' in a docs section, and the
+      // file ALSO has a genuinely truncated conflict at EOF (crashed save).
+      // The quoted-start recovery must not fire without end-candidate
+      // evidence — reclassifying the real start as content would zero the
+      // conflict count and let Mark Resolved write the marker back.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'docs quote:\n<<<<<<< HEAD\ncontext';
+          if (blobArgs?.oid === 'ours-oid')
+            return 'docs quote:\n<<<<<<< HEAD\ncontext\nours-body';
+          if (blobArgs?.oid === 'theirs-oid') return 'docs quote:\n<<<<<<< HEAD\ncontext';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return ['context', '<<<<<<< HEAD', 'ours-body'].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/broken.txt');
+      const internal = internalOf(el);
+      expect(
+        internal.segments.filter((s) => s.type === 'conflict').length,
+        'the truncated conflict must stay a block, keeping Mark Resolved locked'
+      ).to.equal(1);
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled).to.be.true;
+    });
+
     it('keeps an unterminated conflict as a conflict block', async () => {
       const el = await renderEditor();
       const segments = internalOf(el).parseSegments(

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -1138,6 +1138,53 @@ describe('lv-merge-editor', () => {
       await el.updateComplete;
     });
 
+    it('a stale AI call from a previous file does not clear the new file\'s in-flight flag', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      const releases: Array<() => void> = [];
+      aiSuggestion = () =>
+        new Promise((resolve) => {
+          releases.push(() =>
+            resolve({ resolvedContent: 'ai-resolved', explanation: '' })
+          );
+        });
+
+      // Start a suggestion on file A, then switch to file B mid-flight.
+      const el = await renderLoadedEditor('src/a.ts');
+      findConflictButton(el, 'AI Suggest').click();
+      await el.updateComplete;
+
+      const internal = internalOf(el);
+      internal.conflictFile = makeConflictFile('src/b.ts');
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.segments.length > 0) break;
+      }
+      await el.updateComplete;
+
+      // Start a suggestion on file B (the switch reset the in-flight flag).
+      findConflictButton(el, 'AI Suggest').click();
+      await el.updateComplete;
+
+      // File A's stale call resolves — it must not clear B's in-flight flag,
+      // or the AI buttons would re-enable while B's call is still running.
+      releases[0]!();
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+
+      const aiBtn = Array.from(
+        el.shadowRoot!.querySelector('.code-conflict-block')!.querySelectorAll('button')
+      ).find((b) => b.textContent?.includes('AI')) as HTMLButtonElement;
+      expect(aiBtn.disabled).to.be.true;
+
+      // Release B's call and let it settle.
+      releases[1]!();
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+      expect(internalOf(el).segments.some((s) => s.origin === 'ai')).to.be.true;
+    });
+
     it('a slow AI suggestion never overwrites a manual resolution made mid-flight', async () => {
       setupDefaultMocks();
       aiAvailable = true;

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -1504,6 +1504,57 @@ describe('lv-merge-editor', () => {
       expect(events).to.deep.equal(['started', 'finished']);
     });
 
+    it('POC: switching files during an external tool session discards the new file\'s WIP', async () => {
+      setupDefaultMocks();
+      let releaseTool: (() => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'launch_merge_tool') {
+          return new Promise((res) => {
+            releaseTool = () => res({ success: true });
+          });
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/a.ts');
+      const internal = el as unknown as EditorInternal & {
+        handleOpenExternalMergeTool: () => Promise<void>;
+      };
+
+      // Launch the external tool for file A.
+      const toolPromise = internal.handleOpenExternalMergeTool.call(el);
+      await el.updateComplete;
+
+      // Switch to file B while A's tool is still open.
+      internal.conflictFile = makeConflictFile('src/b.ts');
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.segments.length > 0) break;
+      }
+      await el.updateComplete;
+
+      // User does WIP on file B: resolve a conflict block manually.
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      const resolvedCountBefore = internal.segments.filter((s) => s.type === 'resolved' && s.origin === 'ours').length;
+      expect(resolvedCountBefore, 'B has a manual resolution in progress').to.equal(1);
+
+      // A's external tool now finishes.
+      releaseTool!();
+      await toolPromise;
+      await el.updateComplete;
+      console.error('DEBUG conflictFile after tool:', internal.conflictFile?.path, 'segments:', JSON.stringify(internal.segments.map(s => ({type: s.type, origin: s.origin}))));
+
+      // BUG: B's WIP resolution should still be there (untouched by A's tool),
+      // but the unconditional loadContents() in handleOpenExternalMergeTool
+      // reloads whatever this.conflictFile currently is (B), wiping it.
+      const resolvedCountAfter = internal.segments.filter((s) => s.type === 'resolved' && s.origin === 'ours').length;
+      expect(resolvedCountAfter, 'B\'s WIP resolution must survive an unrelated file\'s external tool completing').to.equal(1);
+    });
+
     it('resolve actions and the external tool are mutually exclusive', async () => {
       setupDefaultMocks();
       let releaseTool: (() => void) | null = null;
@@ -1548,7 +1599,7 @@ describe('lv-merge-editor', () => {
       await Promise.all([first, second]);
     });
 
-    it('the external tool button disables while the host locks it', async () => {
+    it('the host lock disables the tool button AND resolve writes', async () => {
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
@@ -1557,6 +1608,8 @@ describe('lv-merge-editor', () => {
       };
 
       const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
       el.externalToolLocked = true;
       await el.updateComplete;
 
@@ -1564,6 +1617,44 @@ describe('lv-merge-editor', () => {
         (b) => b.textContent?.includes('External Tool')
       ) as HTMLButtonElement;
       expect(toolBtn.disabled).to.be.true;
+
+      // The dialog's own tool session runs against this same file — resolve
+      // writes must also be inert, not just the tool button.
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled).to.be.true;
+      invokeHistory.length = 0;
+      await (el as unknown as { handleMarkResolved: () => Promise<void> }).handleMarkResolved.call(el);
+      expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
+    });
+
+    it('a tool run that fully resolves the file dispatches conflict-resolved', async () => {
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'launch_merge_tool') return { success: true };
+        // Post-tool index check: the file is no longer conflicted.
+        if (command === 'get_conflicts') return [];
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/test.ts');
+      let resolvedPath: string | null = null;
+      el.addEventListener('conflict-resolved', ((e: CustomEvent) => {
+        resolvedPath = e.detail.file.path;
+      }) as EventListener);
+
+      const toolBtn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+        (b) => b.textContent?.includes('External Tool')
+      ) as HTMLButtonElement;
+      toolBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Matching the dialog's own tool path: the host marks the file
+      // resolved instead of leaving it listed as unresolved.
+      expect(resolvedPath).to.equal('src/test.ts');
     });
   });
 

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -1366,6 +1366,62 @@ describe('lv-merge-editor', () => {
     });
   });
 
+  // ── External tool session signaling ──────────────────────────────────
+  describe('external tool session signaling', () => {
+    it('announces tool start/finish so the host can lock destructive actions', async () => {
+      setupDefaultMocks();
+      let releaseTool: (() => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'launch_merge_tool') {
+          return new Promise((res) => {
+            releaseTool = () => res({ success: true });
+          });
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor();
+      const events: string[] = [];
+      el.addEventListener('external-tool-started', () => events.push('started'));
+      el.addEventListener('external-tool-finished', () => events.push('finished'));
+
+      const toolBtn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+        (b) => b.textContent?.includes('External Tool')
+      ) as HTMLButtonElement;
+      expect(toolBtn, 'external tool button rendered').to.not.be.undefined;
+      toolBtn.click();
+      await el.updateComplete;
+
+      expect(events).to.deep.equal(['started']);
+
+      releaseTool!();
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+
+      expect(events).to.deep.equal(['started', 'finished']);
+    });
+
+    it('the external tool button disables while the host locks it', async () => {
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor();
+      el.externalToolLocked = true;
+      await el.updateComplete;
+
+      const toolBtn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+        (b) => b.textContent?.includes('External Tool')
+      ) as HTMLButtonElement;
+      expect(toolBtn.disabled).to.be.true;
+    });
+  });
+
   // ── Binary conflicts ────────────────────────────────────────────────────
   describe('binary conflicts', () => {
     it('renders take-side UI (no text editor) for a binary conflict', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -840,6 +840,30 @@ describe('lv-merge-editor', () => {
 
   // ── Side blob read failures ──────────────────────────────────────────
   describe('side blob read failures', () => {
+    it('shows read failed in the base header when the ancestor blob fails', async () => {
+      setupDefaultMocks();
+      mockInvoke = (async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return Promise.reject(new Error('read failed'));
+          if (blobArgs?.oid === 'ours-oid') return 'line1\nline2-ours\nline3';
+          if (blobArgs?.oid === 'theirs-oid') return 'line1\nline2-theirs\nline3';
+          return '';
+        }
+        if (command === 'read_file_content') return DEFAULT_WORKDIR_CONTENT;
+        if (command === 'get_merge_tool_config') return null;
+        if (command === 'is_ai_available') return false;
+        return null;
+      }) as MockInvoke;
+
+      const el = await renderLoadedEditor();
+      const baseHeader = el.shadowRoot!.querySelector('.panel-header.base')!;
+      expect(baseHeader.textContent).to.include('read failed');
+      expect(baseHeader.textContent).to.not.include('0 lines');
+      const basePane = el.shadowRoot!.getElementById('panel-base')!;
+      expect(basePane.textContent).to.include('Could not read this version');
+    });
+
     it('routes a failed read of an existing side to the Retry state', async () => {
       setupDefaultMocks();
       mockInvoke = (async (command: string, args?: unknown) => {
@@ -861,7 +885,9 @@ describe('lv-merge-editor', () => {
       const el = await renderLoadedEditor();
       const internal = internalOf(el);
       expect(internal.loadFailed).to.be.true;
-      expect(shadowText(el)).to.include('Could not read the merged file');
+      // The message must blame the side version, not the (readable) workdir file.
+      expect(shadowText(el)).to.include('Could not read all of this file’s versions');
+      expect(shadowText(el)).to.not.include('merged file from the working directory');
       const markBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
         (b) => b.textContent?.trim() === 'Mark Resolved'
       ) as HTMLButtonElement;

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -37,13 +37,14 @@ const MARKER_CHARS = ['<<<<<<<', '=======', '>>>>>>>', '|||||||'];
 const DEFAULT_WORKDIR_CONTENT =
   'line1\n<<<<<<< HEAD\nline2-ours\n=======\nline2-theirs\n>>>>>>> feature\nline3';
 
-function makeConflictFile(path: string): ConflictFile {
+function makeConflictFile(path: string, markerSize?: number): ConflictFile {
   return {
     path,
     ancestor: { oid: 'base-oid', path, mode: 0o100644 },
     ours: { oid: 'ours-oid', path, mode: 0o100644 },
     theirs: { oid: 'theirs-oid', path, mode: 0o100644 },
     isBinary: false,
+    ...(markerSize !== undefined ? { markerSize } : {}),
   };
 }
 
@@ -335,9 +336,9 @@ describe('lv-merge-editor', () => {
 
     it('a long bracket run with only a coincidental divider stays content', async () => {
       const el = await renderEditor();
-      // An 8-char banner plus a stray 8-equals divider is NOT a conflict —
-      // without a matching 8-char end marker the size lookahead must reject
-      // it instead of swallowing the file into a phantom conflict.
+      // An 8-char banner plus a stray 8-equals divider is NOT a conflict in
+      // a default-size (7) file — only runs of EXACTLY the file's marker
+      // size are markers, so nothing here can open a phantom conflict.
       const segments = internalOf(el).parseSegments(
         '<<<<<<<< banner heading\ntext\n========\nmore text'
       );
@@ -374,8 +375,9 @@ describe('lv-merge-editor', () => {
       expect(segments[0].lines).to.include('<<<<<<<< (a raised-size marker looks like this)');
     });
 
-    it('parses raised conflict-marker-size markers (gitattribute)', async () => {
+    it('parses raised conflict-marker-size markers using the backend-reported size', async () => {
       const el = await renderEditor();
+      internalOf(el).conflictFile = makeConflictFile('src/test.ts', 32);
       const m = (ch: string) => ch.repeat(32);
       const segments = internalOf(el).parseSegments(
         [
@@ -396,6 +398,88 @@ describe('lv-merge-editor', () => {
       expect(segments[1].theirsLines).to.deep.equal(['theirs-line']);
       expect(segments[1].oursLabel).to.equal('HEAD');
       expect(segments[1].theirsLabel).to.equal('feature');
+    });
+
+    it('a complete default-size conflict sample inside a raised-size conflict stays content', async () => {
+      const el = await renderEditor();
+      internalOf(el).conflictFile = makeConflictFile('src/test.ts', 12);
+      const m = (ch: string) => ch.repeat(12);
+      // THE reason conflict-marker-size gets raised: the file's own content
+      // shows what a (7-char) conflict looks like. Every line of the sample
+      // — start, separator, end — must stay ours CONTENT of the real
+      // 12-char conflict; the real markers must parse and never render.
+      const segments = internalOf(el).parseSegments(
+        [
+          'Intro text',
+          `${m('<')} HEAD`,
+          'A conflict looks like:',
+          '<<<<<<< A',
+          'one',
+          '=======',
+          'two',
+          '>>>>>>> B',
+          m('='),
+          'their docs version',
+          `${m('>')} feature`,
+          'tail',
+        ].join('\n')
+      );
+      expect(segments.map((s) => s.type)).to.deep.equal(['resolved', 'conflict', 'resolved']);
+      expect(segments[1].oursLines).to.deep.equal([
+        'A conflict looks like:',
+        '<<<<<<< A',
+        'one',
+        '=======',
+        'two',
+        '>>>>>>> B',
+      ]);
+      expect(segments[1].theirsLines).to.deep.equal(['their docs version']);
+      expect(segments[0].lines).to.deep.equal(['Intro text']);
+      expect(segments[2].lines).to.deep.equal(['tail']);
+    });
+
+    it('raised-size markers are content when the file was written at the default size', async () => {
+      const el = await renderEditor();
+      // No markerSize (or 7) means git wrote 7-char markers; a 12-char docs
+      // sample above the real conflict is content, never a phantom start.
+      const m = (ch: string) => ch.repeat(12);
+      const segments = internalOf(el).parseSegments(
+        [
+          `${m('<')} (a raised-size marker looks like this)`,
+          'some prose',
+          '<<<<<<< HEAD',
+          'real ours line',
+          '=======',
+          'real theirs line',
+          '>>>>>>> feature',
+        ].join('\n')
+      );
+      const conflicts = segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['real ours line']);
+      expect(conflicts[0].theirsLines).to.deep.equal(['real theirs line']);
+      expect(segments[0].lines).to.include(`${m('<')} (a raised-size marker looks like this)`);
+    });
+
+    it('parses a lowered conflict-marker-size', async () => {
+      const el = await renderEditor();
+      internalOf(el).conflictFile = makeConflictFile('src/test.ts', 3);
+      const segments = internalOf(el).parseSegments(
+        '<<< HEAD\nours\n===\ntheirs\n>>> feature'
+      );
+      expect(segments.length).to.equal(1);
+      expect(segments[0].type).to.equal('conflict');
+      expect(segments[0].oursLines).to.deep.equal(['ours']);
+      expect(segments[0].theirsLines).to.deep.equal(['theirs']);
+    });
+
+    it('falls back to size 7 for missing or nonsense marker sizes', async () => {
+      const el = await renderEditor();
+      for (const bad of [0, -3, 2.5, undefined]) {
+        internalOf(el).conflictFile = makeConflictFile('src/test.ts', bad as number | undefined);
+        const segments = internalOf(el).parseSegments(DEFAULT_WORKDIR_CONTENT);
+        expect(segments.filter((s) => s.type === 'conflict').length, `size=${bad}`).to.equal(1);
+      }
     });
 
     it('keeps an unterminated conflict as a conflict block', async () => {
@@ -1785,6 +1869,90 @@ describe('lv-merge-editor', () => {
       toolBtn().click();
       await new Promise((r) => setTimeout(r, 80));
       expect(launchCalls).to.equal(1);
+    });
+
+    it('a double-click during the confirm window launches only one tool session', async () => {
+      setupDefaultMocks();
+      let launchCalls = 0;
+      let confirmCalls = 0;
+      let releaseConfirm: (() => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          // The native confirm is an async IPC round-trip — a second click
+          // can land before it resolves.
+          return new Promise((res) => {
+            releaseConfirm = () => res('Ok');
+          });
+        }
+        if (command === 'launch_merge_tool') {
+          launchCalls++;
+          return { success: true };
+        }
+        if (command === 'get_conflicts') {
+          return [
+            { path: 'src/test.ts', ancestor: null, ours: null, theirs: null, isBinary: false },
+          ];
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/test.ts');
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(el.hasUnsavedResolutions()).to.be.true;
+
+      const internal = el as unknown as EditorInternal & {
+        handleOpenExternalMergeTool: () => Promise<void>;
+      };
+      // Two rapid invocations: the second must be swallowed by the claimed
+      // launch flag, not stack a second confirm/tool session.
+      const first = internal.handleOpenExternalMergeTool();
+      const second = internal.handleOpenExternalMergeTool();
+      await new Promise((r) => setTimeout(r, 30));
+      expect(confirmCalls, 'only one confirm may be shown').to.equal(1);
+      releaseConfirm!();
+      await Promise.all([first, second]);
+      await new Promise((r) => setTimeout(r, 30));
+      expect(launchCalls, 'only one tool session may launch').to.equal(1);
+    });
+
+    it('cancelling the confirm releases the launch claim for a later attempt', async () => {
+      setupDefaultMocks();
+      let launchCalls = 0;
+      const baseMock = mockInvoke;
+      let confirmAnswer: unknown = false;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'plugin:dialog|message') return confirmAnswer;
+        if (command === 'launch_merge_tool') {
+          launchCalls++;
+          return { success: true };
+        }
+        if (command === 'get_conflicts') {
+          return [
+            { path: 'src/test.ts', ancestor: null, ours: null, theirs: null, isBinary: false },
+          ];
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/test.ts');
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+
+      const internal = el as unknown as EditorInternal & {
+        handleOpenExternalMergeTool: () => Promise<void>;
+      };
+      // Declined: the claim must be released, or the button is dead forever.
+      await internal.handleOpenExternalMergeTool();
+      expect(launchCalls).to.equal(0);
+      confirmAnswer = 'Ok';
+      await internal.handleOpenExternalMergeTool();
+      await new Promise((r) => setTimeout(r, 30));
+      expect(launchCalls, 'a fresh attempt after cancel must work').to.equal(1);
     });
 
     it('resolve actions and the external tool are mutually exclusive', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -262,12 +262,31 @@ describe('lv-merge-editor', () => {
 
     it('supports diff3 output without leaking the base section into ours', async () => {
       const el = await renderEditor();
+      internalOf(el).conflictFile = { ...makeConflictFile('src/test.ts'), conflictStyle: 'diff3' };
       const segments = internalOf(el).parseSegments(
         '<<<<<<< HEAD\nours\n||||||| base\nbase-line\n=======\ntheirs\n>>>>>>> other'
       );
       expect(segments.length).to.equal(1);
       expect(segments[0].oursLines).to.deep.equal(['ours']);
       expect(segments[0].theirsLines).to.deep.equal(['theirs']);
+    });
+
+    it('keeps a ||||||| line as ours CONTENT in default merge-style conflicts', async () => {
+      const el = await renderEditor();
+      // The default style has no base sections (and libgit2 never writes
+      // them): a pipe run in ours is real content — discarding the lines
+      // after it as a "base section" would silently lose them from every
+      // Use Ours / Use Both pick.
+      const segments = internalOf(el).parseSegments(
+        '<<<<<<< HEAD\nline A\n|||||||\nline B (part of ours)\n=======\ntheir line\n>>>>>>> branch'
+      );
+      expect(segments.length).to.equal(1);
+      expect(segments[0].oursLines).to.deep.equal([
+        'line A',
+        '|||||||',
+        'line B (part of ours)',
+      ]);
+      expect(segments[0].theirsLines).to.deep.equal(['their line']);
     });
 
     it('does not mistake a divider banner inside ours for the separator', async () => {
@@ -475,7 +494,8 @@ describe('lv-merge-editor', () => {
 
     it('falls back to size 7 for missing or nonsense marker sizes', async () => {
       const el = await renderEditor();
-      for (const bad of [0, -3, 2.5, undefined]) {
+      // 1e9 would drive a gigabyte separator-string allocation if trusted.
+      for (const bad of [0, -3, 2.5, 1_000_000_000, undefined]) {
         internalOf(el).conflictFile = makeConflictFile('src/test.ts', bad as number | undefined);
         const segments = internalOf(el).parseSegments(DEFAULT_WORKDIR_CONTENT);
         expect(segments.filter((s) => s.type === 'conflict').length, `size=${bad}`).to.equal(1);
@@ -788,6 +808,12 @@ describe('lv-merge-editor', () => {
     });
 
     it('Reload re-reads the on-disk merge, restoring conflicts', async () => {
+      // The whole-file accept is unsaved work, so Reload confirms first.
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') return 'Ok';
+        return baseMock(command, args);
+      };
       const el = await renderLoadedEditor();
       const useOurs = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions .btn-ours')).find(
         (b) => b.textContent?.trim() === 'Use Ours'
@@ -1726,20 +1752,79 @@ describe('lv-merge-editor', () => {
       }
       await el.updateComplete;
 
-      // User does WIP on file B: resolve a conflict block manually.
-      findConflictButton(el, 'Use Ours').click();
+      // While ANY tool session is open, in-memory picks are inert (they
+      // could be wiped by a post-tool reload, so they are blocked outright)
+      // and the buttons say so.
+      const useOurs = findConflictButton(el, 'Use Ours');
+      expect(useOurs.disabled, 'picks are disabled during a tool session').to.be.true;
+      useOurs.click();
       await el.updateComplete;
-      const resolvedCountBefore = internal.segments.filter((s) => s.type === 'resolved' && s.origin === 'ours').length;
-      expect(resolvedCountBefore, 'B has a manual resolution in progress').to.equal(1);
+      expect(
+        internal.segments.filter((s) => s.type === 'resolved' && s.origin === 'ours').length,
+        'a click during the session must not resolve anything'
+      ).to.equal(0);
 
       // A's external tool now finishes — its completion must only touch A,
-      // never reload (and wipe) the file the user has since switched to.
+      // never reload the file the user has since switched to, and B's
+      // blocks re-enable for normal work.
       releaseTool!();
       await toolPromise;
       await el.updateComplete;
 
-      const resolvedCountAfter = internal.segments.filter((s) => s.type === 'resolved' && s.origin === 'ours').length;
-      expect(resolvedCountAfter, 'B\'s WIP resolution must survive an unrelated file\'s external tool completing').to.equal(1);
+      expect(findConflictButton(el, 'Use Ours').disabled).to.be.false;
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      const resolvedCountAfter = internal.segments.filter(
+        (s) => s.type === 'resolved' && s.origin === 'ours'
+      ).length;
+      expect(resolvedCountAfter, "B's picks work normally after the session ends").to.equal(1);
+    });
+
+    it('all in-memory mutations are inert while a tool session is open', async () => {
+      setupDefaultMocks();
+      let releaseTool: (() => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'launch_merge_tool') {
+          return new Promise((res) => {
+            releaseTool = () => res({ success: true });
+          });
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/test.ts');
+      const internal = el as unknown as EditorInternal & {
+        handleOpenExternalMergeTool: () => Promise<void>;
+        acceptWholeFile: (origin: string) => void;
+        startEditSegment: (segment: unknown) => void;
+        handleReload: () => Promise<void>;
+        editingSegmentId: number | null;
+      };
+      const toolPromise = internal.handleOpenExternalMergeTool.call(el);
+      await el.updateComplete;
+
+      // Whole-file accept: would be silently destroyed by the post-tool
+      // reload — must be a no-op.
+      internal.acceptWholeFile.call(el, 'ours');
+      await el.updateComplete;
+      expect(internal.segments.some((s) => s.type === 'conflict'), 'accept was inert').to.be.true;
+
+      // Opening an inline edit: same fate.
+      internal.startEditSegment.call(el, internal.segments[0]);
+      expect(internal.editingSegmentId).to.equal(null);
+
+      // Reload: would clear the session's lock semantics mid-flight.
+      invokeHistory.length = 0;
+      await internal.handleReload.call(el);
+      expect(
+        invokeHistory.some((h) => h.command === 'read_file_content'),
+        'reload was inert'
+      ).to.be.false;
+
+      releaseTool!();
+      await toolPromise;
     });
 
     it('a still-conflicted tool exit warns instead of toasting success', async () => {
@@ -1808,7 +1893,7 @@ describe('lv-merge-editor', () => {
       const toolPromise = internal.handleOpenExternalMergeTool.call(el);
       await el.updateComplete;
 
-      // Switch to B and make a pick while A's tool is open.
+      // Switch to B while A's tool is open.
       internal.conflictFile = makeConflictFile('src/b.ts');
       await el.updateComplete;
       for (let i = 0; i < 100; i++) {
@@ -1816,14 +1901,22 @@ describe('lv-merge-editor', () => {
         if (!internal.loading && internal.segments.length > 0) break;
       }
       await el.updateComplete;
-      findConflictButton(el, 'Use Ours').click();
-      await el.updateComplete;
 
+      invokeHistory.length = 0;
       releaseTool!();
       await toolPromise;
       await el.updateComplete;
 
-      // B's pick survived — the still-conflicted branch did not reload B.
+      // The still-conflicted branch must not reload anything: A is no
+      // longer on screen, and reloading B would wipe the state the user is
+      // working in.
+      expect(
+        invokeHistory.some((h) => h.command === 'read_file_content'),
+        'no file may be reloaded when the tool file is no longer selected'
+      ).to.be.false;
+      // B is fully usable after the session ends.
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
       const resolved = internal.segments.filter((s) => s.origin === 'ours').length;
       expect(resolved).to.equal(1);
     });
@@ -2188,6 +2281,165 @@ describe('lv-merge-editor', () => {
       expect((takeSide!.args as Record<string, unknown>).side).to.equal('theirs');
       expect(invokeHistory.some(h => h.command === 'resolve_conflict')).to.be.false;
       expect(resolvedFired).to.be.true;
+    });
+  });
+
+  // ── Hand-edit marker confirmation ─────────────────────────────────────
+  describe('hand-edit marker confirmation', () => {
+    async function renderWithEdit(): Promise<{
+      el: LvMergeEditor;
+      internal: EditorInternal & {
+        startEditSegment: (segment: unknown) => void;
+        applyEditSegment: () => Promise<void>;
+        editingSegmentId: number | null;
+        editDraft: string;
+      };
+    }> {
+      const el = await renderLoadedEditor('src/test.ts');
+      const internal = el as unknown as EditorInternal & {
+        startEditSegment: (segment: unknown) => void;
+        applyEditSegment: () => Promise<void>;
+        editingSegmentId: number | null;
+        editDraft: string;
+      };
+      const conflict = internal.segments.find((s) => s.type === 'conflict')!;
+      internal.startEditSegment.call(el, conflict);
+      await el.updateComplete;
+      return { el, internal };
+    }
+
+    it('a pasted marker line asks for confirmation and declining keeps the edit open', async () => {
+      setupDefaultMocks();
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return false; // decline
+        }
+        return baseMock(command, args);
+      };
+      const { el, internal } = await renderWithEdit();
+      const editedId = internal.editingSegmentId;
+      internal.editDraft = '<<<<<<< HEAD\npasted raw conflict text';
+      await internal.applyEditSegment.call(el);
+      await el.updateComplete;
+
+      expect(confirmCalls, 'marker-shaped edit must confirm').to.equal(1);
+      expect(internal.editingSegmentId, 'declining keeps the edit open').to.equal(editedId);
+      expect(
+        internal.segments.find((s) => s.id === editedId)?.type,
+        'the segment stays an open conflict'
+      ).to.equal('conflict');
+    });
+
+    it('confirming keeps intentional marker-like text (setext underlines are legal)', async () => {
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') return 'Ok';
+        return baseMock(command, args);
+      };
+      const { el, internal } = await renderWithEdit();
+      const editedId = internal.editingSegmentId!;
+      internal.editDraft = 'Heading\n=======';
+      await internal.applyEditSegment.call(el);
+      await el.updateComplete;
+
+      const segment = internal.segments.find((s) => s.id === editedId)!;
+      expect(segment.type).to.equal('resolved');
+      expect(segment.lines).to.deep.equal(['Heading', '=======']);
+      expect(internal.editingSegmentId).to.equal(null);
+    });
+
+    it('marker-free edits apply without any confirmation', async () => {
+      setupDefaultMocks();
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return 'Ok';
+        }
+        return baseMock(command, args);
+      };
+      const { el, internal } = await renderWithEdit();
+      const editedId = internal.editingSegmentId!;
+      internal.editDraft = 'hand merged';
+      await internal.applyEditSegment.call(el);
+      await el.updateComplete;
+
+      expect(confirmCalls).to.equal(0);
+      expect(internal.segments.find((s) => s.id === editedId)?.lines).to.deep.equal([
+        'hand merged',
+      ]);
+    });
+  });
+
+  // ── Reload confirmation ───────────────────────────────────────────────
+  describe('reload confirmation', () => {
+    it('reload with unsaved picks confirms; declining keeps them', async () => {
+      setupDefaultMocks();
+      let confirmAnswer: unknown = false;
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return confirmAnswer;
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/test.ts');
+      const internal = el as unknown as EditorInternal & {
+        handleReload: () => Promise<void>;
+      };
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(el.hasUnsavedResolutions()).to.be.true;
+
+      // Declined: picks stay, nothing reloads.
+      await internal.handleReload.call(el);
+      await el.updateComplete;
+      expect(confirmCalls).to.equal(1);
+      expect(el.hasUnsavedResolutions(), 'declining keeps the picks').to.be.true;
+
+      // Accepted: the file re-parses from disk and the picks are gone.
+      confirmAnswer = 'Ok';
+      await internal.handleReload.call(el);
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.segments.length > 0) break;
+      }
+      await el.updateComplete;
+      expect(el.hasUnsavedResolutions(), 'accepting reloads from disk').to.be.false;
+      expect(internal.segments.some((s) => s.type === 'conflict')).to.be.true;
+    });
+
+    it('reload without unsaved picks does not ask', async () => {
+      setupDefaultMocks();
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return false;
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor('src/test.ts');
+      const internal = el as unknown as EditorInternal & {
+        handleReload: () => Promise<void>;
+      };
+      invokeHistory.length = 0;
+      await internal.handleReload.call(el);
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.segments.length > 0) break;
+      }
+      expect(confirmCalls).to.equal(0);
+      expect(invokeHistory.some((h) => h.command === 'read_file_content')).to.be.true;
     });
   });
 });

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -862,6 +862,14 @@ describe('lv-merge-editor', () => {
       expect(baseHeader.textContent).to.not.include('0 lines');
       const basePane = el.shadowRoot!.getElementById('panel-base')!;
       expect(basePane.textContent).to.include('Could not read this version');
+
+      // The surviving panes must not pretend to know the diff from a base
+      // that never loaded: no fake change counts, no addition highlighting.
+      const oursHeader = el.shadowRoot!.querySelector('.panel-header.ours')!;
+      expect(oursHeader.textContent).to.include('base unavailable');
+      expect(oursHeader.textContent).to.not.include('changes from base');
+      expect(el.shadowRoot!.querySelectorAll('#panel-ours .code-addition').length).to.equal(0);
+      expect(el.shadowRoot!.querySelectorAll('#panel-ours .line-changed').length).to.equal(0);
     });
 
     it('routes a failed read of an existing side to the Retry state', async () => {
@@ -1280,6 +1288,34 @@ describe('lv-merge-editor', () => {
       expect((takeSide!.args as Record<string, unknown>).side).to.equal('theirs');
       expect(invokeHistory.some(h => h.command === 'resolve_conflict')).to.be.false;
       expect(resolvedFired).to.be.true;
+    });
+
+    it('the pane-header Use (delete) stays enabled during a failed load, like the toolbar', async () => {
+      setupDefaultMocks();
+      // theirs deleted the file AND the workdir read fails: deletion staging
+      // is backend-side and content-independent, so it must stay available.
+      workdirContent = () => Promise.reject(new Error('read failed'));
+      const el = await renderEditor();
+      const internal = el as unknown as { conflictFile: ConflictFile; loading: boolean; loadFailed: boolean };
+      internal.conflictFile = { ...makeConflictFile('src/gone.ts'), theirs: null };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.loadFailed) break;
+      }
+      await el.updateComplete;
+      expect(internal.loadFailed).to.be.true;
+
+      const theirsHeaderUse = el.shadowRoot!.querySelector(
+        '.panel-header.theirs .panel-header-btn'
+      ) as HTMLButtonElement;
+      expect(theirsHeaderUse.textContent).to.include('delete');
+      expect(theirsHeaderUse.disabled).to.be.false;
+      // The content-dependent ours side stays disabled.
+      const oursHeaderUse = el.shadowRoot!.querySelector(
+        '.panel-header.ours .panel-header-btn'
+      ) as HTMLButtonElement;
+      expect(oursHeaderUse.disabled).to.be.true;
     });
 
     it('the pane-header Use button also resolves a deleted side as a deletion', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -3427,4 +3427,306 @@ describe('lv-merge-editor', () => {
       expect(invokeHistory.some((h) => h.command === 'read_file_content')).to.be.true;
     });
   });
+
+  // ── Hand-deleted separator recovery ──────────────────────────────────────
+  describe('hand-deleted separator recovery', () => {
+    it('a conflict whose ======= was hand-deleted never shows its orphan end marker', async () => {
+      // The user hand-merged and deleted the separator line but left the
+      // end marker. Shape-only parsing would sweep the marker into the
+      // ours pane — visible AND writable to disk via Accept Ours.
+      setupDefaultMocks();
+      workdirContent = [
+        'line1',
+        '<<<<<<< HEAD',
+        'line2-ours',
+        'line2-theirs',
+        '>>>>>>> feature',
+        'line3',
+      ].join('\n');
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
+
+      expect(internal.segments.map((s) => s.type)).to.deep.equal([
+        'resolved',
+        'conflict',
+        'resolved',
+      ]);
+      // The blob-validated split recovers both sides; the orphan marker is
+      // the region's terminator, not content.
+      expect(internal.segments[1].oursLines).to.deep.equal(['line2-ours']);
+      expect(internal.segments[1].theirsLines).to.deep.equal(['line2-theirs']);
+      expectNoMarkers(el);
+    });
+
+    it('a separator-less conflict at EOF (no trailing content) still recovers', async () => {
+      setupDefaultMocks();
+      workdirContent = [
+        'line1',
+        '<<<<<<< HEAD',
+        'line2-ours',
+        'line2-theirs',
+        '>>>>>>> feature',
+      ].join('\n');
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
+
+      const conflicts = internal.segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['line2-ours']);
+      expect(conflicts[0].theirsLines).to.deep.equal(['line2-theirs']);
+      expectNoMarkers(el);
+    });
+
+    it('a hand-typed end-shaped line before the separator does not close the region early', async () => {
+      // Mid-region junk: an end-shaped line typed BEFORE the real
+      // separator, with the real separator+end below. Closing at the junk
+      // would strand the real markers in "resolved" text.
+      setupDefaultMocks();
+      workdirContent = [
+        'line1',
+        '<<<<<<< HEAD',
+        'line2-ours',
+        '>>>>>>> junk',
+        '=======',
+        'line2-theirs',
+        '>>>>>>> feature',
+        'line3',
+      ].join('\n');
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
+
+      const conflicts = internal.segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      // Closes at the REAL end marker: theirs is intact and line3 resolved.
+      expect(conflicts[0].theirsLines).to.deep.equal(['line2-theirs']);
+      expect(internal.segments[internal.segments.length - 1].lines).to.deep.equal(['line3']);
+    });
+  });
+
+  // ── Orphan-marker write confirmation ─────────────────────────────────────
+  describe('orphan-marker write confirmation', () => {
+    /** Load the junk-marker file and accept the conflict block with ours —
+     * the accepted side then contains a marker-shaped line that is in
+     * NEITHER blob (a real orphaned marker). */
+    async function editorWithOrphanMarkerAccepted(
+      confirmAnswers: { calls: number; answer: unknown },
+    ): Promise<LvMergeEditor> {
+      setupDefaultMocks();
+      workdirContent = [
+        'line1',
+        '<<<<<<< HEAD',
+        'line2-ours',
+        '>>>>>>> junk',
+        '=======',
+        'line2-theirs',
+        '>>>>>>> feature',
+        'line3',
+      ].join('\n');
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmAnswers.calls++;
+          return confirmAnswers.answer;
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      return el;
+    }
+
+    it('marking resolved with an orphaned real marker in an accepted side confirms first', async () => {
+      const confirms = { calls: 0, answer: false as unknown };
+      const el = await editorWithOrphanMarkerAccepted(confirms);
+      invokeHistory.length = 0;
+
+      await internalOf(el).handleMarkResolved.call(el);
+      expect(confirms.calls, 'must confirm before writing an orphan marker').to.equal(1);
+      // Declined: nothing is written.
+      expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
+    });
+
+    it('confirming writes the content as-is', async () => {
+      const confirms = { calls: 0, answer: 'Ok' as unknown };
+      const el = await editorWithOrphanMarkerAccepted(confirms);
+      invokeHistory.length = 0;
+
+      await internalOf(el).handleMarkResolved.call(el);
+      expect(confirms.calls).to.equal(1);
+      const resolve = invokeHistory.find((h) => h.command === 'resolve_conflict');
+      expect(resolve, 'confirmed write proceeds').to.exist;
+      expect((resolve!.args as { content: string }).content).to.include('>>>>>>> junk');
+    });
+
+    it('a clean resolution never raises the orphan-marker confirm', async () => {
+      setupDefaultMocks();
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return false;
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      invokeHistory.length = 0;
+
+      await internalOf(el).handleMarkResolved.call(el);
+      expect(confirmCalls).to.equal(0);
+      expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.true;
+    });
+  });
+
+  // ── Symlink conflicts ─────────────────────────────────────────────────────
+  describe('symlink conflicts', () => {
+    it('names the conflict a symbolic link conflict and shows both targets', async () => {
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'ours-oid') return 'target-a';
+          if (blobArgs?.oid === 'theirs-oid') return 'target-b';
+          return '';
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderEditor();
+      const internal = el as unknown as { conflictFile: ConflictFile; loading: boolean };
+      internal.conflictFile = {
+        ...makeConflictFile('link'),
+        isBinary: true,
+        ours: { oid: 'ours-oid', path: 'link', mode: 0o120000 },
+        theirs: { oid: 'theirs-oid', path: 'link', mode: 0o120000 },
+      };
+      await el.updateComplete;
+      for (let i = 0; i < 50; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading) break;
+      }
+      await el.updateComplete;
+
+      const text = shadowText(el);
+      expect(text).to.include('Symbolic link conflict');
+      expect(text).to.not.include('Binary file conflict');
+      // The choice is between TARGETS — show them.
+      expect(text).to.include('target-a');
+      expect(text).to.include('target-b');
+      expect(el.shadowRoot!.querySelector('.btn-ours')).to.not.be.null;
+      expect(el.shadowRoot!.querySelector('.btn-theirs')).to.not.be.null;
+    });
+
+    it('a file<->symlink type conflict labels the regular-file side honestly', async () => {
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'theirs-oid') return 'target-a';
+          return 'file contents';
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderEditor();
+      const internal = el as unknown as { conflictFile: ConflictFile; loading: boolean };
+      internal.conflictFile = {
+        ...makeConflictFile('thing'),
+        isBinary: true,
+        ours: { oid: 'ours-oid', path: 'thing', mode: 0o100644 },
+        theirs: { oid: 'theirs-oid', path: 'thing', mode: 0o120000 },
+      };
+      await el.updateComplete;
+      for (let i = 0; i < 50; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading) break;
+      }
+      await el.updateComplete;
+
+      const text = shadowText(el);
+      expect(text).to.include('Symbolic link conflict');
+      expect(text).to.include('a regular file');
+      expect(text).to.include('target-a');
+    });
+  });
+
+  // ── Submodule conflicts ───────────────────────────────────────────────────
+  describe('submodule conflicts', () => {
+    function makeSubmoduleConflict(): ConflictFile {
+      return {
+        path: 'sub',
+        ancestor: { oid: 'a'.repeat(40), path: 'sub', mode: 0o160000 },
+        ours: { oid: 'b'.repeat(40), path: 'sub', mode: 0o160000 },
+        theirs: { oid: 'c'.repeat(40), path: 'sub', mode: 0o160000 },
+        isBinary: false,
+        isSubmodule: true,
+      };
+    }
+
+    async function renderSubmoduleEditor(
+      file: ConflictFile = makeSubmoduleConflict(),
+    ): Promise<LvMergeEditor> {
+      setupDefaultMocks();
+      const el = await renderEditor();
+      const internal = el as unknown as { conflictFile: ConflictFile; loading: boolean };
+      internal.conflictFile = file;
+      await el.updateComplete;
+      for (let i = 0; i < 50; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading) break;
+      }
+      await el.updateComplete;
+      return el;
+    }
+
+    it('renders the commit-pointer chooser, never the text editor or blob reads', async () => {
+      invokeHistory.length = 0;
+      const el = await renderSubmoduleEditor();
+
+      const text = shadowText(el);
+      expect(text).to.include('Submodule conflict');
+      // The choice is between COMMITS — show the short OIDs.
+      expect(text).to.include('b'.repeat(7));
+      expect(text).to.include('c'.repeat(7));
+      expect(el.shadowRoot!.querySelector('.output-panel')).to.be.null;
+      // Nothing is readable for a gitlink: no blob/workdir fetches at all.
+      expect(invokeHistory.some((h) => h.command === 'get_blob_content')).to.be.false;
+      expect(invokeHistory.some((h) => h.command === 'read_file_content')).to.be.false;
+      expectNoMarkers(el);
+    });
+
+    it('resolves via take-side and reports success', async () => {
+      const el = await renderSubmoduleEditor();
+      let resolvedFired = false;
+      el.addEventListener('conflict-resolved', () => {
+        resolvedFired = true;
+      });
+
+      invokeHistory.length = 0;
+      (el.shadowRoot!.querySelector('.btn-theirs') as HTMLButtonElement).click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      const takeSide = invokeHistory.find((h) => h.command === 'resolve_conflict_take_side');
+      expect(takeSide, 'take-side called').to.exist;
+      expect((takeSide!.args as Record<string, unknown>).side).to.equal('theirs');
+      expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
+      expect(resolvedFired).to.be.true;
+    });
+
+    it('a deleted side offers removing the submodule and lands in the terminal state', async () => {
+      const file = { ...makeSubmoduleConflict(), theirs: null };
+      const el = await renderSubmoduleEditor(file);
+
+      const theirsBtn = el.shadowRoot!.querySelector('.btn-theirs') as HTMLButtonElement;
+      expect(theirsBtn.textContent).to.include('remove submodule');
+      theirsBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      expect(shadowText(el)).to.include('this submodule was removed');
+    });
+  });
 });

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -1075,6 +1075,30 @@ describe('lv-merge-editor', () => {
       ]);
     });
 
+    it('authoritative hunk positions work for CRLF files (indices align with backend lines())', async () => {
+      // The backend derives indices via Rust lines() (strips \r\n); the
+      // frontend splits on '\n' (keeps '\r' per line, plus a trailing '').
+      // For every index < length the two agree — and the sanity checks
+      // strip CR — so CRLF files parse by positions too.
+      const el = await renderEditor();
+      const internal = el as unknown as EditorInternal;
+      internal.conflictFile = {
+        ...makeConflictFile('src/win.ts'),
+        conflictHunks: [{ start: 1, separator: 3, end: 5 }],
+      };
+      const segments = internal.parseSegments(
+        'ctx\r\n<<<<<<< HEAD\r\nours\r\n=======\r\ntheirs\r\n>>>>>>> feature\r\ntail\r\n'
+      );
+      expect(segments.map((s) => s.type)).to.deep.equal(['resolved', 'conflict', 'resolved']);
+      expect(segments[1].oursLines).to.deep.equal(['ours\r']);
+      expect(segments[1].theirsLines).to.deep.equal(['theirs\r']);
+      expect(segments[1].oursLabel).to.equal('HEAD');
+      expect(segments[1].theirsLabel).to.equal('feature');
+      // Content line endings round-trip verbatim.
+      expect(segments[0].lines).to.deep.equal(['ctx\r']);
+      expect(segments[2].lines).to.deep.equal(['tail\r', '']);
+    });
+
     it('malformed hunk positions fall back to the shape heuristics', async () => {
       const el = await renderEditor();
       const internal = el as unknown as EditorInternal;

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -1181,6 +1181,65 @@ describe('lv-merge-editor', () => {
       expect(internal.segments.flatMap((s) => s.lines).join('\n')).to.equal('b-content');
       expect(internal.loading).to.be.false;
     });
+
+    it('a stale submodule load whose conflict re-check resolves late must not wipe a newer file', async () => {
+      // A submodule's load awaits get_conflicts (isNoLongerConflicted). If the
+      // user switches to a text file while that await is in flight, the stale
+      // submodule load resumes and — without the post-await epoch guard — falls
+      // into the gitlink branch that blanks segments/panes, leaving the NEW
+      // file showing "no conflicts" with Mark Resolved enabled → a 0-byte write.
+      setupDefaultMocks();
+      let releaseConflicts: ((v: unknown) => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = (async (command: string, args?: unknown) => {
+        if (command === 'get_conflicts') {
+          // Park the submodule's re-check until we release it, then report the
+          // submodule STILL conflicted (isNoLongerConflicted → false) so the
+          // stale load reaches the gitlink-wipe branch the guard must skip.
+          return new Promise((res) => {
+            releaseConflicts = res as (v: unknown) => void;
+          });
+        }
+        return baseMock(command, args);
+      }) as MockInvoke;
+
+      const el = await renderEditor();
+      const internal = internalOf(el);
+      internal.conflictFile = {
+        path: 'sub',
+        ancestor: { oid: 'a'.repeat(40), path: 'sub', mode: 0o160000 },
+        ours: { oid: 'b'.repeat(40), path: 'sub', mode: 0o160000 },
+        theirs: { oid: 'c'.repeat(40), path: 'sub', mode: 0o160000 },
+        isBinary: false,
+        isSubmodule: true,
+      };
+      await el.updateComplete;
+      // Let the submodule load park on the hanging get_conflicts.
+      await new Promise((r) => setTimeout(r, 40));
+
+      // User switches to a normal text file, which loads fully.
+      internal.conflictFile = makeConflictFile('src/b.ts');
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.segments.length > 0) break;
+      }
+      const bSegments = internal.segments;
+      expect(bSegments.length, 'text file loaded its segments').to.be.greaterThan(0);
+
+      // The submodule's re-check finally resolves (still conflicted). The stale
+      // load must return without touching the newer file's state.
+      releaseConflicts!([{ path: 'sub' }, { path: 'src/b.ts' }]);
+      await new Promise((r) => setTimeout(r, 40));
+      await el.updateComplete;
+
+      expect(internal.segments, 'newer file segments preserved').to.equal(bSegments);
+      expect(internal.segments.length).to.be.greaterThan(0);
+      expect(
+        (el as unknown as { resolvedInPlace: boolean }).resolvedInPlace,
+        'newer file not falsely resolved'
+      ).to.not.equal(true);
+    });
   });
 
   // ── Load failure handling ────────────────────────────────────────────
@@ -3750,10 +3809,11 @@ describe('lv-merge-editor', () => {
       expectNoMarkers(el);
     });
 
-    it('a hand-typed end-shaped line before the separator does not close the region early', async () => {
-      // Mid-region junk: an end-shaped line typed BEFORE the real
-      // separator, with the real separator+end below. Closing at the junk
-      // would strand the real markers in "resolved" text.
+    it('a hand-typed end-shaped line inside a region never renders raw (whole-file fallback)', async () => {
+      // Mid-region junk: an end-shaped line typed BEFORE the real separator.
+      // Any split that keeps it as pane content would show a raw >>>>>>>
+      // marker, so the safety net presents the whole file as one clean
+      // conflict block instead — no marker is ever displayed.
       setupDefaultMocks();
       workdirContent = [
         'line1',
@@ -3770,31 +3830,28 @@ describe('lv-merge-editor', () => {
 
       const conflicts = internal.segments.filter((s) => s.type === 'conflict');
       expect(conflicts.length).to.equal(1);
-      // Closes at the REAL end marker: theirs is intact and line3 resolved.
-      expect(conflicts[0].theirsLines).to.deep.equal(['line2-theirs']);
-      expect(internal.segments[internal.segments.length - 1].lines).to.deep.equal(['line3']);
+      // No pane contains any raw marker.
+      for (const c of conflicts) {
+        for (const line of [...c.oursLines, ...c.theirsLines]) {
+          expect(/^(<{7,}|={7,}|>{7,}|\|{7,})/.test(line), `pane leaked "${line}"`).to.be.false;
+        }
+      }
+      expectNoMarkers(el);
     });
   });
 
   // ── Orphan-marker write confirmation ─────────────────────────────────────
   describe('orphan-marker write confirmation', () => {
-    /** Load the junk-marker file and accept the conflict block with ours —
-     * the accepted side then contains a marker-shaped line that is in
-     * NEITHER blob (a real orphaned marker). */
+    /** Load a clean editor, then directly install a RESOLVED segment that
+     * carries a real orphaned marker (a marker-shaped line in NEITHER blob,
+     * origin != 'manual'). The parser's whole-file fallback prevents this
+     * shape from arising via parsing, but the write-time confirm gate is
+     * defense-in-depth for any other path (AI, stale segments), so it is
+     * tested by constructing the segment directly. */
     async function editorWithOrphanMarkerAccepted(
       confirmAnswers: { calls: number; answer: unknown },
     ): Promise<LvMergeEditor> {
       setupDefaultMocks();
-      workdirContent = [
-        'line1',
-        '<<<<<<< HEAD',
-        'line2-ours',
-        '>>>>>>> junk',
-        '=======',
-        'line2-theirs',
-        '>>>>>>> feature',
-        'line3',
-      ].join('\n');
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'plugin:dialog|message') {
@@ -3804,7 +3861,23 @@ describe('lv-merge-editor', () => {
         return baseMock(command, args);
       };
       const el = await renderLoadedEditor();
-      findConflictButton(el, 'Use Ours').click();
+      const internal = el as unknown as EditorInternal & {
+        segments: OutputSegmentShape[];
+        nextSegmentId: number;
+      };
+      internal.segments = [
+        {
+          id: internal.nextSegmentId++,
+          type: 'resolved',
+          lines: ['line2-ours', '>>>>>>> junk'],
+          oursLines: [],
+          theirsLines: [],
+          oursLabel: '',
+          theirsLabel: '',
+          origin: 'ours',
+          fromConflict: true,
+        },
+      ];
       await el.updateComplete;
       return el;
     }

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -2710,6 +2710,56 @@ describe('lv-merge-editor', () => {
       expect(launchCalls, 'only one tool session may launch').to.equal(1);
     });
 
+    it('a lock engaging during the launch confirm makes the launch inert', async () => {
+      // The host's Abort/Complete are NOT disabled during this confirm
+      // (the tool-session lock is only announced after it) — a launch
+      // proceeding after an abort would edit a file the operation no
+      // longer owns.
+      setupDefaultMocks();
+      let launchCalls = 0;
+      let startedFired = false;
+      let releaseConfirm: (() => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'plugin:dialog|message') {
+          return new Promise((res) => {
+            releaseConfirm = () => res('Ok');
+          });
+        }
+        if (command === 'launch_merge_tool') {
+          launchCalls++;
+          return { success: true };
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/test.ts');
+      el.addEventListener('external-tool-started', () => {
+        startedFired = true;
+      });
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+
+      const internal = el as unknown as EditorInternal & {
+        handleOpenExternalMergeTool: () => Promise<void>;
+        externalToolLocked: boolean;
+        launchingExternalTool: boolean;
+      };
+      const pending = internal.handleOpenExternalMergeTool();
+      await new Promise((r) => setTimeout(r, 30));
+      // The host locks the editor while the confirm is up (abort/complete
+      // started).
+      internal.externalToolLocked = true;
+      releaseConfirm!();
+      await pending;
+      await new Promise((r) => setTimeout(r, 30));
+
+      expect(launchCalls, 'the tool must not launch under a host lock').to.equal(0);
+      expect(startedFired, 'no tool session may be announced').to.be.false;
+      expect(internal.launchingExternalTool, 'the claim is released').to.be.false;
+    });
+
     it('cancelling the confirm releases the launch claim for a later attempt', async () => {
       setupDefaultMocks();
       let launchCalls = 0;

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -305,6 +305,25 @@ describe('lv-merge-editor', () => {
       expect(segments[1].theirsLabel).to.equal('feature');
     });
 
+    it('treats a >>>>>>>-shaped line before the separator as content', async () => {
+      const el = await renderEditor();
+      // A quoted diff or docs line resembling an end marker inside the ours
+      // section must not terminate the conflict — that would drop the real
+      // theirs side and leak the true markers as "resolved" text.
+      const segments = internalOf(el).parseSegments(
+        '<<<<<<< HEAD\nline1\n>>>>>>> quoted diff header\nline3\n=======\ntheirs line\n>>>>>>> feature'
+      );
+      expect(segments.length).to.equal(1);
+      expect(segments[0].type).to.equal('conflict');
+      expect(segments[0].oursLines).to.deep.equal([
+        'line1',
+        '>>>>>>> quoted diff header',
+        'line3',
+      ]);
+      expect(segments[0].theirsLines).to.deep.equal(['theirs line']);
+      expect(segments[0].theirsLabel).to.equal('feature');
+    });
+
     it('does not mistake 8+ angle brackets for conflict markers', async () => {
       const el = await renderEditor();
       const segments = internalOf(el).parseSegments('<<<<<<<< not a marker\ncontent');
@@ -677,6 +696,32 @@ describe('lv-merge-editor', () => {
       expect(emptySegment, 'placeholder row rendered').to.not.be.undefined;
       expect(emptySegment!.querySelector('.segment-actions .segment-btn')).to.not.be.null;
     });
+
+    it('Edit → Apply on an empty resolution keeps zero lines, not one blank line', async () => {
+      setupDefaultMocks();
+      workdirContent = 'ctx\n<<<<<<< HEAD\n=======\ntheirs-line\n>>>>>>> other\ntail';
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(internalOf(el).segments[1].lines).to.deep.equal([]);
+
+      // Open Edit on the empty placeholder and Apply without typing anything.
+      const segmentEls = el.shadowRoot!.querySelectorAll('.output-segment');
+      const emptySegment = Array.from(segmentEls).find((s) =>
+        s.textContent?.includes('removed the section')
+      )!;
+      (emptySegment.querySelector('.segment-actions .segment-btn') as HTMLButtonElement).click();
+      await el.updateComplete;
+
+      const applyBtn = Array.from(el.shadowRoot!.querySelectorAll('.segment-editor button')).find(
+        (b) => b.textContent?.trim() === 'Apply'
+      ) as HTMLButtonElement;
+      applyBtn.click();
+      await el.updateComplete;
+
+      // Still zero lines — no spurious blank line was inserted.
+      expect(internalOf(el).segments[1].lines).to.deep.equal([]);
+    });
   });
 
   // ── Add/add conflicts (no common ancestor) ───────────────────────────
@@ -932,6 +977,25 @@ describe('lv-merge-editor', () => {
       await el.updateComplete;
     });
 
+    it('rejects an AI suggestion that contains conflict markers', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      aiSuggestion = () =>
+        Promise.resolve({
+          resolvedContent: 'ok line\n<<<<<<< HEAD\nleak\n=======',
+          explanation: 'bad',
+        });
+
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'AI Suggest').click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      // The block stays unresolved and no marker text reaches the DOM.
+      expect(internalOf(el).segments[1].type).to.equal('conflict');
+      expectNoMarkers(el);
+    });
+
     it('drops a stale AI explanation when the block is reset or re-picked', async () => {
       setupDefaultMocks();
       aiAvailable = true;
@@ -1045,6 +1109,35 @@ describe('lv-merge-editor', () => {
 
       const takeSide = invokeHistory.find(h => h.command === 'resolve_conflict_take_side');
       expect(takeSide, 'take-side called for deleted side').to.exist;
+      expect((takeSide!.args as Record<string, unknown>).side).to.equal('theirs');
+      expect(invokeHistory.some(h => h.command === 'resolve_conflict')).to.be.false;
+      expect(resolvedFired).to.be.true;
+    });
+
+    it('the pane-header Use button also resolves a deleted side as a deletion', async () => {
+      const el = await renderEditor();
+      const internal = el as unknown as { conflictFile: ConflictFile; loading: boolean };
+      // theirs deleted the file; ours modified it.
+      internal.conflictFile = { ...makeConflictFile('src/gone.ts'), theirs: null };
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 50));
+      internal.loading = false;
+      await el.updateComplete;
+
+      let resolvedFired = false;
+      el.addEventListener('conflict-resolved', () => { resolvedFired = true; });
+
+      // The THEIRS pane-header "Use" button must stage the deletion like the
+      // toolbar button — not write a 0-byte file from the empty side content.
+      invokeHistory.length = 0;
+      const theirsHeaderUse = el.shadowRoot!.querySelector(
+        '.panel-header.theirs .panel-header-btn'
+      ) as HTMLButtonElement;
+      theirsHeaderUse.click();
+      await new Promise(r => setTimeout(r, 50));
+
+      const takeSide = invokeHistory.find(h => h.command === 'resolve_conflict_take_side');
+      expect(takeSide, 'take-side called from pane header').to.exist;
       expect((takeSide!.args as Record<string, unknown>).side).to.equal('theirs');
       expect(invokeHistory.some(h => h.command === 'resolve_conflict')).to.be.false;
       expect(resolvedFired).to.be.true;

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -268,6 +268,51 @@ describe('lv-merge-editor', () => {
       expect(segments[0].theirsLines).to.deep.equal(['theirs']);
     });
 
+    it('does not mistake a divider banner inside ours for the separator', async () => {
+      const el = await renderEditor();
+      // The ours side contains a legitimate ====-banner line; only the exact
+      // 7-equals line is git's separator.
+      const segments = internalOf(el).parseSegments(
+        '<<<<<<< HEAD\nfoo\n========================\nbar\n=======\ntheirs-content\n>>>>>>> feature'
+      );
+      expect(segments.length).to.equal(1);
+      expect(segments[0].oursLines).to.deep.equal(['foo', '========================', 'bar']);
+      expect(segments[0].theirsLines).to.deep.equal(['theirs-content']);
+    });
+
+    it('treats pipe-banner content and diff3 markers in theirs as content', async () => {
+      const el = await renderEditor();
+      // A ||||||| after the separator is content (git never emits it there);
+      // it must not silently discard following lines.
+      const segments = internalOf(el).parseSegments(
+        '<<<<<<< HEAD\nours\n=======\n||||||||||\ntheirs-content\n>>>>>>> feature'
+      );
+      expect(segments.length).to.equal(1);
+      expect(segments[0].oursLines).to.deep.equal(['ours']);
+      expect(segments[0].theirsLines).to.deep.equal(['||||||||||', 'theirs-content']);
+    });
+
+    it('parses CRLF files, keeping content line endings intact', async () => {
+      const el = await renderEditor();
+      const segments = internalOf(el).parseSegments(
+        'ctx\r\n<<<<<<< HEAD\r\nours\r\n=======\r\ntheirs\r\n>>>>>>> feature\r\ntail\r'
+      );
+      expect(segments.map((s) => s.type)).to.deep.equal(['resolved', 'conflict', 'resolved']);
+      expect(segments[0].lines).to.deep.equal(['ctx\r']);
+      expect(segments[1].oursLines).to.deep.equal(['ours\r']);
+      expect(segments[1].theirsLines).to.deep.equal(['theirs\r']);
+      expect(segments[1].oursLabel).to.equal('HEAD');
+      expect(segments[1].theirsLabel).to.equal('feature');
+    });
+
+    it('does not mistake 8+ angle brackets for conflict markers', async () => {
+      const el = await renderEditor();
+      const segments = internalOf(el).parseSegments('<<<<<<<< not a marker\ncontent');
+      expect(segments.length).to.equal(1);
+      expect(segments[0].type).to.equal('resolved');
+      expect(segments[0].lines).to.deep.equal(['<<<<<<<< not a marker', 'content']);
+    });
+
     it('keeps an unterminated conflict as a conflict block', async () => {
       const el = await renderEditor();
       const segments = internalOf(el).parseSegments(
@@ -563,6 +608,19 @@ describe('lv-merge-editor', () => {
       expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
     });
 
+    it('refuses to write after a failed load even if invoked directly', async () => {
+      setupDefaultMocks();
+      workdirContent = () => Promise.reject(new Error('read failed'));
+      const el = await renderLoadedEditor();
+      expect(internalOf(el).loadFailed).to.be.true;
+
+      // conflictCount is 0 here (no segments), so without the loadFailed
+      // guard this would write an EMPTY file as the resolution.
+      invokeHistory.length = 0;
+      await internalOf(el).handleMarkResolved();
+      expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
+    });
+
     it('writes marker-free content and dispatches conflict-resolved once resolved', async () => {
       const el = await renderLoadedEditor();
       findConflictButton(el, 'Use Both').click();
@@ -592,13 +650,84 @@ describe('lv-merge-editor', () => {
     });
   });
 
-  // ── getResolvedContent ───────────────────────────────────────────────
-  describe('getResolvedContent', () => {
-    it('joins resolved segment lines', async () => {
+  // ── Empty-side conflicts (delete/modify hunks) ───────────────────────
+  describe('empty-side conflicts', () => {
+    it('renders an empty side as such and keeps a removed-section resolution reachable', async () => {
+      setupDefaultMocks();
+      workdirContent = 'ctx\n<<<<<<< HEAD\n=======\ntheirs-line\n>>>>>>> other\ntail';
       const el = await renderLoadedEditor();
+
+      const block = el.shadowRoot!.querySelector('.code-conflict-block')!;
+      expect(block.querySelector('.code-conflict-side-ours')!.textContent).to.include(
+        'no lines on this side'
+      );
+
+      // Resolving to the empty side yields a zero-line segment; it must still
+      // render a placeholder row so its hover actions (Edit/Reset) work.
       findConflictButton(el, 'Use Ours').click();
       await el.updateComplete;
-      expect(el.getResolvedContent()).to.equal('line1\nline2-ours\nline3');
+
+      const resolved = internalOf(el).segments[1];
+      expect(resolved.type).to.equal('resolved');
+      expect(resolved.lines).to.deep.equal([]);
+      const segmentEls = el.shadowRoot!.querySelectorAll('.output-segment');
+      const emptySegment = Array.from(segmentEls).find((s) =>
+        s.textContent?.includes('removed the section')
+      );
+      expect(emptySegment, 'placeholder row rendered').to.not.be.undefined;
+      expect(emptySegment!.querySelector('.segment-actions .segment-btn')).to.not.be.null;
+    });
+  });
+
+  // ── Add/add conflicts (no common ancestor) ───────────────────────────
+  describe('add/add conflicts', () => {
+    it('treats an absent ancestor as zero base lines, coloring both sides as additions', async () => {
+      setupDefaultMocks();
+      mockInvoke = (async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'ours-oid') return 'a\nb';
+          if (blobArgs?.oid === 'theirs-oid') return 'x\ny';
+          return '';
+        }
+        if (command === 'read_file_content')
+          return '<<<<<<< HEAD\na\nb\n=======\nx\ny\n>>>>>>> other';
+        if (command === 'get_merge_tool_config') return null;
+        if (command === 'is_ai_available') return false;
+        return null;
+      }) as MockInvoke;
+
+      const el = await renderEditor();
+      const internal = internalOf(el);
+      internal.conflictFile = { ...makeConflictFile('src/new.ts'), ancestor: null };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.segments.length > 0) break;
+      }
+      await el.updateComplete;
+
+      // No phantom blank base line: every base-pane row is a filler.
+      const baseNumbers = Array.from(
+        el.shadowRoot!.querySelectorAll('#panel-base .line-number')
+      ).map((n) => n.textContent?.trim());
+      expect(baseNumbers.every((n) => n === '')).to.be.true;
+      // All ours lines are additions, none miscolored as changed.
+      expect(el.shadowRoot!.querySelectorAll('#panel-ours .code-addition').length).to.equal(2);
+      expect(el.shadowRoot!.querySelectorAll('#panel-ours .line-changed').length).to.equal(0);
+    });
+  });
+
+  // ── Parsed side labels ───────────────────────────────────────────────
+  describe('parsed side labels', () => {
+    it('shows the branch labels git recorded alongside the generic roles', async () => {
+      const el = await renderLoadedEditor();
+      const block = el.shadowRoot!.querySelector('.code-conflict-block')!;
+      // Default mock content is <<<<<<< HEAD ... >>>>>>> feature
+      expect(block.querySelector('.code-conflict-side-ours .code-conflict-side-label')!.textContent)
+        .to.include('HEAD');
+      expect(block.querySelector('.code-conflict-side-theirs .code-conflict-side-label')!.textContent)
+        .to.include('feature');
     });
   });
 
@@ -650,7 +779,7 @@ describe('lv-merge-editor', () => {
       const changed = el.shadowRoot!.querySelectorAll('#panel-ours .line-changed');
       expect(additions.length).to.equal(1);
       expect(changed.length).to.equal(0);
-      expect(shadowText(el)).to.include('1 changes from base');
+      expect(shadowText(el)).to.include('1 change from base');
     });
   });
 
@@ -729,6 +858,102 @@ describe('lv-merge-editor', () => {
 
       expect(aiCalls).to.equal(1);
       expect(internalOf(el).segments.filter((s) => s.type === 'conflict').length).to.equal(2);
+    });
+
+    it('skips blocks the user resolved mid-batch instead of aborting', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      workdirContent = [
+        '<<<<<<< HEAD', 'a-ours', '=======', 'a-theirs', '>>>>>>> other',
+        'mid',
+        '<<<<<<< HEAD', 'b-ours', '=======', 'b-theirs', '>>>>>>> other',
+      ].join('\n');
+
+      const el = await renderLoadedEditor();
+      let aiCalls = 0;
+      aiSuggestion = () => {
+        aiCalls++;
+        if (aiCalls === 1) {
+          // While the FIRST block's suggestion is in flight, the user
+          // manually resolves the SECOND block. The batch must skip it —
+          // not treat it as a failure and abandon the rest.
+          const second = el.shadowRoot!.querySelectorAll('.code-conflict-block')[1];
+          const useOurs = Array.from(second.querySelectorAll('button')).find(
+            (b) => b.textContent?.trim() === 'Use Ours'
+          ) as HTMLButtonElement;
+          useOurs.click();
+        }
+        return Promise.resolve({ resolvedContent: 'ai-resolved', explanation: '' });
+      };
+
+      await internalOf(el).handleAiResolveAll();
+      await el.updateComplete;
+
+      // Only the first block needed an AI call; the second was skipped as
+      // already-resolved rather than aborting the batch.
+      expect(aiCalls).to.equal(1);
+      expect(internalOf(el).segments.filter((s) => s.type === 'conflict').length).to.equal(0);
+    });
+
+    it('disables AI Suggest on every block while one suggestion is in flight', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      workdirContent = [
+        '<<<<<<< HEAD', 'a-ours', '=======', 'a-theirs', '>>>>>>> other',
+        'mid',
+        '<<<<<<< HEAD', 'b-ours', '=======', 'b-theirs', '>>>>>>> other',
+      ].join('\n');
+      let release: (() => void) | null = null;
+      aiSuggestion = () =>
+        new Promise((resolve) => {
+          release = () =>
+            resolve({ resolvedContent: 'ai-resolved', explanation: '' });
+        });
+
+      const el = await renderLoadedEditor();
+      const blocks = el.shadowRoot!.querySelectorAll('.code-conflict-block');
+      expect(blocks.length).to.equal(2);
+
+      const aiBtn = (block: Element) =>
+        Array.from(block.querySelectorAll('button')).find((b) =>
+          b.textContent?.includes('AI')
+        ) as HTMLButtonElement;
+
+      aiBtn(blocks[0]).click();
+      await el.updateComplete;
+
+      // The OTHER block's AI button must also be disabled — clicking it would
+      // silently no-op otherwise.
+      const secondBtn = aiBtn(el.shadowRoot!.querySelectorAll('.code-conflict-block')[1]);
+      expect(secondBtn.disabled).to.be.true;
+
+      release!();
+      await new Promise((r) => setTimeout(r, 20));
+      await el.updateComplete;
+    });
+
+    it('drops a stale AI explanation when the block is reset or re-picked', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      const el = await renderLoadedEditor();
+
+      findConflictButton(el, 'AI Suggest').click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+      expect(shadowText(el)).to.include('merged by ai');
+
+      // Reset the block: the explanation no longer describes anything.
+      const resetBtn = Array.from(el.shadowRoot!.querySelectorAll('.segment-btn')).find(
+        (b) => b.textContent?.trim() === 'Reset'
+      ) as HTMLButtonElement;
+      resetBtn.click();
+      await el.updateComplete;
+      expect(shadowText(el)).to.not.include('merged by ai');
+
+      // Re-picking a side must not resurrect it.
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(shadowText(el)).to.not.include('merged by ai');
     });
 
     it('clears AI explanations when a different file loads', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -782,6 +782,55 @@ describe('lv-merge-editor', () => {
       expect(resolvedEvents).to.equal(1);
     });
 
+    it('a file switch releases the resolving lock for the new file', async () => {
+      setupDefaultMocks();
+      let releaseResolve: (() => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'resolve_conflict') {
+          return new Promise((res) => {
+            releaseResolve = () => res({ success: true });
+          });
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/a.ts');
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      const internal = el as unknown as EditorInternal & {
+        resolving: boolean;
+        handleMarkResolved: () => Promise<void>;
+      };
+      const pending = internal.handleMarkResolved.call(el);
+      await el.updateComplete;
+      expect(internal.resolving).to.be.true;
+
+      // Switching files must not leave the NEW file's buttons locked by the
+      // old file's in-flight call.
+      internal.conflictFile = makeConflictFile('src/b.ts');
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.segments.length > 0) break;
+      }
+      await el.updateComplete;
+      expect(internal.resolving).to.be.false;
+
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled).to.be.false;
+
+      // The stale call settling must not re-lock the new file either.
+      releaseResolve!();
+      await pending;
+      await el.updateComplete;
+      expect(internal.resolving).to.be.false;
+    });
+
     it('writes marker-free content and dispatches conflict-resolved once resolved', async () => {
       const el = await renderLoadedEditor();
       findConflictButton(el, 'Use Both').click();
@@ -1212,6 +1261,58 @@ describe('lv-merge-editor', () => {
       await el.updateComplete;
     });
 
+    it('AI Resolve All stops when the file changes under it and releases the lock', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      workdirContent = [
+        '<<<<<<< HEAD', 'a-ours', '=======', 'a-theirs', '>>>>>>> other',
+        'mid',
+        '<<<<<<< HEAD', 'b-ours', '=======', 'b-theirs', '>>>>>>> other',
+      ].join('\n');
+      let aiCalls = 0;
+      let releaseFirst: (() => void) | null = null;
+      aiSuggestion = () => {
+        aiCalls++;
+        if (aiCalls === 1) {
+          return new Promise((resolve) => {
+            releaseFirst = () =>
+              resolve({ resolvedContent: 'ai-resolved', explanation: '' });
+          });
+        }
+        return Promise.resolve({ resolvedContent: 'ai-resolved', explanation: '' });
+      };
+
+      const el = await renderLoadedEditor('src/a.ts');
+      const internal = el as unknown as EditorInternal & {
+        suggestingAll: boolean;
+        handleAiResolveAll: () => Promise<void>;
+      };
+      const batch = internal.handleAiResolveAll.call(el);
+      await el.updateComplete;
+      expect(internal.suggestingAll).to.be.true;
+
+      // Switch files while the first suggestion is in flight — the batch must
+      // stop instead of grinding stale ids, and the lock must release for the
+      // new file.
+      internal.conflictFile = makeConflictFile('src/b.ts');
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.segments.length > 0) break;
+      }
+      await el.updateComplete;
+      expect(internal.suggestingAll).to.be.false;
+
+      releaseFirst!();
+      await batch;
+      await el.updateComplete;
+
+      // Only the first (pre-switch) call was made — the loop broke on the
+      // epoch change instead of iterating file A's remaining stale ids.
+      expect(aiCalls).to.equal(1);
+      expect(internal.suggestingAll).to.be.false;
+    });
+
     it('a stale AI call from a previous file does not clear the new file\'s in-flight flag', async () => {
       setupDefaultMocks();
       aiAvailable = true;
@@ -1401,6 +1502,50 @@ describe('lv-merge-editor', () => {
       await el.updateComplete;
 
       expect(events).to.deep.equal(['started', 'finished']);
+    });
+
+    it('resolve actions and the external tool are mutually exclusive', async () => {
+      setupDefaultMocks();
+      let releaseTool: (() => void) | null = null;
+      let launchCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'launch_merge_tool') {
+          launchCalls++;
+          return new Promise((res) => {
+            releaseTool = () => res({ success: true });
+          });
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor();
+      const internal = el as unknown as EditorInternal & {
+        handleOpenExternalMergeTool: () => Promise<void>;
+        handleMarkResolved: () => Promise<void>;
+      };
+
+      // A synchronous double-invocation must launch the tool exactly once.
+      const first = internal.handleOpenExternalMergeTool.call(el);
+      const second = internal.handleOpenExternalMergeTool.call(el);
+      await el.updateComplete;
+      expect(launchCalls).to.equal(1);
+
+      // While the tool session is open, resolve writes must be inert — they
+      // would race the tool's eventual save on the same file.
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled).to.be.true;
+      invokeHistory.length = 0;
+      await internal.handleMarkResolved.call(el);
+      expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
+
+      releaseTool!();
+      await Promise.all([first, second]);
     });
 
     it('the external tool button disables while the host locks it', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -1138,6 +1138,36 @@ describe('lv-merge-editor', () => {
       await el.updateComplete;
     });
 
+    it('a slow AI suggestion never overwrites a manual resolution made mid-flight', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      let releaseAi: (() => void) | null = null;
+      aiSuggestion = () =>
+        new Promise((resolve) => {
+          releaseAi = () =>
+            resolve({ resolvedContent: 'ai-resolved', explanation: 'from ai' });
+        });
+
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'AI Suggest').click();
+      await el.updateComplete;
+
+      // While the suggestion is in flight, the user picks a side manually.
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(internalOf(el).segments[1].origin).to.equal('ours');
+
+      // The late AI response must not replace the user's explicit pick.
+      releaseAi!();
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+
+      const resolved = internalOf(el).segments[1];
+      expect(resolved.origin).to.equal('ours');
+      expect(resolved.lines).to.deep.equal(['line2-ours']);
+      expect(shadowText(el)).to.not.include('from ai');
+    });
+
     it('treats an empty AI suggestion as removing the section, not a blank line', async () => {
       setupDefaultMocks();
       aiAvailable = true;

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -3657,6 +3657,45 @@ describe('lv-merge-editor', () => {
       expect(confirmCalls).to.equal(0);
       expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.true;
     });
+
+    it('Use Base does not false-confirm on a marker-shaped line that is clean ancestor content', async () => {
+      // The ancestor blob has a bare `=======` (a Markdown setext
+      // underline) that both sides changed away. Use Base stages the clean
+      // ancestor verbatim — the orphan-marker check must recognize the
+      // line as base blob content, not a real orphaned marker.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      let confirmCalls = 0;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return false;
+        }
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'Heading\n=======\nbody';
+          if (blobArgs?.oid === 'ours-oid') return 'line1\nline2-ours\nline3';
+          if (blobArgs?.oid === 'theirs-oid') return 'line1\nline2-theirs\nline3';
+          return '';
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+
+      // Use Base replaces all segments with the ancestor content.
+      (el as unknown as { acceptWholeFile: (o: string) => Promise<void> }).acceptWholeFile.call(
+        el,
+        'base',
+      );
+      await el.updateComplete;
+      invokeHistory.length = 0;
+
+      await internalOf(el).handleMarkResolved.call(el);
+      expect(confirmCalls, 'clean ancestor content must not confirm').to.equal(0);
+      const resolve = invokeHistory.find((h) => h.command === 'resolve_conflict');
+      expect(resolve, 'the base content is written').to.exist;
+      expect((resolve!.args as { content: string }).content).to.include('=======');
+    });
   });
 
   // ── Symlink conflicts ─────────────────────────────────────────────────────
@@ -3792,6 +3831,20 @@ describe('lv-merge-editor', () => {
       expect((takeSide!.args as Record<string, unknown>).side).to.equal('theirs');
       expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
       expect(resolvedFired).to.be.true;
+    });
+
+    it('a successful take lands in a terminal state — no live buttons to re-click into an error', async () => {
+      // Without the terminal state the chooser re-renders with enabled
+      // buttons and a second click errors "No conflict found" on a file
+      // that is actually resolved.
+      const el = await renderSubmoduleEditor();
+      (el.shadowRoot!.querySelector('.btn-ours') as HTMLButtonElement).click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      expect(shadowText(el)).to.include('Resolved — the chosen version was staged');
+      expect(el.shadowRoot!.querySelector('.btn-ours'), 'no re-clickable chooser').to.be.null;
+      expect(el.shadowRoot!.querySelector('.btn-theirs')).to.be.null;
     });
 
     it('a submodule<->file type conflict labels the file side honestly, not as a commit', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -1002,6 +1002,93 @@ describe('lv-merge-editor', () => {
       expect(markBtn.disabled).to.be.true;
     });
 
+    it('authoritative hunk positions beat every quoted-marker ambiguity', async () => {
+      // Fable round-16's killer case: theirs quotes a line byte-identical
+      // to the REAL end marker AND the auto-merged trailing interleaves
+      // insertions from both sides, defeating both close-justification
+      // tiers. With backend positions the parse is exact regardless.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'intro\nalpha\nctx1\nctx2\nctx3\ntail';
+          if (blobArgs?.oid === 'ours-oid')
+            return 'intro\nfrom-ours\nctx1\nours-insert\nctx2\nctx3\ntail';
+          if (blobArgs?.oid === 'theirs-oid')
+            return 'intro\nfrom-theirs\nquoted:\n>>>>>>> feature\nctx1\nctx2\ntheirs-insert\nctx3\ntail';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            'intro',
+            '<<<<<<< HEAD',
+            'from-ours',
+            '=======',
+            'from-theirs',
+            'quoted:',
+            '>>>>>>> feature',
+            '>>>>>>> feature',
+            'ctx1',
+            'ours-insert',
+            'ctx2',
+            'theirs-insert',
+            'ctx3',
+            'tail',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderEditor();
+      const internal = el as unknown as EditorInternal;
+      internal.conflictFile = {
+        ...makeConflictFile('docs/notes.md'),
+        conflictHunks: [{ start: 1, separator: 3, end: 7 }],
+      };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && (internal.segments.length > 0 || internal.loadFailed)) break;
+      }
+      await el.updateComplete;
+
+      const conflicts = internal.segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['from-ours']);
+      expect(conflicts[0].theirsLines).to.deep.equal([
+        'from-theirs',
+        'quoted:',
+        '>>>>>>> feature',
+      ]);
+      const resolvedText = internal.segments
+        .filter((s) => s.type === 'resolved')
+        .flatMap((s) => s.lines);
+      expect(resolvedText, 'the real end marker is consumed, never resolved text').to.deep.equal([
+        'intro',
+        'ctx1',
+        'ours-insert',
+        'ctx2',
+        'theirs-insert',
+        'ctx3',
+        'tail',
+      ]);
+    });
+
+    it('malformed hunk positions fall back to the shape heuristics', async () => {
+      const el = await renderEditor();
+      const internal = el as unknown as EditorInternal;
+      // End index far out of range — positions do not describe this text.
+      internal.conflictFile = {
+        ...makeConflictFile('src/test.ts'),
+        conflictHunks: [{ start: 1, separator: 3, end: 999 }],
+      };
+      const segments = internal.parseSegments(DEFAULT_WORKDIR_CONTENT);
+      expect(segments.filter((s) => s.type === 'conflict').length).to.equal(1);
+      const conflict = segments.find((s) => s.type === 'conflict')!;
+      expect(conflict.oursLines).to.deep.equal(['line2-ours']);
+    });
+
     it('keeps an unterminated conflict as a conflict block', async () => {
       const el = await renderEditor();
       const segments = internalOf(el).parseSegments(
@@ -2818,6 +2905,17 @@ describe('lv-merge-editor', () => {
       // theirs deleted the file AND the workdir read fails: deletion staging
       // is backend-side and content-independent, so it must stay available.
       workdirContent = () => Promise.reject(new Error('read failed'));
+      // The file is STILL conflicted in the index (this is a genuine read
+      // failure, not an already-staged deletion).
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_conflicts') {
+          return [
+            { path: 'src/gone.ts', ancestor: null, ours: null, theirs: null, isBinary: false },
+          ];
+        }
+        return baseMock(command, args);
+      };
       const el = await renderEditor();
       const internal = el as unknown as { conflictFile: ConflictFile; loading: boolean; loadFailed: boolean };
       internal.conflictFile = { ...makeConflictFile('src/gone.ts'), theirs: null };
@@ -3176,6 +3274,43 @@ describe('lv-merge-editor', () => {
         (b) => b.textContent?.includes('verbatim') || b.textContent?.trim() === 'Retry'
       );
       expect(verbatimBtns.length).to.equal(0);
+    });
+
+    it('RE-SELECTING a file resolved as a deletion shows the terminal state, not an error', async () => {
+      // The user resolved file A as a deletion, advanced to B, then clicks
+      // A again to double-check. The workdir read fails because the file
+      // is correctly GONE — presenting that as a read error (with a Retry
+      // that loops forever and a verbatim button that resurrects the
+      // deletion) would make a correct resolution look broken.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'read_file_content') throw new Error('file deleted');
+        // The index no longer lists the file — its deletion is staged.
+        if (command === 'get_conflicts') return [];
+        return baseMock(command, args);
+      };
+      const el = await renderEditor();
+      const internal = el as unknown as EditorInternal;
+      internal.conflictFile = { ...makeConflictFile('src/gone.ts'), theirs: null };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (
+          !internal.loading &&
+          ((el as unknown as { resolvedAsDeleted: boolean }).resolvedAsDeleted ||
+            internal.loadFailed)
+        )
+          break;
+      }
+      await el.updateComplete;
+
+      expect(internal.loadFailed, 'a staged deletion is not an error').to.be.false;
+      expect(shadowText(el)).to.include('deleted by the resolution');
+      const badButtons = Array.from(el.shadowRoot!.querySelectorAll('button')).filter(
+        (b) => b.textContent?.includes('verbatim') || b.textContent?.trim() === 'Retry'
+      );
+      expect(badButtons.length, 'no resurrect/retry affordances').to.equal(0);
     });
 
     it('a take-side that KEEPS the file reloads the fresh content', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -332,6 +332,30 @@ describe('lv-merge-editor', () => {
       expect(segments[0].lines).to.deep.equal(['<<<<<<<< not a marker', 'content']);
     });
 
+    it('parses raised conflict-marker-size markers (gitattribute)', async () => {
+      const el = await renderEditor();
+      const m = (ch: string) => ch.repeat(32);
+      const segments = internalOf(el).parseSegments(
+        [
+          'ctx',
+          `${m('<')} HEAD`,
+          'ours-line',
+          '=======',
+          m('='),
+          'theirs-line',
+          `${m('>')} feature`,
+          'tail',
+        ].join('\n')
+      );
+      expect(segments.map((s) => s.type)).to.deep.equal(['resolved', 'conflict', 'resolved']);
+      // The bare 7-equals line inside the ours side is CONTENT for a
+      // 32-char-marker conflict; only the exact 32-equals line separates.
+      expect(segments[1].oursLines).to.deep.equal(['ours-line', '=======']);
+      expect(segments[1].theirsLines).to.deep.equal(['theirs-line']);
+      expect(segments[1].oursLabel).to.equal('HEAD');
+      expect(segments[1].theirsLabel).to.equal('feature');
+    });
+
     it('keeps an unterminated conflict as a conflict block', async () => {
       const el = await renderEditor();
       const segments = internalOf(el).parseSegments(
@@ -1467,6 +1491,34 @@ describe('lv-merge-editor', () => {
     });
   });
 
+  // ── Unsaved-work tracking ─────────────────────────────────────────────
+  describe('hasUnsavedResolutions', () => {
+    it('tracks picks as unsaved until Mark Resolved writes them', async () => {
+      const el = await renderLoadedEditor();
+      expect(el.hasUnsavedResolutions()).to.be.false;
+
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(el.hasUnsavedResolutions()).to.be.true;
+
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      markBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      // The picks are on disk now — navigating away is safe.
+      expect(el.hasUnsavedResolutions()).to.be.false;
+
+      // A new edit after saving is unsaved again.
+      const editBtn = el.shadowRoot!.querySelector('.output-segment .segment-btn') as HTMLButtonElement;
+      editBtn.click();
+      await el.updateComplete;
+      expect(el.hasUnsavedResolutions()).to.be.true;
+    });
+  });
+
   // ── External tool session signaling ──────────────────────────────────
   describe('external tool session signaling', () => {
     it('announces tool start/finish so the host can lock destructive actions', async () => {
@@ -1504,7 +1556,7 @@ describe('lv-merge-editor', () => {
       expect(events).to.deep.equal(['started', 'finished']);
     });
 
-    it('POC: switching files during an external tool session discards the new file\'s WIP', async () => {
+    it("an unrelated file's tool completion must not wipe the current file's picks", async () => {
       setupDefaultMocks();
       let releaseTool: (() => void) | null = null;
       const baseMock = mockInvoke;
@@ -1542,17 +1594,61 @@ describe('lv-merge-editor', () => {
       const resolvedCountBefore = internal.segments.filter((s) => s.type === 'resolved' && s.origin === 'ours').length;
       expect(resolvedCountBefore, 'B has a manual resolution in progress').to.equal(1);
 
-      // A's external tool now finishes.
+      // A's external tool now finishes — its completion must only touch A,
+      // never reload (and wipe) the file the user has since switched to.
       releaseTool!();
       await toolPromise;
       await el.updateComplete;
-      console.error('DEBUG conflictFile after tool:', internal.conflictFile?.path, 'segments:', JSON.stringify(internal.segments.map(s => ({type: s.type, origin: s.origin}))));
 
-      // BUG: B's WIP resolution should still be there (untouched by A's tool),
-      // but the unconditional loadContents() in handleOpenExternalMergeTool
-      // reloads whatever this.conflictFile currently is (B), wiping it.
       const resolvedCountAfter = internal.segments.filter((s) => s.type === 'resolved' && s.origin === 'ours').length;
       expect(resolvedCountAfter, 'B\'s WIP resolution must survive an unrelated file\'s external tool completing').to.equal(1);
+    });
+
+    it('a still-conflicted tool exit reloads only when the file is still selected', async () => {
+      setupDefaultMocks();
+      let releaseTool: (() => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'launch_merge_tool') {
+          return new Promise((res) => {
+            releaseTool = () => res({ success: true });
+          });
+        }
+        // Post-tool index check: the file is STILL conflicted.
+        if (command === 'get_conflicts') {
+          return [
+            { path: 'src/a.ts', ancestor: null, ours: null, theirs: null, isBinary: false },
+          ];
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/a.ts');
+      const internal = el as unknown as EditorInternal & {
+        handleOpenExternalMergeTool: () => Promise<void>;
+      };
+      const toolPromise = internal.handleOpenExternalMergeTool.call(el);
+      await el.updateComplete;
+
+      // Switch to B and make a pick while A's tool is open.
+      internal.conflictFile = makeConflictFile('src/b.ts');
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.segments.length > 0) break;
+      }
+      await el.updateComplete;
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+
+      releaseTool!();
+      await toolPromise;
+      await el.updateComplete;
+
+      // B's pick survived — the still-conflicted branch did not reload B.
+      const resolved = internal.segments.filter((s) => s.origin === 'ours').length;
+      expect(resolved).to.equal(1);
     });
 
     it('resolve actions and the external tool are mutually exclusive', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -3309,7 +3309,9 @@ describe('lv-merge-editor', () => {
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'read_file_content') throw new Error('file deleted');
+        // Structured Tauri error: the file is GONE (not merely undecodable).
+        if (command === 'read_file_content')
+          throw { code: 'FILE_NOT_FOUND', message: 'File not found: src/gone.ts' };
         // The index no longer lists the file — its deletion is staged.
         if (command === 'get_conflicts') return [];
         return baseMock(command, args);
@@ -3335,6 +3337,34 @@ describe('lv-merge-editor', () => {
         (b) => b.textContent?.includes('verbatim') || b.textContent?.trim() === 'Retry'
       );
       expect(badButtons.length, 'no resurrect/retry affordances').to.equal(0);
+    });
+
+    it('a KEPT but undecodable file is a read error, never a false "was deleted"', async () => {
+      // The file was resolved externally by KEEPING it (checkout --ours &&
+      // add) but its content is legacy-encoded, so the strict read fails
+      // the same way a missing file would. The deletion claim requires
+      // FILE_NOT_FOUND — anything else lands in the honest error state.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'read_file_content')
+          throw { code: 'IO_ERROR', message: 'stream did not contain valid UTF-8' };
+        if (command === 'get_conflicts') return [];
+        return baseMock(command, args);
+      };
+      const el = await renderEditor();
+      const internal = el as unknown as EditorInternal;
+      internal.conflictFile = { ...makeConflictFile('src/latin1.ts'), theirs: null };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && (internal.segments.length > 0 || internal.loadFailed)) break;
+      }
+      await el.updateComplete;
+
+      expect(internal.loadFailed).to.be.true;
+      expect(shadowText(el)).to.include('Could not read the merged file');
+      expect(shadowText(el)).to.not.include('deleted by the resolution');
     });
 
     it('a take-side that KEEPS the file reloads the fresh content', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -574,6 +574,156 @@ describe('lv-merge-editor', () => {
       expect(conflicts[0].theirsLines).to.deep.equal(['Heading', '=======']);
     });
 
+    it('a quoted end marker inside THEIRS cannot close the block early', async () => {
+      // The theirs side's CONTENT quotes an end marker (docs example). A
+      // shape-only close at it would strand the real end marker below as
+      // "resolved" text — rendered on screen and written back to disk.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'ctx\ntail';
+          if (blobArgs?.oid === 'ours-oid') return 'ctx\nours line\ntail';
+          if (blobArgs?.oid === 'theirs-oid')
+            return 'ctx\nTheir docs say markers end with:\n>>>>>>> B\nmore theirs text\ntail';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            'ctx',
+            '<<<<<<< HEAD',
+            'ours line',
+            '=======',
+            'Their docs say markers end with:',
+            '>>>>>>> B',
+            'more theirs text',
+            '>>>>>>> feature',
+            'tail',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/doc.md');
+      const segments = internalOf(el).segments;
+      const conflicts = segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['ours line']);
+      expect(conflicts[0].theirsLines).to.deep.equal([
+        'Their docs say markers end with:',
+        '>>>>>>> B',
+        'more theirs text',
+      ]);
+      const resolvedText = segments
+        .filter((s) => s.type === 'resolved')
+        .flatMap((s) => s.lines);
+      expect(resolvedText, 'no real marker may land in resolved text').to.deep.equal([
+        'ctx',
+        'tail',
+      ]);
+    });
+
+    it('a complete quoted example that survived the merge is CONTENT, not a conflict', async () => {
+      // A docs file contains a worked conflict example; the REAL conflict is
+      // elsewhere. The example region exists verbatim in both blobs — it
+      // must render as plain content, not as a pickable phantom block whose
+      // resolution would mangle the documentation.
+      setupDefaultMocks();
+      const example = ['Example of a conflict:', '<<<<<<< HEAD', 'your code', '=======', 'their code', '>>>>>>> branch'];
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return [...example, 'intro', 'BASE'].join('\n');
+          if (blobArgs?.oid === 'ours-oid') return [...example, 'intro', 'OURS'].join('\n');
+          if (blobArgs?.oid === 'theirs-oid') return [...example, 'intro', 'THEIRS'].join('\n');
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            ...example,
+            'intro',
+            '<<<<<<< HEAD',
+            'OURS',
+            '=======',
+            'THEIRS',
+            '>>>>>>> branch',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('docs/conflicts.md');
+      const segments = internalOf(el).segments;
+      const conflicts = segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length, 'only the REAL conflict is a block').to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['OURS']);
+      expect(conflicts[0].theirsLines).to.deep.equal(['THEIRS']);
+      // The example survived as ordinary content, markers and all.
+      const resolvedText = segments
+        .filter((s) => s.type === 'resolved')
+        .flatMap((s) => s.lines);
+      expect(resolvedText).to.deep.equal([...example, 'intro']);
+    });
+
+    it('a committed marker triplet INSIDE a real conflict does not close it early', async () => {
+      // The file was committed with a bare marker triplet as content (a
+      // well-known footgun); a real merge then conflicts around it. The
+      // committed ======= / >>>>>>> must not terminate the real block —
+      // that would orphan git's real separator and end marker as resolved
+      // text.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'ctx\n<<<<<<<\n=======\n>>>>>>>\ntail';
+          if (blobArgs?.oid === 'ours-oid')
+            return 'ctx\nours-real\n<<<<<<<\n=======\n>>>>>>>\nmore-ours\ntail';
+          if (blobArgs?.oid === 'theirs-oid')
+            return 'ctx\n<<<<<<<\n=======\n>>>>>>>\ntheirs-real\ntail';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            'ctx',
+            '<<<<<<< HEAD',
+            'ours-real',
+            '<<<<<<<',
+            '=======',
+            '>>>>>>>',
+            'more-ours',
+            '=======',
+            'theirs-real',
+            '>>>>>>> branch',
+            'tail',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/fixture.txt');
+      const segments = internalOf(el).segments;
+      const conflicts = segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal([
+        'ours-real',
+        '<<<<<<<',
+        '=======',
+        '>>>>>>>',
+        'more-ours',
+      ]);
+      expect(conflicts[0].theirsLines).to.deep.equal(['theirs-real']);
+      const resolvedText = segments
+        .filter((s) => s.type === 'resolved')
+        .flatMap((s) => s.lines);
+      expect(resolvedText, 'the real separator/end must not be orphaned').to.deep.equal([
+        'ctx',
+        'tail',
+      ]);
+    });
+
     it('keeps an unterminated conflict as a conflict block', async () => {
       const el = await renderEditor();
       const segments = internalOf(el).parseSegments(
@@ -710,7 +860,7 @@ describe('lv-merge-editor', () => {
       expect(resolvedFired).to.be.true;
     });
 
-    it('a side-blob read failure does NOT offer verbatim take-side (sides untrustworthy)', async () => {
+    it('verbatim take-side is offered PER SIDE — a failed ours blob hides only ours', async () => {
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
@@ -725,7 +875,29 @@ describe('lv-merge-editor', () => {
       const verbatimBtns = Array.from(
         el.shadowRoot!.querySelectorAll('.output-error button')
       ).filter((b) => b.textContent?.includes('verbatim'));
-      expect(verbatimBtns.length).to.equal(0);
+      expect(verbatimBtns.length).to.equal(1);
+      expect(verbatimBtns[0].classList.contains('btn-theirs')).to.be.true;
+    });
+
+    it('a failed BASE blob does not hide the verbatim escape hatch (take-side never reads base)', async () => {
+      // Missing base object (shallow/partial clone) — ours and theirs are
+      // fully readable, so both verbatim options must stay available or the
+      // user's only way out is aborting the whole operation.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') throw new Error('missing object');
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      expect(internalOf(el).loadFailed).to.be.true;
+      const verbatimBtns = Array.from(
+        el.shadowRoot!.querySelectorAll('.output-error button')
+      ).filter((b) => b.textContent?.includes('verbatim'));
+      expect(verbatimBtns.length).to.equal(2);
     });
   });
 
@@ -1039,6 +1211,13 @@ describe('lv-merge-editor', () => {
       // The event must carry the file the call resolved — marking B resolved
       // without resolving it would let a stash Complete drop the stash early.
       expect(resolvedPaths).to.deep.equal(['src/a.ts']);
+
+      // And A's saved content must NOT be recorded as file B's saved state —
+      // that would corrupt B's unsaved-work detection.
+      expect(
+        (el as unknown as { lastSavedContent: string | null }).lastSavedContent,
+        "a stale write's content must not become the current file's saved state"
+      ).to.equal(null);
     });
 
     it('ignores a double-click while the resolve call is in flight', async () => {
@@ -2533,6 +2712,41 @@ describe('lv-merge-editor', () => {
       expect(internal.editingSegmentId).to.equal(null);
       expect(internal.segments.length).to.equal(1);
       expect(internal.segments[0].origin).to.equal('ours');
+    });
+
+    it('opening Edit on another segment confirms before discarding the open draft', async () => {
+      setupDefaultMocks();
+      let confirmAnswer: unknown = false;
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return confirmAnswer;
+        }
+        return baseMock(command, args);
+      };
+      const { el, internal } = await renderWithEdit();
+      const editedId = internal.editingSegmentId!;
+      internal.editDraft = 'careful hand-typed merge';
+
+      const other = internal.segments.find((s) => s.id !== editedId)!;
+      const start = (
+        el as unknown as { startEditSegment: (s: unknown) => Promise<void> }
+      ).startEditSegment;
+
+      // Declined: the original draft and target stay.
+      await start.call(el, other);
+      await el.updateComplete;
+      expect(confirmCalls).to.equal(1);
+      expect(internal.editingSegmentId).to.equal(editedId);
+      expect(internal.editDraft).to.equal('careful hand-typed merge');
+
+      // Accepted: the edit retargets.
+      confirmAnswer = 'Ok';
+      await start.call(el, other);
+      await el.updateComplete;
+      expect(internal.editingSegmentId).to.equal(other.id);
     });
 
     it('marker-free edits apply without any confirmation', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -342,6 +342,53 @@ describe('lv-merge-editor', () => {
     });
   });
 
+  // ── Stale-load races ─────────────────────────────────────────────────
+  describe('stale-load races', () => {
+    it('ignores a stale load when the user switches files quickly', async () => {
+      setupDefaultMocks();
+      let releaseA: ((v: string) => void) | null = null;
+      mockInvoke = (async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') return 'x';
+        if (command === 'read_file_content') {
+          const filePath = (args as { filePath: string }).filePath;
+          if (filePath === 'src/a.ts') {
+            // File A's read hangs until we release it — simulating a slow
+            // load that resolves AFTER the user has switched to file B.
+            return new Promise((res) => {
+              releaseA = res as (v: string) => void;
+            });
+          }
+          return 'b-content';
+        }
+        if (command === 'get_merge_tool_config') return null;
+        if (command === 'is_ai_available') return false;
+        return null;
+      }) as MockInvoke;
+
+      const el = await renderEditor();
+      const internal = internalOf(el);
+      internal.conflictFile = makeConflictFile('src/a.ts');
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 30));
+
+      internal.conflictFile = makeConflictFile('src/b.ts');
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && internal.segments.length > 0) break;
+      }
+
+      // The stale A load finally resolves — it must NOT overwrite B's state
+      // (Mark Resolved would otherwise stage A's content under B's path).
+      releaseA!('a-content');
+      await new Promise((r) => setTimeout(r, 30));
+      await el.updateComplete;
+
+      expect(internal.segments.flatMap((s) => s.lines).join('\n')).to.equal('b-content');
+      expect(internal.loading).to.be.false;
+    });
+  });
+
   // ── Load failure handling ────────────────────────────────────────────
   describe('load failure', () => {
     it('shows an error state with Retry instead of fabricating a merge', async () => {
@@ -627,6 +674,27 @@ describe('lv-merge-editor', () => {
       expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
     });
 
+    it('refuses to write while an inline edit is open (unapplied draft)', async () => {
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+
+      // Open Edit on the resolved segment — the draft is unapplied.
+      const editBtn = el.shadowRoot!.querySelector('.output-segment .segment-btn') as HTMLButtonElement;
+      editBtn.click();
+      await el.updateComplete;
+
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled).to.be.true;
+
+      // Direct invocation must also refuse — it would stage the PRE-edit text.
+      invokeHistory.length = 0;
+      await internalOf(el).handleMarkResolved();
+      expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
+    });
+
     it('refuses to write after a failed load even if invoked directly', async () => {
       setupDefaultMocks();
       workdirContent = () => Promise.reject(new Error('read failed'));
@@ -798,6 +866,27 @@ describe('lv-merge-editor', () => {
         (b) => b.textContent?.trim() === 'Mark Resolved'
       ) as HTMLButtonElement;
       expect(markBtn.disabled).to.be.true;
+
+      // The failed pane shows an error, not fabricated empty content.
+      const oursPane = el.shadowRoot!.getElementById('panel-ours')!;
+      expect(oursPane.textContent).to.include('Could not read this version');
+      expect(oursPane.querySelectorAll('.code-line').length).to.equal(0);
+      expect(shadowText(el)).to.include('read failed');
+
+      // Whole-file accepts are disabled — their content is not trustworthy.
+      const useOurs = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions .btn-ours')).find(
+        (b) => b.textContent?.trim() === 'Use Ours'
+      ) as HTMLButtonElement;
+      expect(useOurs.disabled).to.be.true;
+      const headerUse = el.shadowRoot!.querySelector(
+        '.panel-header.ours .panel-header-btn'
+      ) as HTMLButtonElement;
+      expect(headerUse.disabled).to.be.true;
+
+      // The output header must not contradict the retry box with "No conflicts".
+      expect(el.shadowRoot!.querySelector('.conflict-count')!.textContent).to.not.include(
+        'No conflicts'
+      );
     });
   });
 
@@ -1013,6 +1102,21 @@ describe('lv-merge-editor', () => {
       release!();
       await new Promise((r) => setTimeout(r, 20));
       await el.updateComplete;
+    });
+
+    it('treats an empty AI suggestion as removing the section, not a blank line', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      aiSuggestion = () => Promise.resolve({ resolvedContent: '', explanation: '' });
+
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'AI Suggest').click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      const resolved = internalOf(el).segments[1];
+      expect(resolved.type).to.equal('resolved');
+      expect(resolved.lines).to.deep.equal([]);
     });
 
     it('rejects an AI suggestion that contains conflict markers', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -708,6 +708,80 @@ describe('lv-merge-editor', () => {
       expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
     });
 
+    it('dispatches the file it actually resolved, not the one selected after a mid-flight switch', async () => {
+      setupDefaultMocks();
+      let releaseResolve: (() => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'resolve_conflict') {
+          return new Promise((res) => {
+            releaseResolve = () => res({ success: true });
+          });
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/a.ts');
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+
+      const resolvedPaths: string[] = [];
+      el.addEventListener('conflict-resolved', ((e: CustomEvent) => {
+        resolvedPaths.push(e.detail.file.path);
+      }) as EventListener);
+
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      markBtn.click();
+      await el.updateComplete;
+
+      // The user selects another file while the backend call is in flight.
+      internalOf(el).conflictFile = makeConflictFile('src/b.ts');
+      await el.updateComplete;
+
+      releaseResolve!();
+      await new Promise((r) => setTimeout(r, 30));
+
+      // The event must carry the file the call resolved — marking B resolved
+      // without resolving it would let a stash Complete drop the stash early.
+      expect(resolvedPaths).to.deep.equal(['src/a.ts']);
+    });
+
+    it('ignores a double-click while the resolve call is in flight', async () => {
+      setupDefaultMocks();
+      let resolveCalls = 0;
+      let releaseResolve: (() => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'resolve_conflict') {
+          resolveCalls++;
+          return new Promise((res) => {
+            releaseResolve = () => res({ success: true });
+          });
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+
+      let resolvedEvents = 0;
+      el.addEventListener('conflict-resolved', () => {
+        resolvedEvents++;
+      });
+
+      const internal = el as unknown as { handleMarkResolved: () => Promise<void> };
+      const first = internal.handleMarkResolved.call(el);
+      const second = internal.handleMarkResolved.call(el);
+      releaseResolve!();
+      await Promise.all([first, second]);
+
+      expect(resolveCalls).to.equal(1);
+      expect(resolvedEvents).to.equal(1);
+    });
+
     it('writes marker-free content and dispatches conflict-resolved once resolved', async () => {
       const el = await renderLoadedEditor();
       findConflictButton(el, 'Use Both').click();

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -3477,6 +3477,34 @@ describe('lv-merge-editor', () => {
       expectNoMarkers(el);
     });
 
+    it('a deleted separator PLUS an edited body line still keeps the orphan marker out of the panes', async () => {
+      // The hand edit removed the separator AND changed a line, so no
+      // blob-validated split exists. The orphan end marker must still act
+      // as the region terminator — sweeping it into the ours pane would
+      // render a raw marker.
+      setupDefaultMocks();
+      workdirContent = [
+        'line1',
+        '<<<<<<< HEAD',
+        'line2-edited',
+        'line2-theirs',
+        '>>>>>>> feature',
+        'line3',
+      ].join('\n');
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
+
+      const conflicts = internal.segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      // No split validates — the body falls back to everything-ours, but
+      // the marker itself is consumed as the terminator.
+      expect(conflicts[0].oursLines).to.deep.equal(['line2-edited', 'line2-theirs']);
+      expect(conflicts[0].theirsLines).to.deep.equal([]);
+      // The trailing content after the terminator is normal resolved text.
+      expect(internal.segments[internal.segments.length - 1].lines).to.deep.equal(['line3']);
+      expectNoMarkers(el);
+    });
+
     it('a hand-typed end-shaped line before the separator does not close the region early', async () => {
       // Mid-region junk: an end-shaped line typed BEFORE the real
       // separator, with the real separator+end below. Closing at the junk
@@ -3714,6 +3742,23 @@ describe('lv-merge-editor', () => {
       expect((takeSide!.args as Record<string, unknown>).side).to.equal('theirs');
       expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
       expect(resolvedFired).to.be.true;
+    });
+
+    it('a submodule<->file type conflict labels the file side honestly, not as a commit', async () => {
+      // is_submodule is set when ANY side is a gitlink, so a type conflict
+      // routes here — the file side's OID is a BLOB and must not be
+      // formatted like a commit pointer.
+      const file = {
+        ...makeSubmoduleConflict(),
+        theirs: { oid: 'd'.repeat(40), path: 'sub', mode: 0o100644 },
+      };
+      const el = await renderSubmoduleEditor(file);
+
+      const text = shadowText(el);
+      expect(text).to.include('a regular file');
+      expect(text, 'blob OID must not be shown as a commit').to.not.include('d'.repeat(7));
+      const theirsBtn = el.shadowRoot!.querySelector('.btn-theirs') as HTMLButtonElement;
+      expect(theirsBtn.textContent).to.include('Use Theirs (file)');
     });
 
     it('a deleted side offers removing the submodule and lands in the terminal state', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -502,6 +502,78 @@ describe('lv-merge-editor', () => {
       }
     });
 
+    it('a setext underline in ours cannot swallow the real separator (blob-validated resplit)', async () => {
+      // Ours legitimately contains a line of exactly seven equals (a
+      // Markdown setext H1 underline). Shape alone cannot tell it from
+      // git's separator — the split must validate against the blobs, or
+      // the real separator leaks into the theirs pane and gets written
+      // back to disk on Use Theirs + Mark Resolved.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'Intro\ntail';
+          if (blobArgs?.oid === 'ours-oid') return 'Intro\nHeading\n=======\nOURS CHANGE\ntail';
+          if (blobArgs?.oid === 'theirs-oid') return 'Intro\nTHEIRS CHANGE\ntail';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            'Intro',
+            '<<<<<<< HEAD',
+            'Heading',
+            '=======',
+            'OURS CHANGE',
+            '=======',
+            'THEIRS CHANGE',
+            '>>>>>>> theirs',
+            'tail',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/doc.md');
+      const segments = internalOf(el).segments;
+      const conflicts = segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['Heading', '=======', 'OURS CHANGE']);
+      expect(conflicts[0].theirsLines).to.deep.equal(['THEIRS CHANGE']);
+    });
+
+    it('a setext underline in THEIRS does not shift the split either', async () => {
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'tail';
+          if (blobArgs?.oid === 'ours-oid') return 'OURS\ntail';
+          if (blobArgs?.oid === 'theirs-oid') return 'Heading\n=======\ntail';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            '<<<<<<< HEAD',
+            'OURS',
+            '=======',
+            'Heading',
+            '=======',
+            '>>>>>>> theirs',
+            'tail',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/doc.md');
+      const conflicts = internalOf(el).segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['OURS']);
+      expect(conflicts[0].theirsLines).to.deep.equal(['Heading', '=======']);
+    });
+
     it('keeps an unterminated conflict as a conflict block', async () => {
       const el = await renderEditor();
       const segments = internalOf(el).parseSegments(
@@ -609,6 +681,51 @@ describe('lv-merge-editor', () => {
       expect(internal.loadFailed).to.be.false;
       expect(internal.segments.length).to.equal(1);
       expect(internal.segments[0].type).to.equal('resolved');
+    });
+
+    it('a workdir-only read failure still offers verbatim take-side resolution', async () => {
+      // Non-UTF-8 (legacy encoding) text files fail read_file_content but
+      // are not binary — without a verbatim escape hatch the file could
+      // never be resolved in-app and Complete would stay disabled forever.
+      setupDefaultMocks();
+      workdirContent = () => Promise.reject(new Error('invalid utf-8'));
+      const el = await renderLoadedEditor();
+      expect(internalOf(el).loadFailed).to.be.true;
+
+      const takeOurs = Array.from(el.shadowRoot!.querySelectorAll('.output-error button')).find(
+        (b) => b.textContent?.includes('verbatim') && b.classList.contains('btn-ours')
+      ) as HTMLButtonElement;
+      expect(takeOurs, 'verbatim Use Ours offered in the error state').to.not.be.undefined;
+
+      let resolvedFired = false;
+      el.addEventListener('conflict-resolved', () => {
+        resolvedFired = true;
+      });
+      invokeHistory.length = 0;
+      takeOurs.click();
+      await new Promise((r) => setTimeout(r, 30));
+      const call = invokeHistory.find((h) => h.command === 'resolve_conflict_take_side');
+      expect(call, 'take-side resolves blob-verbatim').to.not.be.undefined;
+      expect((call!.args as { side: string }).side).to.equal('ours');
+      expect(resolvedFired).to.be.true;
+    });
+
+    it('a side-blob read failure does NOT offer verbatim take-side (sides untrustworthy)', async () => {
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'ours-oid') throw new Error('blob read failed');
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      expect(internalOf(el).loadFailed).to.be.true;
+      const verbatimBtns = Array.from(
+        el.shadowRoot!.querySelectorAll('.output-error button')
+      ).filter((b) => b.textContent?.includes('verbatim'));
+      expect(verbatimBtns.length).to.equal(0);
     });
   });
 
@@ -2350,6 +2467,72 @@ describe('lv-merge-editor', () => {
       expect(segment.type).to.equal('resolved');
       expect(segment.lines).to.deep.equal(['Heading', '=======']);
       expect(internal.editingSegmentId).to.equal(null);
+    });
+
+    it('a lock engaging during the confirm window makes the apply inert', async () => {
+      setupDefaultMocks();
+      let releaseConfirm: (() => void) | null = null;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          return new Promise((res) => {
+            releaseConfirm = () => res('Ok');
+          });
+        }
+        return baseMock(command, args);
+      };
+      const { el, internal } = await renderWithEdit();
+      const editedId = internal.editingSegmentId!;
+      internal.editDraft = '<<<<<<< HEAD\npasted';
+      const applying = internal.applyEditSegment.call(el);
+      await new Promise((r) => setTimeout(r, 10));
+
+      // A host tool session starts while the confirm is up — the apply
+      // must re-check the lock after the await, like Reload does.
+      el.externalToolLocked = true;
+      releaseConfirm!();
+      await applying;
+      await el.updateComplete;
+
+      expect(
+        internal.segments.find((s) => s.id === editedId)?.type,
+        'the apply must be inert once the lock engaged'
+      ).to.equal('conflict');
+      el.externalToolLocked = false;
+    });
+
+    it('whole-file accept with an open edit draft confirms before discarding it', async () => {
+      setupDefaultMocks();
+      let confirmAnswer: unknown = false;
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|message') {
+          confirmCalls++;
+          return confirmAnswer;
+        }
+        return baseMock(command, args);
+      };
+      const { el, internal } = await renderWithEdit();
+      const editedId = internal.editingSegmentId!;
+      internal.editDraft = 'careful hand-typed merge';
+      const accept = (el as unknown as { acceptWholeFile: (o: string) => Promise<void> })
+        .acceptWholeFile;
+
+      // Declined: the draft and the open edit survive.
+      await accept.call(el, 'ours');
+      await el.updateComplete;
+      expect(confirmCalls).to.equal(1);
+      expect(internal.editingSegmentId, 'declining keeps the edit open').to.equal(editedId);
+      expect(internal.editDraft).to.equal('careful hand-typed merge');
+
+      // Accepted: the whole file replaces the segments.
+      confirmAnswer = 'Ok';
+      await accept.call(el, 'ours');
+      await el.updateComplete;
+      expect(internal.editingSegmentId).to.equal(null);
+      expect(internal.segments.length).to.equal(1);
+      expect(internal.segments[0].origin).to.equal('ours');
     });
 
     it('marker-free edits apply without any confirmation', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -1926,6 +1926,10 @@ describe('lv-merge-editor', () => {
         if (command === 'read_file_content') return DEFAULT_WORKDIR_CONTENT;
         if (command === 'get_merge_tool_config') return null;
         if (command === 'is_ai_available') return false;
+        // The file is genuinely STILL conflicted — the read failure is a
+        // side-blob error, not a resolution — so it must land in the error
+        // state, not the resolved terminal.
+        if (command === 'get_conflicts') return [{ path: 'src/test.ts' }];
         return null;
       }) as MockInvoke;
 
@@ -3458,17 +3462,18 @@ describe('lv-merge-editor', () => {
       expect(badButtons.length, 'no resurrect/retry affordances').to.equal(0);
     });
 
-    it('a KEPT but undecodable file is a read error, never a false "was deleted"', async () => {
-      // The file was resolved externally by KEEPING it (checkout --ours &&
-      // add) but its content is legacy-encoded, so the strict read fails
-      // the same way a missing file would. The deletion claim requires
-      // FILE_NOT_FOUND — anything else lands in the honest error state.
+    it('a STILL-conflicted but undecodable file is a read error, never a false "was deleted"', async () => {
+      // The file is genuinely still conflicted but its content is
+      // legacy-encoded, so the strict read fails the same way a missing
+      // file would. Because the index STILL lists it as conflicted, it must
+      // land in the honest error state (Retry/verbatim), not a false
+      // "was deleted" or a false "resolved" terminal.
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'read_file_content')
           throw { code: 'IO_ERROR', message: 'stream did not contain valid UTF-8' };
-        if (command === 'get_conflicts') return [];
+        if (command === 'get_conflicts') return [{ path: 'src/latin1.ts' }];
         return baseMock(command, args);
       };
       const el = await renderEditor();
@@ -3484,6 +3489,37 @@ describe('lv-merge-editor', () => {
       expect(internal.loadFailed).to.be.true;
       expect(shadowText(el)).to.include('Could not read the merged file');
       expect(shadowText(el)).to.not.include('deleted by the resolution');
+      expect(shadowText(el)).to.not.include('the chosen version was staged');
+    });
+
+    it('re-selecting a text file resolved via verbatim take lands terminal, not forever-Retry', async () => {
+      // A legacy-encoded file resolved via "Use Theirs (verbatim)" is no
+      // longer conflicted, but re-selecting it re-fails the same undecodable
+      // read. The index confirms it is resolved, so it must show the
+      // terminal notice, not the error state with a looping Retry and
+      // verbatim buttons that error "No conflict found".
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'read_file_content')
+          throw { code: 'IO_ERROR', message: 'stream did not contain valid UTF-8' };
+        // The index no longer lists it — the verbatim take resolved it.
+        if (command === 'get_conflicts') return [];
+        return baseMock(command, args);
+      };
+      const el = await renderEditor();
+      const internal = el as unknown as EditorInternal;
+      internal.conflictFile = makeConflictFile('src/latin1.ts');
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading) break;
+      }
+      await el.updateComplete;
+
+      expect(internal.loadFailed, 'no forever-Retry error state').to.be.false;
+      expect(shadowText(el)).to.include('Resolved — the chosen version was staged');
+      expect(el.shadowRoot!.querySelector('.output-error')).to.be.null;
     });
 
     it('a take-side that KEEPS the file reloads the fresh content', async () => {
@@ -3574,6 +3610,29 @@ describe('lv-merge-editor', () => {
       // the region's terminator, not content.
       expect(internal.segments[1].oursLines).to.deep.equal(['line2-ours']);
       expect(internal.segments[1].theirsLines).to.deep.equal(['line2-theirs']);
+      expectNoMarkers(el);
+    });
+
+    it('a hand-deleted START marker never leaks the orphan =======/>>>>>>> into the UI', async () => {
+      // The region scan only OPENS on a <<<<<<< line; deleting it leaves an
+      // orphaned separator/end that would otherwise render as resolved text.
+      // The safety net presents the whole file as one clean conflict block.
+      setupDefaultMocks();
+      workdirContent = [
+        'line1',
+        // <<<<<<< HEAD deleted by hand
+        'line2-ours',
+        '=======',
+        'line2-theirs',
+        '>>>>>>> feature',
+        'line3',
+      ].join('\n');
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
+
+      // Falls back to a single conflict block (ours-blob vs theirs-blob).
+      const conflicts = internal.segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
       expectNoMarkers(el);
     });
 

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -724,6 +724,98 @@ describe('lv-merge-editor', () => {
       ]);
     });
 
+    it('a quoted end marker IDENTICAL to the real one cannot close the block early', async () => {
+      // The theirs hunk quotes an end marker whose text exactly matches
+      // git's real end marker (a tutorial quoting `>>>>>>> feature` while
+      // that very branch merges in). Line-membership orphan checks are
+      // blind here — only the strong trailing-is-blob-run justification
+      // can pick the real close.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'ctx\ntail';
+          if (blobArgs?.oid === 'ours-oid') return 'ctx\nours-real\ntail';
+          if (blobArgs?.oid === 'theirs-oid')
+            return 'ctx\ntheirs section unique 1\n>>>>>>> feature\ntheirs section unique 2\ntail';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            'ctx',
+            '<<<<<<< HEAD',
+            'ours-real',
+            '=======',
+            'theirs section unique 1',
+            '>>>>>>> feature',
+            'theirs section unique 2',
+            '>>>>>>> feature',
+            'tail',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('docs/tutorial.md');
+      const segments = internalOf(el).segments;
+      const conflicts = segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['ours-real']);
+      expect(conflicts[0].theirsLines).to.deep.equal([
+        'theirs section unique 1',
+        '>>>>>>> feature',
+        'theirs section unique 2',
+      ]);
+      const resolvedText = segments
+        .filter((s) => s.type === 'resolved')
+        .flatMap((s) => s.lines);
+      expect(resolvedText, 'the real end marker must be consumed, never resolved text').to.deep.equal(
+        ['ctx', 'tail']
+      );
+    });
+
+    it('a quoted marker just AFTER the real end stays trailing content (symmetric case)', async () => {
+      // The mirror image: common content directly after the hunk quotes a
+      // line identical to the real end marker. The close must happen at
+      // the REAL end, keeping the quoted copy as resolved content.
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'ctx\n>>>>>>> feature\ntail';
+          if (blobArgs?.oid === 'ours-oid') return 'ctx\nours1\n>>>>>>> feature\ntail';
+          if (blobArgs?.oid === 'theirs-oid') return 'ctx\ntheirs1\n>>>>>>> feature\ntail';
+          return '';
+        }
+        if (command === 'read_file_content') {
+          return [
+            'ctx',
+            '<<<<<<< HEAD',
+            'ours1',
+            '=======',
+            'theirs1',
+            '>>>>>>> feature',
+            '>>>>>>> feature',
+            'tail',
+          ].join('\n');
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('docs/notes.md');
+      const segments = internalOf(el).segments;
+      const conflicts = segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['ours1']);
+      expect(conflicts[0].theirsLines).to.deep.equal(['theirs1']);
+      const resolvedText = segments
+        .filter((s) => s.type === 'resolved')
+        .flatMap((s) => s.lines);
+      expect(resolvedText).to.deep.equal(['ctx', '>>>>>>> feature', 'tail']);
+    });
+
     it('keeps an unterminated conflict as a conflict block', async () => {
       const el = await renderEditor();
       const segments = internalOf(el).parseSegments(
@@ -879,10 +971,10 @@ describe('lv-merge-editor', () => {
       expect(verbatimBtns[0].classList.contains('btn-theirs')).to.be.true;
     });
 
-    it('a failed BASE blob does not hide the verbatim escape hatch (take-side never reads base)', async () => {
-      // Missing base object (shallow/partial clone) — ours and theirs are
-      // fully readable, so both verbatim options must stay available or the
-      // user's only way out is aborting the whole operation.
+    it('a failed BASE blob keeps the structured editor fully working', async () => {
+      // Missing base object (shallow/partial clone) — parsing and block
+      // resolution never need base content, so the editor must stay alive
+      // with only Use Base disabled, not degrade to whole-file-only.
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
@@ -893,11 +985,24 @@ describe('lv-merge-editor', () => {
         return baseMock(command, args);
       };
       const el = await renderLoadedEditor();
-      expect(internalOf(el).loadFailed).to.be.true;
-      const verbatimBtns = Array.from(
-        el.shadowRoot!.querySelectorAll('.output-error button')
-      ).filter((b) => b.textContent?.includes('verbatim'));
-      expect(verbatimBtns.length).to.equal(2);
+      const internal = internalOf(el);
+      expect(internal.loadFailed).to.be.false;
+      expect(internal.segments.filter((s) => s.type === 'conflict').length).to.equal(1);
+
+      // Per-block resolution still works.
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(internal.segments.filter((s) => s.type === 'conflict').length).to.equal(0);
+
+      // Only Use Base is disabled — its content is not trustworthy.
+      const useBase = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions .btn')).find(
+        (b) => b.textContent?.trim() === 'Use Base'
+      ) as HTMLButtonElement;
+      expect(useBase.disabled).to.be.true;
+      const useOurs = Array.from(
+        el.shadowRoot!.querySelectorAll('.toolbar-actions .btn-ours')
+      ).find((b) => b.textContent?.trim() === 'Use Ours') as HTMLButtonElement;
+      expect(useOurs.disabled).to.be.false;
     });
   });
 
@@ -2812,6 +2917,31 @@ describe('lv-merge-editor', () => {
       await el.updateComplete;
       expect(el.hasUnsavedResolutions(), 'accepting reloads from disk').to.be.false;
       expect(internal.segments.some((s) => s.type === 'conflict')).to.be.true;
+    });
+
+    it('a successful take-side supersedes stale in-memory picks', async () => {
+      // Picks made before a whole-side take are moot once the side is on
+      // disk and staged — leaving userTouched set would make Complete raise
+      // a false "unsaved rework" confirm on the LAST file (no auto-advance).
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'resolve_conflict_take_side') return { success: true };
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor('src/test.ts');
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(el.hasUnsavedResolutions()).to.be.true;
+
+      await (
+        el as unknown as { handleTakeSide: (s: string) => Promise<void> }
+      ).handleTakeSide.call(el, 'theirs');
+      await el.updateComplete;
+      expect(
+        el.hasUnsavedResolutions(),
+        'the write supersedes the in-memory picks'
+      ).to.be.false;
     });
 
     it('reload without unsaved picks does not ask', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -27,6 +27,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 import '../lv-merge-editor.ts';
 import type { LvMergeEditor } from '../lv-merge-editor.ts';
 import type { ConflictFile } from '../../../types/git.types.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
 
 // ── Test data ──────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
@@ -330,6 +331,18 @@ describe('lv-merge-editor', () => {
       expect(segments.length).to.equal(1);
       expect(segments[0].type).to.equal('resolved');
       expect(segments[0].lines).to.deep.equal(['<<<<<<<< not a marker', 'content']);
+    });
+
+    it('a long bracket run with only a coincidental divider stays content', async () => {
+      const el = await renderEditor();
+      // An 8-char banner plus a stray 8-equals divider is NOT a conflict —
+      // without a matching 8-char end marker the size lookahead must reject
+      // it instead of swallowing the file into a phantom conflict.
+      const segments = internalOf(el).parseSegments(
+        '<<<<<<<< banner heading\ntext\n========\nmore text'
+      );
+      expect(segments.length).to.equal(1);
+      expect(segments[0].type).to.equal('resolved');
     });
 
     it('parses raised conflict-marker-size markers (gitattribute)', async () => {
@@ -1517,6 +1530,18 @@ describe('lv-merge-editor', () => {
       await el.updateComplete;
       expect(el.hasUnsavedResolutions()).to.be.true;
     });
+
+    it('counts a whole-file accept as unsaved work too', async () => {
+      const el = await renderLoadedEditor();
+      // Whole-file accepts create segments without fromConflict — they must
+      // still be protected from a silent discard on file switch.
+      const useOurs = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions .btn-ours')).find(
+        (b) => b.textContent?.trim() === 'Use Ours'
+      ) as HTMLButtonElement;
+      useOurs.click();
+      await el.updateComplete;
+      expect(el.hasUnsavedResolutions()).to.be.true;
+    });
   });
 
   // ── External tool session signaling ──────────────────────────────────
@@ -1604,6 +1629,45 @@ describe('lv-merge-editor', () => {
       expect(resolvedCountAfter, 'B\'s WIP resolution must survive an unrelated file\'s external tool completing').to.equal(1);
     });
 
+    it('a still-conflicted tool exit warns instead of toasting success', async () => {
+      setupDefaultMocks();
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'launch_merge_tool') return { success: true };
+        // Post-tool index check: the file is STILL conflicted.
+        if (command === 'get_conflicts') {
+          return [
+            { path: 'src/test.ts', ancestor: null, ours: null, theirs: null, isBinary: false },
+          ];
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/test.ts');
+      let resolvedFired = false;
+      el.addEventListener('conflict-resolved', () => {
+        resolvedFired = true;
+      });
+
+      // Clear toasts accumulated by earlier tests — the store is global.
+      const uiState = uiStore.getState();
+      uiState.toasts.forEach((t) => uiState.removeToast(t.id));
+
+      const toolBtn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+        (b) => b.textContent?.includes('External Tool')
+      ) as HTMLButtonElement;
+      toolBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
+
+      // Not resolved: no conflict-resolved dispatch, and the toast is the
+      // warning, not the success (mirroring the dialog's launcher).
+      expect(resolvedFired).to.be.false;
+      const toasts = uiStore.getState().toasts.map((t) => t.message);
+      expect(toasts.some((m) => m.includes('still has conflicts'))).to.be.true;
+      expect(toasts.some((m) => m.includes('Merge tool completed'))).to.be.false;
+    });
+
     it('a still-conflicted tool exit reloads only when the file is still selected', async () => {
       setupDefaultMocks();
       let releaseTool: (() => void) | null = null;
@@ -1649,6 +1713,49 @@ describe('lv-merge-editor', () => {
       // B's pick survived — the still-conflicted branch did not reload B.
       const resolved = internal.segments.filter((s) => s.origin === 'ours').length;
       expect(resolved).to.equal(1);
+    });
+
+    it('launching the tool with unsaved picks asks for confirmation first', async () => {
+      setupDefaultMocks();
+      let launchCalls = 0;
+      const baseMock = mockInvoke;
+      let confirmAnswer: unknown = false;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_merge_tool_config') return { toolName: 'meld' };
+        if (command === 'plugin:dialog|message') return confirmAnswer;
+        if (command === 'launch_merge_tool') {
+          launchCalls++;
+          return { success: true };
+        }
+        if (command === 'get_conflicts') {
+          return [
+            { path: 'src/test.ts', ancestor: null, ours: null, theirs: null, isBinary: false },
+          ];
+        }
+        return baseMock(command, args);
+      };
+
+      const el = await renderLoadedEditor('src/test.ts');
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(el.hasUnsavedResolutions()).to.be.true;
+
+      const toolBtn = () =>
+        Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions button')).find(
+          (b) => b.textContent?.includes('External Tool')
+        ) as HTMLButtonElement;
+
+      // Declined: the tool never launches and the picks stay.
+      toolBtn().click();
+      await new Promise((r) => setTimeout(r, 50));
+      expect(launchCalls).to.equal(0);
+      expect(el.hasUnsavedResolutions()).to.be.true;
+
+      // Accepted ('Ok' is the plugin's confirmed value): the tool launches.
+      confirmAnswer = 'Ok';
+      toolBtn().click();
+      await new Promise((r) => setTimeout(r, 80));
+      expect(launchCalls).to.equal(1);
     });
 
     it('resolve actions and the external tool are mutually exclusive', async () => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -1,8 +1,10 @@
 /**
  * Tests for lv-merge-editor component
  *
- * Tests merge editor core logic: auto-merge, conflict parsing,
- * accept ours/theirs/base, conflict resolution, and edit modes.
+ * Tests the structured no-markers merge editor: segment parsing, per-block
+ * resolution (ours/theirs/both/edit/reset), whole-file strategies, pane
+ * alignment, AI resolution, mark-resolved gating, and the invariant that raw
+ * conflict markers never appear in the rendered UI.
  */
 
 // ── Tauri mock (must be set before any imports) ────────────────────────────
@@ -29,6 +31,11 @@ import type { ConflictFile } from '../../../types/git.types.ts';
 // ── Test data ──────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
 
+const MARKER_CHARS = ['<<<<<<<', '=======', '>>>>>>>', '|||||||'];
+
+const DEFAULT_WORKDIR_CONTENT =
+  'line1\n<<<<<<< HEAD\nline2-ours\n=======\nline2-theirs\n>>>>>>> feature\nline3';
+
 function makeConflictFile(path: string): ConflictFile {
   return {
     path,
@@ -39,8 +46,42 @@ function makeConflictFile(path: string): ConflictFile {
   };
 }
 
+interface OutputSegmentShape {
+  id: number;
+  type: 'resolved' | 'conflict';
+  lines: string[];
+  oursLines: string[];
+  theirsLines: string[];
+  oursLabel: string;
+  theirsLabel: string;
+  origin: string | null;
+  fromConflict: boolean;
+}
+
+interface EditorInternal {
+  conflictFile: ConflictFile | null;
+  baseContent: string;
+  oursContent: string;
+  theirsContent: string;
+  segments: OutputSegmentShape[];
+  loading: boolean;
+  loadFailed: boolean;
+  aiAvailable: boolean;
+  parseSegments: (text: string) => OutputSegmentShape[];
+  loadContents: () => Promise<void>;
+  handleMarkResolved: () => Promise<void>;
+  handleAiResolveAll: () => Promise<void>;
+}
+
 // ── Helpers ────────────────────────────────────────────────────────────────
+let workdirContent: string | (() => Promise<unknown>) = DEFAULT_WORKDIR_CONTENT;
+let aiAvailable = false;
+let aiSuggestion: (() => Promise<unknown>) | null = null;
+
 function setupDefaultMocks(): void {
+  workdirContent = DEFAULT_WORKDIR_CONTENT;
+  aiAvailable = false;
+  aiSuggestion = null;
   mockInvoke = async (command: string, args?: unknown) => {
     switch (command) {
       case 'get_blob_content': {
@@ -51,12 +92,15 @@ function setupDefaultMocks(): void {
         return '';
       }
       case 'read_file_content':
-        // Working directory file with conflict markers
-        return 'line1\n<<<<<<< HEAD\nline2-ours\n=======\nline2-theirs\n>>>>>>> feature\nline3';
+        if (typeof workdirContent === 'function') return workdirContent();
+        return workdirContent;
       case 'get_merge_tool_config':
         return null;
       case 'is_ai_available':
-        return false;
+        return aiAvailable;
+      case 'suggest_conflict_resolution':
+        if (aiSuggestion) return aiSuggestion();
+        return { resolvedContent: 'ai-resolved', explanation: 'merged by ai' };
       case 'resolve_conflict':
         return { success: true };
       default:
@@ -72,6 +116,43 @@ async function renderEditor(): Promise<LvMergeEditor> {
     ></lv-merge-editor>
   `);
   return el;
+}
+
+/** Render the editor and load a conflict file through the real load path. */
+async function renderLoadedEditor(path = 'src/test.ts'): Promise<LvMergeEditor> {
+  const el = await renderEditor();
+  const internal = el as unknown as EditorInternal;
+  internal.conflictFile = makeConflictFile(path);
+  await el.updateComplete;
+  // loadContents runs from updated(); wait for it to settle.
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+  return el;
+}
+
+function internalOf(el: LvMergeEditor): EditorInternal {
+  return el as unknown as EditorInternal;
+}
+
+function shadowText(el: LvMergeEditor): string {
+  return el.shadowRoot!.textContent ?? '';
+}
+
+function expectNoMarkers(el: LvMergeEditor): void {
+  const text = shadowText(el);
+  for (const marker of MARKER_CHARS) {
+    expect(text, `UI must never contain "${marker}"`).to.not.include(marker);
+  }
+}
+
+function findConflictButton(el: LvMergeEditor, label: string): HTMLButtonElement {
+  const block = el.shadowRoot!.querySelector('.code-conflict-block');
+  expect(block, 'conflict block rendered').to.not.be.null;
+  const btn = Array.from(block!.querySelectorAll('button')).find(
+    (b) => b.textContent?.trim() === label
+  );
+  expect(btn, `conflict button "${label}"`).to.not.be.undefined;
+  return btn as HTMLButtonElement;
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -96,143 +177,32 @@ describe('lv-merge-editor', () => {
       expect(empty!.textContent).to.include('Select a file');
     });
 
-    it('renders toolbar when conflict file is set', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        conflictFile: ConflictFile;
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        outputContent: string;
-        loading: boolean;
-      };
-      internal.conflictFile = makeConflictFile('src/test.ts');
-      internal.baseContent = 'base';
-      internal.oursContent = 'ours';
-      internal.theirsContent = 'theirs';
-      internal.outputContent = 'output';
-      internal.loading = false;
-      await el.updateComplete;
-
-      const toolbar = el.shadowRoot!.querySelector('.toolbar');
-      expect(toolbar).to.exist;
+    it('renders toolbar and panes when a conflict file loads', async () => {
+      const el = await renderLoadedEditor();
+      expect(el.shadowRoot!.querySelector('.toolbar')).to.exist;
+      expect(el.shadowRoot!.querySelector('#panel-ours')).to.exist;
+      expect(el.shadowRoot!.querySelector('#panel-base')).to.exist;
+      expect(el.shadowRoot!.querySelector('#panel-theirs')).to.exist;
+      expect(el.shadowRoot!.querySelector('#panel-output')).to.exist;
     });
 
-    it('renders loading state initially', async () => {
-      const el = await renderEditor();
-      // Without conflictFile, it shouldn't be in loading state
-      const internal = el as unknown as { loading: boolean };
-      expect(internal.loading).to.be.false;
+    it('never renders raw conflict markers even though the file has them', async () => {
+      const el = await renderLoadedEditor();
+      expect(internalOf(el).segments.some((s) => s.type === 'conflict')).to.be.true;
+      expectNoMarkers(el);
+    });
+
+    it('shows the remaining conflict count', async () => {
+      const el = await renderLoadedEditor();
+      expect(shadowText(el)).to.include('1 conflict remaining');
     });
   });
 
-  // ── performAutoMerge ───────────────────────────────────────────────────
-  describe('performAutoMerge', () => {
-    it('merges when both sides agree', async () => {
+  // ── parseSegments ────────────────────────────────────────────────────
+  describe('parseSegments', () => {
+    it('parses content without conflicts as a single resolved segment', async () => {
       const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        performAutoMerge: () => string;
-      };
-
-      internal.baseContent = 'line1\nline2';
-      internal.oursContent = 'line1\nline2';
-      internal.theirsContent = 'line1\nline2';
-
-      const result = internal.performAutoMerge();
-      expect(result).to.equal('line1\nline2');
-    });
-
-    it('takes theirs when only theirs changed', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        performAutoMerge: () => string;
-      };
-
-      internal.baseContent = 'old line';
-      internal.oursContent = 'old line';
-      internal.theirsContent = 'new line';
-
-      const result = internal.performAutoMerge();
-      expect(result).to.equal('new line');
-    });
-
-    it('takes ours when only ours changed', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        performAutoMerge: () => string;
-      };
-
-      internal.baseContent = 'old line';
-      internal.oursContent = 'our change';
-      internal.theirsContent = 'old line';
-
-      const result = internal.performAutoMerge();
-      expect(result).to.equal('our change');
-    });
-
-    it('produces conflict markers when both sides changed differently', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        performAutoMerge: () => string;
-      };
-
-      internal.baseContent = 'original';
-      internal.oursContent = 'our version';
-      internal.theirsContent = 'their version';
-
-      const result = internal.performAutoMerge();
-      expect(result).to.include('<<<<<<< OURS');
-      expect(result).to.include('our version');
-      expect(result).to.include('=======');
-      expect(result).to.include('their version');
-      expect(result).to.include('>>>>>>> THEIRS');
-    });
-
-    it('handles different-length files', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        performAutoMerge: () => string;
-      };
-
-      internal.baseContent = 'line1\nline2';
-      internal.oursContent = 'line1\nline2\nline3-ours';
-      internal.theirsContent = 'line1\nline2';
-
-      const result = internal.performAutoMerge();
-      expect(result).to.include('line1');
-      expect(result).to.include('line2');
-      // Third line: ours added, theirs is empty, base is empty, both different from base
-      // Since ours != theirs and both differ from base (which is empty), it'll be a conflict or auto-resolved
-    });
-  });
-
-  // ── parseOutputSegments ────────────────────────────────────────────────
-  describe('parseOutputSegments', () => {
-    it('parses content without conflicts as single resolved segment', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        parseOutputSegments: () => Array<{ type: string; lines: string[] }>;
-      };
-
-      internal.outputContent = 'line1\nline2\nline3';
-
-      const segments = internal.parseOutputSegments();
+      const segments = internalOf(el).parseSegments('line1\nline2\nline3');
       expect(segments.length).to.equal(1);
       expect(segments[0].type).to.equal('resolved');
       expect(segments[0].lines).to.deep.equal(['line1', 'line2', 'line3']);
@@ -240,492 +210,539 @@ describe('lv-merge-editor', () => {
 
     it('parses content with one conflict', async () => {
       const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        parseOutputSegments: () => Array<{
-          type: string;
-          lines: string[];
-          oursLines: string[];
-          theirsLines: string[];
-          oursLabel: string;
-          theirsLabel: string;
-        }>;
-      };
-
-      internal.outputContent = 'before\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> feature\nafter';
-
-      const segments = internal.parseOutputSegments();
-      expect(segments.length).to.equal(3);
-
-      expect(segments[0].type).to.equal('resolved');
-      expect(segments[0].lines).to.deep.equal(['before']);
-
-      expect(segments[1].type).to.equal('conflict');
-      expect(segments[1].oursLines).to.deep.equal(['ours']);
-      expect(segments[1].theirsLines).to.deep.equal(['theirs']);
-      expect(segments[1].oursLabel).to.equal('HEAD');
-      expect(segments[1].theirsLabel).to.equal('feature');
-
-      expect(segments[2].type).to.equal('resolved');
-      expect(segments[2].lines).to.deep.equal(['after']);
+      const segments = internalOf(el).parseSegments(DEFAULT_WORKDIR_CONTENT);
+      expect(segments.map((s) => s.type)).to.deep.equal(['resolved', 'conflict', 'resolved']);
+      expect(segments[1].oursLines).to.deep.equal(['line2-ours']);
+      expect(segments[1].theirsLines).to.deep.equal(['line2-theirs']);
     });
 
     it('parses multiple conflicts', async () => {
       const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        parseOutputSegments: () => Array<{ type: string }>;
-      };
-
-      internal.outputContent = [
-        'top',
-        '<<<<<<< HEAD',
-        'ours1',
-        '=======',
-        'theirs1',
-        '>>>>>>> branch',
-        'middle',
-        '<<<<<<< HEAD',
-        'ours2',
-        '=======',
-        'theirs2',
-        '>>>>>>> branch',
-        'bottom',
+      const text = [
+        'a',
+        '<<<<<<< HEAD', 'b-ours', '=======', 'b-theirs', '>>>>>>> other',
+        'c',
+        '<<<<<<< HEAD', 'd-ours', '=======', 'd-theirs', '>>>>>>> other',
+        'e',
       ].join('\n');
-
-      const segments = internal.parseOutputSegments();
-      const conflictCount = segments.filter(s => s.type === 'conflict').length;
-      expect(conflictCount).to.equal(2);
+      const segments = internalOf(el).parseSegments(text);
+      expect(segments.filter((s) => s.type === 'conflict').length).to.equal(2);
     });
 
     it('extracts labels from conflict markers', async () => {
       const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        parseOutputSegments: () => Array<{
-          type: string;
-          oursLabel: string;
-          theirsLabel: string;
-        }>;
-      };
-
-      internal.outputContent = '<<<<<<< my-branch\nours\n=======\ntheirs\n>>>>>>> other-branch';
-
-      const segments = internal.parseOutputSegments();
-      const conflict = segments.find(s => s.type === 'conflict')!;
-      expect(conflict.oursLabel).to.equal('my-branch');
-      expect(conflict.theirsLabel).to.equal('other-branch');
+      const segments = internalOf(el).parseSegments(
+        '<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> feature/x'
+      );
+      expect(segments[0].oursLabel).to.equal('HEAD');
+      expect(segments[0].theirsLabel).to.equal('feature/x');
     });
 
     it('defaults to OURS/THEIRS when labels are missing', async () => {
       const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        parseOutputSegments: () => Array<{
-          type: string;
-          oursLabel: string;
-          theirsLabel: string;
-        }>;
-      };
-
-      internal.outputContent = '<<<<<<< \nours\n=======\ntheirs\n>>>>>>> ';
-
-      const segments = internal.parseOutputSegments();
-      const conflict = segments.find(s => s.type === 'conflict')!;
-      // Empty labels default based on implementation
-      expect(conflict.oursLabel).to.not.be.undefined;
-      expect(conflict.theirsLabel).to.not.be.undefined;
+      const segments = internalOf(el).parseSegments('<<<<<<<\nours\n=======\ntheirs\n>>>>>>>');
+      expect(segments[0].oursLabel).to.equal('OURS');
+      expect(segments[0].theirsLabel).to.equal('THEIRS');
     });
 
-    it('treats a nested "<<<<<<<" line as content, preserving prior conflict content', async () => {
+    it('treats a nested "<<<<<<<" line as content', async () => {
       const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        parseOutputSegments: () => Array<{
-          type: string;
-          oursLines: string[];
-          theirsLines: string[];
-        }>;
-      };
-
-      // A '<<<<<<<' line appears within an already-open conflict's ours side.
-      internal.outputContent = [
-        '<<<<<<< HEAD',
-        'real-ours',
-        '<<<<<<< nested-marker-as-content',
-        '=======',
-        'real-theirs',
-        '>>>>>>> feature',
-      ].join('\n');
-
-      const segments = internal.parseOutputSegments();
-      const conflict = segments.find(s => s.type === 'conflict')!;
-      // The nested marker line is retained as ours content (not discarded).
-      expect(conflict.oursLines).to.deep.equal(['real-ours', '<<<<<<< nested-marker-as-content']);
-      expect(conflict.theirsLines).to.deep.equal(['real-theirs']);
+      const segments = internalOf(el).parseSegments(
+        '<<<<<<< HEAD\nours\n<<<<<<< nested\n=======\ntheirs\n>>>>>>> other'
+      );
+      expect(segments.length).to.equal(1);
+      expect(segments[0].oursLines).to.deep.equal(['ours', '<<<<<<< nested']);
     });
 
     it('supports diff3 output without leaking the base section into ours', async () => {
       const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        parseOutputSegments: () => Array<{
-          type: string;
-          oursLines: string[];
-          theirsLines: string[];
-        }>;
-      };
+      const segments = internalOf(el).parseSegments(
+        '<<<<<<< HEAD\nours\n||||||| base\nbase-line\n=======\ntheirs\n>>>>>>> other'
+      );
+      expect(segments.length).to.equal(1);
+      expect(segments[0].oursLines).to.deep.equal(['ours']);
+      expect(segments[0].theirsLines).to.deep.equal(['theirs']);
+    });
 
-      // diff3-style conflict: ours ||||||| base ======= theirs
-      internal.outputContent = [
-        '<<<<<<< HEAD',
-        'our-line',
-        '||||||| merged common ancestors',
-        'base-line',
-        '=======',
-        'their-line',
-        '>>>>>>> feature',
-      ].join('\n');
-
-      const segments = internal.parseOutputSegments();
-      const conflict = segments.find(s => s.type === 'conflict')!;
-      expect(conflict.oursLines).to.deep.equal(['our-line']);
-      expect(conflict.theirsLines).to.deep.equal(['their-line']);
-      // Base content must NOT appear in ours or theirs.
-      expect(conflict.oursLines).to.not.include('base-line');
-      expect(conflict.theirsLines).to.not.include('base-line');
+    it('keeps an unterminated conflict as a conflict block', async () => {
+      const el = await renderEditor();
+      const segments = internalOf(el).parseSegments(
+        'ok\n<<<<<<< HEAD\nours\n=======\ntheirs'
+      );
+      expect(segments.map((s) => s.type)).to.deep.equal(['resolved', 'conflict']);
+      expect(segments[1].theirsLines).to.deep.equal(['theirs']);
     });
   });
 
-  // ── Accept ours/theirs/base ────────────────────────────────────────────
-  describe('accept strategies', () => {
-    it('handleAcceptOurs sets output to ours content', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        outputContent: string;
-        handleAcceptOurs: () => void;
-      };
+  // ── Load failure handling ────────────────────────────────────────────
+  describe('load failure', () => {
+    it('shows an error state with Retry instead of fabricating a merge', async () => {
+      setupDefaultMocks();
+      workdirContent = () => Promise.reject(new Error('read failed'));
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
 
-      internal.baseContent = 'base';
-      internal.oursContent = 'ours content';
-      internal.theirsContent = 'theirs content';
-
-      internal.handleAcceptOurs();
-      expect(internal.outputContent).to.equal('ours content');
+      expect(internal.loadFailed).to.be.true;
+      expect(internal.segments).to.deep.equal([]);
+      expect(shadowText(el)).to.include('Could not read the merged file');
+      const retry = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Retry'
+      );
+      expect(retry).to.not.be.undefined;
+      // Mark Resolved must be disabled — there is nothing trustworthy to write.
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled).to.be.true;
     });
 
-    it('handleAcceptTheirs sets output to theirs content', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        outputContent: string;
-        handleAcceptTheirs: () => void;
-      };
+    it('Retry reloads the file and clears the error state', async () => {
+      setupDefaultMocks();
+      let fail = true;
+      workdirContent = () =>
+        fail ? Promise.reject(new Error('read failed')) : Promise.resolve(DEFAULT_WORKDIR_CONTENT);
+      const el = await renderLoadedEditor();
+      expect(internalOf(el).loadFailed).to.be.true;
 
-      internal.baseContent = 'base';
-      internal.oursContent = 'ours content';
-      internal.theirsContent = 'theirs content';
+      fail = false;
+      const retry = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Retry'
+      ) as HTMLButtonElement;
+      retry.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
 
-      internal.handleAcceptTheirs();
-      expect(internal.outputContent).to.equal('theirs content');
+      expect(internalOf(el).loadFailed).to.be.false;
+      expect(internalOf(el).segments.length).to.be.greaterThan(0);
     });
 
-    it('handleAcceptBase sets output to base content', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        outputContent: string;
-        handleAcceptBase: () => void;
-      };
-
-      internal.baseContent = 'base content';
-      internal.oursContent = 'ours';
-      internal.theirsContent = 'theirs';
-
-      internal.handleAcceptBase();
-      expect(internal.outputContent).to.equal('base content');
+    it('treats an empty working-directory file as valid content, not a failure', async () => {
+      setupDefaultMocks();
+      workdirContent = '';
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
+      expect(internal.loadFailed).to.be.false;
+      expect(internal.segments.length).to.equal(1);
+      expect(internal.segments[0].type).to.equal('resolved');
     });
   });
 
-  // ── resolveOutputConflict ──────────────────────────────────────────────
-  describe('resolveOutputConflict', () => {
-    it('resolves a conflict choosing ours', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        resolveOutputConflict: (segmentIndex: number, choice: 'ours' | 'theirs' | 'both') => void;
-      };
+  // ── Per-block resolution ─────────────────────────────────────────────
+  describe('per-block resolution', () => {
+    it('Use Ours resolves the block with ours lines and records the origin', async () => {
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
 
-      internal.outputContent = 'before\n<<<<<<< HEAD\nours-line\n=======\ntheirs-line\n>>>>>>> branch\nafter';
-
-      internal.resolveOutputConflict(0, 'ours');
-
-      expect(internal.outputContent).to.include('ours-line');
-      expect(internal.outputContent).to.not.include('<<<<<<<');
-      expect(internal.outputContent).to.not.include('theirs-line');
-      expect(internal.outputContent).to.include('before');
-      expect(internal.outputContent).to.include('after');
+      const internal = internalOf(el);
+      const resolved = internal.segments[1];
+      expect(resolved.type).to.equal('resolved');
+      expect(resolved.lines).to.deep.equal(['line2-ours']);
+      expect(resolved.origin).to.equal('ours');
+      expect(resolved.fromConflict).to.be.true;
+      expect(shadowText(el)).to.include('No conflicts');
+      expectNoMarkers(el);
     });
 
-    it('resolves a conflict choosing theirs', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        resolveOutputConflict: (segmentIndex: number, choice: 'ours' | 'theirs' | 'both') => void;
-      };
+    it('Use Theirs resolves the block with theirs lines', async () => {
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Theirs').click();
+      await el.updateComplete;
 
-      internal.outputContent = 'before\n<<<<<<< HEAD\nours-line\n=======\ntheirs-line\n>>>>>>> branch\nafter';
-
-      internal.resolveOutputConflict(0, 'theirs');
-
-      expect(internal.outputContent).to.include('theirs-line');
-      expect(internal.outputContent).to.not.include('<<<<<<<');
-      expect(internal.outputContent).to.not.include('ours-line');
+      const resolved = internalOf(el).segments[1];
+      expect(resolved.lines).to.deep.equal(['line2-theirs']);
+      expect(resolved.origin).to.equal('theirs');
     });
 
-    it('resolves a conflict choosing both', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        resolveOutputConflict: (segmentIndex: number, choice: 'ours' | 'theirs' | 'both') => void;
-      };
+    it('Use Both keeps ours then theirs', async () => {
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Both').click();
+      await el.updateComplete;
 
-      internal.outputContent = 'before\n<<<<<<< HEAD\nours-line\n=======\ntheirs-line\n>>>>>>> branch\nafter';
-
-      internal.resolveOutputConflict(0, 'both');
-
-      expect(internal.outputContent).to.include('ours-line');
-      expect(internal.outputContent).to.include('theirs-line');
-      expect(internal.outputContent).to.not.include('<<<<<<<');
+      const resolved = internalOf(el).segments[1];
+      expect(resolved.lines).to.deep.equal(['line2-ours', 'line2-theirs']);
+      expect(resolved.origin).to.equal('both');
     });
 
     it('resolves only the targeted conflict, preserving others', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        resolveOutputConflict: (segmentIndex: number, choice: 'ours' | 'theirs' | 'both') => void;
-      };
-
-      internal.outputContent = [
-        '<<<<<<< HEAD',
-        'ours1',
-        '=======',
-        'theirs1',
-        '>>>>>>> branch',
-        'middle',
-        '<<<<<<< HEAD',
-        'ours2',
-        '=======',
-        'theirs2',
-        '>>>>>>> branch',
+      setupDefaultMocks();
+      workdirContent = [
+        'a',
+        '<<<<<<< HEAD', 'b-ours', '=======', 'b-theirs', '>>>>>>> other',
+        'c',
+        '<<<<<<< HEAD', 'd-ours', '=======', 'd-theirs', '>>>>>>> other',
       ].join('\n');
+      const el = await renderLoadedEditor();
 
-      // Resolve first conflict, keep second
-      internal.resolveOutputConflict(0, 'ours');
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
 
-      expect(internal.outputContent).to.include('ours1');
-      // Second conflict should still have markers
-      expect(internal.outputContent).to.include('<<<<<<< HEAD');
-      expect(internal.outputContent).to.include('ours2');
-      expect(internal.outputContent).to.include('theirs2');
+      const internal = internalOf(el);
+      const conflicts = internal.segments.filter((s) => s.type === 'conflict');
+      expect(conflicts.length).to.equal(1);
+      expect(conflicts[0].oursLines).to.deep.equal(['d-ours']);
+      expect(shadowText(el)).to.include('1 conflict remaining');
+      expectNoMarkers(el);
+    });
+
+    it('Reset reopens a resolved-from-conflict block', async () => {
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+
+      const resetBtn = Array.from(el.shadowRoot!.querySelectorAll('.segment-btn')).find(
+        (b) => b.textContent?.trim() === 'Reset'
+      ) as HTMLButtonElement;
+      expect(resetBtn, 'Reset button on resolved-from-conflict segment').to.not.be.undefined;
+      resetBtn.click();
+      await el.updateComplete;
+
+      const internal = internalOf(el);
+      expect(internal.segments[1].type).to.equal('conflict');
+      expect(internal.segments[1].oursLines).to.deep.equal(['line2-ours']);
+      expect(shadowText(el)).to.include('1 conflict remaining');
     });
   });
 
-  // ── applyAiSuggestion ─────────────────────────────────────────────────
-  describe('applyAiSuggestion', () => {
-    it('replaces conflict with AI suggestion', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        applyAiSuggestion: (conflictIndex: number, resolvedContent: string) => void;
-      };
+  // ── Inline editing ───────────────────────────────────────────────────
+  describe('inline editing', () => {
+    it('editing a conflict block starts from both sides, never marker text', async () => {
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Edit').click();
+      await el.updateComplete;
 
-      internal.outputContent = 'before\n<<<<<<< HEAD\nours\n=======\ntheirs\n>>>>>>> branch\nafter';
+      const textarea = el.shadowRoot!.querySelector('.segment-editor textarea') as HTMLTextAreaElement;
+      expect(textarea).to.not.be.null;
+      expect(textarea.value).to.equal('line2-ours\nline2-theirs');
+      for (const marker of MARKER_CHARS) {
+        expect(textarea.value).to.not.include(marker);
+      }
+    });
 
-      internal.applyAiSuggestion(0, 'ai-resolved-content');
+    it('applying a conflict edit resolves the block as manual', async () => {
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Edit').click();
+      await el.updateComplete;
 
-      expect(internal.outputContent).to.include('ai-resolved-content');
-      expect(internal.outputContent).to.not.include('<<<<<<<');
-      expect(internal.outputContent).to.include('before');
-      expect(internal.outputContent).to.include('after');
+      const textarea = el.shadowRoot!.querySelector('.segment-editor textarea') as HTMLTextAreaElement;
+      textarea.value = 'hand-merged';
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+
+      const applyBtn = Array.from(el.shadowRoot!.querySelectorAll('.segment-editor button')).find(
+        (b) => b.textContent?.trim() === 'Apply'
+      ) as HTMLButtonElement;
+      applyBtn.click();
+      await el.updateComplete;
+
+      const resolved = internalOf(el).segments[1];
+      expect(resolved.type).to.equal('resolved');
+      expect(resolved.lines).to.deep.equal(['hand-merged']);
+      expect(resolved.origin).to.equal('manual');
+      expect(shadowText(el)).to.include('No conflicts');
+    });
+
+    it('cancelling a conflict edit leaves the block unresolved', async () => {
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Edit').click();
+      await el.updateComplete;
+
+      const cancelBtn = Array.from(el.shadowRoot!.querySelectorAll('.segment-editor button')).find(
+        (b) => b.textContent?.trim() === 'Cancel'
+      ) as HTMLButtonElement;
+      cancelBtn.click();
+      await el.updateComplete;
+
+      expect(internalOf(el).segments[1].type).to.equal('conflict');
+      expect(shadowText(el)).to.include('1 conflict remaining');
+    });
+
+    it('resolved text is editable in place', async () => {
+      const el = await renderLoadedEditor();
+      // First resolved segment ("line1") has an Edit hover action.
+      const editBtn = el.shadowRoot!.querySelector('.output-segment .segment-btn') as HTMLButtonElement;
+      expect(editBtn.textContent?.trim()).to.equal('Edit');
+      editBtn.click();
+      await el.updateComplete;
+
+      const textarea = el.shadowRoot!.querySelector('.segment-editor textarea') as HTMLTextAreaElement;
+      expect(textarea.value).to.equal('line1');
+      textarea.value = 'line1-edited';
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+
+      const applyBtn = Array.from(el.shadowRoot!.querySelectorAll('.segment-editor button')).find(
+        (b) => b.textContent?.trim() === 'Apply'
+      ) as HTMLButtonElement;
+      applyBtn.click();
+      await el.updateComplete;
+
+      expect(internalOf(el).segments[0].lines).to.deep.equal(['line1-edited']);
+      expect(shadowText(el)).to.include('line1-edited');
     });
   });
 
-  // ── Edit mode toggle ───────────────────────────────────────────────────
-  describe('edit mode', () => {
-    it('starts in visual mode', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as { outputEditMode: string };
-      expect(internal.outputEditMode).to.equal('visual');
+  // ── Whole-file strategies ────────────────────────────────────────────
+  describe('whole-file strategies', () => {
+    it('Use Ours replaces the output with ours content', async () => {
+      const el = await renderLoadedEditor();
+      const btn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions .btn-ours')).find(
+        (b) => b.textContent?.trim() === 'Use Ours'
+      ) as HTMLButtonElement;
+      btn.click();
+      await el.updateComplete;
+
+      const internal = internalOf(el);
+      expect(internal.segments.length).to.equal(1);
+      expect(internal.segments[0].lines).to.deep.equal(['line1', 'line2-ours', 'line3']);
+      expect(internal.segments[0].origin).to.equal('ours');
+      expect(shadowText(el)).to.include('No conflicts');
     });
 
-    it('toggles between visual and raw mode', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        outputEditMode: string;
-        toggleOutputEditMode: () => void;
-      };
+    it('Use Theirs replaces the output with theirs content', async () => {
+      const el = await renderLoadedEditor();
+      const btn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions .btn-theirs')).find(
+        (b) => b.textContent?.trim() === 'Use Theirs'
+      ) as HTMLButtonElement;
+      btn.click();
+      await el.updateComplete;
 
-      internal.toggleOutputEditMode();
-      expect(internal.outputEditMode).to.equal('raw');
-
-      internal.toggleOutputEditMode();
-      expect(internal.outputEditMode).to.equal('visual');
-    });
-  });
-
-  // ── Output change ──────────────────────────────────────────────────────
-  describe('output change', () => {
-    it('updates outputContent on textarea change', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        outputContent: string;
-        handleOutputChange: (e: Event) => void;
-      };
-
-      const fakeEvent = {
-        target: { value: 'new content' },
-      } as unknown as Event;
-
-      internal.handleOutputChange(fakeEvent);
-      expect(internal.outputContent).to.equal('new content');
-    });
-  });
-
-  // ── getResolvedContent ─────────────────────────────────────────────────
-  describe('getResolvedContent', () => {
-    it('returns current output content', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as { outputContent: string };
-      internal.outputContent = 'final resolved content';
-
-      expect(el.getResolvedContent()).to.equal('final resolved content');
-    });
-  });
-
-  // ── computeLineOrigins ─────────────────────────────────────────────────
-  describe('computeLineOrigins', () => {
-    it('identifies lines that came from ours', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        outputContent: string;
-        lineOrigins: Map<number, string>;
-        computeLineOrigins: () => void;
-      };
-
-      internal.baseContent = 'shared';
-      internal.oursContent = 'shared\nours-only';
-      internal.theirsContent = 'shared';
-      internal.outputContent = 'shared\nours-only';
-
-      internal.computeLineOrigins();
-
-      // Line 1 ("ours-only") should be marked as 'ours'
-      expect(internal.lineOrigins.get(1)).to.equal('ours');
+      expect(internalOf(el).segments[0].lines).to.deep.equal(['line1', 'line2-theirs', 'line3']);
     });
 
-    it('identifies lines that came from theirs', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        outputContent: string;
-        lineOrigins: Map<number, string>;
-        computeLineOrigins: () => void;
-      };
+    it('Use Base resets the output to the ancestor content', async () => {
+      const el = await renderLoadedEditor();
+      const btn = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions .btn')).find(
+        (b) => b.textContent?.trim() === 'Use Base'
+      ) as HTMLButtonElement;
+      btn.click();
+      await el.updateComplete;
 
-      internal.baseContent = 'shared';
-      internal.oursContent = 'shared';
-      internal.theirsContent = 'shared\ntheirs-only';
-      internal.outputContent = 'shared\ntheirs-only';
-
-      internal.computeLineOrigins();
-
-      expect(internal.lineOrigins.get(1)).to.equal('theirs');
+      expect(internalOf(el).segments[0].lines).to.deep.equal(['line1', 'line2', 'line3']);
+      expect(internalOf(el).segments[0].origin).to.equal('base');
     });
 
-    it('identifies lines present in both as "both"', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        baseContent: string;
-        oursContent: string;
-        theirsContent: string;
-        outputContent: string;
-        lineOrigins: Map<number, string>;
-        computeLineOrigins: () => void;
-      };
+    it('Reload re-reads the on-disk merge, restoring conflicts', async () => {
+      const el = await renderLoadedEditor();
+      const useOurs = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions .btn-ours')).find(
+        (b) => b.textContent?.trim() === 'Use Ours'
+      ) as HTMLButtonElement;
+      useOurs.click();
+      await el.updateComplete;
+      expect(internalOf(el).segments.filter((s) => s.type === 'conflict').length).to.equal(0);
 
-      internal.baseContent = 'base';
-      internal.oursContent = 'base\nnew-in-both';
-      internal.theirsContent = 'base\nnew-in-both';
-      internal.outputContent = 'base\nnew-in-both';
+      const reload = Array.from(el.shadowRoot!.querySelectorAll('.toolbar-actions .btn')).find(
+        (b) => b.textContent?.trim() === 'Reload'
+      ) as HTMLButtonElement;
+      reload.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
 
-      internal.computeLineOrigins();
-
-      expect(internal.lineOrigins.get(1)).to.equal('both');
+      expect(internalOf(el).segments.filter((s) => s.type === 'conflict').length).to.equal(1);
     });
   });
 
   // ── Mark resolved ──────────────────────────────────────────────────────
   describe('mark resolved', () => {
-    it('dispatches conflict-resolved event', async () => {
-      const el = await renderEditor();
-      const internal = el as unknown as {
-        conflictFile: ConflictFile;
-        outputContent: string;
-      };
+    it('is disabled while conflicts remain', async () => {
+      const el = await renderLoadedEditor();
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled).to.be.true;
+    });
 
-      internal.conflictFile = makeConflictFile('src/test.ts');
-      internal.outputContent = 'resolved content';
+    it('refuses to write while conflicts remain even if invoked directly', async () => {
+      const el = await renderLoadedEditor();
+      invokeHistory.length = 0;
+      await internalOf(el).handleMarkResolved();
+      expect(invokeHistory.some((h) => h.command === 'resolve_conflict')).to.be.false;
+    });
 
-      let eventFired = false;
+    it('writes marker-free content and dispatches conflict-resolved once resolved', async () => {
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Both').click();
+      await el.updateComplete;
+
       let eventFile: string | null = null;
       el.addEventListener('conflict-resolved', ((e: CustomEvent) => {
-        eventFired = true;
         eventFile = e.detail.file.path;
       }) as EventListener);
 
-      const handleMarkResolved = (el as unknown as {
-        handleMarkResolved: () => Promise<void>;
-      }).handleMarkResolved.bind(el);
+      invokeHistory.length = 0;
+      const markBtn = Array.from(el.shadowRoot!.querySelectorAll('button')).find(
+        (b) => b.textContent?.trim() === 'Mark Resolved'
+      ) as HTMLButtonElement;
+      expect(markBtn.disabled).to.be.false;
+      markBtn.click();
+      await new Promise((r) => setTimeout(r, 50));
 
-      await handleMarkResolved();
-
-      expect(eventFired).to.be.true;
+      const resolveCall = invokeHistory.find((h) => h.command === 'resolve_conflict');
+      expect(resolveCall).to.exist;
+      const content = (resolveCall!.args as { content: string }).content;
+      expect(content).to.equal('line1\nline2-ours\nline2-theirs\nline3');
+      for (const marker of MARKER_CHARS) {
+        expect(content).to.not.include(marker);
+      }
       expect(eventFile).to.equal('src/test.ts');
     });
+  });
 
-    it('calls resolve_conflict with correct args', async () => {
+  // ── getResolvedContent ───────────────────────────────────────────────
+  describe('getResolvedContent', () => {
+    it('joins resolved segment lines', async () => {
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(el.getResolvedContent()).to.equal('line1\nline2-ours\nline3');
+    });
+  });
+
+  // ── Pane alignment ───────────────────────────────────────────────────
+  describe('pane alignment', () => {
+    it('renders the same number of rows in all three source panes', async () => {
+      setupDefaultMocks();
+      mockInvoke = (async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'a\nb\nc';
+          // ours inserts two lines at the top; theirs deletes one line.
+          if (blobArgs?.oid === 'ours-oid') return 'x\ny\na\nb\nc';
+          if (blobArgs?.oid === 'theirs-oid') return 'a\nc';
+          return '';
+        }
+        if (command === 'read_file_content') return 'a\nb\nc';
+        if (command === 'get_merge_tool_config') return null;
+        if (command === 'is_ai_available') return false;
+        return null;
+      }) as MockInvoke;
+
+      const el = await renderLoadedEditor();
+      const rows = (side: string) =>
+        el.shadowRoot!.querySelectorAll(`#panel-${side} .code-line`).length;
+      expect(rows('ours')).to.equal(rows('base'));
+      expect(rows('base')).to.equal(rows('theirs'));
+    });
+
+    it('an insertion does not mark every following line as changed', async () => {
+      setupDefaultMocks();
+      mockInvoke = (async (command: string, args?: unknown) => {
+        if (command === 'get_blob_content') {
+          const blobArgs = args as { oid: string };
+          if (blobArgs?.oid === 'base-oid') return 'a\nb\nc\nd';
+          if (blobArgs?.oid === 'ours-oid') return 'new\na\nb\nc\nd';
+          if (blobArgs?.oid === 'theirs-oid') return 'a\nb\nc\nd';
+          return '';
+        }
+        if (command === 'read_file_content') return 'a\nb\nc\nd';
+        if (command === 'get_merge_tool_config') return null;
+        if (command === 'is_ai_available') return false;
+        return null;
+      }) as MockInvoke;
+
+      const el = await renderLoadedEditor();
+      // Exactly one added line in ours; nothing else may be highlighted.
+      const additions = el.shadowRoot!.querySelectorAll('#panel-ours .code-addition');
+      const changed = el.shadowRoot!.querySelectorAll('#panel-ours .line-changed');
+      expect(additions.length).to.equal(1);
+      expect(changed.length).to.equal(0);
+      expect(shadowText(el)).to.include('1 changes from base');
+    });
+  });
+
+  // ── Operation-aware labels ───────────────────────────────────────────
+  describe('operation-aware labels', () => {
+    it('labels sides for merge by default', async () => {
+      const el = await renderLoadedEditor();
+      const text = shadowText(el);
+      expect(text).to.include('Ours (Current Branch)');
+      expect(text).to.include('Theirs (Incoming)');
+    });
+
+    it('labels the swapped sides during a rebase', async () => {
       const el = await renderEditor();
-      const internal = el as unknown as {
-        conflictFile: ConflictFile;
-        outputContent: string;
+      el.operationType = 'rebase';
+      const internal = internalOf(el);
+      internal.conflictFile = makeConflictFile('src/test.ts');
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      const text = shadowText(el);
+      expect(text).to.include('Ours (Rebasing Onto)');
+      expect(text).to.include('Theirs (Your Commit)');
+    });
+
+    it('labels stash conflicts as working tree vs stashed changes', async () => {
+      const el = await renderEditor();
+      el.operationType = 'stash';
+      const internal = internalOf(el);
+      internal.conflictFile = makeConflictFile('src/test.ts');
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      const text = shadowText(el);
+      expect(text).to.include('Ours (Working Tree)');
+      expect(text).to.include('Theirs (Stashed Changes)');
+    });
+  });
+
+  // ── AI resolution ────────────────────────────────────────────────────
+  describe('AI resolution', () => {
+    it('applies a per-block AI suggestion with origin "ai"', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      const el = await renderLoadedEditor();
+
+      findConflictButton(el, 'AI Suggest').click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      const resolved = internalOf(el).segments[1];
+      expect(resolved.type).to.equal('resolved');
+      expect(resolved.lines).to.deep.equal(['ai-resolved']);
+      expect(resolved.origin).to.equal('ai');
+      expect(shadowText(el)).to.include('merged by ai');
+    });
+
+    it('AI Resolve All stops after the first failure instead of retrying forever', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      workdirContent = [
+        '<<<<<<< HEAD', 'a-ours', '=======', 'a-theirs', '>>>>>>> other',
+        'mid',
+        '<<<<<<< HEAD', 'b-ours', '=======', 'b-theirs', '>>>>>>> other',
+      ].join('\n');
+      let aiCalls = 0;
+      aiSuggestion = () => {
+        aiCalls++;
+        return Promise.reject(new Error('ai down'));
       };
 
-      internal.conflictFile = makeConflictFile('src/test.ts');
-      internal.outputContent = 'final content';
+      const el = await renderLoadedEditor();
+      await internalOf(el).handleAiResolveAll();
 
-      invokeHistory.length = 0;
+      expect(aiCalls).to.equal(1);
+      expect(internalOf(el).segments.filter((s) => s.type === 'conflict').length).to.equal(2);
+    });
 
-      const handleMarkResolved = (el as unknown as {
-        handleMarkResolved: () => Promise<void>;
-      }).handleMarkResolved.bind(el);
+    it('clears AI explanations when a different file loads', async () => {
+      setupDefaultMocks();
+      aiAvailable = true;
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'AI Suggest').click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+      expect(shadowText(el)).to.include('merged by ai');
 
-      await handleMarkResolved();
+      const internal = internalOf(el);
+      internal.conflictFile = makeConflictFile('src/other.ts');
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
 
-      const resolveCall = invokeHistory.find(h => h.command === 'resolve_conflict');
-      expect(resolveCall).to.exist;
+      expect(shadowText(el)).to.not.include('merged by ai');
     });
   });
 
@@ -787,7 +804,7 @@ describe('lv-merge-editor', () => {
       internal.loading = false;
       await el.updateComplete;
 
-      const theirsBtn = el.shadowRoot!.querySelector('.btn-theirs') as HTMLButtonElement;
+      const theirsBtn = el.shadowRoot!.querySelector('.toolbar-actions .btn-theirs') as HTMLButtonElement;
       expect(theirsBtn.textContent).to.include('delete file');
 
       let resolvedFired = false;

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -1262,6 +1262,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   private handleOpenMergeEditor(): void {
     this.dispatchEvent(
       new CustomEvent('open-conflict-dialog', {
+        // Pass the file so the dialog opens preselected on it.
+        detail: { filePath: this.file?.path },
         bubbles: true,
         composed: true,
       })

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -127,18 +127,6 @@ interface SplitLine {
   inlineSegments?: InlineDiffSegment[];
 }
 
-interface ConflictRegion {
-  index: number;
-  startLine: number;
-  endLine: number;
-  oursStart: number;
-  oursEnd: number;
-  theirsStart: number;
-  theirsEnd: number;
-  oursContent: string;
-  theirsContent: string;
-}
-
 interface DiffContextMenuState {
   visible: boolean;
   x: number;
@@ -667,67 +655,45 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         text-align: center;
       }
 
-      /* Conflict resolution styles */
-      .conflict-banner {
+      /* Conflicted-file redirect (conflicts are resolved in the merge editor) */
+      .conflict-redirect {
         display: flex;
+        flex-direction: column;
         align-items: center;
-        justify-content: space-between;
-        padding: var(--spacing-sm);
-        background: var(--color-error-bg);
-        border-bottom: 1px solid var(--color-error);
+        justify-content: center;
+        gap: var(--spacing-md);
+        height: 100%;
+        padding: var(--spacing-lg);
+        text-align: center;
+        color: var(--color-text-secondary);
       }
 
-      .conflict-info {
-        display: flex;
-        align-items: center;
-        gap: var(--spacing-sm);
-        color: var(--color-error);
+      .conflict-redirect svg {
+        width: 32px;
+        height: 32px;
+        color: var(--color-warning);
+      }
+
+      .conflict-redirect-title {
+        font-size: var(--font-size-md);
+        font-weight: var(--font-weight-semibold);
+        color: var(--color-text-primary);
+      }
+
+      .conflict-redirect-btn {
+        padding: var(--spacing-xs) var(--spacing-md);
+        border-radius: var(--radius-sm);
         font-size: var(--font-size-sm);
         font-weight: var(--font-weight-medium);
-      }
-
-      .conflict-actions {
-        display: flex;
-        gap: var(--spacing-sm);
-      }
-
-      .conflict-btn {
-        padding: var(--spacing-xs) var(--spacing-sm);
-        border-radius: var(--radius-sm);
-        font-size: var(--font-size-xs);
-        font-weight: var(--font-weight-medium);
         cursor: pointer;
-        transition: all 0.15s ease;
+        border: 1px solid var(--color-primary);
+        background: var(--color-primary);
+        color: var(--color-text-inverse);
       }
 
-
-      .conflict-marker {
-        display: flex;
-        align-items: center;
-        padding: var(--spacing-xs) var(--spacing-sm);
-        background: var(--color-error-bg);
-        border-left: 3px solid var(--color-error);
-        font-size: var(--font-size-xs);
-        color: var(--color-error);
-        font-weight: var(--font-weight-bold);
+      .conflict-redirect-btn:hover {
+        background: var(--color-primary-hover);
       }
-
-      .conflict-inline-actions {
-        display: flex;
-        gap: var(--spacing-xs);
-        margin-left: auto;
-        padding-left: var(--spacing-md);
-      }
-
-      .conflict-inline-btn {
-        padding: 2px 6px;
-        border-radius: var(--radius-sm);
-        font-size: 10px;
-        font-weight: var(--font-weight-medium);
-        cursor: pointer;
-        transition: all 0.15s ease;
-      }
-
 
       /* Line selection mode */
       .line-selection-mode .line.code-addition,
@@ -964,8 +930,6 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   @state() private editContent = '';
   @state() private originalContent = '';
   @state() private saving = false;
-  @state() private conflictRegions: ConflictRegion[] = [];
-  @state() private hasConflicts = false;
   @state() private contextMenu: DiffContextMenuState = { visible: false, x: 0, y: 0, line: null, hunk: null };
   @state() private selectedLines: Set<LineKey> = new Set();
   @state() private lineSelectionMode = false;
@@ -1088,6 +1052,9 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
 
   private async loadWorkingDiff(): Promise<void> {
     if (!this.repositoryPath || !this.file) return;
+    // Conflicted files render a redirect to the merge editor — don't load the
+    // marker-laden diff at all.
+    if (this.isConflicted) return;
 
     this.loading = true;
     this.error = null;
@@ -1108,8 +1075,6 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
 
       if (result.success) {
         this.diff = result.data!;
-        // Check for conflict markers in conflicted files
-        await this.checkForConflicts();
       } else {
         this.error = result.error?.message ?? 'Failed to load diff';
       }
@@ -1165,7 +1130,9 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    * Check if edit mode is available (only for working directory changes, not commit diffs)
    */
   private get canEdit(): boolean {
-    return this.file !== null && this.commitFile === null && !this.diff?.isBinary;
+    // Conflicted files must not be free-text edited here — their working-tree
+    // content is git's conflict-marker text.
+    return this.file !== null && this.commitFile === null && !this.diff?.isBinary && !this.isConflicted;
   }
 
   /**
@@ -1291,178 +1258,35 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     return this.file?.isConflicted ?? false;
   }
 
-  /**
-   * Check file content for conflict markers and parse regions
-   */
-  private async checkForConflicts(): Promise<void> {
-    if (!this.isConflicted || !this.repositoryPath || !this.file) {
-      this.hasConflicts = false;
-      this.conflictRegions = [];
-      return;
-    }
-
-    const result = await gitService.readFileContent(this.repositoryPath, this.file.path, false);
-    if (!result.success || !result.data) {
-      this.hasConflicts = false;
-      this.conflictRegions = [];
-      return;
-    }
-
-    this.parseConflictRegions(result.data);
-  }
-
-  /**
-   * Parse conflict markers from file content
-   */
-  private parseConflictRegions(content: string): void {
-    const lines = content.split('\n');
-    const regions: ConflictRegion[] = [];
-    let index = 0;
-
-    for (let i = 0; i < lines.length; i++) {
-      const line = lines[i];
-      if (line.startsWith('<<<<<<<')) {
-        // Found start of conflict
-        const region: ConflictRegion = {
-          index: index++,
-          startLine: i,
-          endLine: -1,
-          oursStart: i + 1,
-          oursEnd: -1,
-          theirsStart: -1,
-          theirsEnd: -1,
-          oursContent: '',
-          theirsContent: '',
-        };
-
-        // Find the separator and end
-        const oursLines: string[] = [];
-        const theirsLines: string[] = [];
-        let inTheirs = false;
-
-        for (let j = i + 1; j < lines.length; j++) {
-          if (lines[j].startsWith('=======')) {
-            region.oursEnd = j - 1;
-            region.theirsStart = j + 1;
-            inTheirs = true;
-          } else if (lines[j].startsWith('>>>>>>>')) {
-            region.theirsEnd = j - 1;
-            region.endLine = j;
-            break;
-          } else if (inTheirs) {
-            theirsLines.push(lines[j]);
-          } else {
-            oursLines.push(lines[j]);
-          }
-        }
-
-        region.oursContent = oursLines.join('\n');
-        region.theirsContent = theirsLines.join('\n');
-        regions.push(region);
-
-        // Skip past this conflict
-        i = region.endLine;
-      }
-    }
-
-    this.conflictRegions = regions;
-    this.hasConflicts = regions.length > 0;
-  }
-
-  /**
-   * Resolve a single conflict region
-   */
-  private async resolveConflict(region: ConflictRegion, choice: 'ours' | 'theirs' | 'both'): Promise<void> {
-    if (!this.repositoryPath || !this.file) return;
-
-    const result = await gitService.readFileContent(this.repositoryPath, this.file.path, false);
-    if (!result.success || !result.data) return;
-
-    const lines = result.data.split('\n');
-    let replacement: string[];
-
-    switch (choice) {
-      case 'ours':
-        replacement = region.oursContent.split('\n');
-        break;
-      case 'theirs':
-        replacement = region.theirsContent.split('\n');
-        break;
-      case 'both':
-        replacement = [...region.oursContent.split('\n'), ...region.theirsContent.split('\n')];
-        break;
-    }
-
-    // Replace the conflict region with the resolution
-    const newLines = [
-      ...lines.slice(0, region.startLine),
-      ...replacement,
-      ...lines.slice(region.endLine + 1),
-    ];
-
-    const newContent = newLines.join('\n');
-    const writeResult = await gitService.writeFileContent(
-      this.repositoryPath,
-      this.file.path,
-      newContent,
-      false
-    );
-
-    if (writeResult.success) {
-      // Reload the diff and re-check for conflicts
-      await this.loadWorkingDiff();
-      await this.checkForConflicts();
-
-      this.dispatchEvent(new CustomEvent('file-edited', {
+  /** Ask the app shell to open the structured conflict-resolution flow. */
+  private handleOpenMergeEditor(): void {
+    this.dispatchEvent(
+      new CustomEvent('open-conflict-dialog', {
         bubbles: true,
         composed: true,
-        detail: { path: this.file.path }
-      }));
-    }
+      })
+    );
   }
 
   /**
-   * Resolve all conflicts with the same choice
+   * Shown instead of the diff for conflicted files: the raw working-tree
+   * content contains conflict markers, which must never be rendered.
    */
-  private async resolveAllConflicts(choice: 'ours' | 'theirs'): Promise<void> {
-    if (!this.repositoryPath || !this.file) return;
-
-    const result = await gitService.readFileContent(this.repositoryPath, this.file.path, false);
-    if (!result.success || !result.data) return;
-
-    let content = result.data;
-
-    // Process conflicts from end to start to maintain line numbers
-    for (const region of [...this.conflictRegions].reverse()) {
-      const lines = content.split('\n');
-      const replacement = choice === 'ours' ? region.oursContent : region.theirsContent;
-
-      const newLines = [
-        ...lines.slice(0, region.startLine),
-        ...replacement.split('\n'),
-        ...lines.slice(region.endLine + 1),
-      ];
-
-      content = newLines.join('\n');
-    }
-
-    const writeResult = await gitService.writeFileContent(
-      this.repositoryPath,
-      this.file.path,
-      content,
-      false
-    );
-
-    if (writeResult.success) {
-      await this.loadWorkingDiff();
-      await this.checkForConflicts();
-
-      this.dispatchEvent(new CustomEvent('file-edited', {
-        bubbles: true,
-        composed: true,
-        detail: { path: this.file.path }
-      }));
-    }
+  private renderConflictedNotice(): ReturnType<typeof html> {
+    return html`
+      <div class="conflict-redirect">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
+          <line x1="12" y1="9" x2="12" y2="13"></line>
+          <line x1="12" y1="17" x2="12.01" y2="17"></line>
+        </svg>
+        <div class="conflict-redirect-title">${this.file?.path ?? ''} has merge conflicts</div>
+        <div>Resolve them side by side in the merge editor.</div>
+        <button class="conflict-redirect-btn" @click=${this.handleOpenMergeEditor}>
+          Open Merge Editor
+        </button>
+      </div>
+    `;
   }
 
   /**
@@ -2634,6 +2458,12 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
       return html`<div class="empty">No file selected</div>`;
     }
 
+    // A conflicted file's working-tree content is git's marker text — never
+    // show it as a diff or free-text edit. Route to the merge editor instead.
+    if (this.isConflicted) {
+      return this.renderConflictedNotice();
+    }
+
     if (this.loading) {
       return html`<div class="loading">Loading diff...</div>`;
     }
@@ -2832,36 +2662,6 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
             </div>
           `
         : nothing}
-      ${this.hasConflicts
-        ? html`
-            <div class="conflict-banner">
-              <div class="conflict-info">
-                <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                  <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"></path>
-                  <line x1="12" y1="9" x2="12" y2="13"></line>
-                  <line x1="12" y1="17" x2="12.01" y2="17"></line>
-                </svg>
-                ${this.conflictRegions.length} conflict${this.conflictRegions.length !== 1 ? 's' : ''} found
-              </div>
-              <div class="conflict-actions">
-                <button
-                  class="conflict-btn code-conflict-btn-ours"
-                  @click=${() => this.resolveAllConflicts('ours')}
-                  title="Accept all changes from current branch"
-                >
-                  Accept All Ours
-                </button>
-                <button
-                  class="conflict-btn code-conflict-btn-theirs"
-                  @click=${() => this.resolveAllConflicts('theirs')}
-                  title="Accept all changes from incoming branch"
-                >
-                  Accept All Theirs
-                </button>
-              </div>
-            </div>
-          `
-        : nothing}
       ${this.diff?.truncated ? html`
         <div class="large-diff-info">
           Showing first ${this.diff.hunks.reduce((sum, h) => sum + h.lines.length, 0).toLocaleString()} of ${this.diff.totalLines?.toLocaleString() ?? 'many'} lines
@@ -2873,36 +2673,6 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     `;
   }
 
-  /**
-   * Render a conflict region with inline resolution buttons
-   */
-  private renderConflictActions(region: ConflictRegion) {
-    return html`
-      <div class="conflict-inline-actions">
-        <button
-          class="conflict-inline-btn code-conflict-btn-ours"
-          @click=${() => this.resolveConflict(region, 'ours')}
-          title="Accept current branch version"
-        >
-          Ours
-        </button>
-        <button
-          class="conflict-inline-btn code-conflict-btn-theirs"
-          @click=${() => this.resolveConflict(region, 'theirs')}
-          title="Accept incoming branch version"
-        >
-          Theirs
-        </button>
-        <button
-          class="conflict-inline-btn code-conflict-btn-both"
-          @click=${() => this.resolveConflict(region, 'both')}
-          title="Keep both versions"
-        >
-          Both
-        </button>
-      </div>
-    `;
-  }
 }
 
 declare global {

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -543,6 +543,15 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   @state() private segments: OutputSegment[] = [];
   @state() private loading = false;
   @state() private loadFailed = false;
+  /**
+   * True after a take-side that DELETED the file while it is still on
+   * screen (the last file has no auto-advance target). Terminal: the
+   * output pane shows a "file deleted" notice, and every write path is
+   * inert — reloading instead would fail the workdir read into an
+   * alarming error whose verbatim button would resurrect the file, and an
+   * empty resolved state would let Mark Resolved write a 0-byte file.
+   */
+  @state() private resolvedAsDeleted = false;
   @state() private launchingExternalTool = false;
   @state() private hasMergeTool = false;
   @state() private aiAvailable = false;
@@ -609,7 +618,8 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       !this.conflictFile ||
       this.externalToolLocked ||
       this.launchingExternalTool ||
-      this.resolving
+      this.resolving ||
+      this.resolvedAsDeleted
     ) {
       return;
     }
@@ -697,6 +707,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
     this.loading = true;
     this.loadFailed = false;
+    this.resolvedAsDeleted = false;
     // Per-file UI state must not leak between files.
     this.editingSegmentId = null;
     this.aiExplanations = new Map();
@@ -901,15 +912,33 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
      * content shaped exactly like the separator (a Markdown setext
      * underline is `=======`) is indistinguishable from git's separator by
      * shape alone. Returns the first candidate split that validates.
+     *
+     * diff3 base markers get the same treatment: a bare `|||||||` line in
+     * the OURS content is shaped exactly like git's base marker, and
+     * cutting ours at the first one would silently truncate the hunk (the
+     * truncated prefix still validates!). Base candidates are therefore
+     * tried longest-ours-first, so the real base marker — the one whose
+     * full ours slice matches the blob — wins.
      */
     const validSplitOf = (b: string[]): { ours: string[]; theirs: string[] } | null => {
       for (const s of splitCandidates(b)) {
-        const split = splitAt(b, s);
-        if (
-          isContiguousRun(split.ours, this.oursLines) &&
-          isContiguousRun(split.theirs, this.theirsLines)
-        ) {
-          return split;
+        const theirs = b.slice(s + 1);
+        if (!isContiguousRun(theirs, this.theirsLines)) continue;
+        const baseCandidates: number[] = [];
+        for (let bi = 0; bi < s; bi++) {
+          if (isBaseMarker(b[bi])) baseCandidates.push(bi);
+        }
+        if (baseCandidates.length === 0) {
+          if (isContiguousRun(b.slice(0, s), this.oursLines)) {
+            return { ours: b.slice(0, s), theirs };
+          }
+          continue;
+        }
+        for (let c = baseCandidates.length - 1; c >= 0; c--) {
+          const ours = b.slice(0, baseCandidates[c]);
+          if (isContiguousRun(ours, this.oursLines)) {
+            return { ours, theirs };
+          }
         }
       }
       return null;
@@ -1126,9 +1155,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   /** Resolve writes and an open external tool must never overlap — both
    * mutate the same on-disk file and the last write would silently win.
    * The host lock counts too: the dialog sets it while ITS tool session or
-   * abort/complete runs against this same file. */
+   * abort/complete runs against this same file. A resolution that DELETED
+   * the on-screen file is terminal: every further action would either fail
+   * or resurrect the file. */
   private get actionsBlocked(): boolean {
-    return this.resolving || this.launchingExternalTool || this.externalToolLocked;
+    return (
+      this.resolving ||
+      this.launchingExternalTool ||
+      this.externalToolLocked ||
+      this.resolvedAsDeleted
+    );
   }
 
   /** Serialized output of the last successful Mark Resolved for this file —
@@ -1597,13 +1633,23 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         if (token === this.resolveToken) {
           this.userTouched = false;
         }
-        // Reload when the taken file is still the one on screen (the last
-        // file has no auto-advance target): the stale pre-take parse would
-        // otherwise sit there with Mark Resolved enabled, and one click
-        // would fs::write the old content back — silently resurrecting a
-        // file whose DELETION the user just staged.
+        // When the taken file is still the one on screen (the last file
+        // has no auto-advance target), the stale pre-take parse must not
+        // sit there with Mark Resolved enabled — one click would fs::write
+        // the old content back. A DELETION cannot reload (the workdir read
+        // would fail into an error state whose verbatim button resurrects
+        // the file); it lands in the terminal deleted state instead.
+        const tookDeletion = side === 'ours' ? !file.ours : !file.theirs;
         if (this.conflictFile?.path === file.path) {
-          await this.loadContents();
+          if (tookDeletion) {
+            if (token === this.resolveToken) {
+              this.segments = [];
+              this.editingSegmentId = null;
+              this.resolvedAsDeleted = true;
+            }
+          } else {
+            await this.loadContents();
+          }
         }
         this.dispatchEvent(new CustomEvent('conflict-resolved', {
           detail: { file },
@@ -1935,6 +1981,15 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   }
 
   private renderOutput(): ReturnType<typeof html> {
+    if (this.resolvedAsDeleted) {
+      // Terminal success state — deliberately NOT the error state: a
+      // Retry/verbatim escape hatch here would resurrect the deletion.
+      return html`
+        <div class="loading">
+          Resolved — this file was deleted by the resolution. Nothing further to do here.
+        </div>
+      `;
+    }
     if (this.loadFailed) {
       // Say what actually failed — blaming the working-directory file when
       // only a side blob was unreadable would be wrong and alarming.
@@ -2062,7 +2117,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             <button
               class="btn"
               @click=${this.handleOpenExternalMergeTool}
-              ?disabled=${this.launchingExternalTool || this.externalToolLocked || this.resolving}
+              ?disabled=${this.launchingExternalTool ||
+              this.externalToolLocked ||
+              this.resolving ||
+              this.resolvedAsDeleted}
               title="Open in external merge tool"
             >
               ${this.launchingExternalTool ? 'Waiting for tool...' : 'External Tool'}

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -556,6 +556,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   private nextSegmentId = 1;
   /** Invalidates in-flight loads when a newer one starts (rapid file switches). */
   private loadEpoch = 0;
+  /** Ownership tokens so stale async completions can't clobber newer state. */
+  private resolveToken = 0;
+  private aiResolveAllToken = 0;
   private baseLines: string[] = [];
   private oursLines: string[] = [];
   private theirsLines: string[] = [];
@@ -600,7 +603,15 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   }
 
   private async handleOpenExternalMergeTool(): Promise<void> {
-    if (!this.repositoryPath || !this.conflictFile || this.externalToolLocked) return;
+    if (
+      !this.repositoryPath ||
+      !this.conflictFile ||
+      this.externalToolLocked ||
+      this.launchingExternalTool ||
+      this.resolving
+    ) {
+      return;
+    }
 
     this.launchingExternalTool = true;
     // Tell the host a tool session is open so its Abort/Complete stay inert —
@@ -642,6 +653,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.editingSegmentId = null;
     this.aiExplanations = new Map();
     this.suggestingSegment = null;
+    // A resolve or resolve-all bound to the previous file must not keep the
+    // new file's buttons disabled; bump the tokens so their finally blocks
+    // can't clear state a newer operation owns.
+    this.resolving = false;
+    this.resolveToken++;
+    this.suggestingAll = false;
+    this.aiResolveAllToken++;
     this.sideReadErrors = { base: false, ours: false, theirs: false };
 
     try {
@@ -843,6 +861,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       origin,
       fromConflict,
     };
+  }
+
+  /** Resolve writes and an open external tool must never overlap — both
+   * mutate the same on-disk file and the last write would silently win. */
+  private get actionsBlocked(): boolean {
+    return this.resolving || this.launchingExternalTool;
   }
 
   private get conflictCount(): number {
@@ -1056,9 +1080,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     const conflictIds = this.segments.filter((s) => s.type === 'conflict').map((s) => s.id);
     if (conflictIds.length === 0) return;
 
+    const epoch = this.loadEpoch;
+    const token = ++this.aiResolveAllToken;
     this.suggestingAll = true;
     try {
       for (const id of conflictIds) {
+        // The file changed under the batch — its ids are stale; stop instead
+        // of grinding through no-op calls while the new file's AI is locked.
+        if (this.loadEpoch !== epoch) break;
         // The user may have resolved this block manually while the batch was
         // running — that's not a failure, just skip it.
         const segment = this.segments.find((s) => s.id === id);
@@ -1067,14 +1096,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         if (!(await this.handleSuggestSegment(id))) break;
       }
     } finally {
-      this.suggestingAll = false;
+      if (token === this.aiResolveAllToken) {
+        this.suggestingAll = false;
+      }
     }
   }
 
   // ── Completion ────────────────────────────────────────────────────────
 
   private async handleMarkResolved(): Promise<void> {
-    if (!this.repositoryPath || !this.conflictFile || this.resolving) return;
+    if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
 
     // The button is disabled in these states; the guards keep the invariant
     // even if invoked directly. A file with open conflict blocks must never
@@ -1100,6 +1131,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     // mark the wrong file resolved (and let a stash Complete drop the stash
     // with a still-conflicted file).
     const file = this.conflictFile;
+    const token = ++this.resolveToken;
     this.resolving = true;
     try {
       const result = await gitService.resolveConflict(
@@ -1119,7 +1151,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         showToast(`Failed to mark file as resolved: ${result.error?.message ?? 'Unknown error'}`, 'error');
       }
     } finally {
-      this.resolving = false;
+      // Only the call that owns the flag may clear it — a file switch resets
+      // it and a newer call may own it by now.
+      if (token === this.resolveToken) {
+        this.resolving = false;
+      }
     }
   }
 
@@ -1133,11 +1169,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    * the file (avoids the text pipeline truncating binary/deleted files).
    */
   private async handleTakeSide(side: 'ours' | 'theirs'): Promise<void> {
-    if (!this.repositoryPath || !this.conflictFile || this.resolving) return;
+    if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
 
     // Same capture-before-await as handleMarkResolved: the dispatched file
     // must be the one the call actually resolved.
     const file = this.conflictFile;
+    const token = ++this.resolveToken;
     this.resolving = true;
     try {
       const result = await gitService.resolveConflictTakeSide(
@@ -1157,7 +1194,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         showToast(`Failed to resolve conflict: ${result.error?.message ?? 'Unknown error'}`, 'error');
       }
     } finally {
-      this.resolving = false;
+      if (token === this.resolveToken) {
+        this.resolving = false;
+      }
     }
   }
 
@@ -1513,10 +1552,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           This file is binary and cannot be merged as text. Choose which version to keep.
         </div>
         <div class="toolbar-actions">
-          <button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} ?disabled=${this.resolving}>
+          <button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} ?disabled=${this.actionsBlocked}>
             ${oursDeleted ? 'Use Ours (delete file)' : 'Use Ours'}
           </button>
-          <button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} ?disabled=${this.resolving}>
+          <button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} ?disabled=${this.actionsBlocked}>
             ${theirsDeleted ? 'Use Theirs (delete file)' : 'Use Theirs'}
           </button>
         </div>
@@ -1550,7 +1589,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             <button
               class="btn"
               @click=${this.handleOpenExternalMergeTool}
-              ?disabled=${this.launchingExternalTool || this.externalToolLocked}
+              ?disabled=${this.launchingExternalTool || this.externalToolLocked || this.resolving}
               title="Open in external merge tool"
             >
               ${this.launchingExternalTool ? 'Waiting for tool...' : 'External Tool'}
@@ -1569,14 +1608,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               </button>`
             : nothing}
           ${this.conflictFile && !this.conflictFile.ours
-            ? html`<button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} ?disabled=${this.resolving} title="Ours deleted this file — keep it deleted">
+            ? html`<button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} ?disabled=${this.actionsBlocked} title="Ours deleted this file — keep it deleted">
                 Use Ours (delete file)
               </button>`
             : html`<button class="btn btn-ours" @click=${this.handleAcceptOurs} ?disabled=${this.loadFailed} title="Use entire file from ${labels.ours}">
                 Use Ours
               </button>`}
           ${this.conflictFile && !this.conflictFile.theirs
-            ? html`<button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} ?disabled=${this.resolving} title="Theirs deleted this file — delete it">
+            ? html`<button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} ?disabled=${this.actionsBlocked} title="Theirs deleted this file — delete it">
                 Use Theirs (delete file)
               </button>`
             : html`<button class="btn btn-theirs" @click=${this.handleAcceptTheirs} ?disabled=${this.loadFailed} title="Use entire file from ${labels.theirs}">
@@ -1595,7 +1634,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <button
             class="btn btn-primary"
             @click=${this.handleMarkResolved}
-            ?disabled=${conflictCount > 0 || this.loadFailed || this.editingSegmentId !== null || this.resolving}
+            ?disabled=${conflictCount > 0 ||
+              this.loadFailed ||
+              this.editingSegmentId !== null ||
+              this.actionsBlocked}
             title=${conflictCount > 0
               ? `Resolve the remaining ${conflictCount} conflict${conflictCount === 1 ? '' : 's'} first`
               : this.editingSegmentId !== null
@@ -1622,7 +1664,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               <button
                 class="panel-header-btn"
                 @click=${this.conflictFile.ours ? this.handleAcceptOurs : () => this.handleTakeSide('ours')}
-                ?disabled=${this.resolving || (this.conflictFile.ours ? this.loadFailed : false)}
+                ?disabled=${this.actionsBlocked || (this.conflictFile.ours ? this.loadFailed : false)}
                 title=${this.conflictFile.ours ? 'Use this version' : 'This side deleted the file — stage the deletion'}
               >
                 ${this.conflictFile.ours ? 'Use' : 'Use (delete)'}
@@ -1658,7 +1700,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               <button
                 class="panel-header-btn"
                 @click=${this.conflictFile.theirs ? this.handleAcceptTheirs : () => this.handleTakeSide('theirs')}
-                ?disabled=${this.resolving || (this.conflictFile.theirs ? this.loadFailed : false)}
+                ?disabled=${this.actionsBlocked || (this.conflictFile.theirs ? this.loadFailed : false)}
                 title=${this.conflictFile.theirs ? 'Use this version' : 'This side deleted the file — stage the deletion'}
               >
                 ${this.conflictFile.theirs ? 'Use' : 'Use (delete)'}

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -852,11 +852,6 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
     const segments: OutputSegment[] = [];
     let currentResolved: string[] = [];
-    let inConflict = false;
-    let seenSeparator = false;
-    let body: string[] = [];
-    let oursLabel = '';
-    let theirsLabel = '';
 
     /** True when `needle` appears as a consecutive slice of `hay`
      * (CR-insensitively — the workdir may be CRLF while blobs are LF). */
@@ -871,49 +866,72 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       }
       return false;
     };
+    // With no blob content at all there is nothing to validate against —
+    // the parser falls back to first-candidate closing (the shape-only
+    // behavior), which is also what direct unit-test invocations exercise.
+    const blobsAvailable = this.oursLines.length > 0 || this.theirsLines.length > 0;
+    const lineInBlobs = (l: string): boolean =>
+      isContiguousRun([l], this.oursLines) || isContiguousRun([l], this.theirsLines);
 
-    /**
-     * Split a conflict block's raw body (the lines between the start and
-     * end markers) into ours/theirs. Content shaped exactly like the
-     * separator — a Markdown setext underline is `=======` — is
-     * indistinguishable from git's separator by shape alone, so when more
-     * than one candidate exists each split is validated against the
-     * ours/theirs blob contents: each side of a hunk is a contiguous slice
-     * of its blob. The first candidate whose BOTH sides validate wins;
-     * with no valid candidate the first is kept (blobs unavailable).
-     */
-    const splitConflictBody = (b: string[]): { ours: string[]; theirs: string[] } => {
-      const baseIdxBefore = (limit: number): number => {
-        for (let i = 0; i < limit; i++) {
-          if (isBaseMarker(b[i])) return i;
-        }
-        return -1;
-      };
-      const oursUpTo = (limit: number): string[] => {
-        const bi = baseIdxBefore(limit);
-        // diff3 base sections (between ||||||| and the separator) are
-        // discarded — never leak base into ours.
-        return b.slice(0, bi < 0 ? limit : bi);
-      };
-      const candidates: number[] = [];
+    const splitCandidates = (b: string[]): number[] => {
+      const out: number[] = [];
       for (let i = 0; i < b.length; i++) {
-        if (isSeparator(b[i])) candidates.push(i);
+        if (isSeparator(b[i])) out.push(i);
       }
-      if (candidates.length === 0) {
-        // Unterminated at EOF before any separator — everything is ours.
-        return { ours: oursUpTo(b.length), theirs: [] };
-      }
-      if (candidates.length > 1) {
-        for (const s of candidates) {
-          const ours = oursUpTo(s);
-          const theirs = b.slice(s + 1);
-          if (isContiguousRun(ours, this.oursLines) && isContiguousRun(theirs, this.theirsLines)) {
-            return { ours, theirs };
-          }
+      return out;
+    };
+    const splitAt = (b: string[], s: number): { ours: string[]; theirs: string[] } => {
+      // diff3 base sections (between ||||||| and the separator) are
+      // discarded — never leak base into ours.
+      let baseIdx = -1;
+      for (let i = 0; i < s; i++) {
+        if (isBaseMarker(b[i])) {
+          baseIdx = i;
+          break;
         }
       }
-      const s = candidates[0];
-      return { ours: oursUpTo(s), theirs: b.slice(s + 1) };
+      return { ours: b.slice(0, baseIdx < 0 ? s : baseIdx), theirs: b.slice(s + 1) };
+    };
+    /**
+     * A split is VALID when each side is a contiguous slice of its blob —
+     * content shaped exactly like the separator (a Markdown setext
+     * underline is `=======`) is indistinguishable from git's separator by
+     * shape alone. Returns the first candidate split that validates.
+     */
+    const validSplitOf = (b: string[]): { ours: string[]; theirs: string[] } | null => {
+      for (const s of splitCandidates(b)) {
+        const split = splitAt(b, s);
+        if (
+          isContiguousRun(split.ours, this.oursLines) &&
+          isContiguousRun(split.theirs, this.theirsLines)
+        ) {
+          return split;
+        }
+      }
+      return null;
+    };
+    const fallbackSplitOf = (b: string[]): { ours: string[]; theirs: string[] } => {
+      const cs = splitCandidates(b);
+      // Unterminated with no separator — everything is ours.
+      if (cs.length === 0) return splitAt(b, b.length);
+      return splitAt(b, cs[0]);
+    };
+    /**
+     * True when the text after a candidate close (up to the next
+     * start-shaped line) contains a marker-shaped line that is NOT content
+     * from either blob — i.e. a real, orphaned git marker. Closing early
+     * (at a QUOTED end marker inside the theirs section) strands the real
+     * separator/end below as "resolved" text; this detects exactly that.
+     * A validated split alone cannot: a PREFIX of the theirs hunk also
+     * validates as contiguous.
+     */
+    const orphanMarkerAfter = (endIdx: number): boolean => {
+      for (let k = endIdx + 1; k < lines.length; k++) {
+        const l = lines[k];
+        if (isConflictStart(l)) return false;
+        if ((isConflictEnd(l) || isSeparator(l)) && !lineInBlobs(l)) return true;
+      }
+      return false;
     };
 
     const flushResolved = (): void => {
@@ -922,58 +940,109 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         currentResolved = [];
       }
     };
-    const pushConflict = (): void => {
-      const { ours, theirs } = splitConflictBody(body);
+    const pushConflict = (
+      split: { ours: string[]; theirs: string[] },
+      oursLabel: string,
+      theirsLabel: string,
+    ): void => {
+      flushResolved();
       segments.push({
         id: this.nextSegmentId++,
         type: 'conflict',
         lines: [],
-        oursLines: ours,
-        theirsLines: theirs,
+        oursLines: split.ours,
+        theirsLines: split.theirs,
         oursLabel,
         theirsLabel,
         origin: null,
         fromConflict: false,
       });
     };
+    const labelOf = (markerLine: string, fallback: string): string =>
+      stripCr(markerLine).slice(markerSize).trim() || fallback;
 
-    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
-      const line = lines[lineIndex];
-      if (!inConflict && isConflictStart(line)) {
-        flushResolved();
-        inConflict = true;
-        seenSeparator = false;
-        body = [];
-        oursLabel = stripCr(line).slice(markerSize).trim() || 'OURS';
-        theirsLabel = '';
-      } else if (inConflict && seenSeparator && isConflictEnd(line)) {
-        // Git always emits '=======' before '>>>>>>>', so an end marker is
-        // only valid once a separator was seen — anywhere earlier it's
-        // content (a quoted diff, docs about conflicts) and treating it as
-        // the end would drop the real theirs side and leak the true markers.
-        theirsLabel = stripCr(line).slice(markerSize).trim() || 'THEIRS';
-        pushConflict();
-        inConflict = false;
-        body = [];
-      } else if (inConflict) {
-        // Everything between the start and end markers — including nested
-        // '<<<<<<<' lines, separator candidates, and diff3 base sections —
-        // is collected raw; splitConflictBody derives the ours/theirs split.
-        if (isSeparator(line)) seenSeparator = true;
-        body.push(line);
-      } else {
+    let i = 0;
+    while (i < lines.length) {
+      const line = lines[i];
+      if (!isConflictStart(line)) {
         currentResolved.push(line);
+        i++;
+        continue;
+      }
+
+      // A start-shaped line opens a candidate conflict region. Walk forward
+      // collecting the body and candidate end markers (end-shaped lines
+      // after at least one separator-shaped line — git always emits
+      // '=======' before '>>>>>>>'). Content can QUOTE markers, so a
+      // candidate close is only accepted when it can be justified against
+      // the blobs; otherwise the end-shaped line is content and scanning
+      // continues to the next candidate.
+      const oursLabel = labelOf(line, 'OURS');
+      const body: string[] = [];
+      let seenSep = false;
+      let firstCandidate: { end: number; body: string[] } | null = null;
+      let closed: { end: number; split: { ours: string[]; theirs: string[] } | null } | null =
+        null;
+
+      for (let j = i + 1; j < lines.length; j++) {
+        const l = lines[j];
+        if (seenSep && isConflictEnd(l)) {
+          if (!blobsAvailable) {
+            closed = { end: j, split: fallbackSplitOf(body) };
+            break;
+          }
+          if (!firstCandidate) firstCandidate = { end: j, body: [...body] };
+          // The whole region (markers included) existing verbatim in a
+          // blob means it is QUOTED content — a docs example that survived
+          // the merge — not a git-generated conflict. Real markers are in
+          // neither blob.
+          const region = lines.slice(i, j + 1);
+          if (isContiguousRun(region, this.oursLines) || isContiguousRun(region, this.theirsLines)) {
+            closed = { end: j, split: null };
+            break;
+          }
+          const split = validSplitOf(body);
+          if (split && !orphanMarkerAfter(j)) {
+            closed = { end: j, split };
+            break;
+          }
+          // Rejected — this end-shaped line is content; keep scanning.
+          body.push(l);
+          continue;
+        }
+        if (isSeparator(l)) seenSep = true;
+        body.push(l);
+      }
+
+      if (closed && closed.split === null) {
+        // Quoted region — plain content, merged into the surrounding run.
+        currentResolved.push(...lines.slice(i, closed.end + 1));
+        i = closed.end + 1;
+      } else if (closed) {
+        pushConflict(closed.split!, oursLabel, labelOf(lines[closed.end], 'THEIRS'));
+        i = closed.end + 1;
+      } else if (firstCandidate) {
+        // No candidate could be justified (nothing validates) — close at
+        // the FIRST candidate, the pre-validation behavior.
+        pushConflict(
+          fallbackSplitOf(firstCandidate.body),
+          oursLabel,
+          labelOf(lines[firstCandidate.end], 'THEIRS'),
+        );
+        i = firstCandidate.end + 1;
+      } else {
+        // Unterminated conflict (truncated file) — keep it as a conflict
+        // block rather than silently promoting marker content to resolved
+        // text.
+        pushConflict(
+          validSplitOf(body) ?? fallbackSplitOf(body),
+          oursLabel,
+          'THEIRS',
+        );
+        i = lines.length;
       }
     }
-
-    if (inConflict) {
-      // Unterminated conflict (truncated file) — keep it as a conflict block
-      // rather than silently promoting marker content to resolved text.
-      theirsLabel = theirsLabel || 'THEIRS';
-      pushConflict();
-    } else {
-      flushResolved();
-    }
+    flushResolved();
 
     return segments;
   }
@@ -1080,8 +1149,17 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.updateSegment(id, { type: 'conflict', lines: [], origin: null, fromConflict: false });
   }
 
-  private startEditSegment(segment: OutputSegment): void {
+  private async startEditSegment(segment: OutputSegment): Promise<void> {
     if (this.actionsBlocked) return;
+    // Opening an edit on ANOTHER segment throws away the current typed
+    // draft — confirm like every other draft-discarding path.
+    if (this.editingSegmentId !== null && this.editingSegmentId !== segment.id) {
+      if (!(await this.confirmDiscardOpenEdit())) return;
+      // Re-check after the confirm's await, and re-find the segment — a
+      // resolve/tool session or reload may have happened while it was up.
+      if (this.actionsBlocked) return;
+      if (!this.segments.some((s) => s.id === segment.id)) return;
+    }
     this.editingSegmentId = segment.id;
     // Editing an open conflict starts from both sides so the user trims what
     // they don't want — never from marker text.
@@ -1385,8 +1463,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       );
 
       if (result.success) {
-        // This exact output is on disk now — navigation away is safe.
-        this.lastSavedContent = content;
+        // This exact output is on disk now — navigation away is safe. But
+        // only record it while this call still owns the editor's state: a
+        // file switch mid-write resets per-file state, and a stale write's
+        // content must not masquerade as the CURRENT file's saved state.
+        if (token === this.resolveToken) {
+          this.lastSavedContent = content;
+        }
         this.dispatchEvent(new CustomEvent('conflict-resolved', {
           detail: { file },
           bubbles: true,
@@ -1783,34 +1866,43 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               : 'Could not read the merged file from the working directory.'}
           </div>
           <button class="btn btn-primary" @click=${this.handleReload}>Retry</button>
-          ${!sideFailed
-            ? html`
-                <div>
-                  This can happen for text files in a legacy (non-UTF-8) encoding. You can
-                  still resolve the conflict by taking one side verbatim:
-                </div>
-                <div>
-                  ${this.conflictFile?.ours
-                    ? html`<button
-                        class="btn btn-ours"
-                        @click=${() => this.handleTakeSide('ours')}
-                        ?disabled=${this.actionsBlocked}
-                      >
-                        Use ${labels.ours} (verbatim)
-                      </button>`
-                    : nothing}
-                  ${this.conflictFile?.theirs
-                    ? html`<button
-                        class="btn btn-theirs"
-                        @click=${() => this.handleTakeSide('theirs')}
-                        ?disabled=${this.actionsBlocked}
-                      >
-                        Use ${labels.theirs} (verbatim)
-                      </button>`
-                    : nothing}
-                </div>
-              `
-            : nothing}
+          ${
+            // Take-side writes one side's blob verbatim — it never touches the
+            // BASE blob or the workdir text, so each side is offerable
+            // whenever ITS OWN blob was readable (per-side, not all-or-none:
+            // a missing base object in a shallow clone must not strand the
+            // user with only Retry and Abort).
+            (this.conflictFile?.ours && !this.sideReadErrors.ours) ||
+            (this.conflictFile?.theirs && !this.sideReadErrors.theirs)
+              ? html`
+                  <div>
+                    This can happen for text files in a legacy (non-UTF-8) encoding or a
+                    missing version object. You can still resolve the conflict by taking one
+                    side verbatim:
+                  </div>
+                  <div>
+                    ${this.conflictFile?.ours && !this.sideReadErrors.ours
+                      ? html`<button
+                          class="btn btn-ours"
+                          @click=${() => this.handleTakeSide('ours')}
+                          ?disabled=${this.actionsBlocked}
+                        >
+                          Use ${labels.ours} (verbatim)
+                        </button>`
+                      : nothing}
+                    ${this.conflictFile?.theirs && !this.sideReadErrors.theirs
+                      ? html`<button
+                          class="btn btn-theirs"
+                          @click=${() => this.handleTakeSide('theirs')}
+                          ?disabled=${this.actionsBlocked}
+                        >
+                          Use ${labels.theirs} (verbatim)
+                        </button>`
+                      : nothing}
+                  </div>
+                `
+              : nothing
+          }
         </div>
       `;
     }

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -650,6 +650,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.dispatchEvent(
       new CustomEvent('external-tool-started', { bubbles: true, composed: true })
     );
+    // Handed to the host with the finished event: the tool may have changed
+    // what get_conflicts reports for this file (markerSize, hunks), and the
+    // host's stale ConflictFile object would misparse its output.
+    let freshConflicts: ConflictFile[] | null = null;
     try {
       const result = await gitService.launchMergeTool(this.repositoryPath, file.path);
       if (result.success && result.data?.success) {
@@ -658,6 +662,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         // like the dialog's own external tool instead of leaving the file
         // listed unresolved until an extra Mark Resolved click.
         const conflictsResult = await gitService.getConflicts(this.repositoryPath);
+        if (conflictsResult.success) {
+          freshConflicts = conflictsResult.data ?? [];
+        }
         const stillConflicted =
           !conflictsResult.success ||
           (conflictsResult.data ?? []).some((c) => c.path === file.path);
@@ -690,7 +697,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     } finally {
       this.launchingExternalTool = false;
       this.dispatchEvent(
-        new CustomEvent('external-tool-finished', { bubbles: true, composed: true })
+        new CustomEvent('external-tool-finished', {
+          detail: { filePath: file.path, freshConflicts },
+          bubbles: true,
+          composed: true,
+        })
       );
     }
   }
@@ -724,6 +735,23 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.sideReadErrors = { base: false, ours: false, theirs: false };
 
     try {
+      // Submodule (gitlink) conflicts have nothing to read: the entry OIDs
+      // are COMMITS (not blobs) and the workdir path is a directory. Every
+      // fetch below would fail and land the editor in a loadFailed state
+      // it never renders — the submodule chooser draws from the entry
+      // metadata alone.
+      if (file.isSubmodule) {
+        this.segments = [];
+        this.baseContent = '';
+        this.oursContent = '';
+        this.theirsContent = '';
+        this.baseLines = [];
+        this.oursLines = [];
+        this.theirsLines = [];
+        this.alignmentRows = [];
+        return;
+      }
+
       // Initialize Shiki highlighter and detect language. Inside the try so
       // a highlighter failure cannot wedge the editor in a permanent
       // loading state (the finally below always clears it).
@@ -1050,6 +1078,23 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       return splitAt(b, cs[0]);
     };
     /**
+     * Exhaustive blob-validated split for a body WITHOUT a separator line
+     * (a hand edit can delete the `=======` itself): the first index where
+     * the prefix is a contiguous ours run AND the suffix a contiguous
+     * theirs run. Bodies are conflict-hunk sized, so the quadratic scan is
+     * cheap.
+     */
+    const validAnySplitOf = (b: string[]): { ours: string[]; theirs: string[] } | null => {
+      for (let s = 0; s <= b.length; s++) {
+        const ours = b.slice(0, s);
+        const theirs = b.slice(s);
+        if (isContiguousRun(ours, this.oursLines) && isContiguousRun(theirs, this.theirsLines)) {
+          return { ours, theirs };
+        }
+      }
+      return null;
+    };
+    /**
      * The text after a candidate close, up to the next REAL start-shaped
      * line. A start-shaped line that is blob content (a quoted example)
      * does not end the window — stopping there would hide an orphaned real
@@ -1176,6 +1221,27 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             weakCandidate = { end: j, split };
           }
           // This end-shaped line may be content; keep scanning.
+          body.push(l);
+          continue;
+        }
+        if (!seenSep && isConflictEnd(l) && blobsAvailable && !lineInBlobs(l)) {
+          // An end-shaped line BEFORE any separator that exists in NEITHER
+          // blob is a real orphaned end marker — a hand edit deleted the
+          // `=======` line (git always emits it before `>>>>>>>`). Close
+          // here when the body blob-justifies a split; the marker line is
+          // the region's terminator and must never surface as pane content
+          // (or round-trip to disk via an accepted side). Without
+          // justification the line may still be typed content — it stays
+          // in the body and scanning continues, so a real separator+end
+          // below still wins (no early close on mid-region junk).
+          const split = validAnySplitOf(body);
+          if (split && trailingIsBlobRun(j)) {
+            closed = { end: j, split };
+            break;
+          }
+          if (split && !weakCandidate && !orphanMarkerAfter(j)) {
+            weakCandidate = { end: j, split };
+          }
           body.push(l);
           continue;
         }
@@ -1371,6 +1437,19 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   private markerEchoPattern(): RegExp {
     const n = Math.min(7, this.effectiveMarkerSize);
     return new RegExp(`^(<{${n},}|={${n},}|>{${n},}|\\|{${n},})( |\\r?$)`, 'm');
+  }
+
+  /** CR-insensitive single-line membership in either side blob. Marker-shaped
+   * text that IS blob content (a setext underline, a quoted example) is
+   * legitimate; marker-shaped text in neither blob is a real orphaned
+   * marker a hand edit left behind. */
+  private lineIsBlobContent(line: string): boolean {
+    const strip = (l: string): string => (l.endsWith('\r') ? l.slice(0, -1) : l);
+    const target = strip(line);
+    return (
+      this.oursLines.some((l) => strip(l) === target) ||
+      this.theirsLines.some((l) => strip(l) === target)
+    );
   }
 
   private async applyEditSegment(): Promise<void> {
@@ -1639,6 +1718,34 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       return;
     }
 
+    // Belt-and-braces for hand-edited files: parser fallbacks can leave a
+    // REAL orphaned marker line inside an accepted side (e.g. a hand edit
+    // deleted the separator and nothing blob-justified a close). Writing it
+    // back SILENTLY would re-serialize a marker as resolved content — the
+    // exact failure this editor exists to prevent — so confirm, like the
+    // inline-edit path does. Manual segments confirmed at apply time, and
+    // marker-shaped lines that are blob content are legitimate; both stay
+    // silent.
+    const echo = this.markerEchoPattern();
+    const hasOrphanMarker = this.segments.some(
+      (s) =>
+        s.type === 'resolved' &&
+        s.origin !== 'manual' &&
+        s.lines.some((l) => echo.test(l) && !this.lineIsBlobContent(l)),
+    );
+    if (hasOrphanMarker) {
+      const proceed = await showConfirm(
+        'Write conflict-marker-like text?',
+        'The resolved content contains lines shaped like git conflict markers that are not part of either version. If a hand edit left real markers behind, cancel and remove them; if the text is intentional it will be written as-is.',
+        'warning',
+      );
+      if (!proceed) return;
+      // Re-check after the await — same re-validation as every other
+      // confirm in this component.
+      if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
+      if (this.loadFailed || this.conflictCount > 0 || this.editingSegmentId !== null) return;
+    }
+
     // Capture the file BEFORE the await: the user may select another file in
     // the dialog while the backend call runs, and dispatching that one would
     // mark the wrong file resolved (and let a stash Complete drop the stash
@@ -1692,6 +1799,20 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
   private get isBinaryConflict(): boolean {
     return this.conflictFile?.isBinary === true;
+  }
+
+  private get isSubmoduleConflict(): boolean {
+    return this.conflictFile?.isSubmodule === true;
+  }
+
+  /** Any side being a symlink (mode 120000) makes this a link conflict —
+   * the "binary" chooser resolves it, but the copy must say what the
+   * choice actually is (link targets), not call a link a binary file. */
+  private get isSymlinkConflict(): boolean {
+    const f = this.conflictFile;
+    return (
+      !!f && [f.ancestor, f.ours, f.theirs].some((e) => e?.mode === 0o120000)
+    );
   }
 
   /**
@@ -2177,6 +2298,22 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
     const oursDeleted = !this.conflictFile.ours;
     const theirsDeleted = !this.conflictFile.theirs;
+    const isLink = this.isSymlinkConflict;
+    const labels = SIDE_LABELS[this.operationType] ?? SIDE_LABELS.merge;
+
+    // For a link side the blob IS its target path (tiny text) — showing it
+    // turns a blind "Use Ours/Theirs" guess into an informed choice.
+    const sideDetail = (
+      entry: ConflictFile['ours'],
+      content: string,
+      readFailed: boolean,
+    ): string => {
+      if (!entry) return 'deleted';
+      if (entry.mode === 0o120000) {
+        return readFailed ? 'a symbolic link (target unreadable)' : `a link → ${content.trim()}`;
+      }
+      return 'a regular file';
+    };
 
     return html`
       <div class="toolbar">
@@ -2184,17 +2321,73 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       </div>
       <div class="empty" style="flex-direction: column; gap: var(--spacing-md);">
         <div>
-          <strong>Binary file conflict</strong>
+          <strong>${isLink ? 'Symbolic link conflict' : 'Binary file conflict'}</strong>
         </div>
         <div style="font-style: normal; text-align: center; max-width: 420px;">
-          This file is binary and cannot be merged as text. Choose which version to keep.
+          ${isLink
+            ? 'The sides disagree about this symbolic link. Choose which version to keep.'
+            : 'This file is binary and cannot be merged as text. Choose which version to keep.'}
         </div>
+        ${isLink
+          ? html`<div style="font-style: normal; text-align: center; max-width: 420px;">
+              ${labels.ours}: ${sideDetail(this.conflictFile.ours, this.oursContent, this.sideReadErrors.ours)}<br />
+              ${labels.theirs}: ${sideDetail(this.conflictFile.theirs, this.theirsContent, this.sideReadErrors.theirs)}
+            </div>`
+          : nothing}
         <div class="toolbar-actions">
           <button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} ?disabled=${this.actionsBlocked}>
             ${oursDeleted ? 'Use Ours (delete file)' : 'Use Ours'}
           </button>
           <button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} ?disabled=${this.actionsBlocked}>
             ${theirsDeleted ? 'Use Theirs (delete file)' : 'Use Theirs'}
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderSubmoduleConflict(): ReturnType<typeof html> {
+    if (!this.conflictFile) {
+      return html`<div class="empty">Select a file to resolve</div>`;
+    }
+    // Same terminal notice as the binary path — a pointer-removal take on
+    // the last file must not leave dead chooser buttons on screen.
+    if (this.resolvedAsDeleted) {
+      return html`
+        <div class="loading">
+          Resolved — this submodule was removed by the resolution. Nothing further to do here.
+        </div>
+      `;
+    }
+
+    const ours = this.conflictFile.ours;
+    const theirs = this.conflictFile.theirs;
+    const labels = SIDE_LABELS[this.operationType] ?? SIDE_LABELS.merge;
+    const short = (oid?: string): string => (oid ? oid.slice(0, 7) : '');
+
+    return html`
+      <div class="toolbar">
+        <span class="toolbar-title">${this.conflictFile.path}</span>
+      </div>
+      <div class="empty" style="flex-direction: column; gap: var(--spacing-md);">
+        <div>
+          <strong>Submodule conflict</strong>
+        </div>
+        <div style="font-style: normal; text-align: center; max-width: 420px;">
+          Each side records a different commit for this submodule. Choose which commit to
+          keep — the submodule's own files are not changed here (update the submodule
+          afterwards to check the chosen commit out).
+        </div>
+        <div style="font-style: normal; text-align: center; max-width: 420px;">
+          ${labels.ours}: ${ours ? html`<code>${short(ours.oid)}</code>` : 'submodule removed'}<br />
+          ${labels.theirs}: ${theirs ? html`<code>${short(theirs.oid)}</code>` : 'submodule removed'}
+        </div>
+        <div class="toolbar-actions">
+          <button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} ?disabled=${this.actionsBlocked}>
+            ${ours ? `Use Ours (${short(ours.oid)})` : 'Use Ours (remove submodule)'}
+          </button>
+          <button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} ?disabled=${this.actionsBlocked}>
+            ${theirs ? `Use Theirs (${short(theirs.oid)})` : 'Use Theirs (remove submodule)'}
           </button>
         </div>
       </div>
@@ -2208,6 +2401,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
     if (this.loading) {
       return html`<div class="loading">Loading file contents...</div>`;
+    }
+
+    // Submodule conflicts have no content at all (commit pointers, not
+    // blobs) — offer the commit-pointer chooser.
+    if (this.isSubmoduleConflict) {
+      return this.renderSubmoduleConflict();
     }
 
     // Binary conflicts cannot be edited as text — editing would truncate the

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -663,7 +663,6 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       this.baseLines = file.ancestor ? this.baseContent.split('\n') : [];
       this.oursLines = file.ours ? this.oursContent.split('\n') : [];
       this.theirsLines = file.theirs ? this.theirsContent.split('\n') : [];
-      this.alignmentRows = alignThreeWay(this.baseLines, this.oursLines, this.theirsLines);
 
       // A failed read of a side that EXISTS must not masquerade as empty
       // content — the panes would lie and whole-file Use Ours/Theirs would
@@ -680,6 +679,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       if (this.sideReadErrors.theirs) this.theirsLines = [];
       const sideReadFailed =
         this.sideReadErrors.base || this.sideReadErrors.ours || this.sideReadErrors.theirs;
+
+      // Align AFTER dropping failed sides, or the rows would reference lines
+      // that no longer exist and pane rendering would crash on them.
+      this.alignmentRows = alignThreeWay(this.baseLines, this.oursLines, this.theirsLines);
 
       // Only git's own merge output is trustworthy. If the working directory
       // file can't be read, show an error state — never fabricate a merge.
@@ -1226,7 +1229,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           if (side !== 'base') {
             if (row.base === null) {
               lineClass = 'code-addition';
-            } else if (line !== this.baseLines[row.base]) {
+            } else if (!this.sideReadErrors.base && line !== this.baseLines[row.base]) {
               if (isWhitespaceOnlyChange(this.baseLines[row.base], line)) {
                 lineClass = 'code-ws-change';
                 wsSegments = computeInlineWhitespaceDiff(this.baseLines[row.base], line);
@@ -1412,9 +1415,17 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
   private renderOutput(): ReturnType<typeof html> {
     if (this.loadFailed) {
+      // Say what actually failed — blaming the working-directory file when
+      // only a side blob was unreadable would be wrong and alarming.
+      const sideFailed =
+        this.sideReadErrors.base || this.sideReadErrors.ours || this.sideReadErrors.theirs;
       return html`
         <div class="output-error">
-          <div>Could not read the merged file from the working directory.</div>
+          <div>
+            ${sideFailed
+              ? 'Could not read all of this file’s versions.'
+              : 'Could not read the merged file from the working directory.'}
+          </div>
           <button class="btn btn-primary" @click=${this.handleReload}>Retry</button>
         </div>
       `;
@@ -1574,7 +1585,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <div class="editor-panel">
             <div class="panel-header base">
               Base (Common Ancestor)
-              <span class="panel-stats">${this.getLineCount(this.baseContent)} lines</span>
+              <span class="panel-stats">
+                ${this.sideReadErrors.base ? 'read failed' : `${this.getLineCount(this.baseContent)} lines`}
+              </span>
             </div>
             <div class="panel-content readonly" id="panel-base" @scroll=${this.handleSourceScroll}>
               ${this.renderAlignedPane('base')}

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -632,9 +632,15 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         const stillConflicted =
           !conflictsResult.success ||
           (conflictsResult.data ?? []).some((c) => c.path === file.path);
-        if (stillConflicted) {
+        // Reload ONLY when the tool's file is still the one on screen: it
+        // must show the tool's output (a stale parse could be written over
+        // the tool's merge if this was the last file and selection stays),
+        // but after a mid-session switch a reload would wipe the picks of
+        // the file the user is now working on.
+        if (this.conflictFile?.path === file.path) {
           await this.loadContents();
-        } else {
+        }
+        if (!stillConflicted) {
           this.dispatchEvent(new CustomEvent('conflict-resolved', {
             detail: { file },
             bubbles: true,
@@ -677,6 +683,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.resolveToken++;
     this.suggestingAll = false;
     this.aiResolveAllToken++;
+    this.lastSavedContent = null;
     this.sideReadErrors = { base: false, ours: false, theirs: false };
 
     try {
@@ -774,12 +781,41 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    */
   private parseSegments(text: string): OutputSegment[] {
     const stripCr = (l: string): string => (l.endsWith('\r') ? l.slice(0, -1) : l);
-    const isConflictStart = (l: string): boolean => /^<{7}( |$)/.test(stripCr(l));
-    const isBaseMarker = (l: string): boolean => /^\|{7}( |$)/.test(stripCr(l));
-    const isSeparator = (l: string): boolean => stripCr(l) === '=======';
-    const isConflictEnd = (l: string): boolean => /^>{7}( |$)/.test(stripCr(l));
+    /**
+     * Length of a marker run of `ch` at the start of the line, or 0 when the
+     * line is not a marker (fewer than 7 chars, or followed by anything other
+     * than a space/EOL). Repos can raise the run length above git's default 7
+     * via the conflict-marker-size gitattribute, so the start marker's run
+     * defines the size the rest of that conflict's markers must match exactly.
+     */
+    const markerRun = (l: string, ch: string): number => {
+      const s = stripCr(l);
+      let n = 0;
+      while (n < s.length && s[n] === ch) n++;
+      return n >= 7 && (s.length === n || s[n] === ' ') ? n : 0;
+    };
+    let markerSize = 7;
+    const isBaseMarker = (l: string): boolean => markerRun(l, '|') === markerSize;
+    const isSeparator = (l: string): boolean => stripCr(l) === '='.repeat(markerSize);
+    const isConflictEnd = (l: string): boolean => markerRun(l, '>') === markerSize;
 
     const lines = text.split('\n');
+
+    /**
+     * A start-marker run of git's default size (7) always opens a conflict.
+     * A LONGER run (raised conflict-marker-size gitattribute) only counts
+     * when a matching exact-size separator follows later — otherwise a
+     * content line like '<<<<<<<< not a marker' would swallow the rest of
+     * the file into a phantom conflict.
+     */
+    const conflictStartSize = (index: number): number => {
+      const n = markerRun(lines[index], '<');
+      if (n === 0) return 0;
+      if (n === 7) return 7;
+      const sep = '='.repeat(n);
+      return lines.slice(index + 1).some((l) => stripCr(l) === sep) ? n : 0;
+    };
+
     const segments: OutputSegment[] = [];
     let currentResolved: string[] = [];
     let inConflict = false;
@@ -809,14 +845,17 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       });
     };
 
-    for (const line of lines) {
-      if (!inConflict && isConflictStart(line)) {
+    for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
+      const line = lines[lineIndex];
+      const startSize = inConflict ? 0 : conflictStartSize(lineIndex);
+      if (!inConflict && startSize > 0) {
         flushResolved();
         inConflict = true;
         section = 'ours';
         oursLines = [];
         theirsLines = [];
-        oursLabel = stripCr(line).slice(7).trim() || 'OURS';
+        markerSize = startSize;
+        oursLabel = stripCr(line).slice(markerSize).trim() || 'OURS';
         theirsLabel = '';
       } else if (inConflict && section === 'ours' && isBaseMarker(line)) {
         // diff3 common-ancestor marker — begin discarding base lines. Only
@@ -829,7 +868,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         // only valid in the theirs section — anywhere earlier it's content
         // (a quoted diff, docs about conflicts) and treating it as the end
         // would drop the real theirs side and leak the true markers.
-        theirsLabel = stripCr(line).slice(7).trim() || 'THEIRS';
+        theirsLabel = stripCr(line).slice(markerSize).trim() || 'THEIRS';
         pushConflict();
         inConflict = false;
         section = 'ours';
@@ -886,6 +925,21 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    * abort/complete runs against this same file. */
   private get actionsBlocked(): boolean {
     return this.resolving || this.launchingExternalTool || this.externalToolLocked;
+  }
+
+  /** Serialized output of the last successful Mark Resolved for this file —
+   * work matching it is on disk and safe to navigate away from. */
+  private lastSavedContent: string | null = null;
+
+  /**
+   * True when the output holds work not yet written to disk: per-block
+   * resolutions or an open inline edit. Nothing persists until Mark
+   * Resolved, so hosts should confirm before navigating away.
+   */
+  public hasUnsavedResolutions(): boolean {
+    if (this.editingSegmentId !== null) return true;
+    if (!this.segments.some((s) => s.fromConflict)) return false;
+    return this.buildResolvedContent() !== this.lastSavedContent;
   }
 
   private get conflictCount(): number {
@@ -1059,8 +1113,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       if (result.success && result.data) {
         // AI output bypasses parseSegments, so it must be validated here:
         // a suggestion that echoes marker lines would otherwise render them
-        // as "resolved" text and let them be written back to the file.
-        if (/^(<{7}|={7}|>{7}|\|{7})( |\r?$)/m.test(result.data.resolvedContent)) {
+        // as "resolved" text and let them be written back to the file. Runs
+        // of 7+ cover repos with a raised conflict-marker-size; being overly
+        // conservative here just leaves the block unresolved, which is safe.
+        if (/^(<{7,}|={7,}|>{7,}|\|{7,})( |\r?$)/m.test(result.data.resolvedContent)) {
           showToast('AI suggestion contained conflict markers — block left unresolved', 'error');
           return false;
         }
@@ -1151,15 +1207,18 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     // with a still-conflicted file).
     const file = this.conflictFile;
     const token = ++this.resolveToken;
+    const content = this.buildResolvedContent();
     this.resolving = true;
     try {
       const result = await gitService.resolveConflict(
         this.repositoryPath,
         file.path,
-        this.buildResolvedContent()
+        content
       );
 
       if (result.success) {
+        // This exact output is on disk now — navigation away is safe.
+        this.lastSavedContent = content;
         this.dispatchEvent(new CustomEvent('conflict-resolved', {
           detail: { file },
           bubbles: true,

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -613,6 +613,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       return;
     }
 
+    const file = this.conflictFile;
     this.launchingExternalTool = true;
     // Tell the host a tool session is open so its Abort/Complete stay inert —
     // they would otherwise race the tool's eventual save.
@@ -620,10 +621,26 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       new CustomEvent('external-tool-started', { bubbles: true, composed: true })
     );
     try {
-      const result = await gitService.launchMergeTool(this.repositoryPath, this.conflictFile.path);
+      const result = await gitService.launchMergeTool(this.repositoryPath, file.path);
       if (result.success && result.data?.success) {
         showToast('Merge tool completed', 'success');
-        await this.loadContents();
+        // The tool may have fully resolved (and staged) the file — verify
+        // against the index and let the host mark it, so this path behaves
+        // like the dialog's own external tool instead of leaving the file
+        // listed unresolved until an extra Mark Resolved click.
+        const conflictsResult = await gitService.getConflicts(this.repositoryPath);
+        const stillConflicted =
+          !conflictsResult.success ||
+          (conflictsResult.data ?? []).some((c) => c.path === file.path);
+        if (stillConflicted) {
+          await this.loadContents();
+        } else {
+          this.dispatchEvent(new CustomEvent('conflict-resolved', {
+            detail: { file },
+            bubbles: true,
+            composed: true,
+          }));
+        }
       } else {
         showToast(result.data?.message ?? result.error?.message ?? 'Merge tool failed', 'error');
       }
@@ -864,9 +881,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   }
 
   /** Resolve writes and an open external tool must never overlap — both
-   * mutate the same on-disk file and the last write would silently win. */
+   * mutate the same on-disk file and the last write would silently win.
+   * The host lock counts too: the dialog sets it while ITS tool session or
+   * abort/complete runs against this same file. */
   private get actionsBlocked(): boolean {
-    return this.resolving || this.launchingExternalTool;
+    return this.resolving || this.launchingExternalTool || this.externalToolLocked;
   }
 
   private get conflictCount(): number {

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -530,6 +530,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   @property({ type: Object }) conflictFile: ConflictFile | null = null;
   /** Which git operation produced the conflict — controls the side labels. */
   @property({ type: String }) operationType: MergeOperationType = 'merge';
+  /**
+   * Set by the host while its own destructive flows (abort/complete) run —
+   * launching an external tool then would race them.
+   */
+  @property({ type: Boolean }) externalToolLocked = false;
 
   @state() private baseContent = '';
   @state() private oursContent = '';
@@ -595,9 +600,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   }
 
   private async handleOpenExternalMergeTool(): Promise<void> {
-    if (!this.repositoryPath || !this.conflictFile) return;
+    if (!this.repositoryPath || !this.conflictFile || this.externalToolLocked) return;
 
     this.launchingExternalTool = true;
+    // Tell the host a tool session is open so its Abort/Complete stay inert —
+    // they would otherwise race the tool's eventual save.
+    this.dispatchEvent(
+      new CustomEvent('external-tool-started', { bubbles: true, composed: true })
+    );
     try {
       const result = await gitService.launchMergeTool(this.repositoryPath, this.conflictFile.path);
       if (result.success && result.data?.success) {
@@ -610,6 +620,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       showToast('Failed to launch merge tool', 'error');
     } finally {
       this.launchingExternalTool = false;
+      this.dispatchEvent(
+        new CustomEvent('external-tool-finished', { bubbles: true, composed: true })
+      );
     }
   }
 
@@ -1537,7 +1550,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             <button
               class="btn"
               @click=${this.handleOpenExternalMergeTool}
-              ?disabled=${this.launchingExternalTool}
+              ?disabled=${this.launchingExternalTool || this.externalToolLocked}
               title="Open in external merge tool"
             >
               ${this.launchingExternalTool ? 'Waiting for tool...' : 'External Tool'}

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -624,7 +624,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       this.externalToolLocked ||
       this.launchingExternalTool ||
       this.resolving ||
-      this.resolvedAsDeleted
+      this.resolvedAsDeleted ||
+      // A chooser/verbatim take-side or gitlink resolution leaves the file
+      // in this terminal state — launching the tool on a no-longer-
+      // conflicted file (and locking the dialog's Complete/Abort behind
+      // editorToolActive) must not be possible.
+      this.resolvedInPlace
     ) {
       return;
     }
@@ -2580,7 +2585,8 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               ?disabled=${this.launchingExternalTool ||
               this.externalToolLocked ||
               this.resolving ||
-              this.resolvedAsDeleted}
+              this.resolvedAsDeleted ||
+              this.resolvedInPlace}
               title="Open in external merge tool"
             >
               ${this.launchingExternalTool ? 'Waiting for tool...' : 'External Tool'}

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -542,6 +542,8 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   @state() private aiAvailable = false;
   @state() private suggestingSegment: number | null = null;
   @state() private suggestingAll = false;
+  /** True while a resolve/take-side backend call is in flight. */
+  @state() private resolving = false;
   @state() private editingSegmentId: number | null = null;
   @state() private editDraft = '';
   @state() private aiExplanations: Map<number, string> = new Map();
@@ -1059,7 +1061,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   // ── Completion ────────────────────────────────────────────────────────
 
   private async handleMarkResolved(): Promise<void> {
-    if (!this.repositoryPath || !this.conflictFile) return;
+    if (!this.repositoryPath || !this.conflictFile || this.resolving) return;
 
     // The button is disabled in these states; the guards keep the invariant
     // even if invoked directly. A file with open conflict blocks must never
@@ -1080,21 +1082,31 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       return;
     }
 
-    const result = await gitService.resolveConflict(
-      this.repositoryPath,
-      this.conflictFile.path,
-      this.buildResolvedContent()
-    );
+    // Capture the file BEFORE the await: the user may select another file in
+    // the dialog while the backend call runs, and dispatching that one would
+    // mark the wrong file resolved (and let a stash Complete drop the stash
+    // with a still-conflicted file).
+    const file = this.conflictFile;
+    this.resolving = true;
+    try {
+      const result = await gitService.resolveConflict(
+        this.repositoryPath,
+        file.path,
+        this.buildResolvedContent()
+      );
 
-    if (result.success) {
-      this.dispatchEvent(new CustomEvent('conflict-resolved', {
-        detail: { file: this.conflictFile },
-        bubbles: true,
-        composed: true,
-      }));
-    } else {
-      console.error('Failed to resolve conflict:', result.error);
-      showToast(`Failed to mark file as resolved: ${result.error?.message ?? 'Unknown error'}`, 'error');
+      if (result.success) {
+        this.dispatchEvent(new CustomEvent('conflict-resolved', {
+          detail: { file },
+          bubbles: true,
+          composed: true,
+        }));
+      } else {
+        console.error('Failed to resolve conflict:', result.error);
+        showToast(`Failed to mark file as resolved: ${result.error?.message ?? 'Unknown error'}`, 'error');
+      }
+    } finally {
+      this.resolving = false;
     }
   }
 
@@ -1108,23 +1120,31 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    * the file (avoids the text pipeline truncating binary/deleted files).
    */
   private async handleTakeSide(side: 'ours' | 'theirs'): Promise<void> {
-    if (!this.repositoryPath || !this.conflictFile) return;
+    if (!this.repositoryPath || !this.conflictFile || this.resolving) return;
 
-    const result = await gitService.resolveConflictTakeSide(
-      this.repositoryPath,
-      this.conflictFile.path,
-      side,
-    );
+    // Same capture-before-await as handleMarkResolved: the dispatched file
+    // must be the one the call actually resolved.
+    const file = this.conflictFile;
+    this.resolving = true;
+    try {
+      const result = await gitService.resolveConflictTakeSide(
+        this.repositoryPath,
+        file.path,
+        side,
+      );
 
-    if (result.success) {
-      this.dispatchEvent(new CustomEvent('conflict-resolved', {
-        detail: { file: this.conflictFile },
-        bubbles: true,
-        composed: true,
-      }));
-    } else {
-      console.error('Failed to resolve conflict:', result.error);
-      showToast(`Failed to resolve conflict: ${result.error?.message ?? 'Unknown error'}`, 'error');
+      if (result.success) {
+        this.dispatchEvent(new CustomEvent('conflict-resolved', {
+          detail: { file },
+          bubbles: true,
+          composed: true,
+        }));
+      } else {
+        console.error('Failed to resolve conflict:', result.error);
+        showToast(`Failed to resolve conflict: ${result.error?.message ?? 'Unknown error'}`, 'error');
+      }
+    } finally {
+      this.resolving = false;
     }
   }
 
@@ -1480,10 +1500,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           This file is binary and cannot be merged as text. Choose which version to keep.
         </div>
         <div class="toolbar-actions">
-          <button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')}>
+          <button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} ?disabled=${this.resolving}>
             ${oursDeleted ? 'Use Ours (delete file)' : 'Use Ours'}
           </button>
-          <button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')}>
+          <button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} ?disabled=${this.resolving}>
             ${theirsDeleted ? 'Use Theirs (delete file)' : 'Use Theirs'}
           </button>
         </div>
@@ -1536,14 +1556,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               </button>`
             : nothing}
           ${this.conflictFile && !this.conflictFile.ours
-            ? html`<button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} title="Ours deleted this file — keep it deleted">
+            ? html`<button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} ?disabled=${this.resolving} title="Ours deleted this file — keep it deleted">
                 Use Ours (delete file)
               </button>`
             : html`<button class="btn btn-ours" @click=${this.handleAcceptOurs} ?disabled=${this.loadFailed} title="Use entire file from ${labels.ours}">
                 Use Ours
               </button>`}
           ${this.conflictFile && !this.conflictFile.theirs
-            ? html`<button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} title="Theirs deleted this file — delete it">
+            ? html`<button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} ?disabled=${this.resolving} title="Theirs deleted this file — delete it">
                 Use Theirs (delete file)
               </button>`
             : html`<button class="btn btn-theirs" @click=${this.handleAcceptTheirs} ?disabled=${this.loadFailed} title="Use entire file from ${labels.theirs}">
@@ -1562,7 +1582,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <button
             class="btn btn-primary"
             @click=${this.handleMarkResolved}
-            ?disabled=${conflictCount > 0 || this.loadFailed || this.editingSegmentId !== null}
+            ?disabled=${conflictCount > 0 || this.loadFailed || this.editingSegmentId !== null || this.resolving}
             title=${conflictCount > 0
               ? `Resolve the remaining ${conflictCount} conflict${conflictCount === 1 ? '' : 's'} first`
               : this.editingSegmentId !== null
@@ -1589,7 +1609,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               <button
                 class="panel-header-btn"
                 @click=${this.conflictFile.ours ? this.handleAcceptOurs : () => this.handleTakeSide('ours')}
-                ?disabled=${this.conflictFile.ours ? this.loadFailed : false}
+                ?disabled=${this.resolving || (this.conflictFile.ours ? this.loadFailed : false)}
                 title=${this.conflictFile.ours ? 'Use this version' : 'This side deleted the file — stage the deletion'}
               >
                 ${this.conflictFile.ours ? 'Use' : 'Use (delete)'}
@@ -1625,7 +1645,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               <button
                 class="panel-header-btn"
                 @click=${this.conflictFile.theirs ? this.handleAcceptTheirs : () => this.handleTakeSide('theirs')}
-                ?disabled=${this.conflictFile.theirs ? this.loadFailed : false}
+                ?disabled=${this.resolving || (this.conflictFile.theirs ? this.loadFailed : false)}
                 title=${this.conflictFile.theirs ? 'Use this version' : 'This side deleted the file — stage the deletion'}
               >
                 ${this.conflictFile.theirs ? 'Use' : 'Use (delete)'}

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -1226,7 +1226,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           const line = sideLines[idx];
           let lineClass = '';
           let wsSegments: ReturnType<typeof computeInlineWhitespaceDiff> | null = null;
-          if (side !== 'base') {
+          // With an unreadable base there is nothing honest to diff against —
+          // don't paint every line as an "addition" relative to a base we
+          // never saw.
+          if (side !== 'base' && !this.sideReadErrors.base) {
             if (row.base === null) {
               lineClass = 'code-addition';
             } else if (!this.sideReadErrors.base && line !== this.baseLines[row.base]) {
@@ -1566,12 +1569,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             <div class="panel-header ours">
               ${labels.ours}
               <span class="panel-stats">
-                ${this.sideReadErrors.ours ? 'read failed' : this.formatChangeCount(this.getChangeCount('ours'))}
+                ${this.sideReadErrors.ours
+                  ? 'read failed'
+                  : this.sideReadErrors.base
+                    ? 'base unavailable'
+                    : this.formatChangeCount(this.getChangeCount('ours'))}
               </span>
               <button
                 class="panel-header-btn"
                 @click=${this.conflictFile.ours ? this.handleAcceptOurs : () => this.handleTakeSide('ours')}
-                ?disabled=${this.loadFailed}
+                ?disabled=${this.conflictFile.ours ? this.loadFailed : false}
                 title=${this.conflictFile.ours ? 'Use this version' : 'This side deleted the file — stage the deletion'}
               >
                 ${this.conflictFile.ours ? 'Use' : 'Use (delete)'}
@@ -1598,12 +1605,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             <div class="panel-header theirs">
               ${labels.theirs}
               <span class="panel-stats">
-                ${this.sideReadErrors.theirs ? 'read failed' : this.formatChangeCount(this.getChangeCount('theirs'))}
+                ${this.sideReadErrors.theirs
+                  ? 'read failed'
+                  : this.sideReadErrors.base
+                    ? 'base unavailable'
+                    : this.formatChangeCount(this.getChangeCount('theirs'))}
               </span>
               <button
                 class="panel-header-btn"
                 @click=${this.conflictFile.theirs ? this.handleAcceptTheirs : () => this.handleTakeSide('theirs')}
-                ?disabled=${this.loadFailed}
+                ?disabled=${this.conflictFile.theirs ? this.loadFailed : false}
                 title=${this.conflictFile.theirs ? 'Use this version' : 'This side deleted the file — stage the deletion'}
               >
                 ${this.conflictFile.theirs ? 'Use' : 'Use (delete)'}

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -552,6 +552,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    * empty resolved state would let Mark Resolved write a 0-byte file.
    */
   @state() private resolvedAsDeleted = false;
+  /** Terminal state after a NON-deletion chooser resolution (binary /
+   * submodule take-side): there is no text pipeline to reload into, and
+   * re-rendering the chooser with live buttons invites a second click
+   * that errors "No conflict found" on an already-resolved file. */
+  @state() private resolvedInPlace = false;
   @state() private launchingExternalTool = false;
   @state() private hasMergeTool = false;
   @state() private aiAvailable = false;
@@ -735,6 +740,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.loading = true;
     this.loadFailed = false;
     this.resolvedAsDeleted = false;
+    this.resolvedInPlace = false;
     // Per-file UI state must not leak between files.
     this.editingSegmentId = null;
     this.aiExplanations = new Map();
@@ -1367,7 +1373,8 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       this.resolving ||
       this.launchingExternalTool ||
       this.externalToolLocked ||
-      this.resolvedAsDeleted
+      this.resolvedAsDeleted ||
+      this.resolvedInPlace
     );
   }
 
@@ -1477,16 +1484,20 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     return new RegExp(`^(<{${n},}|={${n},}|>{${n},}|\\|{${n},})( |\\r?$)`, 'm');
   }
 
-  /** CR-insensitive single-line membership in either side blob. Marker-shaped
-   * text that IS blob content (a setext underline, a quoted example) is
-   * legitimate; marker-shaped text in neither blob is a real orphaned
-   * marker a hand edit left behind. */
+  /** CR-insensitive single-line membership in any of the three version
+   * blobs. Marker-shaped text that IS blob content (a setext underline, a
+   * quoted example) is legitimate; marker-shaped text in no blob is a real
+   * orphaned marker a hand edit left behind. BASE counts too: Use Base
+   * stages ancestor content verbatim, and a `=======` divider that both
+   * sides later changed exists only there — flagging it would raise a
+   * false "conflict markers" confirm over clean ancestor content. */
   private lineIsBlobContent(line: string): boolean {
     const strip = (l: string): string => (l.endsWith('\r') ? l.slice(0, -1) : l);
     const target = strip(line);
     return (
       this.oursLines.some((l) => strip(l) === target) ||
-      this.theirsLines.some((l) => strip(l) === target)
+      this.theirsLines.some((l) => strip(l) === target) ||
+      this.baseLines.some((l) => strip(l) === target)
     );
   }
 
@@ -1905,6 +1916,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               this.segments = [];
               this.editingSegmentId = null;
               this.resolvedAsDeleted = true;
+            }
+          } else if (file.isBinary || file.isSubmodule) {
+            // A chooser resolution has no text pipeline to reload into —
+            // reloading just re-renders the same chooser with live
+            // buttons, and a second click errors "No conflict found" on
+            // the already-resolved file. Terminal state, like deletions.
+            if (token === this.resolveToken) {
+              this.resolvedInPlace = true;
             }
           } else {
             await this.loadContents();
@@ -2333,6 +2352,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         </div>
       `;
     }
+    if (this.resolvedInPlace) {
+      return html`
+        <div class="loading">
+          Resolved — the chosen version was staged. Nothing further to do here.
+        </div>
+      `;
+    }
 
     const oursDeleted = !this.conflictFile.ours;
     const theirsDeleted = !this.conflictFile.theirs;
@@ -2394,6 +2420,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       return html`
         <div class="loading">
           Resolved — this submodule was removed by the resolution. Nothing further to do here.
+        </div>
+      `;
+    }
+    if (this.resolvedInPlace) {
+      return html`
+        <div class="loading">
+          Resolved — the chosen version was staged. Nothing further to do here.
         </div>
       `;
     }

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -9,6 +9,14 @@
  * +------------------+------------------+------------------+
  * |                     OUTPUT (Editable)                  |
  * +-------------------------------------------------------+
+ *
+ * Conflict markers (<<<<<<< / ======= / >>>>>>>) are an internal, on-disk
+ * representation ONLY. They are parsed once into structured segments when the
+ * file loads and are never rendered anywhere in the UI. The output pane is a
+ * list of segments: resolved text (editable in place) and conflict blocks
+ * (ours/theirs side by side with Use Ours / Use Theirs / Use Both / Edit
+ * actions). The file is only written back once no conflict blocks remain, so
+ * markers can never round-trip into a "resolved" file.
  */
 
 import { LitElement, html, css, nothing } from 'lit';
@@ -16,21 +24,55 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import { codeStyles } from '../../styles/code-styles.ts';
 import * as gitService from '../../services/git.service.ts';
-import { showConfirm } from '../../services/dialog.service.ts';
 import * as aiService from '../../services/ai.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import { CodeRenderMixin } from '../../mixins/code-render-mixin.ts';
 import type { ConflictFile } from '../../types/git.types.ts';
-import { isWhitespaceOnlyChange, computeInlineWhitespaceDiff } from '../../utils/diff-utils.ts';
+import {
+  isWhitespaceOnlyChange,
+  computeInlineWhitespaceDiff,
+  alignThreeWay,
+  type ThreeWayRow,
+} from '../../utils/diff-utils.ts';
+
+export type MergeOperationType = 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash';
+
+type SegmentOrigin = 'ours' | 'theirs' | 'both' | 'base' | 'manual' | 'ai';
 
 interface OutputSegment {
+  id: number;
   type: 'resolved' | 'conflict';
+  /** Resolved output lines (empty while type === 'conflict'). */
   lines: string[];
+  /** Conflict side content — kept after resolution so the block can be reset. */
   oursLines: string[];
   theirsLines: string[];
   oursLabel: string;
   theirsLabel: string;
+  /** How a resolved segment was produced (colors the gutter). */
+  origin: SegmentOrigin | null;
+  /** True when a resolved segment came from a conflict block (enables Reset). */
+  fromConflict: boolean;
 }
+
+/** Per-operation pane labels: during a rebase the sides are semantically
+ * swapped (ours = the branch being rebased onto, theirs = your own commit). */
+const SIDE_LABELS: Record<MergeOperationType, { ours: string; theirs: string }> = {
+  merge: { ours: 'Ours (Current Branch)', theirs: 'Theirs (Incoming)' },
+  rebase: { ours: 'Ours (Rebasing Onto)', theirs: 'Theirs (Your Commit)' },
+  'cherry-pick': { ours: 'Ours (Current Branch)', theirs: 'Theirs (Picked Commit)' },
+  revert: { ours: 'Ours (Current Branch)', theirs: 'Theirs (Revert Changes)' },
+  stash: { ours: 'Ours (Working Tree)', theirs: 'Theirs (Stashed Changes)' },
+};
+
+const ORIGIN_LABELS: Record<SegmentOrigin, string> = {
+  ours: 'Ours',
+  theirs: 'Theirs',
+  both: 'Both',
+  base: 'Base',
+  manual: 'Edited',
+  ai: 'AI',
+};
 
 @customElement('lv-merge-editor')
 export class LvMergeEditor extends CodeRenderMixin(LitElement) {
@@ -80,8 +122,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         transition: all var(--transition-fast);
       }
 
-      .btn:hover {
+      .btn:hover:not(:disabled) {
         background: var(--color-bg-hover);
+      }
+
+      .btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
       }
 
       .btn-primary {
@@ -90,7 +137,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         border-color: var(--color-primary);
       }
 
-      .btn-primary:hover {
+      .btn-primary:hover:not(:disabled) {
         background: var(--color-primary-hover);
       }
 
@@ -100,7 +147,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         color: var(--color-success);
       }
 
-      .btn-ours:hover {
+      .btn-ours:hover:not(:disabled) {
         background: rgba(var(--color-success-rgb, 34, 197, 94), 0.25);
       }
 
@@ -110,7 +157,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         color: var(--color-info);
       }
 
-      .btn-theirs:hover {
+      .btn-theirs:hover:not(:disabled) {
         background: rgba(var(--color-info-rgb, 59, 130, 246), 0.25);
       }
 
@@ -120,7 +167,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         color: #a855f7;
       }
 
-      .btn-both:hover {
+      .btn-both:hover:not(:disabled) {
         background: rgba(168, 85, 247, 0.25);
       }
 
@@ -253,114 +300,149 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         word-break: break-all;
       }
 
-      .line-conflict {
+      .line-changed {
         background: rgba(var(--color-warning-rgb, 234, 179, 8), 0.2);
       }
 
-      .line-conflict .line-content {
-        background: rgba(var(--color-warning-rgb, 234, 179, 8), 0.2);
-      }
-
-      .line-conflict .line-number {
+      .line-changed .line-number {
         background: rgba(var(--color-warning-rgb, 234, 179, 8), 0.3);
       }
 
-      /* Resolved line origin highlighting in output */
-      .resolved-ours .line-content {
-        background: rgba(var(--color-success-rgb, 34, 197, 94), 0.1);
+      .line-removed-filler .line-content {
+        background: repeating-linear-gradient(
+          -45deg,
+          transparent,
+          transparent 4px,
+          rgba(var(--color-text-muted-rgb, 128, 128, 128), 0.12) 4px,
+          rgba(var(--color-text-muted-rgb, 128, 128, 128), 0.12) 8px
+        );
       }
 
-      .resolved-ours .line-number {
+      /* Resolved-segment origin highlighting in output */
+      .output-segment.resolved-ours .line-number {
         border-left: 3px solid var(--color-success);
       }
 
-      .resolved-theirs .line-content {
-        background: rgba(var(--color-info-rgb, 59, 130, 246), 0.1);
+      .output-segment.resolved-ours .line-content {
+        background: rgba(var(--color-success-rgb, 34, 197, 94), 0.1);
       }
 
-      .resolved-theirs .line-number {
+      .output-segment.resolved-theirs .line-number {
         border-left: 3px solid var(--color-info);
       }
 
-      .resolved-both .line-content {
-        background: rgba(168, 85, 247, 0.1);
+      .output-segment.resolved-theirs .line-content {
+        background: rgba(var(--color-info-rgb, 59, 130, 246), 0.1);
       }
 
-      .resolved-both .line-number {
+      .output-segment.resolved-both .line-number,
+      .output-segment.resolved-ai .line-number {
         border-left: 3px solid #a855f7;
       }
 
-      .panel-content textarea {
-        width: 100%;
-        height: 100%;
-        border: none;
-        background: var(--color-bg-primary);
-        color: var(--color-text-primary);
-        font-family: var(--font-family-mono);
-        font-size: var(--font-size-sm);
-        line-height: 1.5;
-        padding: var(--spacing-sm);
-        resize: none;
+      .output-segment.resolved-both .line-content,
+      .output-segment.resolved-ai .line-content {
+        background: rgba(168, 85, 247, 0.1);
       }
 
-      .panel-content textarea:focus {
-        outline: none;
+      .output-segment.resolved-manual .line-number {
+        border-left: 3px solid var(--color-warning);
       }
 
-      /* Editable code view with line gutter */
-      .editable-code-container {
+      .output-segment.resolved-manual .line-content {
+        background: rgba(var(--color-warning-rgb, 234, 179, 8), 0.08);
+      }
+
+      .output-segment {
+        position: relative;
+      }
+
+      .segment-actions {
+        position: absolute;
+        top: 2px;
+        right: var(--spacing-sm);
+        display: none;
+        gap: var(--spacing-xs);
+        align-items: center;
+        z-index: 1;
+      }
+
+      .output-segment:hover .segment-actions {
         display: flex;
-        width: 100%;
-        height: 100%;
-        overflow: hidden;
       }
 
-      .line-gutter {
-        flex-shrink: 0;
-        width: 50px;
-        background: var(--color-bg-tertiary);
-        border-right: 1px solid var(--color-border);
-        overflow: hidden;
-        user-select: none;
-      }
-
-      .gutter-line {
-        height: 1.5em;
-        padding: 0 var(--spacing-sm);
-        text-align: right;
-        font-family: var(--font-family-mono);
-        font-size: var(--font-size-sm);
-        line-height: 1.5;
+      .segment-origin-chip {
+        font-size: 10px;
+        font-weight: var(--font-weight-bold);
+        text-transform: uppercase;
+        padding: 1px 6px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--color-border);
         color: var(--color-text-muted);
+        background: var(--color-bg-secondary);
       }
 
-      .editable-textarea {
-        flex: 1;
-        font-family: var(--font-family-mono);
-        font-size: var(--font-size-sm);
-        line-height: 1.5;
-        padding: 0 var(--spacing-sm);
-        margin: 0;
+      .segment-btn {
+        padding: 1px 6px;
+        font-size: var(--font-size-xs);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        border: 1px solid var(--color-border);
+        background: var(--color-bg-secondary);
+        color: var(--color-text-primary);
+      }
+
+      .segment-btn:hover {
+        background: var(--color-bg-hover);
+      }
+
+      /* Inline segment editing */
+      .segment-editor {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-xs);
+        padding: var(--spacing-xs) var(--spacing-sm);
+        border: 1px solid var(--color-primary);
+        border-radius: var(--radius-sm);
+        margin: 2px 0;
+        background: var(--color-bg-primary);
+      }
+
+      .segment-editor textarea {
+        width: 100%;
         border: none;
         background: var(--color-bg-primary);
         color: var(--color-text-primary);
-        resize: none;
-        overflow: auto;
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-sm);
+        line-height: 1.5;
+        resize: vertical;
         white-space: pre;
         tab-size: 4;
       }
 
-      .editable-textarea:focus {
+      .segment-editor textarea:focus {
         outline: none;
       }
 
-      .editable-textarea::selection {
-        background: rgba(var(--color-primary-rgb, 59, 130, 246), 0.3);
+      .segment-editor-actions {
+        display: flex;
+        gap: var(--spacing-sm);
+        justify-content: flex-end;
       }
 
-      /* Line highlighting for conflict markers */
-      .line-conflict-marker {
-        background: rgba(var(--color-warning-rgb, 234, 179, 8), 0.3);
+      /* Side-by-side conflict block body */
+      .conflict-sides {
+        display: grid;
+        grid-template-columns: 1fr 1px 1fr;
+        align-items: stretch;
+      }
+
+      .conflict-side-empty {
+        padding: var(--spacing-xs) var(--spacing-sm);
+        color: var(--color-text-muted);
+        font-style: italic;
+        font-size: var(--font-size-xs);
       }
 
       .loading {
@@ -380,15 +462,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         font-style: italic;
       }
 
-      .resize-handle {
-        height: 4px;
-        background: var(--color-border);
-        cursor: row-resize;
-        transition: background var(--transition-fast);
-      }
-
-      .resize-handle:hover {
-        background: var(--color-primary);
+      .output-error {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: var(--spacing-md);
+        height: 100%;
+        color: var(--color-text-muted);
       }
 
       .diff-indicator {
@@ -397,14 +478,6 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         height: 8px;
         border-radius: 50%;
         margin-left: var(--spacing-xs);
-      }
-
-      .diff-indicator.has-changes {
-        background: var(--color-warning);
-      }
-
-      .diff-indicator.no-changes {
-        background: var(--color-success);
       }
 
       .panel-stats {
@@ -416,10 +489,6 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       .conflict-pick-btn {
         padding: 2px 8px;
         font-size: var(--font-size-xs);
-      }
-
-      .output-mode-toggle {
-        margin-left: var(--spacing-sm);
       }
 
       .conflict-count {
@@ -438,11 +507,6 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         background: rgba(168, 85, 247, 0.25);
       }
 
-      .btn-ai:disabled {
-        opacity: 0.5;
-        cursor: not-allowed;
-      }
-
       .ai-explanation {
         padding: var(--spacing-xs) var(--spacing-sm);
         background: rgba(168, 85, 247, 0.08);
@@ -456,68 +520,31 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
   @property({ type: String }) repositoryPath = '';
   @property({ type: Object }) conflictFile: ConflictFile | null = null;
+  /** Which git operation produced the conflict — controls the side labels. */
+  @property({ type: String }) operationType: MergeOperationType = 'merge';
 
   @state() private baseContent = '';
   @state() private oursContent = '';
   @state() private theirsContent = '';
-  @state() private outputContent = '';
+  @state() private segments: OutputSegment[] = [];
   @state() private loading = false;
-  @state() private outputEditMode: 'visual' | 'raw' = 'visual';
+  @state() private loadFailed = false;
   @state() private launchingExternalTool = false;
   @state() private hasMergeTool = false;
   @state() private aiAvailable = false;
-  @state() private suggestingConflict: number | null = null;
+  @state() private suggestingSegment: number | null = null;
   @state() private suggestingAll = false;
-  @state() private conflictSuggestions: Map<number, { content: string; explanation: string }> = new Map();
+  @state() private editingSegmentId: number | null = null;
+  @state() private editDraft = '';
+  @state() private aiExplanations: Map<number, string> = new Map();
 
-  /**
-   * Maps output line index (within resolved segments) to resolution origin.
-   * Used to color-code resolved lines in the output visual.
-   */
-  private lineOrigins: Map<number, 'ours' | 'theirs' | 'both'> = new Map();
-
-  /**
-   * Compute line origins by comparing resolved output lines against base/ours/theirs.
-   * Lines not present in base but present in ours → 'ours', in theirs → 'theirs'.
-   */
-  private computeLineOrigins(): void {
-    const baseLines = this.baseContent.split('\n');
-    const oursLines = this.oursContent.split('\n');
-    const theirsLines = this.theirsContent.split('\n');
-
-    const baseSet = new Set(baseLines);
-    const oursNewLines = new Set(oursLines.filter(l => !baseSet.has(l)));
-    const theirsNewLines = new Set(theirsLines.filter(l => !baseSet.has(l)));
-
-    const newOrigins = new Map<number, 'ours' | 'theirs' | 'both'>();
-    const segments = this.parseOutputSegments();
-    let lineIdx = 0;
-
-    for (const segment of segments) {
-      if (segment.type === 'resolved') {
-        for (const line of segment.lines) {
-          if (!baseSet.has(line)) {
-            const inOurs = oursNewLines.has(line);
-            const inTheirs = theirsNewLines.has(line);
-
-            if (inOurs && !inTheirs) {
-              newOrigins.set(lineIdx, 'ours');
-            } else if (inTheirs && !inOurs) {
-              newOrigins.set(lineIdx, 'theirs');
-            } else if (inOurs && inTheirs) {
-              newOrigins.set(lineIdx, 'both');
-            }
-          }
-          lineIdx++;
-        }
-      } else {
-        // Skip conflict marker lines in the old output
-        lineIdx += 1 + segment.oursLines.length + 1 + segment.theirsLines.length + 1;
-      }
-    }
-
-    this.lineOrigins = newOrigins;
-  }
+  private nextSegmentId = 1;
+  private baseLines: string[] = [];
+  private oursLines: string[] = [];
+  private theirsLines: string[] = [];
+  private alignmentRows: ThreeWayRow[] = [];
+  /** Guards against scroll-sync feedback loops between the panes. */
+  private syncingScroll = false;
 
   private boundHandleAiSettingsChanged = async () => {
     this.aiAvailable = await aiService.isAiAvailable();
@@ -576,13 +603,18 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     if (!this.repositoryPath || !this.conflictFile) return;
 
     this.loading = true;
+    this.loadFailed = false;
+    // Per-file UI state must not leak between files.
+    this.editingSegmentId = null;
+    this.aiExplanations = new Map();
+    this.suggestingSegment = null;
 
     // Initialize Shiki highlighter and detect language
     await this.initCodeLanguage(this.conflictFile.path);
 
     try {
-      // Load all three versions and the working directory file in parallel
-      // The working directory file contains git's proper 3-way merge with conflict markers
+      // Load all three versions and the working directory file in parallel.
+      // The working directory file contains git's authoritative diff3 merge.
       const [ancestorResult, oursResult, theirsResult, workdirResult] = await Promise.all([
         this.conflictFile.ancestor?.oid
           ? gitService.getBlobContent(this.repositoryPath, this.conflictFile.ancestor.oid)
@@ -593,7 +625,6 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         this.conflictFile.theirs?.oid
           ? gitService.getBlobContent(this.repositoryPath, this.conflictFile.theirs.oid)
           : Promise.resolve({ success: true, data: '' }),
-        // Read the working directory file - git has already done a proper diff3 merge
         gitService.readFileContent(this.repositoryPath, this.conflictFile.path),
       ]);
 
@@ -601,90 +632,70 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       this.oursContent = oursResult.success ? (oursResult.data || '') : '';
       this.theirsContent = theirsResult.success ? (theirsResult.data || '') : '';
 
-      // Use git's merged output from the working directory (has proper conflict markers)
-      // Fall back to naive merge only if we can't read the working directory file
-      this.outputContent = workdirResult.success && workdirResult.data
-        ? workdirResult.data
-        : this.performAutoMerge();
-      // Compute which output lines came from which branch
-      this.computeLineOrigins();
+      this.baseLines = this.baseContent.split('\n');
+      this.oursLines = this.oursContent.split('\n');
+      this.theirsLines = this.theirsContent.split('\n');
+      this.alignmentRows = alignThreeWay(this.baseLines, this.oursLines, this.theirsLines);
+
+      // Only git's own merge output is trustworthy. If the working directory
+      // file can't be read, show an error state — never fabricate a merge.
+      // An empty string is valid content (empty merged file), so test the
+      // type, not truthiness.
+      if (workdirResult.success && typeof workdirResult.data === 'string') {
+        this.segments = this.parseSegments(workdirResult.data);
+      } else {
+        this.segments = [];
+        this.loadFailed = true;
+      }
     } catch (err) {
       console.error('Failed to load conflict contents:', err);
+      this.segments = [];
+      this.loadFailed = true;
     } finally {
       this.loading = false;
     }
   }
 
   /**
-   * Attempt automatic 3-way merge
-   * If there are conflicts, insert conflict markers
+   * Parse git's conflict-marker text into structured segments — the ONLY
+   * place markers are ever interpreted; they never reach the DOM.
+   * Handles diff3-style `|||||||` base sections (discarded) and tolerates an
+   * unterminated conflict at EOF (kept as a conflict block).
    */
-  private performAutoMerge(): string {
-    const baseLines = this.baseContent.split('\n');
-    const oursLines = this.oursContent.split('\n');
-    const theirsLines = this.theirsContent.split('\n');
-
-    // Simple line-by-line merge algorithm
-    const result: string[] = [];
-    const maxLen = Math.max(baseLines.length, oursLines.length, theirsLines.length);
-
-    let i = 0;
-    while (i < maxLen) {
-      const baseLine = baseLines[i] ?? '';
-      const oursLine = oursLines[i] ?? '';
-      const theirsLine = theirsLines[i] ?? '';
-
-      if (oursLine === theirsLine) {
-        // Both sides agree
-        result.push(oursLine);
-      } else if (oursLine === baseLine) {
-        // Only theirs changed
-        result.push(theirsLine);
-      } else if (theirsLine === baseLine) {
-        // Only ours changed
-        result.push(oursLine);
-      } else {
-        // Conflict - both sides changed differently
-        result.push('<<<<<<< OURS');
-        result.push(oursLine);
-        result.push('=======');
-        result.push(theirsLine);
-        result.push('>>>>>>> THEIRS');
-      }
-      i++;
-    }
-
-    return result.join('\n');
-  }
-
-  private parseOutputSegments(): OutputSegment[] {
-    const lines = this.outputContent.split('\n');
+  private parseSegments(text: string): OutputSegment[] {
+    const lines = text.split('\n');
     const segments: OutputSegment[] = [];
     let currentResolved: string[] = [];
     let inConflict = false;
-    // Which side of the conflict we're currently accumulating.
-    // 'base' is the diff3 common-ancestor section — it is discarded, never
-    // mixed into ours.
     let section: 'ours' | 'base' | 'theirs' = 'ours';
     let oursLines: string[] = [];
     let theirsLines: string[] = [];
     let oursLabel = '';
     let theirsLabel = '';
 
+    const flushResolved = (): void => {
+      if (currentResolved.length > 0) {
+        segments.push(this.makeResolvedSegment(currentResolved, null, false));
+        currentResolved = [];
+      }
+    };
+    const pushConflict = (): void => {
+      segments.push({
+        id: this.nextSegmentId++,
+        type: 'conflict',
+        lines: [],
+        oursLines: [...oursLines],
+        theirsLines: [...theirsLines],
+        oursLabel,
+        theirsLabel,
+        origin: null,
+        fromConflict: false,
+      });
+    };
+
     for (const line of lines) {
       if (!inConflict && line.startsWith('<<<<<<<')) {
-        // Flush any accumulated resolved lines
-        if (currentResolved.length > 0) {
-          segments.push({
-            type: 'resolved',
-            lines: currentResolved,
-            oursLines: [],
-            theirsLines: [],
-            oursLabel: '',
-            theirsLabel: '',
-          });
-          currentResolved = [];
-        }
+        flushResolved();
         inConflict = true;
         section = 'ours';
         oursLines = [];
@@ -694,18 +705,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       } else if (inConflict && line.startsWith('|||||||')) {
         // diff3 common-ancestor marker — begin discarding base lines
         section = 'base';
-      } else if (inConflict && line.startsWith('=======')) {
+      } else if (inConflict && section !== 'theirs' && line.startsWith('=======')) {
         section = 'theirs';
       } else if (inConflict && line.startsWith('>>>>>>>')) {
         theirsLabel = line.slice(7).trim() || 'THEIRS';
-        segments.push({
-          type: 'conflict',
-          lines: [],
-          oursLines: [...oursLines],
-          theirsLines: [...theirsLines],
-          oursLabel,
-          theirsLabel,
-        });
+        pushConflict();
         inConflict = false;
         section = 'ours';
         oursLines = [];
@@ -724,193 +728,229 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       }
     }
 
-    // Flush remaining resolved lines
-    if (currentResolved.length > 0) {
-      segments.push({
-        type: 'resolved',
-        lines: currentResolved,
-        oursLines: [],
-        theirsLines: [],
-        oursLabel: '',
-        theirsLabel: '',
-      });
+    if (inConflict) {
+      // Unterminated conflict (truncated file) — keep it as a conflict block
+      // rather than silently promoting marker content to resolved text.
+      theirsLabel = theirsLabel || 'THEIRS';
+      pushConflict();
+    } else {
+      flushResolved();
     }
 
     return segments;
   }
 
-  private handleOutputChange(e: Event): void {
-    const textarea = e.target as HTMLTextAreaElement;
-    this.outputContent = textarea.value;
+  private makeResolvedSegment(
+    lines: string[],
+    origin: SegmentOrigin | null,
+    fromConflict: boolean,
+    conflictData?: Pick<OutputSegment, 'oursLines' | 'theirsLines' | 'oursLabel' | 'theirsLabel'>,
+  ): OutputSegment {
+    return {
+      id: this.nextSegmentId++,
+      type: 'resolved',
+      lines,
+      oursLines: conflictData?.oursLines ?? [],
+      theirsLines: conflictData?.theirsLines ?? [],
+      oursLabel: conflictData?.oursLabel ?? '',
+      theirsLabel: conflictData?.theirsLabel ?? '',
+      origin,
+      fromConflict,
+    };
+  }
+
+  private get conflictCount(): number {
+    return this.segments.filter((s) => s.type === 'conflict').length;
+  }
+
+  /** Serialize the output. Only valid once every conflict block is resolved. */
+  private buildResolvedContent(): string {
+    return this.segments.flatMap((s) => s.lines).join('\n');
+  }
+
+  public getResolvedContent(): string {
+    return this.buildResolvedContent();
+  }
+
+  // ── Segment operations ────────────────────────────────────────────────
+
+  private updateSegment(id: number, update: Partial<OutputSegment>): void {
+    this.segments = this.segments.map((s) => (s.id === id ? { ...s, ...update } : s));
+  }
+
+  private resolveConflictSegment(id: number, choice: 'ours' | 'theirs' | 'both'): void {
+    const segment = this.segments.find((s) => s.id === id);
+    if (!segment || segment.type !== 'conflict') return;
+
+    const lines =
+      choice === 'ours'
+        ? [...segment.oursLines]
+        : choice === 'theirs'
+          ? [...segment.theirsLines]
+          : [...segment.oursLines, ...segment.theirsLines];
+    this.updateSegment(id, { type: 'resolved', lines, origin: choice, fromConflict: true });
+  }
+
+  /** Revert a resolved-from-conflict segment back to an open conflict block. */
+  private resetSegment(id: number): void {
+    const segment = this.segments.find((s) => s.id === id);
+    if (!segment || !segment.fromConflict) return;
+    if (this.editingSegmentId === id) this.editingSegmentId = null;
+    this.updateSegment(id, { type: 'conflict', lines: [], origin: null, fromConflict: false });
+  }
+
+  private startEditSegment(segment: OutputSegment): void {
+    this.editingSegmentId = segment.id;
+    // Editing an open conflict starts from both sides so the user trims what
+    // they don't want — never from marker text.
+    this.editDraft =
+      segment.type === 'conflict'
+        ? [...segment.oursLines, ...segment.theirsLines].join('\n')
+        : segment.lines.join('\n');
+  }
+
+  private applyEditSegment(): void {
+    const id = this.editingSegmentId;
+    if (id === null) return;
+    const segment = this.segments.find((s) => s.id === id);
+    if (!segment) {
+      this.editingSegmentId = null;
+      return;
+    }
+
+    this.updateSegment(id, {
+      type: 'resolved',
+      lines: this.editDraft.split('\n'),
+      origin: 'manual',
+      fromConflict: segment.type === 'conflict' ? true : segment.fromConflict,
+    });
+    this.editingSegmentId = null;
+    this.editDraft = '';
+  }
+
+  private cancelEditSegment(): void {
+    this.editingSegmentId = null;
+    this.editDraft = '';
+  }
+
+  private handleEditDraftInput(e: Event): void {
+    this.editDraft = (e.target as HTMLTextAreaElement).value;
+  }
+
+  // ── Whole-file operations ─────────────────────────────────────────────
+
+  private acceptWholeFile(origin: 'ours' | 'theirs' | 'base'): void {
+    const content =
+      origin === 'ours' ? this.oursContent : origin === 'theirs' ? this.theirsContent : this.baseContent;
+    this.editingSegmentId = null;
+    this.segments = [this.makeResolvedSegment(content.split('\n'), origin, false)];
   }
 
   private handleAcceptOurs(): void {
-    this.outputContent = this.oursContent;
-    this.computeLineOrigins();
+    this.acceptWholeFile('ours');
   }
 
   private handleAcceptTheirs(): void {
-    this.outputContent = this.theirsContent;
-    this.computeLineOrigins();
+    this.acceptWholeFile('theirs');
   }
 
   private handleAcceptBase(): void {
-    this.outputContent = this.baseContent;
-    this.computeLineOrigins();
+    this.acceptWholeFile('base');
   }
 
-  private handleAcceptOursPanel(): void {
-    this.outputContent = this.oursContent;
-    this.computeLineOrigins();
+  /** Re-read the on-disk merge, discarding all in-editor resolutions. */
+  private async handleReload(): Promise<void> {
+    await this.loadContents();
   }
 
-  private handleAcceptTheirsPanel(): void {
-    this.outputContent = this.theirsContent;
-    this.computeLineOrigins();
-  }
+  // ── AI resolution ─────────────────────────────────────────────────────
 
-  private async handleSuggestConflict(conflictIndex: number): Promise<void> {
-    if (!this.conflictFile || this.suggestingConflict !== null) return;
+  /** Resolve one conflict block via AI. Returns false when the call failed. */
+  private async handleSuggestSegment(id: number): Promise<boolean> {
+    if (!this.conflictFile || this.suggestingSegment !== null) return false;
+    const segment = this.segments.find((s) => s.id === id);
+    if (!segment || segment.type !== 'conflict') return false;
 
-    this.suggestingConflict = conflictIndex;
+    this.suggestingSegment = id;
     try {
-      const segments = this.parseOutputSegments();
-      let idx = 0;
-      let targetSegment: OutputSegment | null = null;
-
-      // Find the conflict segment by counting conflict indices
-      for (const segment of segments) {
-        if (segment.type === 'conflict') {
-          if (idx === conflictIndex) {
-            targetSegment = segment;
-            break;
-          }
-          idx++;
-        }
-      }
-
-      if (!targetSegment) return;
-
-      // Collect surrounding resolved context
+      // Surrounding resolved context helps the model match style.
       const resolvedBefore: string[] = [];
       const resolvedAfter: string[] = [];
-      let foundTarget = false;
-      let conflictCount = 0;
-
-      for (const segment of segments) {
-        if (segment.type === 'conflict') {
-          if (conflictCount === conflictIndex) {
-            foundTarget = true;
-          }
-          conflictCount++;
-        } else if (segment.type === 'resolved') {
-          if (!foundTarget) {
-            resolvedBefore.push(...segment.lines);
-          } else {
-            resolvedAfter.push(...segment.lines);
-          }
+      let seenTarget = false;
+      for (const s of this.segments) {
+        if (s.id === id) {
+          seenTarget = true;
+        } else if (s.type === 'resolved') {
+          (seenTarget ? resolvedAfter : resolvedBefore).push(...s.lines);
         }
       }
 
       const result = await aiService.suggestConflictResolution(
         this.conflictFile.path,
-        targetSegment.oursLines.join('\n'),
-        targetSegment.theirsLines.join('\n'),
+        segment.oursLines.join('\n'),
+        segment.theirsLines.join('\n'),
         this.baseContent || undefined,
         resolvedBefore.slice(-20).join('\n') || undefined,
         resolvedAfter.slice(0, 20).join('\n') || undefined,
       );
 
       if (result.success && result.data) {
-        // Apply the suggestion by resolving the conflict
-        this.applyAiSuggestion(conflictIndex, result.data.resolvedContent);
-
-        // Store the explanation
+        this.updateSegment(id, {
+          type: 'resolved',
+          lines: result.data.resolvedContent.split('\n'),
+          origin: 'ai',
+          fromConflict: true,
+        });
         if (result.data.explanation) {
-          this.conflictSuggestions = new Map(this.conflictSuggestions);
-          this.conflictSuggestions.set(conflictIndex, {
-            content: result.data.resolvedContent,
-            explanation: result.data.explanation,
-          });
+          this.aiExplanations = new Map(this.aiExplanations);
+          this.aiExplanations.set(id, result.data.explanation);
         }
-      } else {
-        showToast(result.error?.message ?? 'AI suggestion failed', 'error');
+        return true;
       }
+      showToast(result.error?.message ?? 'AI suggestion failed', 'error');
+      return false;
     } catch {
       showToast('Failed to get AI suggestion', 'error');
+      return false;
     } finally {
-      this.suggestingConflict = null;
+      this.suggestingSegment = null;
     }
-  }
-
-  private applyAiSuggestion(conflictIndex: number, resolvedContent: string): void {
-    const segments = this.parseOutputSegments();
-    const resultLines: string[] = [];
-    let conflictIdx = 0;
-
-    for (const segment of segments) {
-      if (segment.type === 'resolved') {
-        resultLines.push(...segment.lines);
-      } else {
-        if (conflictIdx === conflictIndex) {
-          resultLines.push(...resolvedContent.split('\n'));
-        } else {
-          resultLines.push(`<<<<<<< ${segment.oursLabel}`);
-          resultLines.push(...segment.oursLines);
-          resultLines.push('=======');
-          resultLines.push(...segment.theirsLines);
-          resultLines.push(`>>>>>>> ${segment.theirsLabel}`);
-        }
-        conflictIdx++;
-      }
-    }
-
-    this.outputContent = resultLines.join('\n');
-    this.computeLineOrigins();
   }
 
   private async handleAiResolveAll(): Promise<void> {
     if (this.suggestingAll) return;
 
-    const segments = this.parseOutputSegments();
-    const conflictCount = segments.filter(s => s.type === 'conflict').length;
-    if (conflictCount === 0) return;
+    const conflictIds = this.segments.filter((s) => s.type === 'conflict').map((s) => s.id);
+    if (conflictIds.length === 0) return;
 
     this.suggestingAll = true;
     try {
-      // Resolve conflicts sequentially (index shifts after each resolution)
-      for (let i = 0; i < conflictCount; i++) {
-        // Always resolve index 0 since previous ones get resolved
-        const currentSegments = this.parseOutputSegments();
-        const remainingConflicts = currentSegments.filter(s => s.type === 'conflict').length;
-        if (remainingConflicts === 0) break;
-
-        await this.handleSuggestConflict(0);
+      for (const id of conflictIds) {
+        // Stop on the first failure — retrying would just repeat the error.
+        if (!(await this.handleSuggestSegment(id))) break;
       }
     } finally {
       this.suggestingAll = false;
     }
   }
 
+  // ── Completion ────────────────────────────────────────────────────────
+
   private async handleMarkResolved(): Promise<void> {
     if (!this.repositoryPath || !this.conflictFile) return;
 
-    // Check for remaining conflicts using segment parsing
-    const segments = this.parseOutputSegments();
-    const unresolvedCount = segments.filter(s => s.type === 'conflict').length;
-    if (unresolvedCount > 0) {
-      const proceed = await showConfirm(
-        'Unresolved Conflicts',
-        `There ${unresolvedCount === 1 ? 'is' : 'are'} ${unresolvedCount} unresolved conflict${unresolvedCount === 1 ? '' : 's'}. Are you sure you want to mark this as resolved?`,
-        'warning'
-      );
-      if (!proceed) return;
+    // The button is disabled while conflicts remain; this guard keeps the
+    // invariant even if invoked directly. A file with open conflict blocks
+    // must never be written out (it would re-serialize markers).
+    if (this.conflictCount > 0) {
+      showToast('Resolve all conflict blocks before marking the file resolved', 'warning');
+      return;
     }
 
     const result = await gitService.resolveConflict(
       this.repositoryPath,
       this.conflictFile.path,
-      this.outputContent
+      this.buildResolvedContent()
     );
 
     if (result.success) {
@@ -925,16 +965,8 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     }
   }
 
-  public getResolvedContent(): string {
-    return this.outputContent;
-  }
-
   private get isBinaryConflict(): boolean {
     return this.conflictFile?.isBinary === true;
-  }
-
-  private get isDeletedSideConflict(): boolean {
-    return !!this.conflictFile && (!this.conflictFile.ours || !this.conflictFile.theirs);
   }
 
   /**
@@ -963,26 +995,115 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     }
   }
 
-  private renderCodeView(content: string, diffAgainst?: string): ReturnType<typeof html> {
-    const lines = content.split('\n');
-    const compareLines = diffAgainst?.split('\n') ?? [];
+  // ── Scroll synchronization ────────────────────────────────────────────
+
+  /**
+   * The three source panes share identical row geometry (same aligned row
+   * count), so they mirror scrollTop exactly; the output pane has different
+   * content and is synced proportionally.
+   */
+  private handleSourceScroll(e: Event): void {
+    if (this.syncingScroll) return;
+    this.syncingScroll = true;
+
+    const source = e.target as HTMLElement;
+    for (const id of ['panel-ours', 'panel-base', 'panel-theirs']) {
+      const panel = this.shadowRoot?.getElementById(id);
+      if (panel && panel !== source) {
+        panel.scrollTop = source.scrollTop;
+        panel.scrollLeft = source.scrollLeft;
+      }
+    }
+
+    const output = this.shadowRoot?.getElementById('panel-output');
+    if (output) {
+      const sourceMax = source.scrollHeight - source.clientHeight;
+      const ratio = sourceMax > 0 ? source.scrollTop / sourceMax : 0;
+      output.scrollTop = ratio * (output.scrollHeight - output.clientHeight);
+    }
+
+    requestAnimationFrame(() => {
+      this.syncingScroll = false;
+    });
+  }
+
+  private handleOutputScroll(e: Event): void {
+    if (this.syncingScroll) return;
+    this.syncingScroll = true;
+
+    const output = e.target as HTMLElement;
+    const outputMax = output.scrollHeight - output.clientHeight;
+    const ratio = outputMax > 0 ? output.scrollTop / outputMax : 0;
+
+    for (const id of ['panel-ours', 'panel-base', 'panel-theirs']) {
+      const panel = this.shadowRoot?.getElementById(id);
+      if (panel) {
+        panel.scrollTop = ratio * (panel.scrollHeight - panel.clientHeight);
+      }
+    }
+
+    requestAnimationFrame(() => {
+      this.syncingScroll = false;
+    });
+  }
+
+  // ── Change statistics ─────────────────────────────────────────────────
+
+  private getChangeCount(side: 'ours' | 'theirs'): number {
+    let changes = 0;
+    for (const row of this.alignmentRows) {
+      const idx = row[side];
+      if (row.base === null) {
+        if (idx !== null) changes++; // added
+      } else if (idx === null) {
+        changes++; // removed
+      } else {
+        const sideLine = side === 'ours' ? this.oursLines[idx] : this.theirsLines[idx];
+        if (sideLine !== this.baseLines[row.base]) changes++; // modified
+      }
+    }
+    return changes;
+  }
+
+  private getLineCount(content: string): number {
+    return content ? content.split('\n').length : 0;
+  }
+
+  // ── Rendering ─────────────────────────────────────────────────────────
+
+  /** Render one source pane from the shared three-way alignment rows. */
+  private renderAlignedPane(side: 'ours' | 'base' | 'theirs'): ReturnType<typeof html> {
+    const sideLines =
+      side === 'ours' ? this.oursLines : side === 'theirs' ? this.theirsLines : this.baseLines;
 
     return html`
       <div class="code-view">
-        ${lines.map((line, index) => {
-          const compareLine = compareLines[index];
+        ${this.alignmentRows.map((row) => {
+          const idx = row[side];
+          if (idx === null) {
+            // Filler row keeps the panes vertically aligned. When base has a
+            // line here, this side deleted it — show a struck-out filler.
+            const removed = side !== 'base' && row.base !== null;
+            return html`
+              <div class="code-line ${removed ? 'line-removed-filler' : ''}">
+                <span class="line-number"></span>
+                <span class="line-content"></span>
+              </div>
+            `;
+          }
+
+          const line = sideLines[idx];
           let lineClass = '';
           let wsSegments: ReturnType<typeof computeInlineWhitespaceDiff> | null = null;
-
-          if (diffAgainst !== undefined) {
-            if (compareLine === undefined) {
+          if (side !== 'base') {
+            if (row.base === null) {
               lineClass = 'code-addition';
-            } else if (line !== compareLine) {
-              if (isWhitespaceOnlyChange(compareLine, line)) {
+            } else if (line !== this.baseLines[row.base]) {
+              if (isWhitespaceOnlyChange(this.baseLines[row.base], line)) {
                 lineClass = 'code-ws-change';
-                wsSegments = computeInlineWhitespaceDiff(compareLine, line);
+                wsSegments = computeInlineWhitespaceDiff(this.baseLines[row.base], line);
               } else {
-                lineClass = 'line-conflict';
+                lineClass = 'line-changed';
               }
             }
           }
@@ -993,7 +1114,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
           return html`
             <div class="code-line ${lineClass}">
-              <span class="line-number">${index + 1}</span>
+              <span class="line-number">${idx + 1}</span>
               <span class="line-content">${lineContent}</span>
             </div>
           `;
@@ -1002,210 +1123,171 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     `;
   }
 
-  /**
-   * Render an editable code view with line numbers
-   * Uses a synchronized gutter approach for reliable display
-   */
-  private renderEditableCodeView(content: string): ReturnType<typeof html> {
-    const lineCount = content.split('\n').length;
-
+  private renderSegmentEditor(): ReturnType<typeof html> {
+    const rows = Math.min(Math.max(this.editDraft.split('\n').length + 1, 3), 20);
     return html`
-      <div class="editable-code-container">
-        <div class="line-gutter" id="output-gutter">
-          ${Array.from({ length: lineCount }, (_, i) => html`
-            <div class="gutter-line">${i + 1}</div>
-          `)}
-        </div>
+      <div class="segment-editor">
         <textarea
-          class="editable-textarea"
-          .value=${content}
-          @input=${this.handleOutputChange}
-          @scroll=${this.handleTextareaScroll}
+          rows=${rows}
+          .value=${this.editDraft}
+          @input=${this.handleEditDraftInput}
           spellcheck="false"
         ></textarea>
+        <div class="segment-editor-actions">
+          <button class="btn" @click=${this.cancelEditSegment}>Cancel</button>
+          <button class="btn btn-primary" @click=${this.applyEditSegment}>Apply</button>
+        </div>
       </div>
     `;
   }
 
-  private renderOutputVisual(): ReturnType<typeof html> {
-    const segments = this.parseOutputSegments();
-    let lineNum = 1;
-    let lineIdx = 0;
-    let conflictIdx = 0;
+  private renderResolvedSegment(segment: OutputSegment, startLineNum: number): ReturnType<typeof html> {
+    if (this.editingSegmentId === segment.id) {
+      return this.renderSegmentEditor();
+    }
+
+    const originClass = segment.origin ? `resolved-${segment.origin}` : '';
+    const explanation = this.aiExplanations.get(segment.id);
 
     return html`
-      <div class="code-view">
-        ${segments.map((segment) => {
-          if (segment.type === 'resolved') {
-            return html`${segment.lines.map((line) => {
-              const num = lineNum++;
-              const origin = this.lineOrigins.get(lineIdx);
-              lineIdx++;
-              const originClass = origin === 'ours' ? 'resolved-ours'
-                : origin === 'theirs' ? 'resolved-theirs'
-                : origin === 'both' ? 'resolved-both'
-                : '';
-              return html`
-                <div class="code-line ${originClass}">
-                  <span class="line-number">${num}</span>
-                  <span class="line-content">${this.renderHighlightedContent(line) || html`${' '}`}</span>
-                </div>
-              `;
-            })}`;
-          }
-          // Skip conflict marker lines for lineIdx tracking
-          lineIdx += 1 + segment.oursLines.length + 1 + segment.theirsLines.length + 1;
-          // Conflict segment
-          const oursStart = lineNum;
-          const oursEnd = oursStart + segment.oursLines.length;
-          const theirsEnd = oursEnd + segment.theirsLines.length;
-          // Advance lineNum past all conflict content lines
-          lineNum = theirsEnd;
-
-          const currentConflictIdx = conflictIdx++;
-          const isSuggesting = this.suggestingConflict === currentConflictIdx;
-
-          return html`
-            <div class="code-conflict-block">
-              <div class="code-conflict-header">
-                <span>Conflict</span>
-                <div class="code-conflict-header-actions">
-                  <button class="btn btn-ours conflict-pick-btn" @click=${() => this.resolveOutputConflict(currentConflictIdx, 'ours')}>
-                    Use Ours
-                  </button>
-                  <button class="btn btn-theirs conflict-pick-btn" @click=${() => this.resolveOutputConflict(currentConflictIdx, 'theirs')}>
-                    Use Theirs
-                  </button>
-                  <button class="btn btn-both conflict-pick-btn" @click=${() => this.resolveOutputConflict(currentConflictIdx, 'both')}>
-                    Use Both
-                  </button>
-                  ${this.aiAvailable ? html`
-                    <button
-                      class="btn btn-ai conflict-pick-btn"
-                      @click=${() => this.handleSuggestConflict(currentConflictIdx)}
-                      ?disabled=${isSuggesting || this.suggestingAll}
-                    >
-                      ${isSuggesting ? 'AI...' : 'AI Suggest'}
-                    </button>
-                  ` : nothing}
-                </div>
-              </div>
-              <div class="code-conflict-side-ours">
-                <div class="code-conflict-side-label">${segment.oursLabel}</div>
-                ${segment.oursLines.map((line, i) => html`
-                  <div class="code-line">
-                    <span class="line-number">${oursStart + i}</span>
-                    <span class="line-content">${this.renderHighlightedContent(line) || html`${' '}`}</span>
-                  </div>
-                `)}
-              </div>
-              <div class="code-conflict-divider"></div>
-              <div class="code-conflict-side-theirs">
-                <div class="code-conflict-side-label">${segment.theirsLabel}</div>
-                ${segment.theirsLines.map((line, i) => html`
-                  <div class="code-line">
-                    <span class="line-number">${oursEnd + i}</span>
-                    <span class="line-content">${this.renderHighlightedContent(line) || html`${' '}`}</span>
-                  </div>
-                `)}
-              </div>
+      <div class="output-segment ${originClass}">
+        <div class="segment-actions">
+          ${segment.origin && segment.fromConflict
+            ? html`<span class="segment-origin-chip">${ORIGIN_LABELS[segment.origin]}</span>`
+            : nothing}
+          <button
+            class="segment-btn"
+            @click=${() => this.startEditSegment(segment)}
+            title="Edit this section"
+          >
+            Edit
+          </button>
+          ${segment.fromConflict
+            ? html`
+                <button
+                  class="segment-btn"
+                  @click=${() => this.resetSegment(segment.id)}
+                  title="Undo this resolution and reopen the conflict"
+                >
+                  Reset
+                </button>
+              `
+            : nothing}
+        </div>
+        ${segment.lines.map(
+          (line, i) => html`
+            <div class="code-line">
+              <span class="line-number">${startLineNum + i}</span>
+              <span class="line-content">${this.renderHighlightedContent(line) || html`${' '}`}</span>
             </div>
-          `;
-        })}
-        ${this.conflictSuggestions.size > 0 ? html`
-          <div class="ai-explanation">
-            ${Array.from(this.conflictSuggestions.values())
-              .filter(s => s.explanation)
-              .map(s => html`<div>${s.explanation}</div>`)}
-          </div>
-        ` : nothing}
+          `
+        )}
+        ${explanation ? html`<div class="ai-explanation">${explanation}</div>` : nothing}
       </div>
     `;
   }
 
-  private resolveOutputConflict(segmentIndex: number, choice: 'ours' | 'theirs' | 'both'): void {
-    const segments = this.parseOutputSegments();
+  private renderConflictSegment(segment: OutputSegment): ReturnType<typeof html> {
+    if (this.editingSegmentId === segment.id) {
+      return this.renderSegmentEditor();
+    }
 
-    const resultLines: string[] = [];
-    let conflictIdx = 0;
+    const labels = SIDE_LABELS[this.operationType] ?? SIDE_LABELS.merge;
+    const isSuggesting = this.suggestingSegment === segment.id;
 
-    for (const segment of segments) {
-      if (segment.type === 'resolved') {
-        resultLines.push(...segment.lines);
-      } else {
-        if (conflictIdx === segmentIndex) {
-          if (choice === 'ours' || choice === 'both') {
-            resultLines.push(...segment.oursLines);
+    const renderSide = (lines: string[]) =>
+      lines.length === 0 || (lines.length === 1 && lines[0] === '')
+        ? html`<div class="conflict-side-empty">(no content on this side)</div>`
+        : lines.map(
+            (line) => html`
+              <div class="code-line">
+                <span class="line-number"></span>
+                <span class="line-content">${this.renderHighlightedContent(line) || html`${' '}`}</span>
+              </div>
+            `
+          );
+
+    return html`
+      <div class="code-conflict-block">
+        <div class="code-conflict-header">
+          <span>Conflict</span>
+          <div class="code-conflict-header-actions">
+            <button
+              class="btn btn-ours conflict-pick-btn"
+              @click=${() => this.resolveConflictSegment(segment.id, 'ours')}
+            >
+              Use Ours
+            </button>
+            <button
+              class="btn btn-theirs conflict-pick-btn"
+              @click=${() => this.resolveConflictSegment(segment.id, 'theirs')}
+            >
+              Use Theirs
+            </button>
+            <button
+              class="btn btn-both conflict-pick-btn"
+              @click=${() => this.resolveConflictSegment(segment.id, 'both')}
+            >
+              Use Both
+            </button>
+            <button
+              class="btn conflict-pick-btn"
+              @click=${() => this.startEditSegment(segment)}
+              title="Write this section by hand (starts from both sides)"
+            >
+              Edit
+            </button>
+            ${this.aiAvailable
+              ? html`
+                  <button
+                    class="btn btn-ai conflict-pick-btn"
+                    @click=${() => this.handleSuggestSegment(segment.id)}
+                    ?disabled=${isSuggesting || this.suggestingAll}
+                  >
+                    ${isSuggesting ? 'AI...' : 'AI Suggest'}
+                  </button>
+                `
+              : nothing}
+          </div>
+        </div>
+        <div class="conflict-sides">
+          <div class="code-conflict-side-ours">
+            <div class="code-conflict-side-label">${labels.ours}</div>
+            ${renderSide(segment.oursLines)}
+          </div>
+          <div class="code-conflict-divider"></div>
+          <div class="code-conflict-side-theirs">
+            <div class="code-conflict-side-label">${labels.theirs}</div>
+            ${renderSide(segment.theirsLines)}
+          </div>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderOutput(): ReturnType<typeof html> {
+    if (this.loadFailed) {
+      return html`
+        <div class="output-error">
+          <div>Could not read the merged file from the working directory.</div>
+          <button class="btn btn-primary" @click=${this.handleReload}>Retry</button>
+        </div>
+      `;
+    }
+
+    let lineNum = 1;
+    return html`
+      <div class="code-view">
+        ${this.segments.map((segment) => {
+          if (segment.type === 'resolved') {
+            const startLineNum = lineNum;
+            lineNum += segment.lines.length;
+            return this.renderResolvedSegment(segment, startLineNum);
           }
-          if (choice === 'theirs' || choice === 'both') {
-            resultLines.push(...segment.theirsLines);
-          }
-        } else {
-          // Keep conflict markers for unresolved conflicts
-          resultLines.push(`<<<<<<< ${segment.oursLabel}`);
-          resultLines.push(...segment.oursLines);
-          resultLines.push('=======');
-          resultLines.push(...segment.theirsLines);
-          resultLines.push(`>>>>>>> ${segment.theirsLabel}`);
-        }
-        conflictIdx++;
-      }
-    }
-
-    this.outputContent = resultLines.join('\n');
-    this.computeLineOrigins();
-  }
-
-  private toggleOutputEditMode(): void {
-    this.outputEditMode = this.outputEditMode === 'visual' ? 'raw' : 'visual';
-  }
-
-  /**
-   * Sync scroll position from the output panel to all source panels.
-   * Uses scroll percentage to handle panels with different content heights.
-   */
-  private handleOutputScroll(e: Event): void {
-    const output = e.target as HTMLElement;
-    const scrollRatio = output.scrollHeight > output.clientHeight
-      ? output.scrollTop / (output.scrollHeight - output.clientHeight)
-      : 0;
-
-    const panelIds = ['panel-ours', 'panel-base', 'panel-theirs'];
-    for (const id of panelIds) {
-      const panel = this.shadowRoot?.getElementById(id);
-      if (panel) {
-        const maxScroll = panel.scrollHeight - panel.clientHeight;
-        panel.scrollTop = scrollRatio * maxScroll;
-      }
-    }
-  }
-
-  /**
-   * Sync scroll position between textarea and line gutter
-   */
-  private handleTextareaScroll(e: Event): void {
-    const textarea = e.target as HTMLTextAreaElement;
-    const gutter = this.shadowRoot?.getElementById('output-gutter');
-    if (gutter) {
-      gutter.scrollTop = textarea.scrollTop;
-    }
-  }
-
-  private getLineCount(content: string): number {
-    return content ? content.split('\n').length : 0;
-  }
-
-  private getDiffCount(content: string, base: string): number {
-    const lines = content.split('\n');
-    const baseLines = base.split('\n');
-    let diffs = 0;
-
-    const maxLen = Math.max(lines.length, baseLines.length);
-    for (let i = 0; i < maxLen; i++) {
-      if (lines[i] !== baseLines[i]) diffs++;
-    }
-
-    return diffs;
+          return this.renderConflictSegment(segment);
+        })}
+      </div>
+    `;
   }
 
   private renderBinaryConflict(): ReturnType<typeof html> {
@@ -1254,10 +1336,8 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       return this.renderBinaryConflict();
     }
 
-    const oursChanges = this.getDiffCount(this.oursContent, this.baseContent);
-    const theirsChanges = this.getDiffCount(this.theirsContent, this.baseContent);
-    const outputSegments = this.parseOutputSegments();
-    const conflictCount = outputSegments.filter(s => s.type === 'conflict').length;
+    const labels = SIDE_LABELS[this.operationType] ?? SIDE_LABELS.merge;
+    const conflictCount = this.conflictCount;
 
     return html`
       <div class="toolbar">
@@ -1273,6 +1353,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               ${this.launchingExternalTool ? 'Waiting for tool...' : 'External Tool'}
             </button>
           ` : nothing}
+          <button
+            class="btn"
+            @click=${this.handleReload}
+            title="Reload the file from disk, discarding resolutions made here"
+          >
+            Reload
+          </button>
           <button class="btn" @click=${this.handleAcceptBase} title="Reset to common ancestor">
             Use Base
           </button>
@@ -1280,27 +1367,34 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             ? html`<button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} title="Ours deleted this file — keep it deleted">
                 Use Ours (delete file)
               </button>`
-            : html`<button class="btn btn-ours" @click=${this.handleAcceptOurs} title="Use entire file from current branch">
+            : html`<button class="btn btn-ours" @click=${this.handleAcceptOurs} title="Use entire file from ${labels.ours}">
                 Use Ours
               </button>`}
           ${this.conflictFile && !this.conflictFile.theirs
             ? html`<button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} title="Theirs deleted this file — delete it">
                 Use Theirs (delete file)
               </button>`
-            : html`<button class="btn btn-theirs" @click=${this.handleAcceptTheirs} title="Use entire file from incoming branch">
+            : html`<button class="btn btn-theirs" @click=${this.handleAcceptTheirs} title="Use entire file from ${labels.theirs}">
                 Use Theirs
               </button>`}
-          ${this.aiAvailable ? html`
+          ${this.aiAvailable && conflictCount > 0 ? html`
             <button
               class="btn btn-ai"
               @click=${this.handleAiResolveAll}
-              ?disabled=${this.suggestingAll || this.suggestingConflict !== null}
+              ?disabled=${this.suggestingAll || this.suggestingSegment !== null}
               title="Use AI to resolve all remaining conflicts"
             >
               ${this.suggestingAll ? 'AI Resolving...' : 'AI Resolve All'}
             </button>
           ` : nothing}
-          <button class="btn btn-primary" @click=${this.handleMarkResolved}>
+          <button
+            class="btn btn-primary"
+            @click=${this.handleMarkResolved}
+            ?disabled=${conflictCount > 0 || this.loadFailed}
+            title=${conflictCount > 0
+              ? `Resolve the remaining ${conflictCount} conflict${conflictCount === 1 ? '' : 's'} first`
+              : 'Stage this file as resolved'}
+          >
             Mark Resolved
           </button>
         </div>
@@ -1310,14 +1404,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         <div class="source-panels">
           <div class="editor-panel">
             <div class="panel-header ours">
-              Ours (Current Branch)
-              <span class="panel-stats">${oursChanges} changes from base</span>
-              <button class="panel-header-btn" @click=${this.handleAcceptOursPanel} title="Use this version">
+              ${labels.ours}
+              <span class="panel-stats">${this.getChangeCount('ours')} changes from base</span>
+              <button class="panel-header-btn" @click=${this.handleAcceptOurs} title="Use this version">
                 Use
               </button>
             </div>
-            <div class="panel-content readonly" id="panel-ours">
-              ${this.renderCodeView(this.oursContent, this.baseContent)}
+            <div class="panel-content readonly" id="panel-ours" @scroll=${this.handleSourceScroll}>
+              ${this.renderAlignedPane('ours')}
             </div>
           </div>
 
@@ -1326,21 +1420,21 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               Base (Common Ancestor)
               <span class="panel-stats">${this.getLineCount(this.baseContent)} lines</span>
             </div>
-            <div class="panel-content readonly" id="panel-base">
-              ${this.renderCodeView(this.baseContent)}
+            <div class="panel-content readonly" id="panel-base" @scroll=${this.handleSourceScroll}>
+              ${this.renderAlignedPane('base')}
             </div>
           </div>
 
           <div class="editor-panel">
             <div class="panel-header theirs">
-              Theirs (Incoming)
-              <span class="panel-stats">${theirsChanges} changes from base</span>
-              <button class="panel-header-btn" @click=${this.handleAcceptTheirsPanel} title="Use this version">
+              ${labels.theirs}
+              <span class="panel-stats">${this.getChangeCount('theirs')} changes from base</span>
+              <button class="panel-header-btn" @click=${this.handleAcceptTheirs} title="Use this version">
                 Use
               </button>
             </div>
-            <div class="panel-content readonly" id="panel-theirs">
-              ${this.renderCodeView(this.theirsContent, this.baseContent)}
+            <div class="panel-content readonly" id="panel-theirs" @scroll=${this.handleSourceScroll}>
+              ${this.renderAlignedPane('theirs')}
             </div>
           </div>
         </div>
@@ -1351,18 +1445,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             ${conflictCount > 0
               ? html`<span class="conflict-count">${conflictCount} conflict${conflictCount === 1 ? '' : 's'} remaining</span>`
               : html`<span class="conflict-count">No conflicts</span>`}
-            <button class="panel-header-btn output-mode-toggle" @click=${this.toggleOutputEditMode}>
-              ${this.outputEditMode === 'visual' ? 'Raw Edit' : 'Visual'}
-            </button>
           </div>
-          <div
-            class="panel-content${this.outputEditMode === 'visual' ? ' readonly' : ''}"
-            id="panel-output"
-            @scroll=${this.handleOutputScroll}
-          >
-            ${this.outputEditMode === 'visual'
-              ? this.renderOutputVisual()
-              : this.renderEditableCodeView(this.outputContent)}
+          <div class="panel-content" id="panel-output" @scroll=${this.handleOutputScroll}>
+            ${this.renderOutput()}
           </div>
         </div>
       </div>

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -920,11 +920,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       if (cs.length === 0) return splitAt(b, b.length);
       return splitAt(b, cs[0]);
     };
-    /** The text after a candidate close, up to the next start-shaped line. */
+    /**
+     * The text after a candidate close, up to the next REAL start-shaped
+     * line. A start-shaped line that is blob content (a quoted example)
+     * does not end the window — stopping there would hide an orphaned real
+     * end marker sitting below it from both justification checks.
+     */
     const trailingAfter = (endIdx: number): string[] => {
       const out: string[] = [];
       for (let k = endIdx + 1; k < lines.length; k++) {
-        if (isConflictStart(lines[k])) break;
+        if (isConflictStart(lines[k]) && !lineInBlobs(lines[k])) break;
         out.push(lines[k]);
       }
       return out;
@@ -1059,6 +1064,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       } else if (closed) {
         pushConflict(closed.split!, oursLabel, labelOf(lines[closed.end], 'THEIRS'));
         i = closed.end + 1;
+      } else if (blobsAvailable && lineInBlobs(line)) {
+        // NOTHING below this start-shaped line validates, and the line
+        // itself is blob content — it is a quoted example sitting directly
+        // above the real conflict, and it opened the region one line too
+        // early (every candidate ours-slice began with the real start
+        // marker, which is in neither blob). Treat it as content and
+        // rescan from the next line so the REAL start can open a region
+        // whose split validates.
+        currentResolved.push(line);
+        i++;
       } else if (firstCandidate) {
         // No candidate could be justified (nothing validates) — close at
         // the FIRST candidate, the pre-validation behavior.
@@ -1571,6 +1586,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         // raise a false confirm.
         if (token === this.resolveToken) {
           this.userTouched = false;
+        }
+        // Reload when the taken file is still the one on screen (the last
+        // file has no auto-advance target): the stale pre-take parse would
+        // otherwise sit there with Mark Resolved enabled, and one click
+        // would fs::write the old content back — silently resurrecting a
+        // file whose DELETION the user just staged.
+        if (this.conflictFile?.path === file.path) {
+          await this.loadContents();
         }
         this.dispatchEvent(new CustomEvent('conflict-resolved', {
           detail: { file },

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -830,15 +830,26 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       const n = markerRun(lines[index], '<');
       if (n === 0) return 0;
       if (n === 7) return 7;
-      // A raised size must look like a REAL git conflict: both the exact-size
-      // separator AND an exact-size end marker must follow. Requiring only
-      // the separator would let a banner line plus one coincidental divider
-      // swallow the rest of the file into a phantom conflict.
+      // A raised size must look like a REAL git conflict, in git's emission
+      // order: the exact-size separator, then an exact-size end marker.
+      // Bail if a DEFAULT-size start appears before the separator — the
+      // raised "start" would otherwise swallow a real conflict (and its
+      // markers) as pickable content, e.g. in a docs file that shows a long
+      // marker example above an actual conflict.
       const sep = '='.repeat(n);
-      const rest = lines.slice(index + 1);
-      const hasSeparator = rest.some((l) => stripCr(l) === sep);
-      const hasEnd = rest.some((l) => markerRun(l, '>') === n);
-      return hasSeparator && hasEnd ? n : 0;
+      let sepIndex = -1;
+      for (let j = index + 1; j < lines.length; j++) {
+        if (markerRun(lines[j], '<') === 7) return 0;
+        if (stripCr(lines[j]) === sep) {
+          sepIndex = j;
+          break;
+        }
+      }
+      if (sepIndex < 0) return 0;
+      for (let j = sepIndex + 1; j < lines.length; j++) {
+        if (markerRun(lines[j], '>') === n) return n;
+      }
+      return 0;
     };
 
     const segments: OutputSegment[] = [];

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -648,11 +648,20 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       this.theirsLines = this.conflictFile.theirs ? this.theirsContent.split('\n') : [];
       this.alignmentRows = alignThreeWay(this.baseLines, this.oursLines, this.theirsLines);
 
+      // A failed read of a side that EXISTS must not masquerade as empty
+      // content — the panes would lie and whole-file Use Ours/Theirs would
+      // truncate the file. Route it to the same Retry state as a failed
+      // workdir read.
+      const sideReadFailed =
+        (!!this.conflictFile.ancestor?.oid && !ancestorResult.success) ||
+        (!!this.conflictFile.ours?.oid && !oursResult.success) ||
+        (!!this.conflictFile.theirs?.oid && !theirsResult.success);
+
       // Only git's own merge output is trustworthy. If the working directory
       // file can't be read, show an error state — never fabricate a merge.
       // An empty string is valid content (empty merged file), so test the
       // type, not truthiness.
-      if (workdirResult.success && typeof workdirResult.data === 'string') {
+      if (!sideReadFailed && workdirResult.success && typeof workdirResult.data === 'string') {
         this.segments = this.parseSegments(workdirResult.data);
       } else {
         this.segments = [];
@@ -1447,9 +1456,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           >
             Reload
           </button>
-          <button class="btn" @click=${this.handleAcceptBase} title="Reset to common ancestor">
-            Use Base
-          </button>
+          ${this.conflictFile.ancestor
+            ? html`<button class="btn" @click=${this.handleAcceptBase} title="Reset to common ancestor">
+                Use Base
+              </button>`
+            : nothing}
           ${this.conflictFile && !this.conflictFile.ours
             ? html`<button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} title="Ours deleted this file — keep it deleted">
                 Use Ours (delete file)

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -445,6 +445,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         font-size: var(--font-size-xs);
       }
 
+      /* Placeholder row for a resolution that removed all lines — keeps the
+         segment hoverable so its Edit/Reset actions stay reachable */
+      .segment-empty-note {
+        color: var(--color-text-muted);
+        font-style: italic;
+        font-size: var(--font-size-xs);
+      }
+
       .loading {
         display: flex;
         align-items: center;
@@ -632,9 +640,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       this.oursContent = oursResult.success ? (oursResult.data || '') : '';
       this.theirsContent = theirsResult.success ? (theirsResult.data || '') : '';
 
-      this.baseLines = this.baseContent.split('\n');
-      this.oursLines = this.oursContent.split('\n');
-      this.theirsLines = this.theirsContent.split('\n');
+      // A side with no entry (add/add conflicts have no ancestor; delete/modify
+      // conflicts miss one side) has ZERO lines — ''.split('\n') would invent a
+      // phantom blank line that misaligns and miscolors the panes.
+      this.baseLines = this.conflictFile.ancestor ? this.baseContent.split('\n') : [];
+      this.oursLines = this.conflictFile.ours ? this.oursContent.split('\n') : [];
+      this.theirsLines = this.conflictFile.theirs ? this.theirsContent.split('\n') : [];
       this.alignmentRows = alignThreeWay(this.baseLines, this.oursLines, this.theirsLines);
 
       // Only git's own merge output is trustworthy. If the working directory
@@ -661,8 +672,22 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    * place markers are ever interpreted; they never reach the DOM.
    * Handles diff3-style `|||||||` base sections (discarded) and tolerates an
    * unterminated conflict at EOF (kept as a conflict block).
+   *
+   * Git emits exactly seven marker characters, optionally followed by a
+   * space and label (the `=======` separator is always bare). Content lines
+   * that merely BEGIN with 7+ of the character — banner comments, Markdown
+   * setext underlines, `====…` dividers — must not match, or the ours/theirs
+   * split silently corrupts and the real separator leaks in as content.
+   * Lines are compared with a trailing CR stripped so CRLF files parse, but
+   * content lines are stored verbatim to round-trip their line endings.
    */
   private parseSegments(text: string): OutputSegment[] {
+    const stripCr = (l: string): string => (l.endsWith('\r') ? l.slice(0, -1) : l);
+    const isConflictStart = (l: string): boolean => /^<{7}( |$)/.test(stripCr(l));
+    const isBaseMarker = (l: string): boolean => /^\|{7}( |$)/.test(stripCr(l));
+    const isSeparator = (l: string): boolean => stripCr(l) === '=======';
+    const isConflictEnd = (l: string): boolean => /^>{7}( |$)/.test(stripCr(l));
+
     const lines = text.split('\n');
     const segments: OutputSegment[] = [];
     let currentResolved: string[] = [];
@@ -694,21 +719,22 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     };
 
     for (const line of lines) {
-      if (!inConflict && line.startsWith('<<<<<<<')) {
+      if (!inConflict && isConflictStart(line)) {
         flushResolved();
         inConflict = true;
         section = 'ours';
         oursLines = [];
         theirsLines = [];
-        oursLabel = line.slice(7).trim() || 'OURS';
+        oursLabel = stripCr(line).slice(7).trim() || 'OURS';
         theirsLabel = '';
-      } else if (inConflict && line.startsWith('|||||||')) {
-        // diff3 common-ancestor marker — begin discarding base lines
+      } else if (inConflict && section === 'ours' && isBaseMarker(line)) {
+        // diff3 common-ancestor marker — begin discarding base lines. Only
+        // valid directly after the ours section; anywhere else it's content.
         section = 'base';
-      } else if (inConflict && section !== 'theirs' && line.startsWith('=======')) {
+      } else if (inConflict && section !== 'theirs' && isSeparator(line)) {
         section = 'theirs';
-      } else if (inConflict && line.startsWith('>>>>>>>')) {
-        theirsLabel = line.slice(7).trim() || 'THEIRS';
+      } else if (inConflict && isConflictEnd(line)) {
+        theirsLabel = stripCr(line).slice(7).trim() || 'THEIRS';
         pushConflict();
         inConflict = false;
         section = 'ours';
@@ -768,14 +794,22 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     return this.segments.flatMap((s) => s.lines).join('\n');
   }
 
-  public getResolvedContent(): string {
-    return this.buildResolvedContent();
-  }
-
   // ── Segment operations ────────────────────────────────────────────────
 
   private updateSegment(id: number, update: Partial<OutputSegment>): void {
     this.segments = this.segments.map((s) => (s.id === id ? { ...s, ...update } : s));
+  }
+
+  /**
+   * Drop a stored AI explanation once the segment's content no longer comes
+   * from that suggestion (reset, re-picked, or hand-edited) — a stale
+   * rationale under unrelated content is worse than none.
+   */
+  private clearAiExplanation(id: number): void {
+    if (!this.aiExplanations.has(id)) return;
+    const next = new Map(this.aiExplanations);
+    next.delete(id);
+    this.aiExplanations = next;
   }
 
   private resolveConflictSegment(id: number, choice: 'ours' | 'theirs' | 'both'): void {
@@ -788,6 +822,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         : choice === 'theirs'
           ? [...segment.theirsLines]
           : [...segment.oursLines, ...segment.theirsLines];
+    this.clearAiExplanation(id);
     this.updateSegment(id, { type: 'resolved', lines, origin: choice, fromConflict: true });
   }
 
@@ -796,6 +831,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     const segment = this.segments.find((s) => s.id === id);
     if (!segment || !segment.fromConflict) return;
     if (this.editingSegmentId === id) this.editingSegmentId = null;
+    this.clearAiExplanation(id);
     this.updateSegment(id, { type: 'conflict', lines: [], origin: null, fromConflict: false });
   }
 
@@ -818,6 +854,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       return;
     }
 
+    this.clearAiExplanation(id);
     this.updateSegment(id, {
       type: 'resolved',
       lines: this.editDraft.split('\n'),
@@ -926,7 +963,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.suggestingAll = true;
     try {
       for (const id of conflictIds) {
-        // Stop on the first failure — retrying would just repeat the error.
+        // The user may have resolved this block manually while the batch was
+        // running — that's not a failure, just skip it.
+        const segment = this.segments.find((s) => s.id === id);
+        if (!segment || segment.type !== 'conflict') continue;
+        // Stop on the first real failure — retrying would just repeat the error.
         if (!(await this.handleSuggestSegment(id))) break;
       }
     } finally {
@@ -939,9 +980,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   private async handleMarkResolved(): Promise<void> {
     if (!this.repositoryPath || !this.conflictFile) return;
 
-    // The button is disabled while conflicts remain; this guard keeps the
-    // invariant even if invoked directly. A file with open conflict blocks
-    // must never be written out (it would re-serialize markers).
+    // The button is disabled in these states; the guards keep the invariant
+    // even if invoked directly. A file with open conflict blocks must never
+    // be written out (it would re-serialize markers), and a failed load has
+    // no trustworthy content to write (it would truncate the file to empty).
+    if (this.loadFailed) {
+      showToast('The merged file could not be read — retry loading it before resolving', 'warning');
+      return;
+    }
     if (this.conflictCount > 0) {
       showToast('Resolve all conflict blocks before marking the file resolved', 'warning');
       return;
@@ -998,28 +1044,32 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   // ── Scroll synchronization ────────────────────────────────────────────
 
   /**
-   * The three source panes share identical row geometry (same aligned row
-   * count), so they mirror scrollTop exactly; the output pane has different
-   * content and is synced proportionally.
+   * All panes sync proportionally. The source panes share a row COUNT, but
+   * line wrapping (`white-space: pre-wrap`) gives them different pixel
+   * heights, so mirroring absolute scrollTop would misalign and, at the
+   * bottom of a taller pane, snap the user's scroll back. Writes are skipped
+   * when the target is already in place, so the echo scroll event a synced
+   * pane fires (after the rAF guard has cleared) finds nothing to change and
+   * the loop terminates instead of yanking the source pane around.
    */
-  private handleSourceScroll(e: Event): void {
+  private syncScrollTo(target: HTMLElement, top: number): void {
+    if (Math.abs(target.scrollTop - top) > 1) {
+      target.scrollTop = top;
+    }
+  }
+
+  private syncPanesFrom(source: HTMLElement, targetIds: string[]): void {
     if (this.syncingScroll) return;
     this.syncingScroll = true;
 
-    const source = e.target as HTMLElement;
-    for (const id of ['panel-ours', 'panel-base', 'panel-theirs']) {
+    const sourceMax = source.scrollHeight - source.clientHeight;
+    const ratio = sourceMax > 0 ? source.scrollTop / sourceMax : 0;
+
+    for (const id of targetIds) {
       const panel = this.shadowRoot?.getElementById(id);
       if (panel && panel !== source) {
-        panel.scrollTop = source.scrollTop;
-        panel.scrollLeft = source.scrollLeft;
+        this.syncScrollTo(panel, ratio * (panel.scrollHeight - panel.clientHeight));
       }
-    }
-
-    const output = this.shadowRoot?.getElementById('panel-output');
-    if (output) {
-      const sourceMax = source.scrollHeight - source.clientHeight;
-      const ratio = sourceMax > 0 ? source.scrollTop / sourceMax : 0;
-      output.scrollTop = ratio * (output.scrollHeight - output.clientHeight);
     }
 
     requestAnimationFrame(() => {
@@ -1027,24 +1077,17 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     });
   }
 
+  private handleSourceScroll(e: Event): void {
+    this.syncPanesFrom(e.target as HTMLElement, [
+      'panel-ours',
+      'panel-base',
+      'panel-theirs',
+      'panel-output',
+    ]);
+  }
+
   private handleOutputScroll(e: Event): void {
-    if (this.syncingScroll) return;
-    this.syncingScroll = true;
-
-    const output = e.target as HTMLElement;
-    const outputMax = output.scrollHeight - output.clientHeight;
-    const ratio = outputMax > 0 ? output.scrollTop / outputMax : 0;
-
-    for (const id of ['panel-ours', 'panel-base', 'panel-theirs']) {
-      const panel = this.shadowRoot?.getElementById(id);
-      if (panel) {
-        panel.scrollTop = ratio * (panel.scrollHeight - panel.clientHeight);
-      }
-    }
-
-    requestAnimationFrame(() => {
-      this.syncingScroll = false;
-    });
+    this.syncPanesFrom(e.target as HTMLElement, ['panel-ours', 'panel-base', 'panel-theirs']);
   }
 
   // ── Change statistics ─────────────────────────────────────────────────
@@ -1067,6 +1110,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
   private getLineCount(content: string): number {
     return content ? content.split('\n').length : 0;
+  }
+
+  private formatChangeCount(count: number): string {
+    return `${count} change${count === 1 ? '' : 's'} from base`;
   }
 
   // ── Rendering ─────────────────────────────────────────────────────────
@@ -1174,14 +1221,21 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               `
             : nothing}
         </div>
-        ${segment.lines.map(
-          (line, i) => html`
-            <div class="code-line">
-              <span class="line-number">${startLineNum + i}</span>
-              <span class="line-content">${this.renderHighlightedContent(line) || html`${' '}`}</span>
-            </div>
-          `
-        )}
+        ${segment.lines.length === 0
+          ? html`
+              <div class="code-line">
+                <span class="line-number"></span>
+                <span class="line-content segment-empty-note">(this resolution removed the section)</span>
+              </div>
+            `
+          : segment.lines.map(
+              (line, i) => html`
+                <div class="code-line">
+                  <span class="line-number">${startLineNum + i}</span>
+                  <span class="line-content">${this.renderHighlightedContent(line) || html`${' '}`}</span>
+                </div>
+              `
+            )}
         ${explanation ? html`<div class="ai-explanation">${explanation}</div>` : nothing}
       </div>
     `;
@@ -1194,10 +1248,20 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
     const labels = SIDE_LABELS[this.operationType] ?? SIDE_LABELS.merge;
     const isSuggesting = this.suggestingSegment === segment.id;
+    // Surface the labels git recorded (branch names, commit refs) alongside
+    // the generic role — they disambiguate the sides better than roles alone.
+    const oursSideLabel = segment.oursLabel && segment.oursLabel !== 'OURS'
+      ? `${labels.ours} · ${segment.oursLabel}`
+      : labels.ours;
+    const theirsSideLabel = segment.theirsLabel && segment.theirsLabel !== 'THEIRS'
+      ? `${labels.theirs} · ${segment.theirsLabel}`
+      : labels.theirs;
 
+    // A side with a single empty string is one blank line, NOT empty —
+    // choosing it inserts a blank line, so it must render as one.
     const renderSide = (lines: string[]) =>
-      lines.length === 0 || (lines.length === 1 && lines[0] === '')
-        ? html`<div class="conflict-side-empty">(no content on this side)</div>`
+      lines.length === 0
+        ? html`<div class="conflict-side-empty">(no lines on this side)</div>`
         : lines.map(
             (line) => html`
               <div class="code-line">
@@ -1242,7 +1306,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
                   <button
                     class="btn btn-ai conflict-pick-btn"
                     @click=${() => this.handleSuggestSegment(segment.id)}
-                    ?disabled=${isSuggesting || this.suggestingAll}
+                    ?disabled=${this.suggestingSegment !== null || this.suggestingAll}
                   >
                     ${isSuggesting ? 'AI...' : 'AI Suggest'}
                   </button>
@@ -1252,12 +1316,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         </div>
         <div class="conflict-sides">
           <div class="code-conflict-side-ours">
-            <div class="code-conflict-side-label">${labels.ours}</div>
+            <div class="code-conflict-side-label">${oursSideLabel}</div>
             ${renderSide(segment.oursLines)}
           </div>
           <div class="code-conflict-divider"></div>
           <div class="code-conflict-side-theirs">
-            <div class="code-conflict-side-label">${labels.theirs}</div>
+            <div class="code-conflict-side-label">${theirsSideLabel}</div>
             ${renderSide(segment.theirsLines)}
           </div>
         </div>
@@ -1405,7 +1469,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <div class="editor-panel">
             <div class="panel-header ours">
               ${labels.ours}
-              <span class="panel-stats">${this.getChangeCount('ours')} changes from base</span>
+              <span class="panel-stats">${this.formatChangeCount(this.getChangeCount('ours'))}</span>
               <button class="panel-header-btn" @click=${this.handleAcceptOurs} title="Use this version">
                 Use
               </button>
@@ -1428,7 +1492,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <div class="editor-panel">
             <div class="panel-header theirs">
               ${labels.theirs}
-              <span class="panel-stats">${this.getChangeCount('theirs')} changes from base</span>
+              <span class="panel-stats">${this.formatChangeCount(this.getChangeCount('theirs'))}</span>
               <button class="panel-header-btn" @click=${this.handleAcceptTheirs} title="Use this version">
                 Use
               </button>

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -643,6 +643,22 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         if (!proceed) this.launchingExternalTool = false;
       }
       if (!proceed) return;
+      // Re-check after the await: the HOST's Abort/Complete are not
+      // disabled during this confirm — editorToolActive is only set below,
+      // and the internal launch claim is invisible to the dialog — so an
+      // abort/complete/resolve or a file switch may have happened while
+      // the confirm was up. Launching now would edit a file the operation
+      // no longer owns (e.g. write stale conflict text into a post-abort
+      // clean tree). Same re-check as every sibling confirm.
+      if (
+        this.externalToolLocked ||
+        this.resolving ||
+        this.resolvedAsDeleted ||
+        this.conflictFile !== file
+      ) {
+        this.launchingExternalTool = false;
+        return;
+      }
     }
 
     // Tell the host a tool session is open so its Abort/Complete stay inert —

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -733,7 +733,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         section = 'base';
       } else if (inConflict && section !== 'theirs' && isSeparator(line)) {
         section = 'theirs';
-      } else if (inConflict && isConflictEnd(line)) {
+      } else if (inConflict && section === 'theirs' && isConflictEnd(line)) {
+        // Git always emits '=======' before '>>>>>>>', so an end marker is
+        // only valid in the theirs section — anywhere earlier it's content
+        // (a quoted diff, docs about conflicts) and treating it as the end
+        // would drop the real theirs side and leak the true markers.
         theirsLabel = stripCr(line).slice(7).trim() || 'THEIRS';
         pushConflict();
         inConflict = false;
@@ -857,7 +861,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.clearAiExplanation(id);
     this.updateSegment(id, {
       type: 'resolved',
-      lines: this.editDraft.split('\n'),
+      // An empty draft means ZERO lines (section removed) — ''.split('\n')
+      // would silently turn it into one blank line.
+      lines: this.editDraft === '' ? [] : this.editDraft.split('\n'),
       origin: 'manual',
       fromConflict: segment.type === 'conflict' ? true : segment.fromConflict,
     });
@@ -877,6 +883,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   // ── Whole-file operations ─────────────────────────────────────────────
 
   private acceptWholeFile(origin: 'ours' | 'theirs' | 'base'): void {
+    // A side with no entry DELETED the file — accepting it means staging the
+    // deletion, not writing a 0-byte file from its empty content.
+    if (
+      (origin === 'ours' && !this.conflictFile?.ours) ||
+      (origin === 'theirs' && !this.conflictFile?.theirs)
+    ) {
+      void this.handleTakeSide(origin);
+      return;
+    }
+
     const content =
       origin === 'ours' ? this.oursContent : origin === 'theirs' ? this.theirsContent : this.baseContent;
     this.editingSegmentId = null;
@@ -932,6 +948,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       );
 
       if (result.success && result.data) {
+        // AI output bypasses parseSegments, so it must be validated here:
+        // a suggestion that echoes marker lines would otherwise render them
+        // as "resolved" text and let them be written back to the file.
+        if (/^(<{7}|={7}|>{7}|\|{7})( |\r?$)/m.test(result.data.resolvedContent)) {
+          showToast('AI suggestion contained conflict markers — block left unresolved', 'error');
+          return false;
+        }
         this.updateSegment(id, {
           type: 'resolved',
           lines: result.data.resolvedContent.split('\n'),

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -695,7 +695,18 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         // but after a mid-session switch a reload would wipe the picks of
         // the file the user is now working on.
         if (this.conflictFile?.path === file.path) {
-          await this.loadContents();
+          const fresh = freshConflicts?.find((c) => c.path === file.path);
+          if (fresh && fresh !== this.conflictFile) {
+            // The tool may have changed the file's markerSize/style/hunks;
+            // adopt the fresh metadata BEFORE parsing (the reactive updated()
+            // reloads with it) instead of re-parsing with the stale object
+            // and only correcting once the host echoes it back. The host
+            // adopts the SAME object via external-tool-finished, so it will
+            // not trigger a second reload.
+            this.conflictFile = fresh;
+          } else {
+            await this.loadContents();
+          }
         }
         // Mirror the dialog's launcher: success only when the index confirms
         // the resolution — a green toast over "N conflicts remaining" would
@@ -757,6 +768,21 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.sideReadErrors = { base: false, ours: false, theirs: false };
 
     try {
+      // Re-SELECTING an already-resolved chooser file (binary/submodule):
+      // its buttons would call take-side on a path the index no longer
+      // lists as conflicted, erroring "No conflict found". The blob reads
+      // for a binary file also fail (undecodable) and would render the live
+      // chooser regardless of loadFailed. Land in the terminal resolved
+      // state instead — the resolution is already staged.
+      if (file.isBinary || file.isSubmodule) {
+        if (await this.isNoLongerConflicted(file.path)) {
+          if (epoch !== this.loadEpoch) return;
+          this.segments = [];
+          this.resolvedInPlace = true;
+          return;
+        }
+      }
+
       // Submodule (gitlink) conflicts have nothing to read: the entry OIDs
       // are COMMITS (not blobs) and the workdir path is a directory. Every
       // fetch below would fail and land the editor in a loadFailed state
@@ -846,7 +872,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         // in the error/Retry/verbatim state, not a false "was deleted".
         workdirResult.error?.code === 'FILE_NOT_FOUND' &&
         (!file.ours || !file.theirs) &&
-        (await this.isResolvedDeletion(file.path))
+        (await this.isNoLongerConflicted(file.path))
       ) {
         // RE-SELECTING a file already resolved as a deletion: the workdir
         // read fails because the file is correctly GONE. The generic error
@@ -875,12 +901,15 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   }
 
   /**
-   * True when `path`'s deletion is already STAGED: the file has a missing
-   * side, the workdir copy is gone, and the index no longer lists it as
-   * conflicted. Distinguishes a resolved deletion from a genuine read
-   * failure.
+   * True when the index no longer lists `path` as conflicted — i.e. the
+   * file has already been resolved (deleted, or a chooser take-side that
+   * staged a side). Distinguishes an ALREADY-RESOLVED re-selection from a
+   * genuine read failure, so the editor can show a terminal notice instead
+   * of a live chooser / forever-Retry whose buttons error "No conflict
+   * found". A failed getConflicts returns false (treat as still
+   * conflicted) so a transient error never fabricates a "resolved" state.
    */
-  private async isResolvedDeletion(path: string): Promise<boolean> {
+  private async isNoLongerConflicted(path: string): Promise<boolean> {
     if (!this.repositoryPath) return false;
     const conflicts = await gitService.getConflicts(this.repositoryPath);
     return conflicts.success && !(conflicts.data ?? []).some((c) => c.path === path);
@@ -1747,6 +1776,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
   private async handleMarkResolved(): Promise<void> {
     if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
+    // Identity of the file when the button was clicked. The orphan-marker
+    // confirm below yields to the event loop (native confirms do NOT block
+    // it), and nav is not yet locked (resolve-started fires later), so a
+    // file switch could retarget conflictFile mid-confirm — marking the
+    // WRONG file resolved. Re-checked after the await.
+    const startFile = this.conflictFile;
 
     // The button is disabled in these states; the guards keep the invariant
     // even if invoked directly. A file with open conflict blocks must never
@@ -1790,8 +1825,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       );
       if (!proceed) return;
       // Re-check after the await — same re-validation as every other
-      // confirm in this component.
+      // confirm in this component, plus file identity: a switch during the
+      // confirm must not let this call mark a different file resolved.
       if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
+      if (this.conflictFile !== startFile) return;
       if (this.loadFailed || this.conflictCount > 0 || this.editingSegmentId !== null) return;
     }
 
@@ -1871,13 +1908,17 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    */
   private async handleTakeSide(side: 'ours' | 'theirs'): Promise<void> {
     if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
+    const startFile = this.conflictFile;
     // Taking a side writes the whole file — an open typed-but-unapplied
     // draft would vanish silently. (The acceptWholeFile delegation already
     // confirmed and cleared the edit, so this only fires for the direct
     // deleted-side buttons.)
     if (this.editingSegmentId !== null) {
       if (!(await this.confirmDiscardOpenEdit())) return;
+      // Re-check identity too: a file switch during the discard confirm
+      // must not let this call take a side on a different file.
       if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
+      if (this.conflictFile !== startFile) return;
       this.editingSegmentId = null;
       this.editDraft = '';
     }
@@ -1885,6 +1926,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     // Same capture-before-await as handleMarkResolved: the dispatched file
     // must be the one the call actually resolved.
     const file = this.conflictFile;
+    // The verbatim take-side buttons only appear in the side-read-failure
+    // (loadFailed) state — a reload afterwards would re-read the same
+    // undecodable side blob and loop forever on Retry, presenting a
+    // successful resolution as a failure. Remember it to land terminal.
+    const wasLoadFailed = this.loadFailed;
     const token = ++this.resolveToken;
     this.resolving = true;
     this.dispatchEvent(new CustomEvent('resolve-started', { bubbles: true, composed: true }));
@@ -1917,11 +1963,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               this.editingSegmentId = null;
               this.resolvedAsDeleted = true;
             }
-          } else if (file.isBinary || file.isSubmodule) {
-            // A chooser resolution has no text pipeline to reload into —
-            // reloading just re-renders the same chooser with live
-            // buttons, and a second click errors "No conflict found" on
-            // the already-resolved file. Terminal state, like deletions.
+          } else if (file.isBinary || file.isSubmodule || wasLoadFailed) {
+            // A chooser resolution (binary/submodule) has no text pipeline
+            // to reload into, and a verbatim take from the side-read-failure
+            // state would just re-fail the same undecodable blob — reloading
+            // either re-renders live chooser/verbatim buttons whose second
+            // click errors "No conflict found", or loops on Retry. Terminal
+            // state, like deletions.
             if (token === this.resolveToken) {
               this.resolvedInPlace = true;
             }
@@ -2268,6 +2316,17 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         </div>
       `;
     }
+    if (this.resolvedInPlace) {
+      // A verbatim take from the side-read-failure state succeeded — show
+      // the terminal notice, NOT the error state, whose Retry would loop on
+      // the same undecodable blob and whose verbatim buttons would error
+      // "No conflict found" on the already-resolved file.
+      return html`
+        <div class="loading">
+          Resolved — the chosen version was staged. Nothing further to do here.
+        </div>
+      `;
+    }
     if (this.loadFailed) {
       // Say what actually failed — blaming the working-directory file when
       // only a side blob was unreadable would be wrong and alarming.
@@ -2281,7 +2340,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               ? 'Could not read all of this file’s versions.'
               : 'Could not read the merged file from the working directory.'}
           </div>
-          <button class="btn btn-primary" @click=${this.handleReload}>Retry</button>
+          <button class="btn btn-primary" @click=${this.handleReload} ?disabled=${this.actionsBlocked}>Retry</button>
           ${
             // Take-side writes one side's blob verbatim — it never touches the
             // BASE blob or the workdir text, so each side is offerable
@@ -2424,9 +2483,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       `;
     }
     if (this.resolvedInPlace) {
+      // A submodule pointer is staged, but its worktree files are NOT
+      // checked out here — telling the user "nothing further to do" would
+      // contradict the pre-resolution guidance and leave them confused by a
+      // still-changed submodule path in the status pane.
       return html`
         <div class="loading">
-          Resolved — the chosen version was staged. Nothing further to do here.
+          Resolved — the chosen commit is staged. Run <code>git submodule update</code> to
+          check out its files.
         </div>
       `;
     }

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -790,6 +790,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         this.segments = this.parseSegments(workdirResult.data);
       } else if (
         !workdirResult.success &&
+        // The deletion claim requires the file to actually be GONE — a
+        // kept-but-undecodable file (legacy encoding, resolved externally
+        // with checkout --ours) fails the read the same way but must land
+        // in the error/Retry/verbatim state, not a false "was deleted".
+        workdirResult.error?.code === 'FILE_NOT_FOUND' &&
         (!file.ours || !file.theirs) &&
         (await this.isResolvedDeletion(file.path))
       ) {

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -547,9 +547,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   @state() private aiExplanations: Map<number, string> = new Map();
 
   private nextSegmentId = 1;
+  /** Invalidates in-flight loads when a newer one starts (rapid file switches). */
+  private loadEpoch = 0;
   private baseLines: string[] = [];
   private oursLines: string[] = [];
   private theirsLines: string[] = [];
+  /** Per-pane read failures — that pane shows an error, not fake content. */
+  private sideReadErrors = { base: false, ours: false, theirs: false };
   private alignmentRows: ThreeWayRow[] = [];
   /** Guards against scroll-sync feedback loops between the panes. */
   private syncingScroll = false;
@@ -610,31 +614,44 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   private async loadContents(): Promise<void> {
     if (!this.repositoryPath || !this.conflictFile) return;
 
+    // Rapid file switches start overlapping loads; only the NEWEST may write
+    // state, or a slow earlier load would overwrite the panes/segments with
+    // another file's content under the current file's path — and Mark
+    // Resolved would then stage that wrong content.
+    const epoch = ++this.loadEpoch;
+    const file = this.conflictFile;
+
     this.loading = true;
     this.loadFailed = false;
     // Per-file UI state must not leak between files.
     this.editingSegmentId = null;
     this.aiExplanations = new Map();
     this.suggestingSegment = null;
-
-    // Initialize Shiki highlighter and detect language
-    await this.initCodeLanguage(this.conflictFile.path);
+    this.sideReadErrors = { base: false, ours: false, theirs: false };
 
     try {
+      // Initialize Shiki highlighter and detect language. Inside the try so
+      // a highlighter failure cannot wedge the editor in a permanent
+      // loading state (the finally below always clears it).
+      await this.initCodeLanguage(file.path);
+
       // Load all three versions and the working directory file in parallel.
       // The working directory file contains git's authoritative diff3 merge.
       const [ancestorResult, oursResult, theirsResult, workdirResult] = await Promise.all([
-        this.conflictFile.ancestor?.oid
-          ? gitService.getBlobContent(this.repositoryPath, this.conflictFile.ancestor.oid)
+        file.ancestor?.oid
+          ? gitService.getBlobContent(this.repositoryPath, file.ancestor.oid)
           : Promise.resolve({ success: true, data: '' }),
-        this.conflictFile.ours?.oid
-          ? gitService.getBlobContent(this.repositoryPath, this.conflictFile.ours.oid)
+        file.ours?.oid
+          ? gitService.getBlobContent(this.repositoryPath, file.ours.oid)
           : Promise.resolve({ success: true, data: '' }),
-        this.conflictFile.theirs?.oid
-          ? gitService.getBlobContent(this.repositoryPath, this.conflictFile.theirs.oid)
+        file.theirs?.oid
+          ? gitService.getBlobContent(this.repositoryPath, file.theirs.oid)
           : Promise.resolve({ success: true, data: '' }),
-        gitService.readFileContent(this.repositoryPath, this.conflictFile.path),
+        gitService.readFileContent(this.repositoryPath, file.path),
       ]);
+
+      // A newer load superseded this one while it was awaiting.
+      if (epoch !== this.loadEpoch) return;
 
       this.baseContent = ancestorResult.success ? (ancestorResult.data || '') : '';
       this.oursContent = oursResult.success ? (oursResult.data || '') : '';
@@ -643,19 +660,26 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       // A side with no entry (add/add conflicts have no ancestor; delete/modify
       // conflicts miss one side) has ZERO lines — ''.split('\n') would invent a
       // phantom blank line that misaligns and miscolors the panes.
-      this.baseLines = this.conflictFile.ancestor ? this.baseContent.split('\n') : [];
-      this.oursLines = this.conflictFile.ours ? this.oursContent.split('\n') : [];
-      this.theirsLines = this.conflictFile.theirs ? this.theirsContent.split('\n') : [];
+      this.baseLines = file.ancestor ? this.baseContent.split('\n') : [];
+      this.oursLines = file.ours ? this.oursContent.split('\n') : [];
+      this.theirsLines = file.theirs ? this.theirsContent.split('\n') : [];
       this.alignmentRows = alignThreeWay(this.baseLines, this.oursLines, this.theirsLines);
 
       // A failed read of a side that EXISTS must not masquerade as empty
       // content — the panes would lie and whole-file Use Ours/Theirs would
       // truncate the file. Route it to the same Retry state as a failed
-      // workdir read.
+      // workdir read, track which pane failed, and drop its fabricated
+      // ''-split line so nothing renders as fake content.
+      this.sideReadErrors = {
+        base: !!file.ancestor?.oid && !ancestorResult.success,
+        ours: !!file.ours?.oid && !oursResult.success,
+        theirs: !!file.theirs?.oid && !theirsResult.success,
+      };
+      if (this.sideReadErrors.base) this.baseLines = [];
+      if (this.sideReadErrors.ours) this.oursLines = [];
+      if (this.sideReadErrors.theirs) this.theirsLines = [];
       const sideReadFailed =
-        (!!this.conflictFile.ancestor?.oid && !ancestorResult.success) ||
-        (!!this.conflictFile.ours?.oid && !oursResult.success) ||
-        (!!this.conflictFile.theirs?.oid && !theirsResult.success);
+        this.sideReadErrors.base || this.sideReadErrors.ours || this.sideReadErrors.theirs;
 
       // Only git's own merge output is trustworthy. If the working directory
       // file can't be read, show an error state — never fabricate a merge.
@@ -669,10 +693,15 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       }
     } catch (err) {
       console.error('Failed to load conflict contents:', err);
-      this.segments = [];
-      this.loadFailed = true;
+      if (epoch === this.loadEpoch) {
+        this.segments = [];
+        this.loadFailed = true;
+      }
     } finally {
-      this.loading = false;
+      // A superseding load owns the loading flag now — don't clear it early.
+      if (epoch === this.loadEpoch) {
+        this.loading = false;
+      }
     }
   }
 
@@ -892,6 +921,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   // ── Whole-file operations ─────────────────────────────────────────────
 
   private acceptWholeFile(origin: 'ours' | 'theirs' | 'base'): void {
+    // With a failed load the side contents are not trustworthy — accepting
+    // one would replace the segments with fabricated (possibly empty) text.
+    if (this.loadFailed) return;
+
     // A side with no entry DELETED the file — accepting it means staging the
     // deletion, not writing a 0-byte file from its empty content.
     if (
@@ -966,7 +999,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         }
         this.updateSegment(id, {
           type: 'resolved',
-          lines: result.data.resolvedContent.split('\n'),
+          // An empty suggestion means ZERO lines (remove the section) —
+          // ''.split('\n') would fabricate one blank line.
+          lines: result.data.resolvedContent === '' ? [] : result.data.resolvedContent.split('\n'),
           origin: 'ai',
           fromConflict: true,
         });
@@ -1022,6 +1057,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     }
     if (this.conflictCount > 0) {
       showToast('Resolve all conflict blocks before marking the file resolved', 'warning');
+      return;
+    }
+    // An open inline edit holds an unapplied draft — writing now would stage
+    // the PRE-edit text while the screen shows the draft, silently losing it.
+    if (this.editingSegmentId !== null) {
+      showToast('Apply or cancel the open edit before marking the file resolved', 'warning');
       return;
     }
 
@@ -1152,6 +1193,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
   /** Render one source pane from the shared three-way alignment rows. */
   private renderAlignedPane(side: 'ours' | 'base' | 'theirs'): ReturnType<typeof html> {
+    if (this.sideReadErrors[side]) {
+      return html`
+        <div class="output-error">
+          <div>Could not read this version.</div>
+        </div>
+      `;
+    }
+
     const sideLines =
       side === 'ours' ? this.oursLines : side === 'theirs' ? this.theirsLines : this.baseLines;
 
@@ -1457,7 +1506,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             Reload
           </button>
           ${this.conflictFile.ancestor
-            ? html`<button class="btn" @click=${this.handleAcceptBase} title="Reset to common ancestor">
+            ? html`<button class="btn" @click=${this.handleAcceptBase} ?disabled=${this.loadFailed} title="Reset to common ancestor">
                 Use Base
               </button>`
             : nothing}
@@ -1465,14 +1514,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             ? html`<button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} title="Ours deleted this file — keep it deleted">
                 Use Ours (delete file)
               </button>`
-            : html`<button class="btn btn-ours" @click=${this.handleAcceptOurs} title="Use entire file from ${labels.ours}">
+            : html`<button class="btn btn-ours" @click=${this.handleAcceptOurs} ?disabled=${this.loadFailed} title="Use entire file from ${labels.ours}">
                 Use Ours
               </button>`}
           ${this.conflictFile && !this.conflictFile.theirs
             ? html`<button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} title="Theirs deleted this file — delete it">
                 Use Theirs (delete file)
               </button>`
-            : html`<button class="btn btn-theirs" @click=${this.handleAcceptTheirs} title="Use entire file from ${labels.theirs}">
+            : html`<button class="btn btn-theirs" @click=${this.handleAcceptTheirs} ?disabled=${this.loadFailed} title="Use entire file from ${labels.theirs}">
                 Use Theirs
               </button>`}
           ${this.aiAvailable && conflictCount > 0 ? html`
@@ -1488,10 +1537,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <button
             class="btn btn-primary"
             @click=${this.handleMarkResolved}
-            ?disabled=${conflictCount > 0 || this.loadFailed}
+            ?disabled=${conflictCount > 0 || this.loadFailed || this.editingSegmentId !== null}
             title=${conflictCount > 0
               ? `Resolve the remaining ${conflictCount} conflict${conflictCount === 1 ? '' : 's'} first`
-              : 'Stage this file as resolved'}
+              : this.editingSegmentId !== null
+                ? 'Apply or cancel the open edit first'
+                : 'Stage this file as resolved'}
           >
             Mark Resolved
           </button>
@@ -1503,9 +1554,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <div class="editor-panel">
             <div class="panel-header ours">
               ${labels.ours}
-              <span class="panel-stats">${this.formatChangeCount(this.getChangeCount('ours'))}</span>
-              <button class="panel-header-btn" @click=${this.handleAcceptOurs} title="Use this version">
-                Use
+              <span class="panel-stats">
+                ${this.sideReadErrors.ours ? 'read failed' : this.formatChangeCount(this.getChangeCount('ours'))}
+              </span>
+              <button
+                class="panel-header-btn"
+                @click=${this.conflictFile.ours ? this.handleAcceptOurs : () => this.handleTakeSide('ours')}
+                ?disabled=${this.loadFailed}
+                title=${this.conflictFile.ours ? 'Use this version' : 'This side deleted the file — stage the deletion'}
+              >
+                ${this.conflictFile.ours ? 'Use' : 'Use (delete)'}
               </button>
             </div>
             <div class="panel-content readonly" id="panel-ours" @scroll=${this.handleSourceScroll}>
@@ -1526,9 +1584,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <div class="editor-panel">
             <div class="panel-header theirs">
               ${labels.theirs}
-              <span class="panel-stats">${this.formatChangeCount(this.getChangeCount('theirs'))}</span>
-              <button class="panel-header-btn" @click=${this.handleAcceptTheirs} title="Use this version">
-                Use
+              <span class="panel-stats">
+                ${this.sideReadErrors.theirs ? 'read failed' : this.formatChangeCount(this.getChangeCount('theirs'))}
+              </span>
+              <button
+                class="panel-header-btn"
+                @click=${this.conflictFile.theirs ? this.handleAcceptTheirs : () => this.handleTakeSide('theirs')}
+                ?disabled=${this.loadFailed}
+                title=${this.conflictFile.theirs ? 'Use this version' : 'This side deleted the file — stage the deletion'}
+              >
+                ${this.conflictFile.theirs ? 'Use' : 'Use (delete)'}
               </button>
             </div>
             <div class="panel-content readonly" id="panel-theirs" @scroll=${this.handleSourceScroll}>
@@ -1540,9 +1605,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         <div class="output-panel">
           <div class="panel-header output">
             Output
-            ${conflictCount > 0
-              ? html`<span class="conflict-count">${conflictCount} conflict${conflictCount === 1 ? '' : 's'} remaining</span>`
-              : html`<span class="conflict-count">No conflicts</span>`}
+            ${this.loadFailed
+              ? html`<span class="conflict-count">load failed</span>`
+              : conflictCount > 0
+                ? html`<span class="conflict-count">${conflictCount} conflict${conflictCount === 1 ? '' : 's'} remaining</span>`
+                : html`<span class="conflict-count">No conflicts</span>`}
           </div>
           <div class="panel-content" id="panel-output" @scroll=${this.handleOutputScroll}>
             ${this.renderOutput()}

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -788,6 +788,19 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       // type, not truthiness.
       if (!sideReadFailed && workdirResult.success && typeof workdirResult.data === 'string') {
         this.segments = this.parseSegments(workdirResult.data);
+      } else if (
+        !workdirResult.success &&
+        (!file.ours || !file.theirs) &&
+        (await this.isResolvedDeletion(file.path))
+      ) {
+        // RE-SELECTING a file already resolved as a deletion: the workdir
+        // read fails because the file is correctly GONE. The generic error
+        // state would present the success as a failure — with a Retry that
+        // loops forever and a verbatim button that resurrects the staged
+        // deletion. Land in the terminal deleted state instead.
+        if (epoch !== this.loadEpoch) return;
+        this.segments = [];
+        this.resolvedAsDeleted = true;
       } else {
         this.segments = [];
         this.loadFailed = true;
@@ -804,6 +817,18 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         this.loading = false;
       }
     }
+  }
+
+  /**
+   * True when `path`'s deletion is already STAGED: the file has a missing
+   * side, the workdir copy is gone, and the index no longer lists it as
+   * conflicted. Distinguishes a resolved deletion from a genuine read
+   * failure.
+   */
+  private async isResolvedDeletion(path: string): Promise<boolean> {
+    if (!this.repositoryPath) return false;
+    const conflicts = await gitService.getConflicts(this.repositoryPath);
+    return conflicts.success && !(conflicts.data ?? []).some((c) => c.path === path);
   }
 
   /**
@@ -838,7 +863,77 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    * Lines are compared with a trailing CR stripped so CRLF files parse, but
    * content lines are stored verbatim to round-trip their line endings.
    */
+  /**
+   * Parse using the backend's authoritative marker positions. Returns null
+   * when the positions don't describe this text (out of range, unordered,
+   * or not pointing at marker-shaped lines) — the caller then falls back
+   * to the validated shape heuristics.
+   */
+  private parseSegmentsFromHunks(
+    text: string,
+    hunks: NonNullable<ConflictFile['conflictHunks']>,
+  ): OutputSegment[] | null {
+    const markerSize = this.effectiveMarkerSize;
+    const stripCr = (l: string): string => (l.endsWith('\r') ? l.slice(0, -1) : l);
+    const runIs = (l: string, ch: string): boolean => {
+      const s = stripCr(l);
+      let n = 0;
+      while (n < s.length && s[n] === ch) n++;
+      return n === markerSize && (s.length === n || s[n] === ' ');
+    };
+    const lines = text.split('\n');
+    const ordered = [...hunks].sort((a, b) => a.start - b.start);
+
+    const segments: OutputSegment[] = [];
+    let cursor = 0;
+    for (const h of ordered) {
+      const base = h.base ?? null;
+      // Sanity: markers must be ordered, in range, and actually marker-shaped.
+      if (
+        h.start < cursor ||
+        h.end >= lines.length ||
+        h.start >= h.separator ||
+        h.separator >= h.end ||
+        (base !== null && (base <= h.start || base >= h.separator)) ||
+        !runIs(lines[h.start], '<') ||
+        stripCr(lines[h.separator]) !== '='.repeat(markerSize) ||
+        !runIs(lines[h.end], '>') ||
+        (base !== null && !runIs(lines[base], '|'))
+      ) {
+        return null;
+      }
+      if (h.start > cursor) {
+        segments.push(this.makeResolvedSegment(lines.slice(cursor, h.start), null, false));
+      }
+      segments.push({
+        id: this.nextSegmentId++,
+        type: 'conflict',
+        lines: [],
+        oursLines: lines.slice(h.start + 1, base ?? h.separator),
+        theirsLines: lines.slice(h.separator + 1, h.end),
+        oursLabel: stripCr(lines[h.start]).slice(markerSize).trim() || 'OURS',
+        theirsLabel: stripCr(lines[h.end]).slice(markerSize).trim() || 'THEIRS',
+        origin: null,
+        fromConflict: false,
+      });
+      cursor = h.end + 1;
+    }
+    if (cursor < lines.length) {
+      segments.push(this.makeResolvedSegment(lines.slice(cursor), null, false));
+    }
+    return segments;
+  }
+
   private parseSegments(text: string): OutputSegment[] {
+    // AUTHORITATIVE positions from the backend's collision-free replay win
+    // outright — position-based parsing cannot be confused by content that
+    // quotes marker lines, even byte-identical ones. Heuristics remain for
+    // hand-edited files (no replay match) and malformed position data.
+    const hunks = this.conflictFile?.conflictHunks;
+    if (hunks && hunks.length > 0) {
+      const fromHunks = this.parseSegmentsFromHunks(text, hunks);
+      if (fromHunks) return fromHunks;
+    }
     const markerSize = this.effectiveMarkerSize;
     const stripCr = (l: string): string => (l.endsWith('\r') ? l.slice(0, -1) : l);
     /**
@@ -2063,6 +2158,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   private renderBinaryConflict(): ReturnType<typeof html> {
     if (!this.conflictFile) {
       return html`<div class="empty">Select a file to resolve</div>`;
+    }
+    // Same terminal notice as the text path — without it, a binary
+    // deletion take on the last file leaves the "Choose which version to
+    // keep" prompt on screen with both buttons dead forever.
+    if (this.resolvedAsDeleted) {
+      return html`
+        <div class="loading">
+          Resolved — this file was deleted by the resolution. Nothing further to do here.
+        </div>
+      `;
     }
 
     const oursDeleted = !this.conflictFile.ours;

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -992,6 +992,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         resolvedAfter.slice(0, 20).join('\n') || undefined,
       );
 
+      // The user may have resolved this block manually while the call was in
+      // flight — their explicit pick wins; never overwrite it. Not a failure,
+      // so Resolve All continues past it.
+      const current = this.segments.find((s) => s.id === id);
+      if (!current || current.type !== 'conflict') return true;
+
       if (result.success && result.data) {
         // AI output bypasses parseSegments, so it must be validated here:
         // a suggestion that echoes marker lines would otherwise render them

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -1185,6 +1185,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       const body: string[] = [];
       let seenSep = false;
       let firstCandidate: { end: number; body: string[] } | null = null;
+      let orphanTerminator: { end: number; body: string[] } | null = null;
       let weakCandidate: { end: number; split: { ours: string[]; theirs: string[] } } | null =
         null;
       let closed: { end: number; split: { ours: string[]; theirs: string[] } | null } | null =
@@ -1242,6 +1243,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           if (split && !weakCandidate && !orphanMarkerAfter(j)) {
             weakCandidate = { end: j, split };
           }
+          // Even when nothing blob-justifies a split (the hand edit also
+          // changed body lines), remember the orphan marker as a region
+          // TERMINATOR: if no real separator+end ever shows up below, the
+          // region must close here rather than sweep this line into the
+          // ours pane as visible marker text.
+          if (!orphanTerminator) {
+            orphanTerminator = { end: j, body: [...body] };
+          }
           body.push(l);
           continue;
         }
@@ -1282,6 +1291,19 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           labelOf(lines[firstCandidate.end], 'THEIRS'),
         );
         i = firstCandidate.end + 1;
+      } else if (orphanTerminator) {
+        // The only end-shaped evidence is an ORPHAN real end marker with
+        // no separator anywhere below it (a hand edit deleted the
+        // `=======` AND changed body lines, so no split blob-justified).
+        // The marker is still the region's terminator — closing here keeps
+        // it out of the panes; falling through to the unterminated case
+        // would render it verbatim inside the ours side.
+        pushConflict(
+          validSplitOf(orphanTerminator.body) ?? fallbackSplitOf(orphanTerminator.body),
+          oursLabel,
+          labelOf(lines[orphanTerminator.end], 'THEIRS'),
+        );
+        i = orphanTerminator.end + 1;
       } else {
         // Unterminated conflict (truncated file) — keep it as a conflict
         // block rather than silently promoting marker content to resolved
@@ -2364,6 +2386,22 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     const theirs = this.conflictFile.theirs;
     const labels = SIDE_LABELS[this.operationType] ?? SIDE_LABELS.merge;
     const short = (oid?: string): string => (oid ? oid.slice(0, 7) : '');
+    // A submodule↔file TYPE conflict routes here too (any side being a
+    // gitlink does) — the non-gitlink side's OID is a BLOB, and formatting
+    // it like a commit pointer would mislead.
+    const isLinkSide = (e: typeof ours): boolean => e?.mode === 0o160000;
+    const sideDesc = (e: typeof ours): ReturnType<typeof html> | string =>
+      !e
+        ? 'submodule removed'
+        : isLinkSide(e)
+          ? html`commit <code>${short(e.oid)}</code>`
+          : 'a regular file';
+    const buttonLabel = (e: typeof ours, name: string): string =>
+      !e
+        ? `Use ${name} (remove submodule)`
+        : isLinkSide(e)
+          ? `Use ${name} (${short(e.oid)})`
+          : `Use ${name} (file)`;
 
     return html`
       <div class="toolbar">
@@ -2374,20 +2412,20 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <strong>Submodule conflict</strong>
         </div>
         <div style="font-style: normal; text-align: center; max-width: 420px;">
-          Each side records a different commit for this submodule. Choose which commit to
-          keep — the submodule's own files are not changed here (update the submodule
-          afterwards to check the chosen commit out).
+          The sides disagree about this submodule. Choose which version to keep — the
+          submodule's own files are not changed here (update the submodule afterwards to
+          check a chosen commit out).
         </div>
         <div style="font-style: normal; text-align: center; max-width: 420px;">
-          ${labels.ours}: ${ours ? html`<code>${short(ours.oid)}</code>` : 'submodule removed'}<br />
-          ${labels.theirs}: ${theirs ? html`<code>${short(theirs.oid)}</code>` : 'submodule removed'}
+          ${labels.ours}: ${sideDesc(ours)}<br />
+          ${labels.theirs}: ${sideDesc(theirs)}
         </div>
         <div class="toolbar-actions">
           <button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} ?disabled=${this.actionsBlocked}>
-            ${ours ? `Use Ours (${short(ours.oid)})` : 'Use Ours (remove submodule)'}
+            ${buttonLabel(ours, 'Ours')}
           </button>
           <button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} ?disabled=${this.actionsBlocked}>
-            ${theirs ? `Use Theirs (${short(theirs.oid)})` : 'Use Theirs (remove submodule)'}
+            ${buttonLabel(theirs, 'Theirs')}
           </button>
         </div>
       </div>

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -853,11 +853,68 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     const segments: OutputSegment[] = [];
     let currentResolved: string[] = [];
     let inConflict = false;
-    let section: 'ours' | 'base' | 'theirs' = 'ours';
-    let oursLines: string[] = [];
-    let theirsLines: string[] = [];
+    let seenSeparator = false;
+    let body: string[] = [];
     let oursLabel = '';
     let theirsLabel = '';
+
+    /** True when `needle` appears as a consecutive slice of `hay`
+     * (CR-insensitively — the workdir may be CRLF while blobs are LF). */
+    const isContiguousRun = (needle: string[], hay: string[]): boolean => {
+      if (needle.length === 0) return true;
+      const n = needle.map(stripCr);
+      outer: for (let i = 0; i + n.length <= hay.length; i++) {
+        for (let j = 0; j < n.length; j++) {
+          if (stripCr(hay[i + j]) !== n[j]) continue outer;
+        }
+        return true;
+      }
+      return false;
+    };
+
+    /**
+     * Split a conflict block's raw body (the lines between the start and
+     * end markers) into ours/theirs. Content shaped exactly like the
+     * separator — a Markdown setext underline is `=======` — is
+     * indistinguishable from git's separator by shape alone, so when more
+     * than one candidate exists each split is validated against the
+     * ours/theirs blob contents: each side of a hunk is a contiguous slice
+     * of its blob. The first candidate whose BOTH sides validate wins;
+     * with no valid candidate the first is kept (blobs unavailable).
+     */
+    const splitConflictBody = (b: string[]): { ours: string[]; theirs: string[] } => {
+      const baseIdxBefore = (limit: number): number => {
+        for (let i = 0; i < limit; i++) {
+          if (isBaseMarker(b[i])) return i;
+        }
+        return -1;
+      };
+      const oursUpTo = (limit: number): string[] => {
+        const bi = baseIdxBefore(limit);
+        // diff3 base sections (between ||||||| and the separator) are
+        // discarded — never leak base into ours.
+        return b.slice(0, bi < 0 ? limit : bi);
+      };
+      const candidates: number[] = [];
+      for (let i = 0; i < b.length; i++) {
+        if (isSeparator(b[i])) candidates.push(i);
+      }
+      if (candidates.length === 0) {
+        // Unterminated at EOF before any separator — everything is ours.
+        return { ours: oursUpTo(b.length), theirs: [] };
+      }
+      if (candidates.length > 1) {
+        for (const s of candidates) {
+          const ours = oursUpTo(s);
+          const theirs = b.slice(s + 1);
+          if (isContiguousRun(ours, this.oursLines) && isContiguousRun(theirs, this.theirsLines)) {
+            return { ours, theirs };
+          }
+        }
+      }
+      const s = candidates[0];
+      return { ours: oursUpTo(s), theirs: b.slice(s + 1) };
+    };
 
     const flushResolved = (): void => {
       if (currentResolved.length > 0) {
@@ -866,12 +923,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       }
     };
     const pushConflict = (): void => {
+      const { ours, theirs } = splitConflictBody(body);
       segments.push({
         id: this.nextSegmentId++,
         type: 'conflict',
         lines: [],
-        oursLines: [...oursLines],
-        theirsLines: [...theirsLines],
+        oursLines: ours,
+        theirsLines: theirs,
         oursLabel,
         theirsLabel,
         origin: null,
@@ -884,37 +942,25 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       if (!inConflict && isConflictStart(line)) {
         flushResolved();
         inConflict = true;
-        section = 'ours';
-        oursLines = [];
-        theirsLines = [];
+        seenSeparator = false;
+        body = [];
         oursLabel = stripCr(line).slice(markerSize).trim() || 'OURS';
         theirsLabel = '';
-      } else if (inConflict && section === 'ours' && isBaseMarker(line)) {
-        // diff3 common-ancestor marker — begin discarding base lines. Only
-        // valid directly after the ours section; anywhere else it's content.
-        section = 'base';
-      } else if (inConflict && section !== 'theirs' && isSeparator(line)) {
-        section = 'theirs';
-      } else if (inConflict && section === 'theirs' && isConflictEnd(line)) {
+      } else if (inConflict && seenSeparator && isConflictEnd(line)) {
         // Git always emits '=======' before '>>>>>>>', so an end marker is
-        // only valid in the theirs section — anywhere earlier it's content
-        // (a quoted diff, docs about conflicts) and treating it as the end
-        // would drop the real theirs side and leak the true markers.
+        // only valid once a separator was seen — anywhere earlier it's
+        // content (a quoted diff, docs about conflicts) and treating it as
+        // the end would drop the real theirs side and leak the true markers.
         theirsLabel = stripCr(line).slice(markerSize).trim() || 'THEIRS';
         pushConflict();
         inConflict = false;
-        section = 'ours';
-        oursLines = [];
-        theirsLines = [];
+        body = [];
       } else if (inConflict) {
-        // A nested '<<<<<<<' (or any non-marker line) while already inside a
-        // conflict is treated as content, not as a new conflict start.
-        if (section === 'ours') {
-          oursLines.push(line);
-        } else if (section === 'theirs') {
-          theirsLines.push(line);
-        }
-        // section === 'base': discard — never leak base into ours
+        // Everything between the start and end markers — including nested
+        // '<<<<<<<' lines, separator candidates, and diff3 base sections —
+        // is collected raw; splitConflictBody derives the ours/theirs split.
+        if (isSeparator(line)) seenSeparator = true;
+        body.push(line);
       } else {
         currentResolved.push(line);
       }
@@ -1079,8 +1125,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       if (!proceed) return;
       // The confirm awaited — the edit may have been closed or retargeted
       // by a file switch in the meantime; applying a stale draft would
-      // write it into the wrong segment.
+      // write it into the wrong segment. A resolve/tool session may also
+      // have started while the confirm was up (same re-check as Reload).
       if (this.editingSegmentId !== id || !this.segments.some((s) => s.id === id)) return;
+      if (this.actionsBlocked) return;
     }
 
     this.clearAiExplanation(id);
@@ -1108,12 +1156,36 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
   // ── Whole-file operations ─────────────────────────────────────────────
 
-  private acceptWholeFile(origin: 'ours' | 'theirs' | 'base'): void {
+  /**
+   * True when it is safe to throw away an open inline-edit draft: no edit
+   * is open, or the user confirmed the discard. Whole-file operations
+   * replace ALL segments, so a typed-but-unapplied draft would vanish
+   * silently without this — the same hazard Reload and file switches
+   * already confirm for.
+   */
+  private async confirmDiscardOpenEdit(): Promise<boolean> {
+    if (this.editingSegmentId === null) return true;
+    return showConfirm(
+      'Discard the open edit?',
+      'This section has an edit that was not applied — continuing discards the typed text.',
+      'warning',
+    );
+  }
+
+  private async acceptWholeFile(origin: 'ours' | 'theirs' | 'base'): Promise<void> {
     // With a failed load the side contents are not trustworthy — accepting
     // one would replace the segments with fabricated (possibly empty) text.
     // Blocked during resolve writes / tool sessions like every other
-    // in-memory mutation (the take-side delegation below re-checks too).
+    // in-memory mutation.
     if (this.loadFailed || this.actionsBlocked) return;
+    if (this.editingSegmentId !== null) {
+      if (!(await this.confirmDiscardOpenEdit())) return;
+      // Re-check after the confirm's await — a resolve/tool session may
+      // have started while it was up (same re-check as Reload and Apply).
+      if (this.loadFailed || this.actionsBlocked) return;
+      this.editingSegmentId = null;
+      this.editDraft = '';
+    }
 
     // A side with no entry DELETED the file — accepting it means staging the
     // deletion, not writing a 0-byte file from its empty content.
@@ -1127,21 +1199,20 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
     const content =
       origin === 'ours' ? this.oursContent : origin === 'theirs' ? this.theirsContent : this.baseContent;
-    this.editingSegmentId = null;
     this.userTouched = true;
     this.segments = [this.makeResolvedSegment(content.split('\n'), origin, false)];
   }
 
   private handleAcceptOurs(): void {
-    this.acceptWholeFile('ours');
+    void this.acceptWholeFile('ours');
   }
 
   private handleAcceptTheirs(): void {
-    this.acceptWholeFile('theirs');
+    void this.acceptWholeFile('theirs');
   }
 
   private handleAcceptBase(): void {
-    this.acceptWholeFile('base');
+    void this.acceptWholeFile('base');
   }
 
   /** Re-read the on-disk merge, discarding all in-editor resolutions. */
@@ -1346,6 +1417,16 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    */
   private async handleTakeSide(side: 'ours' | 'theirs'): Promise<void> {
     if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
+    // Taking a side writes the whole file — an open typed-but-unapplied
+    // draft would vanish silently. (The acceptWholeFile delegation already
+    // confirmed and cleared the edit, so this only fires for the direct
+    // deleted-side buttons.)
+    if (this.editingSegmentId !== null) {
+      if (!(await this.confirmDiscardOpenEdit())) return;
+      if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
+      this.editingSegmentId = null;
+      this.editDraft = '';
+    }
 
     // Same capture-before-await as handleMarkResolved: the dispatched file
     // must be the one the call actually resolved.
@@ -1693,6 +1774,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       // only a side blob was unreadable would be wrong and alarming.
       const sideFailed =
         this.sideReadErrors.base || this.sideReadErrors.ours || this.sideReadErrors.theirs;
+      const labels = SIDE_LABELS[this.operationType] ?? SIDE_LABELS.merge;
       return html`
         <div class="output-error">
           <div>
@@ -1701,6 +1783,34 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               : 'Could not read the merged file from the working directory.'}
           </div>
           <button class="btn btn-primary" @click=${this.handleReload}>Retry</button>
+          ${!sideFailed
+            ? html`
+                <div>
+                  This can happen for text files in a legacy (non-UTF-8) encoding. You can
+                  still resolve the conflict by taking one side verbatim:
+                </div>
+                <div>
+                  ${this.conflictFile?.ours
+                    ? html`<button
+                        class="btn btn-ours"
+                        @click=${() => this.handleTakeSide('ours')}
+                        ?disabled=${this.actionsBlocked}
+                      >
+                        Use ${labels.ours} (verbatim)
+                      </button>`
+                    : nothing}
+                  ${this.conflictFile?.theirs
+                    ? html`<button
+                        class="btn btn-theirs"
+                        @click=${() => this.handleTakeSide('theirs')}
+                        ?disabled=${this.actionsBlocked}
+                      >
+                        Use ${labels.theirs} (verbatim)
+                      </button>`
+                    : nothing}
+                </div>
+              `
+            : nothing}
         </div>
       `;
     }

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -664,6 +664,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         this.externalToolLocked ||
         this.resolving ||
         this.resolvedAsDeleted ||
+        this.resolvedInPlace ||
         this.conflictFile !== file
       ) {
         this.launchingExternalTool = false;
@@ -1030,7 +1031,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     const hunks = this.conflictFile?.conflictHunks;
     if (hunks && hunks.length > 0) {
       const fromHunks = this.parseSegmentsFromHunks(text, hunks);
-      if (fromHunks) return fromHunks;
+      // The safety net applies to the position-based output too: its hunk
+      // positions are fetched once at open and NOT refreshed by Reload, so
+      // an externally-added marker block OUTSIDE the original hunk range
+      // would be swept into a resolved segment and rendered raw.
+      if (fromHunks) return this.enforceNoOrphanMarkers(fromHunks);
     }
     const markerSize = this.effectiveMarkerSize;
     const stripCr = (l: string): string => (l.endsWith('\r') ? l.slice(0, -1) : l);
@@ -1383,40 +1388,56 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     }
     flushResolved();
 
-    // Invariant-1 safety net. The region scan above only OPENS on a
-    // start-shaped line, so a hand edit that deleted the `<<<<<<<` (leaving
-    // an orphaned `=======`/`>>>>>>>`) sweeps those markers into resolved
-    // text — a raw marker in the UI. If any resolved segment carries a
-    // marker-shaped line that is in NEITHER blob (a real orphaned marker,
-    // not quoted content), the heuristic parse is unreliable: present the
-    // whole file as a single unresolved conflict (ours vs theirs from the
-    // blobs) so it is resolved cleanly and no marker is ever displayed. The
-    // user's on-disk hand edits are untouched (Reload re-reads them).
-    if (blobsAvailable) {
-      const echo = this.markerEchoPattern();
-      const hasOrphanMarker = segments.some(
-        (s) =>
-          s.type === 'resolved' &&
-          s.lines.some((l) => echo.test(l) && !this.lineIsBlobContent(l)),
-      );
-      if (hasOrphanMarker) {
-        return [
-          {
-            id: this.nextSegmentId++,
-            type: 'conflict',
-            lines: [],
-            oursLines: this.oursLines,
-            theirsLines: this.theirsLines,
-            oursLabel: 'OURS',
-            theirsLabel: 'THEIRS',
-            origin: null,
-            fromConflict: false,
-          },
-        ];
-      }
-    }
+    return this.enforceNoOrphanMarkers(segments);
+  }
 
-    return segments;
+  /**
+   * Invariant-1 safety net, applied to BOTH parser paths. A hand edit can
+   * delete a `<<<<<<<` start marker (leaving an orphaned `=======`/`>>>>>>>`
+   * the region scan sweeps into RESOLVED text), and a fallback split can
+   * push an unvalidated marker line into a CONFLICT pane — either renders a
+   * raw marker. If ANY segment carries a marker-shaped line that is in NO
+   * blob (a real orphaned marker, not quoted content), the parse is
+   * unreliable: present the whole file as one unresolved conflict (ours vs
+   * theirs from the blobs) so it is resolved cleanly and no marker is ever
+   * displayed. The user's on-disk hand edits are untouched (Reload re-reads
+   * them).
+   */
+  private enforceNoOrphanMarkers(segments: OutputSegment[]): OutputSegment[] {
+    const blobsAvailable = this.oursLines.length > 0 || this.theirsLines.length > 0;
+    if (!blobsAvailable) return segments;
+    const echo = this.markerEchoPattern();
+    // A conflict side's content is everything BETWEEN markers, so a START
+    // marker (`<<<<<<<`) inside a pane is always a swept orphan (a fallback
+    // split pulled a nested/orphaned start into content) — a leak. An
+    // end/separator SHAPE in a side can be legitimate hand-typed content
+    // the parser deliberately keeps, so only start shapes are flagged in
+    // panes. Blob content (a quoted example) is never flagged.
+    const n = Math.min(7, this.effectiveMarkerSize);
+    const startEcho = new RegExp(`^<{${n},}( |\\r?$)`);
+    const orphanResolved = (lines: string[]): boolean =>
+      lines.some((l) => echo.test(l) && !this.lineIsBlobContent(l));
+    const orphanPane = (lines: string[]): boolean =>
+      lines.some((l) => startEcho.test(l) && !this.lineIsBlobContent(l));
+    const hasOrphanMarker = segments.some((s) =>
+      s.type === 'resolved'
+        ? orphanResolved(s.lines)
+        : orphanPane(s.oursLines) || orphanPane(s.theirsLines),
+    );
+    if (!hasOrphanMarker) return segments;
+    return [
+      {
+        id: this.nextSegmentId++,
+        type: 'conflict',
+        lines: [],
+        oursLines: this.oursLines,
+        theirsLines: this.theirsLines,
+        oursLabel: 'OURS',
+        theirsLabel: 'THEIRS',
+        origin: null,
+        fromConflict: false,
+      },
+    ];
   }
 
   private makeResolvedSegment(

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -801,7 +801,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    */
   private get effectiveMarkerSize(): number {
     const size = this.conflictFile?.markerSize;
-    return typeof size === 'number' && Number.isInteger(size) && size >= 1 ? size : 7;
+    // The backend caps sizes at u16 range; anything beyond that here is a
+    // corrupt value and must not drive giant separator-string allocations.
+    return typeof size === 'number' && Number.isInteger(size) && size >= 1 && size <= 65535
+      ? size
+      : 7;
   }
 
   /**
@@ -834,7 +838,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       return n === markerSize && (s.length === n || s[n] === ' ');
     };
     const isConflictStart = (l: string): boolean => isMarker(l, '<');
-    const isBaseMarker = (l: string): boolean => isMarker(l, '|');
+    // `|||||||` is a base-section marker ONLY in diff3-style emission. In
+    // the default 'merge' style (which is also all libgit2 ever writes) a
+    // pipe run is ours CONTENT — treating it as a marker would silently
+    // discard every ours line after it. The backend reports the style it
+    // verified against the file's actual emission.
+    const diff3 = this.conflictFile?.conflictStyle === 'diff3';
+    const isBaseMarker = (l: string): boolean => diff3 && isMarker(l, '|');
     const isSeparator = (l: string): boolean => stripCr(l) === '='.repeat(markerSize);
     const isConflictEnd = (l: string): boolean => isMarker(l, '>');
 
@@ -996,6 +1006,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   }
 
   private resolveConflictSegment(id: number, choice: 'ours' | 'theirs' | 'both'): void {
+    // In-memory picks are blocked while a resolve write or external tool
+    // session runs: the post-write/post-tool reload would silently destroy
+    // them (the pre-launch confirm only covers picks made BEFORE launch).
+    if (this.actionsBlocked) return;
     const segment = this.segments.find((s) => s.id === id);
     if (!segment || segment.type !== 'conflict') return;
 
@@ -1012,6 +1026,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
   /** Revert a resolved-from-conflict segment back to an open conflict block. */
   private resetSegment(id: number): void {
+    if (this.actionsBlocked) return;
     const segment = this.segments.find((s) => s.id === id);
     if (!segment || !segment.fromConflict) return;
     if (this.editingSegmentId === id) this.editingSegmentId = null;
@@ -1020,6 +1035,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   }
 
   private startEditSegment(segment: OutputSegment): void {
+    if (this.actionsBlocked) return;
     this.editingSegmentId = segment.id;
     // Editing an open conflict starts from both sides so the user trims what
     // they don't want — never from marker text.
@@ -1029,13 +1045,42 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         : segment.lines.join('\n');
   }
 
-  private applyEditSegment(): void {
+  /**
+   * Matches lines that LOOK like conflict markers. Runs of min(7, size)+
+   * cover the default, raised, AND lowered conflict-marker-size cases.
+   * Used to keep marker-shaped text out of resolved output unless the user
+   * explicitly wants it there.
+   */
+  private markerEchoPattern(): RegExp {
+    const n = Math.min(7, this.effectiveMarkerSize);
+    return new RegExp(`^(<{${n},}|={${n},}|>{${n},}|\\|{${n},})( |\\r?$)`, 'm');
+  }
+
+  private async applyEditSegment(): Promise<void> {
+    if (this.actionsBlocked) return;
     const id = this.editingSegmentId;
     if (id === null) return;
     const segment = this.segments.find((s) => s.id === id);
     if (!segment) {
       this.editingSegmentId = null;
       return;
+    }
+
+    // Marker-shaped lines in a hand edit are usually an accidental paste of
+    // raw conflict text — writing them back would defeat the whole editor.
+    // But they CAN be legitimate (a Markdown setext underline is exactly
+    // `=======`), so unlike the AI path this confirms instead of blocking.
+    if (this.markerEchoPattern().test(this.editDraft)) {
+      const proceed = await showConfirm(
+        'Keep conflict-marker-like text?',
+        'Your edit contains lines that look like git conflict markers. If you pasted raw conflict text, cancel and remove the marker lines; if the text is intentional it will be kept as-is.',
+        'warning',
+      );
+      if (!proceed) return;
+      // The confirm awaited — the edit may have been closed or retargeted
+      // by a file switch in the meantime; applying a stale draft would
+      // write it into the wrong segment.
+      if (this.editingSegmentId !== id || !this.segments.some((s) => s.id === id)) return;
     }
 
     this.clearAiExplanation(id);
@@ -1066,7 +1111,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   private acceptWholeFile(origin: 'ours' | 'theirs' | 'base'): void {
     // With a failed load the side contents are not trustworthy — accepting
     // one would replace the segments with fabricated (possibly empty) text.
-    if (this.loadFailed) return;
+    // Blocked during resolve writes / tool sessions like every other
+    // in-memory mutation (the take-side delegation below re-checks too).
+    if (this.loadFailed || this.actionsBlocked) return;
 
     // A side with no entry DELETED the file — accepting it means staging the
     // deletion, not writing a 0-byte file from its empty content.
@@ -1099,6 +1146,22 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
   /** Re-read the on-disk merge, discarding all in-editor resolutions. */
   private async handleReload(): Promise<void> {
+    // Reloading mid-write would clear the resolve lock for THIS file and
+    // let a second write race the first; reloading mid-tool-session is the
+    // session's own job when it ends.
+    if (this.actionsBlocked) return;
+    // Reload discards exactly like a file switch does — same confirm.
+    if (this.hasUnsavedResolutions()) {
+      const proceed = await showConfirm(
+        'Discard in-progress resolution?',
+        'Reloading re-reads the file from disk and discards your unsaved picks and edits.',
+        'warning',
+      );
+      if (!proceed) return;
+      // Re-check: a resolve/tool session may have started while the
+      // confirm was up.
+      if (this.actionsBlocked) return;
+    }
     await this.loadContents();
   }
 
@@ -1106,7 +1169,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
   /** Resolve one conflict block via AI. Returns false when the call failed. */
   private async handleSuggestSegment(id: number): Promise<boolean> {
-    if (!this.conflictFile || this.suggestingSegment !== null) return false;
+    if (!this.conflictFile || this.suggestingSegment !== null || this.actionsBlocked) return false;
     const segment = this.segments.find((s) => s.id === id);
     if (!segment || segment.type !== 'conflict') return false;
 
@@ -1142,13 +1205,11 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       if (result.success && result.data) {
         // AI output bypasses parseSegments, so it must be validated here:
         // a suggestion that echoes marker lines would otherwise render them
-        // as "resolved" text and let them be written back to the file. Runs
-        // of min(7, size)+ cover the default, raised, AND lowered
-        // conflict-marker-size cases; being overly conservative here just
-        // leaves the block unresolved, which is safe.
-        const n = Math.min(7, this.effectiveMarkerSize);
-        const markerEcho = new RegExp(`^(<{${n},}|={${n},}|>{${n},}|\\|{${n},})( |\\r?$)`, 'm');
-        if (markerEcho.test(result.data.resolvedContent)) {
+        // as "resolved" text and let them be written back to the file.
+        // Unlike the hand-edit path this hard-blocks — AI output is
+        // untrusted, and being overly conservative just leaves the block
+        // unresolved, which is safe.
+        if (this.markerEchoPattern().test(result.data.resolvedContent)) {
           showToast('AI suggestion contained conflict markers — block left unresolved', 'error');
           return false;
         }
@@ -1183,7 +1244,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   }
 
   private async handleAiResolveAll(): Promise<void> {
-    if (this.suggestingAll) return;
+    if (this.suggestingAll || this.actionsBlocked) return;
 
     const conflictIds = this.segments.filter((s) => s.type === 'conflict').map((s) => s.id);
     if (conflictIds.length === 0) return;
@@ -1469,7 +1530,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         ></textarea>
         <div class="segment-editor-actions">
           <button class="btn" @click=${this.cancelEditSegment}>Cancel</button>
-          <button class="btn btn-primary" @click=${this.applyEditSegment}>Apply</button>
+          <button class="btn btn-primary" @click=${this.applyEditSegment} ?disabled=${this.actionsBlocked}>
+            Apply
+          </button>
         </div>
       </div>
     `;
@@ -1492,6 +1555,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <button
             class="segment-btn"
             @click=${() => this.startEditSegment(segment)}
+            ?disabled=${this.actionsBlocked}
             title="Edit this section"
           >
             Edit
@@ -1501,6 +1565,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
                 <button
                   class="segment-btn"
                   @click=${() => this.resetSegment(segment.id)}
+                  ?disabled=${this.actionsBlocked}
                   title="Undo this resolution and reopen the conflict"
                 >
                   Reset
@@ -1566,24 +1631,28 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             <button
               class="btn btn-ours conflict-pick-btn"
               @click=${() => this.resolveConflictSegment(segment.id, 'ours')}
+              ?disabled=${this.actionsBlocked}
             >
               Use Ours
             </button>
             <button
               class="btn btn-theirs conflict-pick-btn"
               @click=${() => this.resolveConflictSegment(segment.id, 'theirs')}
+              ?disabled=${this.actionsBlocked}
             >
               Use Theirs
             </button>
             <button
               class="btn btn-both conflict-pick-btn"
               @click=${() => this.resolveConflictSegment(segment.id, 'both')}
+              ?disabled=${this.actionsBlocked}
             >
               Use Both
             </button>
             <button
               class="btn conflict-pick-btn"
               @click=${() => this.startEditSegment(segment)}
+              ?disabled=${this.actionsBlocked}
               title="Write this section by hand (starts from both sides)"
             >
               Edit
@@ -1593,7 +1662,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
                   <button
                     class="btn btn-ai conflict-pick-btn"
                     @click=${() => this.handleSuggestSegment(segment.id)}
-                    ?disabled=${this.suggestingSegment !== null || this.suggestingAll}
+                    ?disabled=${this.suggestingSegment !== null ||
+                    this.suggestingAll ||
+                    this.actionsBlocked}
                   >
                     ${isSuggesting ? 'AI...' : 'AI Suggest'}
                   </button>
@@ -1715,12 +1786,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           <button
             class="btn"
             @click=${this.handleReload}
+            ?disabled=${this.actionsBlocked}
             title="Reload the file from disk, discarding resolutions made here"
           >
             Reload
           </button>
           ${this.conflictFile.ancestor
-            ? html`<button class="btn" @click=${this.handleAcceptBase} ?disabled=${this.loadFailed} title="Reset to common ancestor">
+            ? html`<button class="btn" @click=${this.handleAcceptBase} ?disabled=${this.loadFailed || this.actionsBlocked} title="Reset to common ancestor">
                 Use Base
               </button>`
             : nothing}
@@ -1728,21 +1800,23 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             ? html`<button class="btn btn-ours" @click=${() => this.handleTakeSide('ours')} ?disabled=${this.actionsBlocked} title="Ours deleted this file — keep it deleted">
                 Use Ours (delete file)
               </button>`
-            : html`<button class="btn btn-ours" @click=${this.handleAcceptOurs} ?disabled=${this.loadFailed} title="Use entire file from ${labels.ours}">
+            : html`<button class="btn btn-ours" @click=${this.handleAcceptOurs} ?disabled=${this.loadFailed || this.actionsBlocked} title="Use entire file from ${labels.ours}">
                 Use Ours
               </button>`}
           ${this.conflictFile && !this.conflictFile.theirs
             ? html`<button class="btn btn-theirs" @click=${() => this.handleTakeSide('theirs')} ?disabled=${this.actionsBlocked} title="Theirs deleted this file — delete it">
                 Use Theirs (delete file)
               </button>`
-            : html`<button class="btn btn-theirs" @click=${this.handleAcceptTheirs} ?disabled=${this.loadFailed} title="Use entire file from ${labels.theirs}">
+            : html`<button class="btn btn-theirs" @click=${this.handleAcceptTheirs} ?disabled=${this.loadFailed || this.actionsBlocked} title="Use entire file from ${labels.theirs}">
                 Use Theirs
               </button>`}
           ${this.aiAvailable && conflictCount > 0 ? html`
             <button
               class="btn btn-ai"
               @click=${this.handleAiResolveAll}
-              ?disabled=${this.suggestingAll || this.suggestingSegment !== null}
+              ?disabled=${this.suggestingAll ||
+              this.suggestingSegment !== null ||
+              this.actionsBlocked}
               title="Use AI to resolve all remaining conflicts"
             >
               ${this.suggestingAll ? 'AI Resolving...' : 'AI Resolve All'}

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -760,8 +760,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       if (this.sideReadErrors.base) this.baseLines = [];
       if (this.sideReadErrors.ours) this.oursLines = [];
       if (this.sideReadErrors.theirs) this.theirsLines = [];
-      const sideReadFailed =
-        this.sideReadErrors.base || this.sideReadErrors.ours || this.sideReadErrors.theirs;
+      // The BASE blob is never needed for parsing or block resolution
+      // (parseSegments validates only against ours/theirs, and diff3 base
+      // sections are identified by the backend-reported style) — a missing
+      // ancestor object (shallow/partial clone) must not disable the whole
+      // structured editor, only the Use Base button and its pane content.
+      const sideReadFailed = this.sideReadErrors.ours || this.sideReadErrors.theirs;
 
       // Align AFTER dropping failed sides, or the rows would reference lines
       // that no longer exist and pane rendering would crash on them.
@@ -916,19 +920,40 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       if (cs.length === 0) return splitAt(b, b.length);
       return splitAt(b, cs[0]);
     };
+    /** The text after a candidate close, up to the next start-shaped line. */
+    const trailingAfter = (endIdx: number): string[] => {
+      const out: string[] = [];
+      for (let k = endIdx + 1; k < lines.length; k++) {
+        if (isConflictStart(lines[k])) break;
+        out.push(lines[k]);
+      }
+      return out;
+    };
     /**
-     * True when the text after a candidate close (up to the next
-     * start-shaped line) contains a marker-shaped line that is NOT content
-     * from either blob — i.e. a real, orphaned git marker. Closing early
-     * (at a QUOTED end marker inside the theirs section) strands the real
-     * separator/end below as "resolved" text; this detects exactly that.
-     * A validated split alone cannot: a PREFIX of the theirs hunk also
+     * STRONG close justification: everything after the close (up to the
+     * next region) is a contiguous run of some blob — genuinely merged
+     * content. This distinguishes even a quoted marker line that is
+     * TEXTUALLY IDENTICAL to the real end marker (a tutorial quoting
+     * `>>>>>>> feature-branch` while that very branch merges in): closing
+     * at the quoted copy leaves the real marker stranded in the trailing
+     * text, which then matches no blob run.
+     */
+    const trailingIsBlobRun = (endIdx: number): boolean => {
+      const trailing = trailingAfter(endIdx);
+      return (
+        isContiguousRun(trailing, this.oursLines) || isContiguousRun(trailing, this.theirsLines)
+      );
+    };
+    /**
+     * WEAK close justification: the trailing text contains no marker-shaped
+     * line that is absent from both blobs (i.e. no orphaned real marker).
+     * Needed because auto-merged trailing text can mix one-sided insertions
+     * from both blobs and so fail the strong contiguity check. A validated
+     * split alone justifies nothing: a PREFIX of the theirs hunk also
      * validates as contiguous.
      */
     const orphanMarkerAfter = (endIdx: number): boolean => {
-      for (let k = endIdx + 1; k < lines.length; k++) {
-        const l = lines[k];
-        if (isConflictStart(l)) return false;
+      for (const l of trailingAfter(endIdx)) {
         if ((isConflictEnd(l) || isSeparator(l)) && !lineInBlobs(l)) return true;
       }
       return false;
@@ -981,6 +1006,8 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       const body: string[] = [];
       let seenSep = false;
       let firstCandidate: { end: number; body: string[] } | null = null;
+      let weakCandidate: { end: number; split: { ours: string[]; theirs: string[] } } | null =
+        null;
       let closed: { end: number; split: { ours: string[]; theirs: string[] } | null } | null =
         null;
 
@@ -1002,16 +1029,27 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             break;
           }
           const split = validSplitOf(body);
-          if (split && !orphanMarkerAfter(j)) {
+          // STRONG close — decisive even against quoted marker lines that
+          // are textually identical to the real markers, which defeat the
+          // weak (line-membership) orphan test.
+          if (split && trailingIsBlobRun(j)) {
             closed = { end: j, split };
             break;
           }
-          // Rejected — this end-shaped line is content; keep scanning.
+          // WEAK close — remembered, but scanning continues in case a
+          // later candidate closes strongly.
+          if (split && !weakCandidate && !orphanMarkerAfter(j)) {
+            weakCandidate = { end: j, split };
+          }
+          // This end-shaped line may be content; keep scanning.
           body.push(l);
           continue;
         }
         if (isSeparator(l)) seenSep = true;
         body.push(l);
+      }
+      if (!closed && weakCandidate) {
+        closed = weakCandidate;
       }
 
       if (closed && closed.split === null) {
@@ -1254,8 +1292,10 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     // With a failed load the side contents are not trustworthy — accepting
     // one would replace the segments with fabricated (possibly empty) text.
     // Blocked during resolve writes / tool sessions like every other
-    // in-memory mutation.
+    // in-memory mutation. A base-only read failure keeps the editor alive,
+    // so Use Base must check its own side too.
     if (this.loadFailed || this.actionsBlocked) return;
+    if (origin === 'base' && this.sideReadErrors.base) return;
     if (this.editingSegmentId !== null) {
       if (!(await this.confirmDiscardOpenEdit())) return;
       // Re-check after the confirm's await — a resolve/tool session may
@@ -1525,6 +1565,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       );
 
       if (result.success) {
+        // The whole-side write supersedes any in-memory picks made before
+        // it — without this, a resolved LAST file (no auto-advance target)
+        // would flag its stale picks as "unsaved rework" and make Complete
+        // raise a false confirm.
+        if (token === this.resolveToken) {
+          this.userTouched = false;
+        }
         this.dispatchEvent(new CustomEvent('conflict-resolved', {
           detail: { file },
           bubbles: true,
@@ -1994,7 +2041,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
             Reload
           </button>
           ${this.conflictFile.ancestor
-            ? html`<button class="btn" @click=${this.handleAcceptBase} ?disabled=${this.loadFailed || this.actionsBlocked} title="Reset to common ancestor">
+            ? html`<button
+                class="btn"
+                @click=${this.handleAcceptBase}
+                ?disabled=${this.loadFailed || this.actionsBlocked || this.sideReadErrors.base}
+                title=${this.sideReadErrors.base
+                  ? 'The base version could not be read'
+                  : 'Reset to common ancestor'}
+              >
                 Use Base
               </button>`
             : nothing}

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -887,6 +887,15 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         if (epoch !== this.loadEpoch) return;
         this.segments = [];
         this.resolvedAsDeleted = true;
+      } else if ((sideReadFailed || !workdirResult.success) && (await this.isNoLongerConflicted(file.path))) {
+        // RE-SELECTING a text file already resolved via a verbatim take
+        // (its side blob is undecodable): the same reads fail again, but
+        // the file is no longer conflicted. The generic error state would
+        // loop forever on Retry and its verbatim buttons would error "No
+        // conflict found" — present the terminal resolved state instead.
+        if (epoch !== this.loadEpoch) return;
+        this.segments = [];
+        this.resolvedInPlace = true;
       } else {
         this.segments = [];
         this.loadFailed = true;
@@ -1374,6 +1383,39 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     }
     flushResolved();
 
+    // Invariant-1 safety net. The region scan above only OPENS on a
+    // start-shaped line, so a hand edit that deleted the `<<<<<<<` (leaving
+    // an orphaned `=======`/`>>>>>>>`) sweeps those markers into resolved
+    // text — a raw marker in the UI. If any resolved segment carries a
+    // marker-shaped line that is in NEITHER blob (a real orphaned marker,
+    // not quoted content), the heuristic parse is unreliable: present the
+    // whole file as a single unresolved conflict (ours vs theirs from the
+    // blobs) so it is resolved cleanly and no marker is ever displayed. The
+    // user's on-disk hand edits are untouched (Reload re-reads them).
+    if (blobsAvailable) {
+      const echo = this.markerEchoPattern();
+      const hasOrphanMarker = segments.some(
+        (s) =>
+          s.type === 'resolved' &&
+          s.lines.some((l) => echo.test(l) && !this.lineIsBlobContent(l)),
+      );
+      if (hasOrphanMarker) {
+        return [
+          {
+            id: this.nextSegmentId++,
+            type: 'conflict',
+            lines: [],
+            oursLines: this.oursLines,
+            theirsLines: this.theirsLines,
+            oursLabel: 'OURS',
+            theirsLabel: 'THEIRS',
+            origin: null,
+            fromConflict: false,
+          },
+        ];
+      }
+    }
+
     return segments;
   }
 
@@ -1613,11 +1655,15 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     // so Use Base must check its own side too.
     if (this.loadFailed || this.actionsBlocked) return;
     if (origin === 'base' && this.sideReadErrors.base) return;
+    const startFile = this.conflictFile;
     if (this.editingSegmentId !== null) {
       if (!(await this.confirmDiscardOpenEdit())) return;
       // Re-check after the confirm's await — a resolve/tool session may
-      // have started while it was up (same re-check as Reload and Apply).
+      // have started while it was up (same re-check as Reload and Apply),
+      // and file IDENTITY too: a switch during the confirm must not let
+      // this call overwrite a DIFFERENT file's segments with this side.
       if (this.loadFailed || this.actionsBlocked) return;
+      if (this.conflictFile !== startFile) return;
       this.editingSegmentId = null;
       this.editDraft = '';
     }

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -615,18 +615,26 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     }
 
     const file = this.conflictFile;
+    // Claim the launch BEFORE any await: the confirm below yields to the
+    // event loop, and a second click landing in that window would pass the
+    // entry guard again — two tool sessions editing the same file.
+    this.launchingExternalTool = true;
     // The tool edits the ON-DISK file, which doesn't have the editor's
     // unsaved picks — its output will replace them on reload. Confirm first.
     if (this.hasUnsavedResolutions()) {
-      const proceed = await showConfirm(
-        'Discard in-progress resolution?',
-        'The external tool works on the file as saved on disk — your unsaved picks here will be replaced by its result.',
-        'warning',
-      );
+      let proceed = false;
+      try {
+        proceed = await showConfirm(
+          'Discard in-progress resolution?',
+          'The external tool works on the file as saved on disk — your unsaved picks here will be replaced by its result.',
+          'warning',
+        );
+      } finally {
+        if (!proceed) this.launchingExternalTool = false;
+      }
       if (!proceed) return;
     }
 
-    this.launchingExternalTool = true;
     // Tell the host a tool session is open so its Abort/Complete stay inert —
     // they would otherwise race the tool's eventual save.
     this.dispatchEvent(
@@ -784,73 +792,53 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   }
 
   /**
+   * Marker size the current file's conflict hunks were written with. The
+   * backend reports it per file (conflict-marker-size gitattribute verified
+   * against the file's actual emission); git's default 7 is the fallback
+   * for missing or nonsense values. Parsing MUST use this exact size — the
+   * same byte pattern is a real conflict at one size and plain content at
+   * another, so it is not decidable from file bytes alone.
+   */
+  private get effectiveMarkerSize(): number {
+    const size = this.conflictFile?.markerSize;
+    return typeof size === 'number' && Number.isInteger(size) && size >= 1 ? size : 7;
+  }
+
+  /**
    * Parse git's conflict-marker text into structured segments — the ONLY
    * place markers are ever interpreted; they never reach the DOM.
    * Handles diff3-style `|||||||` base sections (discarded) and tolerates an
    * unterminated conflict at EOF (kept as a conflict block).
    *
-   * Git emits exactly seven marker characters, optionally followed by a
-   * space and label (the `=======` separator is always bare). Content lines
-   * that merely BEGIN with 7+ of the character — banner comments, Markdown
-   * setext underlines, `====…` dividers — must not match, or the ours/theirs
-   * split silently corrupts and the real separator leaks in as content.
+   * Git emits exactly `effectiveMarkerSize` marker characters, optionally
+   * followed by a space and label (the `=======` separator is always bare).
+   * Content lines with runs of any OTHER length — banner comments, Markdown
+   * setext underlines, `====…` dividers, docs samples showing default-size
+   * markers inside a raised-size conflict — must not match, or the
+   * ours/theirs split silently corrupts and real markers leak as content.
    * Lines are compared with a trailing CR stripped so CRLF files parse, but
    * content lines are stored verbatim to round-trip their line endings.
    */
   private parseSegments(text: string): OutputSegment[] {
+    const markerSize = this.effectiveMarkerSize;
     const stripCr = (l: string): string => (l.endsWith('\r') ? l.slice(0, -1) : l);
     /**
-     * Length of a marker run of `ch` at the start of the line, or 0 when the
-     * line is not a marker (fewer than 7 chars, or followed by anything other
-     * than a space/EOL). Repos can raise the run length above git's default 7
-     * via the conflict-marker-size gitattribute, so the start marker's run
-     * defines the size the rest of that conflict's markers must match exactly.
+     * True when the line is a marker of `ch`: a run of EXACTLY the file's
+     * marker size followed by a space or end-of-line. Longer or shorter
+     * runs are content.
      */
-    const markerRun = (l: string, ch: string): number => {
+    const isMarker = (l: string, ch: string): boolean => {
       const s = stripCr(l);
       let n = 0;
       while (n < s.length && s[n] === ch) n++;
-      return n >= 7 && (s.length === n || s[n] === ' ') ? n : 0;
+      return n === markerSize && (s.length === n || s[n] === ' ');
     };
-    let markerSize = 7;
-    const isBaseMarker = (l: string): boolean => markerRun(l, '|') === markerSize;
+    const isConflictStart = (l: string): boolean => isMarker(l, '<');
+    const isBaseMarker = (l: string): boolean => isMarker(l, '|');
     const isSeparator = (l: string): boolean => stripCr(l) === '='.repeat(markerSize);
-    const isConflictEnd = (l: string): boolean => markerRun(l, '>') === markerSize;
+    const isConflictEnd = (l: string): boolean => isMarker(l, '>');
 
     const lines = text.split('\n');
-
-    /**
-     * A start-marker run of git's default size (7) always opens a conflict.
-     * A LONGER run (raised conflict-marker-size gitattribute) only counts
-     * when a matching exact-size separator follows later — otherwise a
-     * content line like '<<<<<<<< not a marker' would swallow the rest of
-     * the file into a phantom conflict.
-     */
-    const conflictStartSize = (index: number): number => {
-      const n = markerRun(lines[index], '<');
-      if (n === 0) return 0;
-      if (n === 7) return 7;
-      // A raised size must look like a REAL git conflict, in git's emission
-      // order: the exact-size separator, then an exact-size end marker.
-      // Bail if a DEFAULT-size start appears before the separator — the
-      // raised "start" would otherwise swallow a real conflict (and its
-      // markers) as pickable content, e.g. in a docs file that shows a long
-      // marker example above an actual conflict.
-      const sep = '='.repeat(n);
-      let sepIndex = -1;
-      for (let j = index + 1; j < lines.length; j++) {
-        if (markerRun(lines[j], '<') === 7) return 0;
-        if (stripCr(lines[j]) === sep) {
-          sepIndex = j;
-          break;
-        }
-      }
-      if (sepIndex < 0) return 0;
-      for (let j = sepIndex + 1; j < lines.length; j++) {
-        if (markerRun(lines[j], '>') === n) return n;
-      }
-      return 0;
-    };
 
     const segments: OutputSegment[] = [];
     let currentResolved: string[] = [];
@@ -883,14 +871,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
 
     for (let lineIndex = 0; lineIndex < lines.length; lineIndex++) {
       const line = lines[lineIndex];
-      const startSize = inConflict ? 0 : conflictStartSize(lineIndex);
-      if (!inConflict && startSize > 0) {
+      if (!inConflict && isConflictStart(line)) {
         flushResolved();
         inConflict = true;
         section = 'ours';
         oursLines = [];
         theirsLines = [];
-        markerSize = startSize;
         oursLabel = stripCr(line).slice(markerSize).trim() || 'OURS';
         theirsLabel = '';
       } else if (inConflict && section === 'ours' && isBaseMarker(line)) {
@@ -1157,9 +1143,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         // AI output bypasses parseSegments, so it must be validated here:
         // a suggestion that echoes marker lines would otherwise render them
         // as "resolved" text and let them be written back to the file. Runs
-        // of 7+ cover repos with a raised conflict-marker-size; being overly
-        // conservative here just leaves the block unresolved, which is safe.
-        if (/^(<{7,}|={7,}|>{7,}|\|{7,})( |\r?$)/m.test(result.data.resolvedContent)) {
+        // of min(7, size)+ cover the default, raised, AND lowered
+        // conflict-marker-size cases; being overly conservative here just
+        // leaves the block unresolved, which is safe.
+        const n = Math.min(7, this.effectiveMarkerSize);
+        const markerEcho = new RegExp(`^(<{${n},}|={${n},}|>{${n},}|\\|{${n},})( |\\r?$)`, 'm');
+        if (markerEcho.test(result.data.resolvedContent)) {
           showToast('AI suggestion contained conflict markers — block left unresolved', 'error');
           return false;
         }

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -787,6 +787,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           this.resolvedInPlace = true;
           return;
         }
+        // The isNoLongerConflicted await (a slow per-file get_conflicts)
+        // yielded — a newer file selection may have superseded this load.
+        // Without this, the submodule early-return below would WIPE the
+        // newer file's segments/panes, leaving it with "No conflicts" and
+        // Mark Resolved enabled → a 0-byte write. (The binary path is
+        // guarded by the post-Promise.all epoch check further down.)
+        if (epoch !== this.loadEpoch) return;
       }
 
       // Submodule (gitlink) conflicts have nothing to read: the entry OIDs
@@ -1407,22 +1414,18 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     const blobsAvailable = this.oursLines.length > 0 || this.theirsLines.length > 0;
     if (!blobsAvailable) return segments;
     const echo = this.markerEchoPattern();
-    // A conflict side's content is everything BETWEEN markers, so a START
-    // marker (`<<<<<<<`) inside a pane is always a swept orphan (a fallback
-    // split pulled a nested/orphaned start into content) — a leak. An
-    // end/separator SHAPE in a side can be legitimate hand-typed content
-    // the parser deliberately keeps, so only start shapes are flagged in
-    // panes. Blob content (a quoted example) is never flagged.
-    const n = Math.min(7, this.effectiveMarkerSize);
-    const startEcho = new RegExp(`^<{${n},}( |\\r?$)`);
-    const orphanResolved = (lines: string[]): boolean =>
+    // A marker-shaped line (any shape: <<<<<<< / ======= / >>>>>>> / |||||||)
+    // that is in NO blob is a real orphaned marker, whether it landed in a
+    // resolved segment (hand-deleted start marker) or a conflict pane (an
+    // unvalidated fallback split swept it into a side). A VALIDATED split's
+    // sides are contiguous blob runs, so every line IS blob content and is
+    // never flagged — only unvalidated fallbacks (genuinely malformed
+    // input) can carry a non-blob marker line into a pane. Either way it
+    // would render raw, so fall back to the whole-file conflict.
+    const orphan = (lines: string[]): boolean =>
       lines.some((l) => echo.test(l) && !this.lineIsBlobContent(l));
-    const orphanPane = (lines: string[]): boolean =>
-      lines.some((l) => startEcho.test(l) && !this.lineIsBlobContent(l));
     const hasOrphanMarker = segments.some((s) =>
-      s.type === 'resolved'
-        ? orphanResolved(s.lines)
-        : orphanPane(s.oursLines) || orphanPane(s.theirsLines),
+      s.type === 'resolved' ? orphan(s.lines) : orphan(s.oursLines) || orphan(s.theirsLines),
     );
     if (!hasOrphanMarker) return segments;
     return [

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -1026,7 +1026,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       showToast('Failed to get AI suggestion', 'error');
       return false;
     } finally {
-      this.suggestingSegment = null;
+      // Only clear the in-flight flag if it still tracks THIS call — a file
+      // switch resets it and a newer suggestion may own it by now; clobbering
+      // that would re-enable the AI buttons while a call is genuinely running.
+      if (this.suggestingSegment === id) {
+        this.suggestingSegment = null;
+      }
     }
   }
 

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -1064,14 +1064,18 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       } else if (closed) {
         pushConflict(closed.split!, oursLabel, labelOf(lines[closed.end], 'THEIRS'));
         i = closed.end + 1;
-      } else if (blobsAvailable && lineInBlobs(line)) {
+      } else if (blobsAvailable && lineInBlobs(line) && firstCandidate) {
         // NOTHING below this start-shaped line validates, and the line
         // itself is blob content — it is a quoted example sitting directly
         // above the real conflict, and it opened the region one line too
         // early (every candidate ours-slice began with the real start
         // marker, which is in neither blob). Treat it as content and
         // rescan from the next line so the REAL start can open a region
-        // whose split validates.
+        // whose split validates. The recovery requires END-CANDIDATE
+        // evidence: with no end-shaped line anywhere below, this is a
+        // genuinely unterminated conflict at EOF — reclassifying its start
+        // as content would zero the conflict count and let Mark Resolved
+        // write the real marker back to disk.
         currentResolved.push(line);
         i++;
       } else if (firstCandidate) {
@@ -1534,6 +1538,12 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         console.error('Failed to resolve conflict:', result.error);
         showToast(`Failed to mark file as resolved: ${result.error?.message ?? 'Unknown error'}`, 'error');
       }
+    } catch (err) {
+      // invokeCommand is designed not to throw, but a silent failure here
+      // would strand the user with no feedback — same catch as the
+      // external-tool sibling.
+      console.error('Failed to resolve conflict:', err);
+      showToast('Failed to mark file as resolved', 'error');
     } finally {
       // Only the call that owns the flag may clear it — a file switch resets
       // it and a newer call may own it by now.
@@ -1604,6 +1614,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         console.error('Failed to resolve conflict:', result.error);
         showToast(`Failed to resolve conflict: ${result.error?.message ?? 'Unknown error'}`, 'error');
       }
+    } catch (err) {
+      console.error('Failed to resolve conflict:', err);
+      showToast('Failed to resolve conflict', 'error');
     } finally {
       if (token === this.resolveToken) {
         this.resolving = false;

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -26,6 +26,7 @@ import { codeStyles } from '../../styles/code-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import * as aiService from '../../services/ai.service.ts';
 import { showToast } from '../../services/notification.service.ts';
+import { showConfirm } from '../../services/dialog.service.ts';
 import { CodeRenderMixin } from '../../mixins/code-render-mixin.ts';
 import type { ConflictFile } from '../../types/git.types.ts';
 import {
@@ -614,6 +615,17 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     }
 
     const file = this.conflictFile;
+    // The tool edits the ON-DISK file, which doesn't have the editor's
+    // unsaved picks — its output will replace them on reload. Confirm first.
+    if (this.hasUnsavedResolutions()) {
+      const proceed = await showConfirm(
+        'Discard in-progress resolution?',
+        'The external tool works on the file as saved on disk — your unsaved picks here will be replaced by its result.',
+        'warning',
+      );
+      if (!proceed) return;
+    }
+
     this.launchingExternalTool = true;
     // Tell the host a tool session is open so its Abort/Complete stay inert —
     // they would otherwise race the tool's eventual save.
@@ -623,7 +635,6 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     try {
       const result = await gitService.launchMergeTool(this.repositoryPath, file.path);
       if (result.success && result.data?.success) {
-        showToast('Merge tool completed', 'success');
         // The tool may have fully resolved (and staged) the file — verify
         // against the index and let the host mark it, so this path behaves
         // like the dialog's own external tool instead of leaving the file
@@ -640,7 +651,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
         if (this.conflictFile?.path === file.path) {
           await this.loadContents();
         }
-        if (!stillConflicted) {
+        // Mirror the dialog's launcher: success only when the index confirms
+        // the resolution — a green toast over "N conflicts remaining" would
+        // read as success for an unfinished merge.
+        if (stillConflicted) {
+          showToast('File still has conflicts', 'warning');
+        } else {
+          showToast('Merge tool completed', 'success');
           this.dispatchEvent(new CustomEvent('conflict-resolved', {
             detail: { file },
             bubbles: true,
@@ -684,6 +701,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.suggestingAll = false;
     this.aiResolveAllToken++;
     this.lastSavedContent = null;
+    this.userTouched = false;
     this.sideReadErrors = { base: false, ours: false, theirs: false };
 
     try {
@@ -812,8 +830,15 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       const n = markerRun(lines[index], '<');
       if (n === 0) return 0;
       if (n === 7) return 7;
+      // A raised size must look like a REAL git conflict: both the exact-size
+      // separator AND an exact-size end marker must follow. Requiring only
+      // the separator would let a banner line plus one coincidental divider
+      // swallow the rest of the file into a phantom conflict.
       const sep = '='.repeat(n);
-      return lines.slice(index + 1).some((l) => stripCr(l) === sep) ? n : 0;
+      const rest = lines.slice(index + 1);
+      const hasSeparator = rest.some((l) => stripCr(l) === sep);
+      const hasEnd = rest.some((l) => markerRun(l, '>') === n);
+      return hasSeparator && hasEnd ? n : 0;
     };
 
     const segments: OutputSegment[] = [];
@@ -930,15 +955,19 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   /** Serialized output of the last successful Mark Resolved for this file —
    * work matching it is on disk and safe to navigate away from. */
   private lastSavedContent: string | null = null;
+  /** True once the user changed the output in this file (per-block picks,
+   * edits, OR whole-file accepts — the latter carry no fromConflict flag). */
+  private userTouched = false;
 
   /**
    * True when the output holds work not yet written to disk: per-block
-   * resolutions or an open inline edit. Nothing persists until Mark
-   * Resolved, so hosts should confirm before navigating away.
+   * resolutions, whole-file accepts, or an open inline edit. Nothing
+   * persists until Mark Resolved, so hosts should confirm before
+   * navigating away.
    */
   public hasUnsavedResolutions(): boolean {
     if (this.editingSegmentId !== null) return true;
-    if (!this.segments.some((s) => s.fromConflict)) return false;
+    if (!this.userTouched) return false;
     return this.buildResolvedContent() !== this.lastSavedContent;
   }
 
@@ -980,6 +1009,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           ? [...segment.theirsLines]
           : [...segment.oursLines, ...segment.theirsLines];
     this.clearAiExplanation(id);
+    this.userTouched = true;
     this.updateSegment(id, { type: 'resolved', lines, origin: choice, fromConflict: true });
   }
 
@@ -1012,6 +1042,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     }
 
     this.clearAiExplanation(id);
+    this.userTouched = true;
     this.updateSegment(id, {
       type: 'resolved',
       // An empty draft means ZERO lines (section removed) — ''.split('\n')
@@ -1053,6 +1084,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     const content =
       origin === 'ours' ? this.oursContent : origin === 'theirs' ? this.theirsContent : this.baseContent;
     this.editingSegmentId = null;
+    this.userTouched = true;
     this.segments = [this.makeResolvedSegment(content.split('\n'), origin, false)];
   }
 
@@ -1120,6 +1152,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
           showToast('AI suggestion contained conflict markers — block left unresolved', 'error');
           return false;
         }
+        this.userTouched = true;
         this.updateSegment(id, {
           type: 'resolved',
           // An empty suggestion means ZERO lines (remove the section) —
@@ -1209,6 +1242,9 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     const token = ++this.resolveToken;
     const content = this.buildResolvedContent();
     this.resolving = true;
+    // Announce the write so the host can lock its own tool launcher against
+    // it (same pattern as the external-tool session events).
+    this.dispatchEvent(new CustomEvent('resolve-started', { bubbles: true, composed: true }));
     try {
       const result = await gitService.resolveConflict(
         this.repositoryPath,
@@ -1234,6 +1270,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       if (token === this.resolveToken) {
         this.resolving = false;
       }
+      this.dispatchEvent(new CustomEvent('resolve-finished', { bubbles: true, composed: true }));
     }
   }
 
@@ -1254,6 +1291,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     const file = this.conflictFile;
     const token = ++this.resolveToken;
     this.resolving = true;
+    this.dispatchEvent(new CustomEvent('resolve-started', { bubbles: true, composed: true }));
     try {
       const result = await gitService.resolveConflictTakeSide(
         this.repositoryPath,
@@ -1275,6 +1313,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       if (token === this.resolveToken) {
         this.resolving = false;
       }
+      this.dispatchEvent(new CustomEvent('resolve-finished', { bubbles: true, composed: true }));
     }
   }
 

--- a/src/components/sidebar/__tests__/lv-branch-list-conflict-hidden.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-conflict-hidden.test.ts
@@ -127,7 +127,12 @@ describe('lv-branch-list conflict dispatch', () => {
     await (el as unknown as { handleRebaseBranch: () => Promise<void> }).handleRebaseBranch();
 
     expect(conflictEvent, 'open-conflict-dialog should be dispatched').to.not.be.null;
-    expect(conflictEvent!.detail).to.deep.equal({ operationType: 'rebase' });
+    // The event carries the repo the rebase ran on so the dialog pins to it
+    // even if the active tab changed while the rebase was in flight.
+    expect(conflictEvent!.detail).to.deep.equal({
+      operationType: 'rebase',
+      repositoryPath: '/test/repo',
+    });
     expect(conflictEvent!.bubbles).to.be.true;
     expect(conflictEvent!.composed).to.be.true;
     expect(invokeCalls.filter(c => c.command === 'abort_rebase')).to.have.length(0);

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -93,43 +93,29 @@ describe('lv-branch-list operationInProgress guards', () => {
     expect((el as unknown as { operationInProgress: boolean }).operationInProgress).to.equal(false);
   });
 
-  it('renders the embedded dialogs in BOTH the loading and loaded templates', async () => {
-    // A background refresh flips loading true→false. If the loading
-    // placeholder replaced the whole template, the embedded rebase dialog
-    // would be torn down and recreated, silently discarding an in-progress
-    // rebase plan the user built before switching tabs. Both the loading
-    // and loaded render outputs must contain the dialogs. We inspect the
-    // TemplateResult directly (no DOM commit) to avoid re-rendering the
-    // live modal in the headless test env.
+  it('preserves the interactive-rebase dialog ELEMENT across a loading toggle', async () => {
+    // A background refresh flips loading true→false. With a single stable
+    // outer template the dialog element instance must survive the toggle —
+    // recreating it (as three distinct top-level templates did) would reset
+    // its state and silently discard an in-progress rebase plan.
     const el = await createComponent();
-    const internal = el as unknown as {
-      loading: boolean;
-      render: () => unknown;
-    };
+    const internal = el as unknown as { loading: boolean };
+    const dialogBefore = el.shadowRoot!.querySelector('lv-interactive-rebase-dialog');
+    expect(dialogBefore, 'dialog present when loaded').to.not.be.null;
 
-    // Recurse through nested TemplateResults (the dialogs live in a `${...}`
-    // interpolation, so they're in `.values`, not the outer `.strings`).
-    const containsDialog = (t: unknown): boolean => {
-      if (Array.isArray(t)) return t.some(containsDialog);
-      const tr = t as { strings?: readonly string[]; values?: unknown[] } | null;
-      if (!tr || !tr.strings) return false;
-      return (
-        tr.strings.some((s) => s.includes('lv-interactive-rebase-dialog')) ||
-        (tr.values ?? []).some(containsDialog)
-      );
-    };
-    const templateHasDialog = (): boolean => containsDialog(internal.render());
-
-    // Loaded state.
-    internal.loading = false;
-    expect(templateHasDialog(), 'dialog in the loaded template').to.be.true;
-
-    // Loading state — the dialog must still be present (same position).
     internal.loading = true;
-    expect(templateHasDialog(), 'dialog in the loading template').to.be.true;
+    await el.updateComplete;
+    expect(
+      el.shadowRoot!.querySelector('lv-interactive-rebase-dialog'),
+      'same element instance while loading',
+    ).to.equal(dialogBefore);
 
-    // Restore so the scheduled reactive update renders a valid state.
     internal.loading = false;
+    await el.updateComplete;
+    expect(
+      el.shadowRoot!.querySelector('lv-interactive-rebase-dialog'),
+      'same element instance after loading clears',
+    ).to.equal(dialogBefore);
   });
 
   it('handleCheckout should skip when operationInProgress is true', async () => {

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -496,6 +496,42 @@ describe('lv-branch-list operationInProgress guards', () => {
     expect(detail!.repositoryPath).to.equal(REPO_PATH);
   });
 
+  it('handleBranchCreated pins to the event repo when the tab switched before the event fired', async () => {
+    // The create-branch dialog captures its repo at open() and reports it in
+    // branch-created.detail. If the user switched tabs while the dialog was
+    // open, our live repositoryPath is now the OTHER repo — the refresh must
+    // follow the event's repo, and we must NOT reload our (mismatched) view.
+    const el = await createComponent();
+
+    let branchesCalls = 0;
+    mockInvoke = (command: string) => {
+      if (command === 'get_branches') {
+        branchesCalls++;
+        return Promise.resolve([]);
+      }
+      return defaultMockInvoke(command);
+    };
+
+    let detail: { repositoryPath?: string } | null = null;
+    el.addEventListener('branches-changed', (e) => {
+      detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    });
+
+    branchesCalls = 0;
+    // The tag/branch was created on /origin/repo, but we're now showing REPO_PATH.
+    await (
+      el as unknown as {
+        handleBranchCreated: (e: CustomEvent<{ repositoryPath?: string }>) => Promise<void>;
+      }
+    ).handleBranchCreated(
+      new CustomEvent('branch-created', { detail: { repositoryPath: '/origin/repo' } }),
+    );
+
+    expect(detail, 'branches-changed dispatched').to.not.be.null;
+    expect(detail!.repositoryPath, 'refresh pinned to the event repo').to.equal('/origin/repo');
+    expect(branchesCalls, 'no reload of the mismatched active view').to.equal(0);
+  });
+
   it('handleMergeBranch merges the origin repo, not the tab switched to during the confirm', async () => {
     // showConfirm's await yields; a tab switch during it rebinds
     // this.repositoryPath. The merge must run on the repo it was invoked on.

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -287,6 +287,39 @@ describe('lv-branch-list operationInProgress guards', () => {
     repositoryStore.getState().reset();
   });
 
+  it('closes its embedded create-branch dialog when the pinned repo tab is removed', async () => {
+    // The sidebar's own create-branch dialog persists across tab switches;
+    // app-shell's self-close guard only reaches app-shell's instance. Closing
+    // the pinned tab must dismiss this one too, or Create + checkout would run
+    // on a repo no longer in the tab bar.
+    repositoryStore.getState().reset();
+    repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
+    repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+
+    const el = await createComponent();
+    for (let i = 0; i < 50; i++) {
+      if ((el as unknown as { storeUnsubscribe?: () => void }).storeUnsubscribe) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    let closed = false;
+    Object.defineProperty(el, 'createBranchDialog', {
+      configurable: true,
+      value: {
+        pinnedRepositoryPathIfOpen: '/repo/a',
+        close: () => {
+          closed = true;
+        },
+      },
+    });
+
+    repositoryStore.getState().removeRepository('/repo/a');
+    await el.updateComplete;
+
+    expect(closed, 'create-branch dialog closed when its pinned tab was removed').to.be.true;
+    repositoryStore.getState().reset();
+  });
+
   it('leaves the dialog open when a DIFFERENT repo tab is removed', async () => {
     // Only the pinned repo's removal cancels the rebase; unrelated tab churn
     // must not disrupt an in-progress plan.

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -334,6 +334,93 @@ describe('lv-branch-list operationInProgress guards', () => {
     expect(detail!.repositoryPath).to.equal('/repo/origin');
   });
 
+  it('handleTrackRemoteBranch runs create AND set-upstream against the origin repo after a mid-op switch', async () => {
+    // Both git ops must target the repo the operation was invoked on. The
+    // second op (set-upstream) runs AFTER the create IPC await — a tab switch
+    // during that await must not split the two operations across repos.
+    const el = await createComponent();
+
+    let resolveCreate!: (v: unknown) => void;
+    mockInvoke = (command: string) => {
+      if (command === 'create_branch') {
+        return new Promise((resolve) => {
+          resolveCreate = resolve;
+        });
+      }
+      return defaultMockInvoke(command);
+    };
+
+    const branch = makeBranch({ name: 'origin/feature/x', shorthand: 'feature/x', isRemote: true });
+    (
+      el as unknown as {
+        contextMenu: { visible: boolean; x: number; y: number; branch: typeof branch | null };
+      }
+    ).contextMenu = { visible: true, x: 0, y: 0, branch };
+
+    invokeCalls.length = 0;
+    const promise = (
+      el as unknown as { handleTrackRemoteBranch: () => Promise<void> }
+    ).handleTrackRemoteBranch();
+
+    // The create IPC is now in flight; user switches tabs.
+    await new Promise((r) => setTimeout(r, 10));
+    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
+
+    resolveCreate({ name: 'feature/x' });
+    await promise;
+
+    const createCall = invokeCalls.find((c) => c.command === 'create_branch');
+    const upstreamCall = invokeCalls.find((c) => c.command === 'set_upstream_branch');
+    expect(createCall, 'create_branch called').to.not.be.undefined;
+    expect(upstreamCall, 'set_upstream_branch called').to.not.be.undefined;
+    expect((createCall!.args as { path: string }).path).to.equal(REPO_PATH);
+    expect((upstreamCall!.args as { path: string }).path).to.equal(REPO_PATH);
+  });
+
+  it('handleRenameBranch renames the origin repo, not the tab switched to during the prompt', async () => {
+    // showPrompt is an in-app Lit overlay, not a native modal: the window stays
+    // interactive, so the user can switch tabs while the rename prompt is open.
+    // The rename must still run against the repo it was invoked on.
+    const el = await createComponent();
+
+    mockInvoke = (command: string) => defaultMockInvoke(command);
+
+    const branch = makeBranch({ name: 'feature/old', shorthand: 'feature/old', isHead: false, isRemote: false });
+    (
+      el as unknown as {
+        contextMenu: { visible: boolean; x: number; y: number; branch: typeof branch | null };
+      }
+    ).contextMenu = { visible: true, x: 0, y: 0, branch };
+
+    invokeCalls.length = 0;
+    const promise = (
+      el as unknown as { handleRenameBranch: () => Promise<void> }
+    ).handleRenameBranch();
+
+    // Wait for the in-app prompt dialog to mount.
+    let dialog: (Element & { value: string }) | null = null;
+    for (let i = 0; i < 50; i++) {
+      await new Promise((r) => setTimeout(r, 10));
+      dialog = document.querySelector('lv-prompt-dialog') as (Element & { value: string }) | null;
+      if (dialog && (dialog as unknown as { resolve: unknown }).resolve) break;
+    }
+    expect(dialog, 'prompt dialog mounted').to.not.be.null;
+
+    // User switches tabs while the prompt is open, then confirms a new name.
+    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
+    (dialog as unknown as { value: string }).value = 'feature/new';
+    await (dialog as unknown as { updateComplete: Promise<unknown> }).updateComplete;
+    const confirmBtn = dialog!.shadowRoot!.querySelector('.btn-primary') as HTMLButtonElement;
+    confirmBtn.click();
+
+    await promise;
+
+    const renameCall = invokeCalls.find((c) => c.command === 'rename_branch');
+    expect(renameCall, 'rename_branch called').to.not.be.undefined;
+    expect((renameCall!.args as { path: string }).path).to.equal(REPO_PATH);
+    expect((renameCall!.args as { newName: string }).newName).to.equal('feature/new');
+  });
+
   it('handleUnsetUpstream emits branches-changed pinned to the origin repo after a mid-op switch', async () => {
     // Regression: these context-menu handlers previously dispatched a bare
     // branches-changed with no repositoryPath, so a mid-op tab switch made the

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -334,6 +334,50 @@ describe('lv-branch-list operationInProgress guards', () => {
     expect(detail!.repositoryPath).to.equal('/repo/origin');
   });
 
+  it('handleUnsetUpstream emits branches-changed pinned to the origin repo after a mid-op switch', async () => {
+    // Regression: these context-menu handlers previously dispatched a bare
+    // branches-changed with no repositoryPath, so a mid-op tab switch made the
+    // host refresh the wrong (newly active) repo. repoPath is captured
+    // pre-await; the event must still name the origin repo.
+    const el = await createComponent();
+
+    let resolveUnset!: (v: unknown) => void;
+    mockInvoke = (command: string) => {
+      if (command === 'unset_upstream_branch') {
+        return new Promise((resolve) => {
+          resolveUnset = resolve;
+        });
+      }
+      return defaultMockInvoke(command);
+    };
+
+    let detail: { repositoryPath?: string } | null = null;
+    el.addEventListener('branches-changed', (e) => {
+      detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    });
+
+    const branch = makeBranch({ name: 'feature/up', isRemote: false, upstream: 'origin/feature/up' });
+    (
+      el as unknown as {
+        contextMenu: { visible: boolean; x: number; y: number; branch: typeof branch | null };
+      }
+    ).contextMenu = { visible: true, x: 0, y: 0, branch };
+
+    const promise = (
+      el as unknown as { handleUnsetUpstream: () => Promise<void> }
+    ).handleUnsetUpstream();
+
+    // User switches tabs mid-operation.
+    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
+
+    resolveUnset({ success: true });
+    await promise;
+    await el.updateComplete;
+
+    expect(detail, 'branches-changed dispatched').to.not.be.null;
+    expect(detail!.repositoryPath).to.equal(REPO_PATH);
+  });
+
   it('handleCheckout should clear operationInProgress even on error', async () => {
     const el = await createComponent();
 

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -320,6 +320,38 @@ describe('lv-branch-list operationInProgress guards', () => {
     repositoryStore.getState().reset();
   });
 
+  it('closes its embedded branch-cleanup dialog when the pinned repo tab is removed', async () => {
+    // Branch cleanup force-deletes branches + prunes remotes on the pinned repo;
+    // a closed tab must dismiss it, or Delete would mutate a repo not in the tab
+    // bar. app-shell's guard can't reach this sidebar-embedded instance.
+    repositoryStore.getState().reset();
+    repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
+    repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+
+    const el = await createComponent();
+    for (let i = 0; i < 50; i++) {
+      if ((el as unknown as { storeUnsubscribe?: () => void }).storeUnsubscribe) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    let closed = false;
+    Object.defineProperty(el, 'branchCleanupDialog', {
+      configurable: true,
+      value: {
+        pinnedRepositoryPathIfOpen: '/repo/a',
+        close: () => {
+          closed = true;
+        },
+      },
+    });
+
+    repositoryStore.getState().removeRepository('/repo/a');
+    await el.updateComplete;
+
+    expect(closed, 'branch-cleanup dialog closed when its pinned tab was removed').to.be.true;
+    repositoryStore.getState().reset();
+  });
+
   it('leaves the dialog open when a DIFFERENT repo tab is removed', async () => {
     // Only the pinned repo's removal cancels the rebase; unrelated tab churn
     // must not disrupt an in-progress plan.

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -421,6 +421,81 @@ describe('lv-branch-list operationInProgress guards', () => {
     expect((renameCall!.args as { newName: string }).newName).to.equal('feature/new');
   });
 
+  it('handleDeleteMergedBranches deletes from the origin repo after a mid-confirm switch', async () => {
+    // Irreversible bulk delete. repoPath must be captured before the confirm —
+    // a mid-confirm tab switch must not redirect the deletes to another repo.
+    const el = await createComponent();
+
+    const merged = makeBranch({ name: 'feature/merged', shorthand: 'feature/merged', isHead: false });
+    (el as unknown as { localBranchGroups: Array<{ branches: unknown[] }> }).localBranchGroups = [
+      { branches: [merged] },
+    ];
+    (el as unknown as { mergedBranchNames: Set<string> }).mergedBranchNames = new Set([
+      'feature/merged',
+    ]);
+
+    let resolveConfirm!: (v: unknown) => void;
+    mockInvoke = (command: string) => {
+      if (command === 'plugin:dialog|message') {
+        return new Promise((resolve) => {
+          resolveConfirm = resolve;
+        });
+      }
+      if (command === 'delete_branch') return Promise.resolve(null);
+      return defaultMockInvoke(command);
+    };
+
+    invokeCalls.length = 0;
+    const promise = (
+      el as unknown as { handleDeleteMergedBranches: () => Promise<void> }
+    ).handleDeleteMergedBranches();
+
+    await new Promise((r) => setTimeout(r, 10));
+    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
+
+    resolveConfirm('Ok');
+    await promise;
+
+    const deleteCall = invokeCalls.find((c) => c.command === 'delete_branch');
+    expect(deleteCall, 'delete_branch called').to.not.be.undefined;
+    expect((deleteCall!.args as { path: string }).path).to.equal(REPO_PATH);
+  });
+
+  it('handleBranchCreated refreshes the origin repo, not the tab switched to during the reload', async () => {
+    const el = await createComponent();
+
+    // The initial load already ran (via defaultMockInvoke) during
+    // createComponent; make the NEXT get_branches — the one inside
+    // handleBranchCreated — hang so we can switch tabs mid-reload.
+    let resolveLoad!: (v: unknown) => void;
+    mockInvoke = (command: string) => {
+      if (command === 'get_branches') {
+        return new Promise((resolve) => {
+          resolveLoad = resolve;
+        });
+      }
+      return defaultMockInvoke(command);
+    };
+
+    let detail: { repositoryPath?: string } | null = null;
+    el.addEventListener('branches-changed', (e) => {
+      detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    });
+
+    const promise = (
+      el as unknown as { handleBranchCreated: () => Promise<void> }
+    ).handleBranchCreated();
+
+    await new Promise((r) => setTimeout(r, 10));
+    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
+
+    resolveLoad([]);
+    await promise;
+
+    expect(detail, 'branches-changed dispatched').to.not.be.null;
+    expect(detail!.repositoryPath).to.equal(REPO_PATH);
+  });
+
   it('handleMergeBranch merges the origin repo, not the tab switched to during the confirm', async () => {
     // showConfirm's await yields; a tab switch during it rebinds
     // this.repositoryPath. The merge must run on the repo it was invoked on.

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -421,6 +421,45 @@ describe('lv-branch-list operationInProgress guards', () => {
     expect((renameCall!.args as { newName: string }).newName).to.equal('feature/new');
   });
 
+  it('handleMergeBranch merges the origin repo, not the tab switched to during the confirm', async () => {
+    // showConfirm's await yields; a tab switch during it rebinds
+    // this.repositoryPath. The merge must run on the repo it was invoked on.
+    const el = await createComponent();
+
+    let resolveConfirm!: (v: unknown) => void;
+    mockInvoke = (command: string) => {
+      if (command === 'plugin:dialog|message') {
+        return new Promise((resolve) => {
+          resolveConfirm = resolve;
+        });
+      }
+      if (command === 'merge') return Promise.resolve({ success: true });
+      return defaultMockInvoke(command);
+    };
+
+    const branch = makeBranch({ name: 'feature/m', shorthand: 'feature/m', isHead: false });
+    (
+      el as unknown as {
+        contextMenu: { visible: boolean; x: number; y: number; branch: typeof branch | null };
+      }
+    ).contextMenu = { visible: true, x: 0, y: 0, branch };
+
+    invokeCalls.length = 0;
+    const promise = (
+      el as unknown as { handleMergeBranch: () => Promise<void> }
+    ).handleMergeBranch();
+
+    await new Promise((r) => setTimeout(r, 10));
+    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
+
+    resolveConfirm('Ok');
+    await promise;
+
+    const mergeCall = invokeCalls.find((c) => c.command === 'merge');
+    expect(mergeCall, 'merge called').to.not.be.undefined;
+    expect((mergeCall!.args as { path: string }).path).to.equal(REPO_PATH);
+  });
+
   it('handleUnsetUpstream emits branches-changed pinned to the origin repo after a mid-op switch', async () => {
     // Regression: these context-menu handlers previously dispatched a bare
     // branches-changed with no repositoryPath, so a mid-op tab switch made the

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -93,6 +93,45 @@ describe('lv-branch-list operationInProgress guards', () => {
     expect((el as unknown as { operationInProgress: boolean }).operationInProgress).to.equal(false);
   });
 
+  it('renders the embedded dialogs in BOTH the loading and loaded templates', async () => {
+    // A background refresh flips loading true→false. If the loading
+    // placeholder replaced the whole template, the embedded rebase dialog
+    // would be torn down and recreated, silently discarding an in-progress
+    // rebase plan the user built before switching tabs. Both the loading
+    // and loaded render outputs must contain the dialogs. We inspect the
+    // TemplateResult directly (no DOM commit) to avoid re-rendering the
+    // live modal in the headless test env.
+    const el = await createComponent();
+    const internal = el as unknown as {
+      loading: boolean;
+      render: () => unknown;
+    };
+
+    // Recurse through nested TemplateResults (the dialogs live in a `${...}`
+    // interpolation, so they're in `.values`, not the outer `.strings`).
+    const containsDialog = (t: unknown): boolean => {
+      if (Array.isArray(t)) return t.some(containsDialog);
+      const tr = t as { strings?: readonly string[]; values?: unknown[] } | null;
+      if (!tr || !tr.strings) return false;
+      return (
+        tr.strings.some((s) => s.includes('lv-interactive-rebase-dialog')) ||
+        (tr.values ?? []).some(containsDialog)
+      );
+    };
+    const templateHasDialog = (): boolean => containsDialog(internal.render());
+
+    // Loaded state.
+    internal.loading = false;
+    expect(templateHasDialog(), 'dialog in the loaded template').to.be.true;
+
+    // Loading state — the dialog must still be present (same position).
+    internal.loading = true;
+    expect(templateHasDialog(), 'dialog in the loading template').to.be.true;
+
+    // Restore so the scheduled reactive update renders a valid state.
+    internal.loading = false;
+  });
+
   it('handleCheckout should skip when operationInProgress is true', async () => {
     const el = await createComponent();
 

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -24,9 +24,25 @@ const invokeCalls: Array<{ command: string; args?: unknown }> = [];
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
 import { expect, fixture, html } from '@open-wc/testing';
 import type { LvBranchList } from '../lv-branch-list.ts';
+import { repositoryStore } from '../../../stores/index.ts';
+import type { Repository } from '../../../types/git.types.ts';
 
 // Import the actual component
 import '../lv-branch-list.ts';
+
+function mockRepo(path: string, name: string): Repository {
+  return {
+    path,
+    name,
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
@@ -231,6 +247,91 @@ describe('lv-branch-list operationInProgress guards', () => {
 
     const rebaseCalls = invokeCalls.filter(c => c.command === 'rebase');
     expect(rebaseCalls).to.have.length(0);
+  });
+
+  it('closes its embedded interactive-rebase dialog when the pinned repo tab is removed', async () => {
+    // The dialog is kept alive across background refreshes by the single stable
+    // template. If the user closes the repo tab the rebase was started on, the
+    // dialog must self-close — otherwise Execute would rewrite a repo with no
+    // tab observing it. The store subscription in connectedCallback owns this.
+    repositoryStore.getState().reset();
+    repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
+    repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+
+    const el = await createComponent();
+    // connectedCallback subscribes only AFTER an async loadBranches(); wait
+    // until the store subscription is actually registered.
+    for (let i = 0; i < 50; i++) {
+      if ((el as unknown as { storeUnsubscribe?: () => void }).storeUnsubscribe) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    // Shadow the @query getter with a fake dialog pinned to repo A.
+    let closed = false;
+    Object.defineProperty(el, 'interactiveRebaseDialog', {
+      configurable: true,
+      value: {
+        pinnedRepositoryPathIfOpen: '/repo/a',
+        close: () => {
+          closed = true;
+        },
+      },
+    });
+
+    // Closing A's tab must trigger the subscription to close the dialog.
+    repositoryStore.getState().removeRepository('/repo/a');
+    await el.updateComplete;
+
+    expect(closed, 'dialog closed when its pinned repo tab was removed').to.be.true;
+
+    repositoryStore.getState().reset();
+  });
+
+  it('leaves the dialog open when a DIFFERENT repo tab is removed', async () => {
+    // Only the pinned repo's removal cancels the rebase; unrelated tab churn
+    // must not disrupt an in-progress plan.
+    repositoryStore.getState().reset();
+    repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
+    repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+
+    const el = await createComponent();
+
+    let closed = false;
+    Object.defineProperty(el, 'interactiveRebaseDialog', {
+      configurable: true,
+      value: {
+        pinnedRepositoryPathIfOpen: '/repo/a',
+        close: () => {
+          closed = true;
+        },
+      },
+    });
+
+    repositoryStore.getState().removeRepository('/repo/b');
+    await el.updateComplete;
+
+    expect(closed, 'dialog stays open when an unrelated tab is removed').to.be.false;
+
+    repositoryStore.getState().reset();
+  });
+
+  it('branches-changed carries the originating repositoryPath so refreshes pin correctly', async () => {
+    // The host pins its refresh to detail.repositoryPath (the repo the mutation
+    // ran on), not the active tab. A branches-changed with no repositoryPath
+    // would refresh whichever tab happens to be active after a mid-op switch.
+    const el = await createComponent();
+
+    let detail: { repositoryPath?: string } | null = null;
+    el.addEventListener('branches-changed', (e) => {
+      detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    });
+
+    (el as unknown as { dispatchBranchesChanged: (p: string) => void }).dispatchBranchesChanged(
+      '/repo/origin'
+    );
+
+    expect(detail, 'branches-changed dispatched').to.not.be.null;
+    expect(detail!.repositoryPath).to.equal('/repo/origin');
   });
 
   it('handleCheckout should clear operationInProgress even on error', async () => {

--- a/src/components/sidebar/__tests__/lv-file-status-conflict-stage.test.ts
+++ b/src/components/sidebar/__tests__/lv-file-status-conflict-stage.test.ts
@@ -160,4 +160,79 @@ describe('lv-file-status conflicted staging guards', () => {
     expect(calls.length).to.equal(1);
     expect((calls[0].args as { paths: string[] }).paths).to.deep.equal(['src/ok.ts']);
   });
+
+  // ── Discard guards (siblings of the stage guards above) ────────────────
+  // Discarding a conflicted path either silently no-ops or DELETES the
+  // merged working file (no stage-0 index entry) while the index stays
+  // conflicted — it must be routed to the merge editor / skipped instead.
+
+  function discardCalls(): Array<{ command: string; args?: unknown }> {
+    return invokeHistory.filter((h) => h.command === 'discard_changes');
+  }
+
+  it('discarding a conflicted file opens the conflict flow instead', async () => {
+    const conflicted = makeEntry({
+      path: 'src/conflict.ts',
+      status: 'conflicted',
+      isConflicted: true,
+    });
+    const el = await renderFileStatus([conflicted]);
+
+    let dialogRequestedFor: string | null = null;
+    el.addEventListener('open-conflict-dialog', ((e: CustomEvent) => {
+      dialogRequestedFor = e.detail?.filePath ?? null;
+    }) as EventListener);
+
+    invokeHistory.length = 0;
+    await (
+      el as unknown as { handleDiscardFile: (f: StatusEntry, e: Event) => Promise<void> }
+    ).handleDiscardFile(conflicted, new Event('click'));
+
+    expect(discardCalls().length, 'discard_changes must not be called').to.equal(0);
+    expect(dialogRequestedFor).to.equal('src/conflict.ts');
+  });
+
+  it('discard-selected skips conflicted files and discards the rest', async () => {
+    const clean = makeEntry({ path: 'src/ok.ts' });
+    const conflicted = makeEntry({
+      path: 'src/conflict.ts',
+      status: 'conflicted',
+      isConflicted: true,
+    });
+    const el = await renderFileStatus([clean, conflicted]);
+    const internal = el as unknown as FileStatusInternal & {
+      handleDiscardSelected: () => Promise<void>;
+    };
+    internal.selectedFiles = new Set(['src/ok.ts', 'src/conflict.ts']);
+
+    // The destructive confirm must be accepted for the clean file's discard.
+    const baseMock = mockInvoke;
+    mockInvoke = async (command: string, args?: unknown) => {
+      if (command === 'plugin:dialog|message') return 'Ok';
+      return baseMock(command, args);
+    };
+
+    invokeHistory.length = 0;
+    await internal.handleDiscardSelected();
+
+    const calls = discardCalls();
+    expect(calls.length).to.equal(1);
+    expect((calls[0].args as { paths: string[] }).paths).to.deep.equal(['src/ok.ts']);
+  });
+
+  it('discard-selected with only conflicted files discards nothing', async () => {
+    const conflicted = makeEntry({
+      path: 'src/conflict.ts',
+      status: 'conflicted',
+      isConflicted: true,
+    });
+    const el = await renderFileStatus([conflicted]);
+    const internal = el as unknown as FileStatusInternal & {
+      handleDiscardSelected: () => Promise<void>;
+    };
+    internal.selectedFiles = new Set(['src/conflict.ts']);
+    invokeHistory.length = 0;
+    await internal.handleDiscardSelected();
+    expect(discardCalls().length).to.equal(0);
+  });
 });

--- a/src/components/sidebar/__tests__/lv-file-status-conflict-stage.test.ts
+++ b/src/components/sidebar/__tests__/lv-file-status-conflict-stage.test.ts
@@ -1,0 +1,144 @@
+/**
+ * Tests that lv-file-status never stages conflicted files raw.
+ *
+ * Staging a conflicted file would write git's conflict-marker text into the
+ * index and clear the conflict entries — git would then treat the file as
+ * "resolved" with markers in it, bypassing the merge editor entirely.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeHistory: Array<{ command: string; args?: unknown }> = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-file-status.ts';
+import type { LvFileStatus } from '../lv-file-status.ts';
+import type { StatusEntry } from '../../../types/git.types.ts';
+
+// ── Test data ──────────────────────────────────────────────────────────────
+const REPO_PATH = '/test/repo';
+
+function makeEntry(overrides: Partial<StatusEntry> = {}): StatusEntry {
+  return {
+    path: 'src/main.ts',
+    status: 'modified',
+    isStaged: false,
+    isConflicted: false,
+    ...overrides,
+  };
+}
+
+interface FileStatusInternal {
+  stagedFiles: StatusEntry[];
+  unstagedFiles: StatusEntry[];
+  selectedFiles: Set<string>;
+  handleStageFile: (file: StatusEntry, e: Event) => Promise<void>;
+  handleStageAll: () => Promise<void>;
+  handleStageSelected: () => Promise<void>;
+}
+
+function internalOf(el: LvFileStatus): FileStatusInternal {
+  return el as unknown as FileStatusInternal;
+}
+
+function stageCalls(): Array<{ command: string; args?: unknown }> {
+  return invokeHistory.filter((h) => h.command === 'stage_files');
+}
+
+async function renderFileStatus(entries: StatusEntry[]): Promise<LvFileStatus> {
+  mockInvoke = async (command: string) => {
+    switch (command) {
+      case 'get_status':
+        return entries;
+      case 'stage_files':
+      case 'unstage_files':
+        return null;
+      default:
+        return null;
+    }
+  };
+
+  const el = await fixture<LvFileStatus>(html`
+    <lv-file-status .repositoryPath=${REPO_PATH}></lv-file-status>
+  `);
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+  const internal = internalOf(el);
+  internal.unstagedFiles = entries.filter((f) => !f.isStaged);
+  internal.stagedFiles = entries.filter((f) => f.isStaged);
+  await el.updateComplete;
+  return el;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+describe('lv-file-status conflicted staging guards', () => {
+  beforeEach(() => {
+    invokeHistory.length = 0;
+  });
+
+  it('staging a conflicted file opens the conflict flow instead of staging markers', async () => {
+    const conflicted = makeEntry({ path: 'src/conflict.ts', status: 'conflicted', isConflicted: true });
+    const el = await renderFileStatus([conflicted]);
+
+    let dialogRequestedFor: string | null = null;
+    el.addEventListener('open-conflict-dialog', ((e: CustomEvent) => {
+      dialogRequestedFor = e.detail?.filePath ?? null;
+    }) as EventListener);
+
+    invokeHistory.length = 0;
+    await internalOf(el).handleStageFile(conflicted, new Event('click'));
+
+    expect(stageCalls().length, 'stage_files must not be called').to.equal(0);
+    expect(dialogRequestedFor).to.equal('src/conflict.ts');
+  });
+
+  it('stage-all skips conflicted files and stages the rest', async () => {
+    const clean = makeEntry({ path: 'src/ok.ts' });
+    const conflicted = makeEntry({ path: 'src/conflict.ts', status: 'conflicted', isConflicted: true });
+    const el = await renderFileStatus([clean, conflicted]);
+
+    invokeHistory.length = 0;
+    await internalOf(el).handleStageAll();
+
+    const calls = stageCalls();
+    expect(calls.length).to.equal(1);
+    expect((calls[0].args as { paths: string[] }).paths).to.deep.equal(['src/ok.ts']);
+  });
+
+  it('stage-all with only conflicted files stages nothing', async () => {
+    const conflicted = makeEntry({ path: 'src/conflict.ts', status: 'conflicted', isConflicted: true });
+    const el = await renderFileStatus([conflicted]);
+
+    invokeHistory.length = 0;
+    await internalOf(el).handleStageAll();
+
+    expect(stageCalls().length).to.equal(0);
+  });
+
+  it('stage-selected skips conflicted files', async () => {
+    const clean = makeEntry({ path: 'src/ok.ts' });
+    const conflicted = makeEntry({ path: 'src/conflict.ts', status: 'conflicted', isConflicted: true });
+    const el = await renderFileStatus([clean, conflicted]);
+
+    const internal = internalOf(el);
+    internal.selectedFiles = new Set(['src/ok.ts', 'src/conflict.ts']);
+    invokeHistory.length = 0;
+    await internal.handleStageSelected();
+
+    const calls = stageCalls();
+    expect(calls.length).to.equal(1);
+    expect((calls[0].args as { paths: string[] }).paths).to.deep.equal(['src/ok.ts']);
+  });
+});

--- a/src/components/sidebar/__tests__/lv-file-status-conflict-stage.test.ts
+++ b/src/components/sidebar/__tests__/lv-file-status-conflict-stage.test.ts
@@ -127,6 +127,25 @@ describe('lv-file-status conflicted staging guards', () => {
     expect(stageCalls().length).to.equal(0);
   });
 
+  it('stage-click on a conflicted file in a multi-selection stages the clean subset', async () => {
+    const clean = makeEntry({ path: 'src/ok.ts' });
+    const conflicted = makeEntry({ path: 'src/conflict.ts', status: 'conflicted', isConflicted: true });
+    const el = await renderFileStatus([clean, conflicted]);
+
+    const internal = internalOf(el);
+    internal.selectedFiles = new Set(['src/ok.ts', 'src/conflict.ts']);
+
+    // Clicking the stage button on the CONFLICTED row of a multi-selection
+    // must still stage the other selected files (skipping the conflicted
+    // one), not silently drop them.
+    invokeHistory.length = 0;
+    await internal.handleStageFile(conflicted, new Event('click'));
+
+    const calls = stageCalls();
+    expect(calls.length).to.equal(1);
+    expect((calls[0].args as { paths: string[] }).paths).to.deep.equal(['src/ok.ts']);
+  });
+
   it('stage-selected skips conflicted files', async () => {
     const clean = makeEntry({ path: 'src/ok.ts' });
     const conflicted = makeEntry({ path: 'src/conflict.ts', status: 'conflicted', isConflicted: true });

--- a/src/components/sidebar/__tests__/lv-stash-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-stash-list-guards.test.ts
@@ -218,6 +218,44 @@ describe('lv-stash-list operationInProgress guards', () => {
     expect(detail!.repositoryPath).to.equal(REPO_PATH);
   });
 
+  it('handleDropStash drops from the origin repo, not the tab switched to during the confirm', async () => {
+    // Dropping is irreversible and stash.index is from THIS repo's list.
+    // showConfirm's await yields; a tab switch during it rebinds
+    // this.repositoryPath. The drop must target the repo it was invoked on.
+    const el = await createComponent();
+
+    let resolveConfirm!: (v: unknown) => void;
+    mockInvoke = (command: string) => {
+      if (command === 'plugin:dialog|message') {
+        return new Promise((resolve) => {
+          resolveConfirm = resolve;
+        });
+      }
+      if (command === 'drop_stash') return Promise.resolve(null);
+      return defaultMockInvoke(command);
+    };
+
+    const stash = makeStash({ index: 0 });
+    (
+      el as unknown as {
+        contextMenu: { visible: boolean; x: number; y: number; stash: typeof stash | null };
+      }
+    ).contextMenu = { visible: true, x: 0, y: 0, stash };
+
+    invokeCalls.length = 0;
+    const promise = (el as unknown as { handleDropStash: () => Promise<void> }).handleDropStash();
+
+    await new Promise((r) => setTimeout(r, 10));
+    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
+
+    resolveConfirm('Ok');
+    await promise;
+
+    const dropCall = invokeCalls.find((c) => c.command === 'drop_stash');
+    expect(dropCall, 'drop_stash called').to.not.be.undefined;
+    expect((dropCall!.args as { path: string }).path).to.equal(REPO_PATH);
+  });
+
   it('isStashing guard prevents double createStash', async () => {
     const el = await createComponent();
 

--- a/src/components/sidebar/__tests__/lv-stash-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-stash-list-guards.test.ts
@@ -175,6 +175,49 @@ describe('lv-stash-list operationInProgress guards', () => {
     expect((el as unknown as { operationInProgress: boolean }).operationInProgress).to.equal(false);
   });
 
+  it('stash-applied carries the repo the apply ran on, even after a mid-op tab switch', async () => {
+    // repoPath is captured BEFORE the await. If the active tab (and thus
+    // .repositoryPath) rebinds while apply_stash is in flight, the event must
+    // still name the origin repo so the host pins its refresh correctly.
+    const el = await createComponent();
+
+    let resolveApply!: (v: unknown) => void;
+    mockInvoke = (command: string) => {
+      if (command === 'apply_stash') {
+        return new Promise((resolve) => {
+          resolveApply = resolve;
+        });
+      }
+      return defaultMockInvoke(command);
+    };
+
+    let detail: { repositoryPath?: string } | null = null;
+    el.addEventListener('stash-applied', (e) => {
+      detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    });
+
+    const stash = makeStash({ index: 0 });
+    (
+      el as unknown as {
+        contextMenu: { visible: boolean; x: number; y: number; stash: typeof stash | null };
+      }
+    ).contextMenu = { visible: true, x: 0, y: 0, stash };
+
+    const promise = (
+      el as unknown as { handleApplyStash: () => Promise<void> }
+    ).handleApplyStash();
+
+    // User switches tabs mid-apply: the prop rebinds to another repo.
+    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
+
+    resolveApply({ success: true });
+    await promise;
+    await el.updateComplete;
+
+    expect(detail, 'stash-applied dispatched').to.not.be.null;
+    expect(detail!.repositoryPath).to.equal(REPO_PATH);
+  });
+
   it('isStashing guard prevents double createStash', async () => {
     const el = await createComponent();
 

--- a/src/components/sidebar/__tests__/lv-tag-list-feedback.test.ts
+++ b/src/components/sidebar/__tests__/lv-tag-list-feedback.test.ts
@@ -97,6 +97,47 @@ describe('lv-tag-list feedback', () => {
     expect(successToast!.message).to.equal('Pushed tag v2.0.0 to remote');
   });
 
+  it('handlePushTag pins push + tags-changed to the origin repo after a mid-push tab switch', async () => {
+    // Pushing is a slow network op; a tab switch during it rebinds
+    // this.repositoryPath. Both the push and the tags-changed refresh must pin
+    // to the origin repo so the host refreshes the right (backgrounded) tab.
+    const el = await createComponent();
+
+    let resolvePush!: (v: unknown) => void;
+    let pushArgs: { path?: string } | null = null;
+    mockInvoke = (command: string, args?: unknown) => {
+      if (command === 'push_tag') {
+        pushArgs = args as { path?: string };
+        return new Promise((resolve) => {
+          resolvePush = resolve;
+        });
+      }
+      return defaultMockInvoke(command);
+    };
+
+    let detail: { repositoryPath?: string } | null = null;
+    el.addEventListener('tags-changed', (e) => {
+      detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    });
+
+    const tag = makeTag('v4.0.0');
+    (el as unknown as { contextMenu: { visible: boolean; x: number; y: number; tag: typeof tag | null } }).contextMenu = {
+      visible: true, x: 0, y: 0, tag,
+    };
+
+    const promise = (el as unknown as { handlePushTag: () => Promise<void> }).handlePushTag();
+    await new Promise((r) => setTimeout(r, 10));
+    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
+
+    resolvePush(null);
+    await promise;
+
+    expect(pushArgs, 'push_tag called').to.not.be.null;
+    expect(pushArgs!.path).to.equal(REPO_PATH);
+    expect(detail, 'tags-changed dispatched').to.not.be.null;
+    expect(detail!.repositoryPath).to.equal(REPO_PATH);
+  });
+
   it('tag-checkout carries the repo the checkout ran on, even after a mid-op tab switch', async () => {
     // repoPath is captured BEFORE the checkout await; if .repositoryPath
     // rebinds mid-flight (tab switch), the event must still name the origin

--- a/src/components/sidebar/__tests__/lv-tag-list-feedback.test.ts
+++ b/src/components/sidebar/__tests__/lv-tag-list-feedback.test.ts
@@ -96,4 +96,42 @@ describe('lv-tag-list feedback', () => {
     expect(successToast, 'a success toast should be shown').to.not.be.undefined;
     expect(successToast!.message).to.equal('Pushed tag v2.0.0 to remote');
   });
+
+  it('tag-checkout carries the repo the checkout ran on, even after a mid-op tab switch', async () => {
+    // repoPath is captured BEFORE the checkout await; if .repositoryPath
+    // rebinds mid-flight (tab switch), the event must still name the origin
+    // repo so the host pins its refresh there, not to the newly-active tab.
+    const el = await createComponent();
+
+    let resolveCheckout!: (v: unknown) => void;
+    mockInvoke = (command: string) => {
+      if (command === 'checkout_with_autostash') {
+        return new Promise((resolve) => {
+          resolveCheckout = resolve;
+        });
+      }
+      return defaultMockInvoke(command);
+    };
+
+    let detail: { repositoryPath?: string } | null = null;
+    el.addEventListener('tag-checkout', (e) => {
+      detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+    });
+
+    const tag = makeTag('v3.0.0');
+    (el as unknown as { contextMenu: { visible: boolean; x: number; y: number; tag: typeof tag | null } }).contextMenu = {
+      visible: true, x: 0, y: 0, tag,
+    };
+
+    const promise = (el as unknown as { handleCheckoutTag: () => Promise<void> }).handleCheckoutTag();
+    // Let the confirm resolve and the checkout await begin, then switch tabs.
+    await new Promise((r) => setTimeout(r, 10));
+    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
+
+    resolveCheckout({ success: true, data: { success: true, message: 'ok', stashed: false, stashApplied: false, stashConflict: false } });
+    await promise;
+
+    expect(detail, 'tag-checkout dispatched').to.not.be.null;
+    expect(detail!.repositoryPath).to.equal(REPO_PATH);
+  });
 });

--- a/src/components/sidebar/__tests__/lv-tag-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-tag-list-guards.test.ts
@@ -27,9 +27,25 @@ import type { LvTagList } from '../lv-tag-list.ts';
 
 // Import the actual component
 import '../lv-tag-list.ts';
+import { repositoryStore } from '../../../stores/repository.store.ts';
+import type { Repository } from '../../../types/git.types.ts';
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
+
+function mockRepo(path: string, name: string): Repository {
+  return {
+    path,
+    name,
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
 
 function makeTag(overrides: Partial<{
   name: string;
@@ -75,6 +91,62 @@ describe('lv-tag-list operationInProgress guards', () => {
   it('should have operationInProgress initially false', async () => {
     const el = await createComponent();
     expect((el as unknown as { operationInProgress: boolean }).operationInProgress).to.equal(false);
+  });
+
+  it('preserves the create-tag dialog element across an empty<->non-empty tag flip', async () => {
+    // The dialog must live at ONE template position; flipping the tag list
+    // empty<->non-empty (e.g. a watcher refresh after an external git tag) must
+    // not destroy an open dialog (losing its pinned repo / in-progress input).
+    const el = await createComponent();
+    await el.updateComplete;
+    const before = el.shadowRoot!.querySelector('lv-create-tag-dialog');
+    expect(before, 'dialog present when empty').to.not.be.null;
+
+    (el as unknown as { tags: unknown[] }).tags = [makeTag({ name: 'v1.0.0' })];
+    await el.updateComplete;
+    expect(
+      el.shadowRoot!.querySelector('lv-create-tag-dialog'),
+      'same element instance after tags appear',
+    ).to.equal(before);
+
+    (el as unknown as { tags: unknown[] }).tags = [];
+    await el.updateComplete;
+    expect(
+      el.shadowRoot!.querySelector('lv-create-tag-dialog'),
+      'same element instance after flipping back to empty',
+    ).to.equal(before);
+  });
+
+  it('closes its embedded create-tag dialog when the pinned repo tab is removed', async () => {
+    // lv-tag-list embeds its own create-tag dialog; app-shell's self-close
+    // guard can't reach it. Closing the pinned tab must dismiss it, or Create
+    // would run against a repo no longer in the tab bar.
+    repositoryStore.getState().reset();
+    repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
+    repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+
+    const el = await createComponent();
+    for (let i = 0; i < 50; i++) {
+      if ((el as unknown as { storeUnsubscribe?: () => void }).storeUnsubscribe) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+
+    let closed = false;
+    Object.defineProperty(el, 'createTagDialog', {
+      configurable: true,
+      value: {
+        pinnedRepositoryPathIfOpen: '/repo/a',
+        close: () => {
+          closed = true;
+        },
+      },
+    });
+
+    repositoryStore.getState().removeRepository('/repo/a');
+    await el.updateComplete;
+
+    expect(closed, 'create-tag dialog closed when its pinned tab was removed').to.be.true;
+    repositoryStore.getState().reset();
   });
 
   it('handleCheckoutTag should skip when operationInProgress is true', async () => {

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -596,10 +596,20 @@ export class LvBranchList extends LitElement {
     // stable template) floats over a closed repo and Execute would rewrite
     // a repo with no tab to observe it.
     this.storeUnsubscribe = repositoryStore.subscribe((state) => {
-      const pinned = this.interactiveRebaseDialog?.pinnedRepositoryPathIfOpen ?? null;
-      if (pinned && !state.openRepositories.some((r) => r.repository.path === pinned)) {
+      const gone = (p: string | null): boolean =>
+        !!p && !state.openRepositories.some((r) => r.repository.path === p);
+      const rbPinned = this.interactiveRebaseDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (gone(rbPinned)) {
         this.interactiveRebaseDialog.close();
         showToast('The repository tab was closed — interactive rebase cancelled', 'warning');
+      }
+      // Same for our OWN embedded create-branch dialog: app-shell's guard only
+      // reaches app-shell's instance, not this one in the sidebar's shadow
+      // root. Create + checkout on a closed repo would be a silent mutation.
+      const cbPinned = this.createBranchDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (gone(cbPinned)) {
+        this.createBranchDialog.close();
+        showToast('The repository tab was closed — branch creation cancelled', 'warning');
       }
     });
   }

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1112,7 +1112,7 @@ export class LvBranchList extends LitElement {
         }
         await this.loadBranches();
         this.dispatchEvent(new CustomEvent('branch-checkout', {
-          detail: { branch },
+          detail: { branch, repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -2164,16 +2164,23 @@ export class LvBranchList extends LitElement {
       ></lv-branch-cleanup-dialog>
     `;
 
-    if (this.loading) {
-      return html`${dialogs}<div class="loading">Loading branches...</div>`;
-    }
-
-    if (this.error) {
-      return html`${dialogs}<div class="error">${this.error}</div>`;
-    }
-
+    // ONE stable outer template: the dialogs sit at a FIXED position and the
+    // loading/error/content choice is a nested conditional slot. Returning
+    // three DIFFERENT top-level templates (as before) made lit-html re-clone
+    // the whole subtree on every loading toggle — recreating the dialogs in
+    // their closed state and discarding an in-progress rebase plan.
     return html`
       ${dialogs}
+      ${this.loading
+        ? html`<div class="loading">Loading branches...</div>`
+        : this.error
+          ? html`<div class="error">${this.error}</div>`
+          : this.renderBody()}
+    `;
+  }
+
+  private renderBody(): ReturnType<typeof html> {
+    return html`
       ${this.renderControls()}
 
       <!-- Local branches -->

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1081,11 +1081,14 @@ export class LvBranchList extends LitElement {
     // Close context menu immediately
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the await: conflict events must carry the repo the
+    // operation actually ran on, even if the prop is rebound mid-flight.
+    const repoPath = this.repositoryPath;
     try {
       // Use branch.name for both local and remote branches
       // - For local branches: branch.name is the branch name (e.g., "main", "feature/my-branch")
       // - For remote branches: branch.name is the full remote reference (e.g., "origin/feature/my-branch")
-      const result = await gitService.checkoutWithAutoStash(this.repositoryPath, branch.name);
+      const result = await gitService.checkoutWithAutoStash(repoPath, branch.name);
 
       if (result.success && result.data?.success) {
         const data = result.data;
@@ -1095,7 +1098,12 @@ export class LvBranchList extends LitElement {
             bubbles: true,
             composed: true,
             // Auto-stash is pop semantics: entry at index 0, drop it once resolved.
-            detail: { operationType: 'stash', stashIndex: 0, dropStashOnComplete: true },
+            detail: {
+              operationType: 'stash',
+              stashIndex: 0,
+              dropStashOnComplete: true,
+              repositoryPath: repoPath,
+            },
           }));
         } else if (data.stashed && data.stashApplied) {
           showToast(data.message, data.message.includes('staged status was not preserved') ? 'warning' : 'info');
@@ -1241,9 +1249,10 @@ export class LvBranchList extends LitElement {
 
     this.operationInProgress = true;
 
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.merge({
-        path: this.repositoryPath,
+        path: repoPath,
         sourceRef: branch.shorthand,
       });
 
@@ -1255,7 +1264,11 @@ export class LvBranchList extends LitElement {
         }));
       } else if (result.error?.code === 'MERGE_CONFLICT') {
         // Open the conflict-resolution dialog (same flow as the drag-drop path)
-        this.dispatchEvent(new CustomEvent('merge-conflict', { bubbles: true, composed: true }));
+        this.dispatchEvent(new CustomEvent('merge-conflict', {
+          bubbles: true,
+          composed: true,
+          detail: { repositoryPath: repoPath },
+        }));
       } else {
         console.error('Merge failed:', result.error);
         showToast(`Merge failed: ${result.error?.message ?? 'Unknown error'}`, 'error');
@@ -1281,9 +1294,10 @@ export class LvBranchList extends LitElement {
 
     this.operationInProgress = true;
 
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.rebase({
-        path: this.repositoryPath,
+        path: repoPath,
         onto: branch.shorthand,
       });
 
@@ -1298,7 +1312,7 @@ export class LvBranchList extends LitElement {
         this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
           bubbles: true,
           composed: true,
-          detail: { operationType: 'rebase' },
+          detail: { operationType: 'rebase', repositoryPath: repoPath },
         }));
       } else {
         console.error('Rebase failed:', result.error);
@@ -1619,6 +1633,10 @@ export class LvBranchList extends LitElement {
     this.dropAction = null;
     dragDropService.endDrag();
 
+    // Captured BEFORE the awaits below: conflict events must carry the repo
+    // the operation actually ran on, even if the prop is rebound mid-flight.
+    const repoPath = this.repositoryPath;
+
     // If target is HEAD, merge source into current
     if (targetBranch.isHead) {
       if (action === 'merge') {
@@ -1631,7 +1649,7 @@ export class LvBranchList extends LitElement {
         if (!confirmed) return;
 
         const result = await gitService.merge({
-          path: this.repositoryPath,
+          path: repoPath,
           sourceRef: sourceBranch.shorthand,
         });
 
@@ -1639,7 +1657,11 @@ export class LvBranchList extends LitElement {
           await this.loadBranches();
           this.dispatchEvent(new CustomEvent('branches-changed', { bubbles: true, composed: true }));
         } else if (result.error?.code === 'MERGE_CONFLICT') {
-          this.dispatchEvent(new CustomEvent('merge-conflict', { bubbles: true, composed: true }));
+          this.dispatchEvent(new CustomEvent('merge-conflict', {
+            bubbles: true,
+            composed: true,
+            detail: { repositoryPath: repoPath },
+          }));
         } else {
           showToast(`Merge failed: ${result.error?.message ?? 'Unknown error'}`, 'error');
         }
@@ -1653,7 +1675,7 @@ export class LvBranchList extends LitElement {
         if (!confirmed) return;
 
         const result = await gitService.rebase({
-          path: this.repositoryPath,
+          path: repoPath,
           onto: sourceBranch.shorthand,
         });
 
@@ -1664,7 +1686,7 @@ export class LvBranchList extends LitElement {
           this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
             bubbles: true,
             composed: true,
-            detail: { operationType: 'rebase' },
+            detail: { operationType: 'rebase', repositoryPath: repoPath },
           }));
         } else {
           showToast(`Rebase failed: ${result.error?.message ?? 'Unknown error'}`, 'error');
@@ -1684,7 +1706,7 @@ export class LvBranchList extends LitElement {
       // Use the full branch.name — for remote branches this is the full
       // "origin/topic" reference the backend needs to create/use a local
       // tracking branch; the stripped shorthand ("topic") cannot be resolved.
-      const checkoutResult = await gitService.checkoutWithAutoStash(this.repositoryPath, targetBranch.name);
+      const checkoutResult = await gitService.checkoutWithAutoStash(repoPath, targetBranch.name);
 
       if (!checkoutResult.success || !checkoutResult.data?.success) {
         console.error('Checkout failed:', checkoutResult.data?.message || checkoutResult.error);
@@ -1702,7 +1724,12 @@ export class LvBranchList extends LitElement {
           bubbles: true,
           composed: true,
           // Auto-stash is pop semantics: entry at index 0, drop it once resolved.
-          detail: { operationType: 'stash', stashIndex: 0, dropStashOnComplete: true },
+          detail: {
+            operationType: 'stash',
+            stashIndex: 0,
+            dropStashOnComplete: true,
+            repositoryPath: repoPath,
+          },
         }));
         // The working tree is conflicted from the failed stash pop; do NOT fall
         // through into merge/rebase on a conflicted tree — the user must resolve
@@ -1717,7 +1744,7 @@ export class LvBranchList extends LitElement {
       // Then perform the action
       if (action === 'merge') {
         const result = await gitService.merge({
-          path: this.repositoryPath,
+          path: repoPath,
           sourceRef: sourceBranch.shorthand,
         });
 
@@ -1725,13 +1752,17 @@ export class LvBranchList extends LitElement {
           await this.loadBranches();
           this.dispatchEvent(new CustomEvent('branches-changed', { bubbles: true, composed: true }));
         } else if (result.error?.code === 'MERGE_CONFLICT') {
-          this.dispatchEvent(new CustomEvent('merge-conflict', { bubbles: true, composed: true }));
+          this.dispatchEvent(new CustomEvent('merge-conflict', {
+            bubbles: true,
+            composed: true,
+            detail: { repositoryPath: repoPath },
+          }));
         } else {
           showToast(`Merge failed: ${result.error?.message ?? 'Unknown error'}`, 'error');
         }
       } else {
         const result = await gitService.rebase({
-          path: this.repositoryPath,
+          path: repoPath,
           onto: sourceBranch.shorthand,
         });
 
@@ -1742,7 +1773,7 @@ export class LvBranchList extends LitElement {
           this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
             bubbles: true,
             composed: true,
-            detail: { operationType: 'rebase' },
+            detail: { operationType: 'rebase', repositoryPath: repoPath },
           }));
         } else {
           showToast(`Rebase failed: ${result.error?.message ?? 'Unknown error'}`, 'error');

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1074,12 +1074,16 @@ export class LvBranchList extends LitElement {
     }
   }
 
-  private async handleBranchCreated(): Promise<void> {
-    // Captured BEFORE the loadBranches await: the refresh must pin to the repo
-    // the branch was created on, not whichever tab is active if the user
-    // switches during the reload (which rebinds this.repositoryPath).
-    const repoPath = this.repositoryPath;
-    await this.loadBranches();
+  private async handleBranchCreated(e?: CustomEvent<{ repositoryPath?: string }>): Promise<void> {
+    // The dialog pins to the repo it was opened for and reports it here. The
+    // user may have switched tabs while the dialog was open (rebinding our live
+    // repositoryPath), so trust the event's repo — not our current prop — and
+    // only reload OUR view when it matches the repo we're showing. Mirrors
+    // handleRebaseComplete.
+    const repoPath = e?.detail?.repositoryPath ?? this.repositoryPath;
+    if (repoPath === this.repositoryPath) {
+      await this.loadBranches();
+    }
     this.dispatchBranchesChanged(repoPath);
   }
 

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1331,7 +1331,15 @@ export class LvBranchList extends LitElement {
     this.interactiveRebaseDialog.open(branch.shorthand);
   }
 
-  private async handleRebaseComplete(): Promise<void> {
+  private async handleRebaseComplete(e: Event): Promise<void> {
+    // Reload our OWN view only when the rebase ran on the repo we're
+    // showing. After a mid-rebase tab switch the completed repo may be
+    // backgrounded (this.repositoryPath has rebound) — reloading it here
+    // would refresh the wrong repo; app-shell's host-level rebase-complete
+    // listener marks the originating repo stale for refresh on
+    // reactivation. The event still bubbles there (no stopPropagation).
+    const repoPath = (e as CustomEvent<{ repositoryPath?: string }>).detail?.repositoryPath;
+    if (repoPath && repoPath !== this.repositoryPath) return;
     await this.loadBranches();
     this.dispatchEvent(new CustomEvent('branches-changed', {
       bubbles: true,

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -2140,17 +2140,14 @@ export class LvBranchList extends LitElement {
   }
 
   render() {
-    if (this.loading) {
-      return html`<div class="loading">Loading branches...</div>`;
-    }
-
-    if (this.error) {
-      return html`<div class="error">${this.error}</div>`;
-    }
-
-    return html`
-      ${this.renderControls()}
-
+    // The dialogs are rendered UNCONDITIONALLY and FIRST so a background
+    // refresh (which flips `loading` true→false and would otherwise swap the
+    // whole template for the loading placeholder) cannot tear down and
+    // recreate the embedded interactive-rebase dialog — that would silently
+    // discard an in-progress rebase plan the user built before switching
+    // tabs. Keeping them at a stable template position preserves the element
+    // instances across loading/error toggles.
+    const dialogs = html`
       <lv-create-branch-dialog
         .repositoryPath=${this.repositoryPath}
         @branch-created=${this.handleBranchCreated}
@@ -2165,6 +2162,19 @@ export class LvBranchList extends LitElement {
         .repositoryPath=${this.repositoryPath}
         @cleanup-complete=${this.handleCleanupComplete}
       ></lv-branch-cleanup-dialog>
+    `;
+
+    if (this.loading) {
+      return html`${dialogs}<div class="loading">Loading branches...</div>`;
+    }
+
+    if (this.error) {
+      return html`${dialogs}<div class="error">${this.error}</div>`;
+    }
+
+    return html`
+      ${dialogs}
+      ${this.renderControls()}
 
       <!-- Local branches -->
       ${this.localBranchGroups.length > 0 ? html`

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1018,6 +1018,10 @@ export class LvBranchList extends LitElement {
    * Delete all branches that are merged into HEAD
    */
   private async handleDeleteMergedBranches(): Promise<void> {
+    // Captured BEFORE the confirm await: these irreversible deletes (and the
+    // refresh) must target the repo they were invoked on, even if the user
+    // switches tabs while the confirm is up and this.repositoryPath rebinds.
+    const repoPath = this.repositoryPath;
     const mergedBranches = this.getMergedBranches();
 
     if (mergedBranches.length === 0) {
@@ -1039,7 +1043,6 @@ export class LvBranchList extends LitElement {
     if (!confirmed) return;
 
     // Delete branches one by one
-    const repoPath = this.repositoryPath;
     let deleted = 0;
     let failed = 0;
 
@@ -1072,8 +1075,12 @@ export class LvBranchList extends LitElement {
   }
 
   private async handleBranchCreated(): Promise<void> {
+    // Captured BEFORE the loadBranches await: the refresh must pin to the repo
+    // the branch was created on, not whichever tab is active if the user
+    // switches during the reload (which rebinds this.repositoryPath).
+    const repoPath = this.repositoryPath;
     await this.loadBranches();
-    this.dispatchBranchesChanged(this.repositoryPath);
+    this.dispatchBranchesChanged(repoPath);
   }
 
   private handleBranchClick(branch: Branch): void {

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1006,8 +1006,12 @@ export class LvBranchList extends LitElement {
    * Handle cleanup completion by refreshing branches
    */
   private async handleCleanupComplete(): Promise<void> {
+    // Captured BEFORE the loadBranches await: the refresh must pin to the repo
+    // the cleanup ran on, not whichever tab is active if the user switches
+    // during the reload (which rebinds this.repositoryPath).
+    const repoPath = this.repositoryPath;
     await this.loadBranches();
-    this.dispatchBranchesChanged(this.repositoryPath);
+    this.dispatchBranchesChanged(repoPath);
   }
 
   /**
@@ -1246,6 +1250,9 @@ export class LvBranchList extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the confirm await: the merge must run on the repo it was
+    // invoked on, even if the user switches tabs while the confirm is up.
+    const repoPath = this.repositoryPath;
     const confirmed = await showConfirm(
       'Merge Branch',
       `Merge "${branch.shorthand}" into the current branch?`,
@@ -1256,7 +1263,6 @@ export class LvBranchList extends LitElement {
 
     this.operationInProgress = true;
 
-    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.merge({
         path: repoPath,
@@ -1288,6 +1294,9 @@ export class LvBranchList extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the confirm await: the rebase must run on the repo it was
+    // invoked on, even if the user switches tabs while the confirm is up.
+    const repoPath = this.repositoryPath;
     const confirmed = await showConfirm(
       'Rebase Branch',
       `Rebase current branch onto "${branch.shorthand}"?\n\nThis will rewrite commit history.`,
@@ -1298,7 +1307,6 @@ export class LvBranchList extends LitElement {
 
     this.operationInProgress = true;
 
-    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.rebase({
         path: repoPath,

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -611,6 +611,13 @@ export class LvBranchList extends LitElement {
         this.createBranchDialog.close();
         showToast('The repository tab was closed — branch creation cancelled', 'warning');
       }
+      // And the branch-cleanup dialog: its Delete force-deletes branches +
+      // prunes remotes on the pinned repo, so a closed tab must dismiss it.
+      const clPinned = this.branchCleanupDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (gone(clPinned)) {
+        this.branchCleanupDialog.close();
+        showToast('The repository tab was closed — branch cleanup cancelled', 'warning');
+      }
     });
   }
 
@@ -1015,12 +1022,15 @@ export class LvBranchList extends LitElement {
   /**
    * Handle cleanup completion by refreshing branches
    */
-  private async handleCleanupComplete(): Promise<void> {
-    // Captured BEFORE the loadBranches await: the refresh must pin to the repo
-    // the cleanup ran on, not whichever tab is active if the user switches
-    // during the reload (which rebinds this.repositoryPath).
-    const repoPath = this.repositoryPath;
-    await this.loadBranches();
+  private async handleCleanupComplete(e?: CustomEvent<{ repositoryPath?: string }>): Promise<void> {
+    // The cleanup dialog pins to the repo it ran on and reports it here. The
+    // user may have switched tabs while it was open (rebinding our live
+    // repositoryPath), so trust the event's repo and only reload OUR view when
+    // it matches. Mirrors handleBranchCreated / handleRebaseComplete.
+    const repoPath = e?.detail?.repositoryPath ?? this.repositoryPath;
+    if (repoPath === this.repositoryPath) {
+      await this.loadBranches();
+    }
     this.dispatchBranchesChanged(repoPath);
   }
 

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1041,7 +1041,7 @@ export class LvBranchList extends LitElement {
 
     for (const branch of mergedBranches) {
       const result = await gitService.deleteBranch(
-        this.repositoryPath,
+        repoPath,
         branch.name,
         false
       );
@@ -1147,6 +1147,10 @@ export class LvBranchList extends LitElement {
   private async handleRenameBranch(): Promise<void> {
     const branch = this.contextMenu.branch;
     if (!branch || this.operationInProgress) return;
+    // Captured BEFORE the in-app prompt await (a Lit overlay, NOT a native
+    // modal — the window stays interactive, so the user can switch tabs while
+    // it is open). The rename must run against the repo it was invoked on, not
+    // whichever tab is active when the prompt resolves.
     const repoPath = this.repositoryPath;
 
     this.contextMenu = { ...this.contextMenu, visible: false };
@@ -1164,7 +1168,7 @@ export class LvBranchList extends LitElement {
     this.operationInProgress = true;
 
     try {
-      const result = await gitService.renameBranch(this.repositoryPath, {
+      const result = await gitService.renameBranch(repoPath, {
         oldName: branch.name,
         newName: newName.trim(),
       });
@@ -1205,7 +1209,7 @@ export class LvBranchList extends LitElement {
 
     try {
       let result = await gitService.deleteBranch(
-        this.repositoryPath,
+        repoPath,
         branch.name,
         false
       );
@@ -1221,7 +1225,7 @@ export class LvBranchList extends LitElement {
           'warning'
         );
         if (!forceConfirmed) return;
-        result = await gitService.deleteBranch(this.repositoryPath, branch.name, true);
+        result = await gitService.deleteBranch(repoPath, branch.name, true);
       }
 
       if (result.success) {
@@ -1375,7 +1379,7 @@ export class LvBranchList extends LitElement {
     const remoteBranchRef = branch.name;
 
     try {
-      const createResult = await gitService.createBranch(this.repositoryPath, {
+      const createResult = await gitService.createBranch(repoPath, {
         name: localName,
         startPoint: remoteBranchRef,
         checkout: false,
@@ -1387,7 +1391,7 @@ export class LvBranchList extends LitElement {
       }
 
       const upstreamResult = await gitService.setUpstreamBranch(
-        this.repositoryPath,
+        repoPath,
         localName,
         remoteBranchRef,
       );
@@ -1410,14 +1414,18 @@ export class LvBranchList extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the in-app prompt await (a Lit overlay, NOT a native
+    // modal — the window stays interactive, so the user can switch tabs while
+    // it is open). Without this the set-upstream would run against whichever
+    // repo is active when the prompt resolves, not the one it was invoked on.
+    const repoPath = this.repositoryPath;
     const defaultUpstream = branch.upstream ?? `origin/${branch.shorthand}`;
     const upstream = await showPrompt('Set Upstream', `Set upstream for "${branch.shorthand}":`, defaultUpstream);
     if (!upstream) return;
 
-    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.setUpstreamBranch(
-        this.repositoryPath,
+        repoPath,
         branch.name,
         upstream.trim(),
       );
@@ -1443,7 +1451,7 @@ export class LvBranchList extends LitElement {
     const repoPath = this.repositoryPath;
     try {
       const result = await gitService.unsetUpstreamBranch(
-        this.repositoryPath,
+        repoPath,
         branch.name,
       );
 

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1395,7 +1395,7 @@ export class LvBranchList extends LitElement {
       if (upstreamResult.success) {
         showToast(`Tracking ${remoteBranchRef} as ${localName}`, 'success');
         await this.loadBranches();
-        this.dispatchEvent(new CustomEvent('branches-changed', { bubbles: true, composed: true }));
+        this.dispatchBranchesChanged(repoPath);
       } else {
         showToast(`Failed to set upstream: ${upstreamResult.error?.message ?? 'Unknown error'}`, 'error');
       }
@@ -1425,7 +1425,7 @@ export class LvBranchList extends LitElement {
       if (result.success) {
         showToast(`Upstream set to ${upstream.trim()}`, 'success');
         await this.loadBranches();
-        this.dispatchEvent(new CustomEvent('branches-changed', { bubbles: true, composed: true }));
+        this.dispatchBranchesChanged(repoPath);
       } else {
         showToast(`Failed to set upstream: ${result.error?.message ?? 'Unknown error'}`, 'error');
       }
@@ -1450,7 +1450,7 @@ export class LvBranchList extends LitElement {
       if (result.success) {
         showToast(`Upstream removed for ${branch.shorthand}`, 'success');
         await this.loadBranches();
-        this.dispatchEvent(new CustomEvent('branches-changed', { bubbles: true, composed: true }));
+        this.dispatchBranchesChanged(repoPath);
       } else {
         showToast(`Failed to unset upstream: ${result.error?.message ?? 'Unknown error'}`, 'error');
       }
@@ -1672,7 +1672,7 @@ export class LvBranchList extends LitElement {
 
         if (result.success) {
           await this.loadBranches();
-          this.dispatchEvent(new CustomEvent('branches-changed', { bubbles: true, composed: true }));
+          this.dispatchBranchesChanged(repoPath);
         } else if (result.error?.code === 'MERGE_CONFLICT') {
           this.dispatchEvent(new CustomEvent('merge-conflict', {
             bubbles: true,
@@ -1698,7 +1698,7 @@ export class LvBranchList extends LitElement {
 
         if (result.success) {
           await this.loadBranches();
-          this.dispatchEvent(new CustomEvent('branches-changed', { bubbles: true, composed: true }));
+          this.dispatchBranchesChanged(repoPath);
         } else if (result.error?.code === 'REBASE_CONFLICT') {
           this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
             bubbles: true,
@@ -1767,7 +1767,7 @@ export class LvBranchList extends LitElement {
 
         if (result.success) {
           await this.loadBranches();
-          this.dispatchEvent(new CustomEvent('branches-changed', { bubbles: true, composed: true }));
+          this.dispatchBranchesChanged(repoPath);
         } else if (result.error?.code === 'MERGE_CONFLICT') {
           this.dispatchEvent(new CustomEvent('merge-conflict', {
             bubbles: true,
@@ -1785,7 +1785,7 @@ export class LvBranchList extends LitElement {
 
         if (result.success) {
           await this.loadBranches();
-          this.dispatchEvent(new CustomEvent('branches-changed', { bubbles: true, composed: true }));
+          this.dispatchBranchesChanged(repoPath);
         } else if (result.error?.code === 'REBASE_CONFLICT') {
           this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
             bubbles: true,

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -580,6 +580,8 @@ export class LvBranchList extends LitElement {
 
   private static readonly HIDDEN_BRANCHES_STORAGE_PREFIX = 'lv-hidden-branches:';
 
+  private storeUnsubscribe?: () => void;
+
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
     this.loadHiddenBranches();
@@ -588,6 +590,18 @@ export class LvBranchList extends LitElement {
     document.addEventListener('keydown', this.handleKeydown);
     window.addEventListener('open-branch-cleanup', this.handleExternalCleanupOpen);
     window.addEventListener('repository-refresh', this.handleRepositoryRefresh);
+    // Close our OWN embedded interactive-rebase dialog when its pinned repo's
+    // tab is closed — mirrors app-shell's guard for the app-level dialogs.
+    // Without it, the dialog (kept alive across refreshes by the single
+    // stable template) floats over a closed repo and Execute would rewrite
+    // a repo with no tab to observe it.
+    this.storeUnsubscribe = repositoryStore.subscribe((state) => {
+      const pinned = this.interactiveRebaseDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (pinned && !state.openRepositories.some((r) => r.repository.path === pinned)) {
+        this.interactiveRebaseDialog.close();
+        showToast('The repository tab was closed — interactive rebase cancelled', 'warning');
+      }
+    });
   }
 
   disconnectedCallback(): void {
@@ -596,6 +610,7 @@ export class LvBranchList extends LitElement {
     document.removeEventListener('keydown', this.handleKeydown);
     window.removeEventListener('open-branch-cleanup', this.handleExternalCleanupOpen);
     window.removeEventListener('repository-refresh', this.handleRepositoryRefresh);
+    this.storeUnsubscribe?.();
   }
 
   private handleRepositoryRefresh = (): void => {
@@ -992,10 +1007,7 @@ export class LvBranchList extends LitElement {
    */
   private async handleCleanupComplete(): Promise<void> {
     await this.loadBranches();
-    this.dispatchEvent(new CustomEvent('branches-changed', {
-      bubbles: true,
-      composed: true,
-    }));
+    this.dispatchBranchesChanged(this.repositoryPath);
   }
 
   /**
@@ -1023,6 +1035,7 @@ export class LvBranchList extends LitElement {
     if (!confirmed) return;
 
     // Delete branches one by one
+    const repoPath = this.repositoryPath;
     let deleted = 0;
     let failed = 0;
 
@@ -1042,10 +1055,7 @@ export class LvBranchList extends LitElement {
 
     if (deleted > 0) {
       await this.loadBranches();
-      this.dispatchEvent(new CustomEvent('branches-changed', {
-        bubbles: true,
-        composed: true,
-      }));
+      this.dispatchBranchesChanged(repoPath);
     }
 
     if (failed > 0) {
@@ -1059,10 +1069,7 @@ export class LvBranchList extends LitElement {
 
   private async handleBranchCreated(): Promise<void> {
     await this.loadBranches();
-    this.dispatchEvent(new CustomEvent('branches-changed', {
-      bubbles: true,
-      composed: true,
-    }));
+    this.dispatchBranchesChanged(this.repositoryPath);
   }
 
   private handleBranchClick(branch: Branch): void {
@@ -1140,6 +1147,7 @@ export class LvBranchList extends LitElement {
   private async handleRenameBranch(): Promise<void> {
     const branch = this.contextMenu.branch;
     if (!branch || this.operationInProgress) return;
+    const repoPath = this.repositoryPath;
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
@@ -1163,10 +1171,7 @@ export class LvBranchList extends LitElement {
 
       if (result.success) {
         await this.loadBranches();
-        this.dispatchEvent(new CustomEvent('branches-changed', {
-          bubbles: true,
-          composed: true,
-        }));
+        this.dispatchBranchesChanged(repoPath);
       } else {
         console.error('Rename branch failed:', result.error);
         showToast(`Failed to rename branch: ${result.error?.message ?? 'Unknown error'}`, 'error');
@@ -1179,6 +1184,7 @@ export class LvBranchList extends LitElement {
   private async handleDeleteBranch(): Promise<void> {
     const branch = this.contextMenu.branch;
     if (!branch || this.operationInProgress) return;
+    const repoPath = this.repositoryPath;
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
@@ -1220,10 +1226,7 @@ export class LvBranchList extends LitElement {
 
       if (result.success) {
         await this.loadBranches();
-        this.dispatchEvent(new CustomEvent('branches-changed', {
-          bubbles: true,
-          composed: true,
-        }));
+        this.dispatchBranchesChanged(repoPath);
       } else {
         console.error('Delete branch failed:', result.error);
         showToast(`Failed to delete branch: ${result.error?.message ?? 'Unknown error'}`, 'error');
@@ -1258,10 +1261,7 @@ export class LvBranchList extends LitElement {
 
       if (result.success) {
         await this.loadBranches();
-        this.dispatchEvent(new CustomEvent('branches-changed', {
-          bubbles: true,
-          composed: true,
-        }));
+        this.dispatchBranchesChanged(repoPath);
       } else if (result.error?.code === 'MERGE_CONFLICT') {
         // Open the conflict-resolution dialog (same flow as the drag-drop path)
         this.dispatchEvent(new CustomEvent('merge-conflict', {
@@ -1303,10 +1303,7 @@ export class LvBranchList extends LitElement {
 
       if (result.success) {
         await this.loadBranches();
-        this.dispatchEvent(new CustomEvent('branches-changed', {
-          bubbles: true,
-          composed: true,
-        }));
+        this.dispatchBranchesChanged(repoPath);
       } else if (result.error?.code === 'REBASE_CONFLICT') {
         // Open the conflict-resolution dialog (same flow as the drag-drop path)
         this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
@@ -1331,6 +1328,18 @@ export class LvBranchList extends LitElement {
     this.interactiveRebaseDialog.open(branch.shorthand);
   }
 
+  /** Dispatch branches-changed carrying the repo the mutating operation ran
+   * on (captured pre-await by the caller), so the host pins the refresh to
+   * that repo instead of whichever tab is active if the user switched
+   * mid-operation. Pass `this.repositoryPath` for synchronous callers. */
+  private dispatchBranchesChanged(repoPath: string): void {
+    this.dispatchEvent(new CustomEvent('branches-changed', {
+      detail: { repositoryPath: repoPath },
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
   private async handleRebaseComplete(e: Event): Promise<void> {
     // Reload our OWN view only when the rebase ran on the repo we're
     // showing. After a mid-rebase tab switch the completed repo may be
@@ -1341,10 +1350,7 @@ export class LvBranchList extends LitElement {
     const repoPath = (e as CustomEvent<{ repositoryPath?: string }>).detail?.repositoryPath;
     if (repoPath && repoPath !== this.repositoryPath) return;
     await this.loadBranches();
-    this.dispatchEvent(new CustomEvent('branches-changed', {
-      bubbles: true,
-      composed: true,
-    }));
+    this.dispatchBranchesChanged(repoPath ?? this.repositoryPath);
   }
 
   private handleCreateBranchFrom(): void {
@@ -1361,6 +1367,7 @@ export class LvBranchList extends LitElement {
   private async handleTrackRemoteBranch(): Promise<void> {
     const branch = this.contextMenu.branch;
     if (!branch || !branch.isRemote) return;
+    const repoPath = this.repositoryPath;
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
@@ -1407,6 +1414,7 @@ export class LvBranchList extends LitElement {
     const upstream = await showPrompt('Set Upstream', `Set upstream for "${branch.shorthand}":`, defaultUpstream);
     if (!upstream) return;
 
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.setUpstreamBranch(
         this.repositoryPath,
@@ -1432,6 +1440,7 @@ export class LvBranchList extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.unsetUpstreamBranch(
         this.repositoryPath,

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -709,7 +709,8 @@ export class LvFileStatus extends LitElement {
     const filesToDiscard = this.getFilesUnderPath(this.unstagedFiles, dirPath);
     if (filesToDiscard.length === 0) return;
 
-    const paths = filesToDiscard.map((f) => f.path);
+    const paths = this.discardablePaths(filesToDiscard);
+    if (paths.length === 0) return;
     const confirmed = await showConfirm(
       "Discard Changes",
       `Discard changes to ${paths.length} file${paths.length > 1 ? "s" : ""} in "${dirPath}"? This cannot be undone.`,
@@ -1181,6 +1182,24 @@ export class LvFileStatus extends LitElement {
     return files.filter((f) => !f.isConflicted).map((f) => f.path);
   }
 
+  /**
+   * Filter conflicted files out of a bulk discard, with feedback for what
+   * was skipped. A conflicted path has no stage-0 index entry, so the
+   * backend either silently no-ops or DELETES the merged working file while
+   * the index stays conflicted — either way the conflict must be resolved
+   * (or the operation aborted) in the merge editor instead.
+   */
+  private discardablePaths(files: StatusEntry[]): string[] {
+    const conflicted = files.filter((f) => f.isConflicted);
+    if (conflicted.length > 0) {
+      showToast(
+        `${conflicted.length} conflicted file${conflicted.length === 1 ? '' : 's'} skipped — resolve ${conflicted.length === 1 ? 'it' : 'them'} in the merge editor (or abort the operation) instead`,
+        'warning',
+      );
+    }
+    return files.filter((f) => !f.isConflicted).map((f) => f.path);
+  }
+
   private async handleStageFile(file: StatusEntry, e: Event): Promise<void> {
     e.stopPropagation();
 
@@ -1229,10 +1248,18 @@ export class LvFileStatus extends LitElement {
 
   private async handleDiscardFile(file: StatusEntry, e: Event): Promise<void> {
     e.stopPropagation();
-    
+
     // If multiple files are selected and this file is one of them, discard all selected
     if (this.selectedFiles.size > 1 && this.selectedFiles.has(file.path)) {
       await this.handleDiscardSelected();
+      return;
+    }
+
+    // Discarding a conflicted file either silently no-ops or deletes the
+    // merged working file (no stage-0 entry) — route to the merge editor,
+    // matching the stage guard.
+    if (file.isConflicted) {
+      this.redirectConflictedToMergeEditor(file);
       return;
     }
 
@@ -1370,9 +1397,9 @@ export class LvFileStatus extends LitElement {
   }
 
   private async handleDiscardSelected(): Promise<void> {
-    const paths = this.unstagedFiles
-      .filter((f) => this.selectedFiles.has(f.path))
-      .map((f) => f.path);
+    const paths = this.discardablePaths(
+      this.unstagedFiles.filter((f) => this.selectedFiles.has(f.path))
+    );
     if (paths.length === 0) return;
 
     const confirmed = await showConfirm(
@@ -1498,6 +1525,10 @@ export class LvFileStatus extends LitElement {
     const file = this.contextMenu.file;
     if (!file) return;
     this.contextMenu = { ...this.contextMenu, visible: false };
+    if (file.isConflicted) {
+      this.redirectConflictedToMergeEditor(file);
+      return;
+    }
     const confirmed = await showConfirm(
       "Discard Changes",
       `Discard changes to "${file.path}"? This cannot be undone.`,

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -670,7 +670,8 @@ export class LvFileStatus extends LitElement {
     const filesToStage = this.getFilesUnderPath(this.unstagedFiles, dirPath);
     if (filesToStage.length === 0) return;
 
-    const paths = filesToStage.map((f) => f.path);
+    const paths = this.stageablePaths(filesToStage);
+    if (paths.length === 0) return;
     const result = await gitService.stageFiles(this.repositoryPath, { paths });
     if (result.success) {
       await this.loadStatus();
@@ -1150,15 +1151,50 @@ export class LvFileStatus extends LitElement {
     return inStaged && inUnstaged;
   }
 
+  /**
+   * Staging a conflicted file would put git's conflict-marker text into the
+   * index and clear the conflict entries — git would then treat the file as
+   * "resolved" with markers in it. Route to the merge editor instead.
+   */
+  private redirectConflictedToMergeEditor(file: StatusEntry): void {
+    this.dispatchEvent(
+      new CustomEvent('open-conflict-dialog', {
+        detail: { filePath: file.path },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  /**
+   * Filter conflicted files out of a bulk stage, with feedback for what was
+   * skipped — they must be resolved in the merge editor, not staged raw.
+   */
+  private stageablePaths(files: StatusEntry[]): string[] {
+    const conflicted = files.filter((f) => f.isConflicted);
+    if (conflicted.length > 0) {
+      showToast(
+        `${conflicted.length} conflicted file${conflicted.length === 1 ? '' : 's'} skipped — resolve ${conflicted.length === 1 ? 'it' : 'them'} in the merge editor first`,
+        'warning',
+      );
+    }
+    return files.filter((f) => !f.isConflicted).map((f) => f.path);
+  }
+
   private async handleStageFile(file: StatusEntry, e: Event): Promise<void> {
     e.stopPropagation();
-    
+
+    if (file.isConflicted) {
+      this.redirectConflictedToMergeEditor(file);
+      return;
+    }
+
     // If multiple files are selected and this file is one of them, stage all selected
     if (this.selectedFiles.size > 1 && this.selectedFiles.has(file.path)) {
       await this.handleStageSelected();
       return;
     }
-    
+
     const result = await gitService.stageFiles(this.repositoryPath, {
       paths: [file.path],
     });
@@ -1216,7 +1252,7 @@ export class LvFileStatus extends LitElement {
   }
 
   private async handleStageAll(): Promise<void> {
-    const paths = this.unstagedFiles.map((f) => f.path);
+    const paths = this.stageablePaths(this.unstagedFiles);
     if (paths.length === 0) return;
 
     const result = await gitService.stageFiles(this.repositoryPath, { paths });
@@ -1294,9 +1330,9 @@ export class LvFileStatus extends LitElement {
 
   // Batch operation handlers
   private async handleStageSelected(): Promise<void> {
-    const paths = this.unstagedFiles
-      .filter((f) => this.selectedFiles.has(f.path))
-      .map((f) => f.path);
+    const paths = this.stageablePaths(
+      this.unstagedFiles.filter((f) => this.selectedFiles.has(f.path))
+    );
     if (paths.length === 0) return;
 
     const result = await gitService.stageFiles(this.repositoryPath, { paths });
@@ -1375,6 +1411,10 @@ export class LvFileStatus extends LitElement {
     const file = this.contextMenu.file;
     if (!file) return;
     this.contextMenu = { ...this.contextMenu, visible: false };
+    if (file.isConflicted) {
+      this.redirectConflictedToMergeEditor(file);
+      return;
+    }
     const result = await gitService.stageFiles(this.repositoryPath, {
       paths: [file.path],
     });

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -1184,14 +1184,17 @@ export class LvFileStatus extends LitElement {
   private async handleStageFile(file: StatusEntry, e: Event): Promise<void> {
     e.stopPropagation();
 
-    if (file.isConflicted) {
-      this.redirectConflictedToMergeEditor(file);
+    // If multiple files are selected and this file is one of them, stage all
+    // selected — handleStageSelected stages the non-conflicted subset with a
+    // toast for what was skipped. This must run BEFORE the single-file
+    // conflict redirect, or the other selected files would be silently dropped.
+    if (this.selectedFiles.size > 1 && this.selectedFiles.has(file.path)) {
+      await this.handleStageSelected();
       return;
     }
 
-    // If multiple files are selected and this file is one of them, stage all selected
-    if (this.selectedFiles.size > 1 && this.selectedFiles.has(file.path)) {
-      await this.handleStageSelected();
+    if (file.isConflicted) {
+      this.redirectConflictedToMergeEditor(file);
       return;
     }
 

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -711,6 +711,10 @@ export class LvFileStatus extends LitElement {
 
     const paths = this.discardablePaths(filesToDiscard);
     if (paths.length === 0) return;
+    // Captured BEFORE the confirm await: discarding is irreversible and must
+    // target the repo it was invoked on, even if the user switches tabs (which
+    // rebinds this.repositoryPath) while the confirm is up.
+    const repoPath = this.repositoryPath;
     const confirmed = await showConfirm(
       "Discard Changes",
       `Discard changes to ${paths.length} file${paths.length > 1 ? "s" : ""} in "${dirPath}"? This cannot be undone.`,
@@ -718,7 +722,7 @@ export class LvFileStatus extends LitElement {
     );
     if (!confirmed) return;
 
-    const result = await gitService.discardChanges(this.repositoryPath, paths);
+    const result = await gitService.discardChanges(repoPath, paths);
     if (result.success) {
       await this.loadStatus();
     } else {
@@ -1263,6 +1267,10 @@ export class LvFileStatus extends LitElement {
       return;
     }
 
+    // Captured BEFORE the confirm await: discarding is irreversible and must
+    // target the repo it was invoked on, even if the user switches tabs (which
+    // rebinds this.repositoryPath) while the confirm is up.
+    const repoPath = this.repositoryPath;
     const confirmed = await showConfirm(
       "Discard Changes",
       `Are you sure you want to discard changes to "${file.path}"? This action cannot be undone.`,
@@ -1271,7 +1279,7 @@ export class LvFileStatus extends LitElement {
 
     if (!confirmed) return;
 
-    const result = await gitService.discardChanges(this.repositoryPath, [
+    const result = await gitService.discardChanges(repoPath, [
       file.path,
     ]);
     if (result.success) {
@@ -1402,6 +1410,10 @@ export class LvFileStatus extends LitElement {
     );
     if (paths.length === 0) return;
 
+    // Captured BEFORE the confirm await: discarding is irreversible and must
+    // target the repo it was invoked on, even if the user switches tabs (which
+    // rebinds this.repositoryPath) while the confirm is up.
+    const repoPath = this.repositoryPath;
     const confirmed = await showConfirm(
       "Discard Changes",
       `Discard changes to ${paths.length} file${paths.length > 1 ? "s" : ""}? This cannot be undone.`,
@@ -1409,7 +1421,7 @@ export class LvFileStatus extends LitElement {
     );
     if (!confirmed) return;
 
-    const result = await gitService.discardChanges(this.repositoryPath, paths);
+    const result = await gitService.discardChanges(repoPath, paths);
     if (result.success) {
       const newSelected = new Set(this.selectedFiles);
       paths.forEach((p) => newSelected.delete(p));
@@ -1529,13 +1541,17 @@ export class LvFileStatus extends LitElement {
       this.redirectConflictedToMergeEditor(file);
       return;
     }
+    // Captured BEFORE the confirm await: discarding is irreversible and must
+    // target the repo it was invoked on, even if the user switches tabs (which
+    // rebinds this.repositoryPath) while the confirm is up.
+    const repoPath = this.repositoryPath;
     const confirmed = await showConfirm(
       "Discard Changes",
       `Discard changes to "${file.path}"? This cannot be undone.`,
       "warning",
     );
     if (!confirmed) return;
-    const result = await gitService.discardChanges(this.repositoryPath, [
+    const result = await gitService.discardChanges(repoPath, [
       file.path,
     ]);
     if (result.success) {

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -279,6 +279,12 @@ export class LvGitflowPanel extends LitElement {
   @state() private activeHotfixes: ActiveItem[] = [];
   @state() private expandedSections = new Set<GitFlowCategory>(['feature', 'release', 'hotfix']);
   @state() private operationInProgress = false;
+  /** Per-path load sequence: a slow load for repo A must not overwrite the
+   * panel with A's config/items after the user switched to repo B (whose
+   * load already resolved). Mirrors lv-branch-list's branchesLoadSeq. The
+   * Finish buttons bind directly to these items, so stale data here could
+   * finish/delete the wrong branch. */
+  private configLoadSeq = new Map<string, number>();
 
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
@@ -311,33 +317,61 @@ export class LvGitflowPanel extends LitElement {
   private async loadConfig(): Promise<void> {
     if (!this.repositoryPath) return;
 
+    // Capture the repo and bump the per-path sequence at the START — a
+    // response that lands after a newer load (for this or another repo) is
+    // discarded rather than overwriting the panel with stale data.
+    const loadedPath = this.repositoryPath;
+    const seq = (this.configLoadSeq.get(loadedPath) ?? 0) + 1;
+    this.configLoadSeq.set(loadedPath, seq);
+    const isLatest = (): boolean =>
+      this.repositoryPath === loadedPath && this.configLoadSeq.get(loadedPath) === seq;
+
     this.loading = true;
     this.error = null;
 
     try {
-      const result = await gitService.getGitFlowConfig(this.repositoryPath);
+      const result = await gitService.getGitFlowConfig(loadedPath);
+      if (!isLatest()) return;
       if (result.success && result.data) {
         this.config = result.data;
         if (this.config.initialized) {
-          await this.loadActiveItems();
+          await this.loadActiveItems(loadedPath, isLatest);
         }
       } else {
         this.config = null;
       }
     } catch (err) {
       console.error('Failed to load git flow config:', err);
-      this.error = 'Failed to load Git Flow configuration';
+      if (isLatest()) this.error = 'Failed to load Git Flow configuration';
     } finally {
-      this.loading = false;
+      if (isLatest()) this.loading = false;
     }
   }
 
-  private async loadActiveItems(): Promise<void> {
+  private async loadActiveItems(
+    loadedPath: string = this.repositoryPath,
+    isLatest?: () => boolean,
+  ): Promise<void> {
     if (!this.config || !this.config.initialized) return;
 
+    // Post-operation callers (start/finish handlers) pass no guard — they
+    // just refresh the panel for whatever repo it currently shows. Establish
+    // a fresh sequence guard so their reload is subject to the same
+    // stale-response discard as loadConfig's.
+    let latest = isLatest;
+    if (!latest) {
+      const seq = (this.configLoadSeq.get(loadedPath) ?? 0) + 1;
+      this.configLoadSeq.set(loadedPath, seq);
+      latest = (): boolean =>
+        this.repositoryPath === loadedPath && this.configLoadSeq.get(loadedPath) === seq;
+    }
+
     try {
-      const branchResult = await gitService.getBranches(this.repositoryPath);
-      if (!branchResult.success || !branchResult.data) return;
+      const branchResult = await gitService.getBranches(loadedPath);
+      // Discard a stale response — the Finish buttons bind directly to these
+      // items, so writing repo A's items under repo B's tab could
+      // finish/delete the wrong branch.
+      if (!latest() || !branchResult.success || !branchResult.data) return;
 
       const branches = branchResult.data.filter((b: Branch) => !b.isRemote);
 

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -618,7 +618,12 @@ export class LvGitflowPanel extends LitElement {
     this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
       bubbles: true,
       composed: true,
-      detail: { operationType: 'merge', squash, gitflowFinish },
+      detail: {
+        operationType: 'merge',
+        squash,
+        gitflowFinish,
+        repositoryPath: this.repositoryPath,
+      },
     }));
   }
 

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -413,13 +413,11 @@ export class LvGitflowPanel extends LitElement {
     this.error = null;
     this.operationInProgress = true;
 
+    // Captured BEFORE the awaits: the conflict dialog must pin to the repo
+    // the finish actually ran on, even if the prop is rebound mid-flight.
+    const repoPath = this.repositoryPath;
     try {
-      const result = await gitService.gitFlowFinishFeature(
-        this.repositoryPath,
-        item.name,
-        true,
-        squash,
-      );
+      const result = await gitService.gitFlowFinishFeature(repoPath, item.name, true, squash);
       if (result.success) {
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
@@ -433,12 +431,16 @@ export class LvGitflowPanel extends LitElement {
         // a single-parent squash commit, not a two-parent merge commit. The finish
         // context lets the dialog complete the finish (delete branch / re-invoke)
         // once the conflict is resolved.
-        this.openConflictDialog(squash, {
-          kind: 'feature',
-          name: item.name,
-          branchName: item.branch,
-          deleteBranch: true,
-        });
+        this.openConflictDialog(
+          squash,
+          {
+            kind: 'feature',
+            name: item.name,
+            branchName: item.branch,
+            deleteBranch: true,
+          },
+          repoPath,
+        );
       } else {
         this.error = result.error?.message || 'Failed to finish feature';
       }
@@ -484,9 +486,10 @@ export class LvGitflowPanel extends LitElement {
     this.error = null;
     this.operationInProgress = true;
 
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.gitFlowFinishRelease(
-        this.repositoryPath,
+        repoPath,
         item.name,
         tagMessage || undefined,
         true,
@@ -500,16 +503,20 @@ export class LvGitflowPanel extends LitElement {
         }));
       } else if (result.error?.code === 'MERGE_CONFLICT') {
         await this.loadActiveItems();
-        this.openConflictDialog(false, {
-          kind: 'release',
-          name: item.name,
-          branchName: item.branch,
-          deleteBranch: true,
-          tagMessage: tagMessage || undefined,
-          // The backend merges+tags master BEFORE the develop merge; a conflict
-          // while HEAD is on develop means that master merge + tag already landed.
-          priorFinishCommitLanded: await this.isOnDevelopBranch(),
-        });
+        this.openConflictDialog(
+          false,
+          {
+            kind: 'release',
+            name: item.name,
+            branchName: item.branch,
+            deleteBranch: true,
+            tagMessage: tagMessage || undefined,
+            // The backend merges+tags master BEFORE the develop merge; a conflict
+            // while HEAD is on develop means that master merge + tag already landed.
+            priorFinishCommitLanded: await this.isOnDevelopBranch(repoPath),
+          },
+          repoPath,
+        );
       } else {
         this.error = result.error?.message || 'Failed to finish release';
       }
@@ -555,9 +562,10 @@ export class LvGitflowPanel extends LitElement {
     this.error = null;
     this.operationInProgress = true;
 
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.gitFlowFinishHotfix(
-        this.repositoryPath,
+        repoPath,
         item.name,
         tagMessage || undefined,
         true,
@@ -571,16 +579,20 @@ export class LvGitflowPanel extends LitElement {
         }));
       } else if (result.error?.code === 'MERGE_CONFLICT') {
         await this.loadActiveItems();
-        this.openConflictDialog(false, {
-          kind: 'hotfix',
-          name: item.name,
-          branchName: item.branch,
-          deleteBranch: true,
-          tagMessage: tagMessage || undefined,
-          // The backend merges+tags master BEFORE the develop merge; a conflict
-          // while HEAD is on develop means that master merge + tag already landed.
-          priorFinishCommitLanded: await this.isOnDevelopBranch(),
-        });
+        this.openConflictDialog(
+          false,
+          {
+            kind: 'hotfix',
+            name: item.name,
+            branchName: item.branch,
+            deleteBranch: true,
+            tagMessage: tagMessage || undefined,
+            // The backend merges+tags master BEFORE the develop merge; a conflict
+            // while HEAD is on develop means that master merge + tag already landed.
+            priorFinishCommitLanded: await this.isOnDevelopBranch(repoPath),
+          },
+          repoPath,
+        );
       } else {
         this.error = result.error?.message || 'Failed to finish hotfix';
       }
@@ -607,14 +619,21 @@ export class LvGitflowPanel extends LitElement {
    * conflict this means the backend already merged into master and created the
    * version tag (both happen before the develop merge), so those survive an abort.
    */
-  private async isOnDevelopBranch(): Promise<boolean> {
+  private async isOnDevelopBranch(repoPath: string): Promise<boolean> {
     const develop = this.config?.developBranch ?? 'develop';
-    const result = await gitService.getBranches(this.repositoryPath);
+    // The caller's PRE-AWAIT capture — this runs after the finish's awaits,
+    // when this.repositoryPath may already point at another repo whose HEAD
+    // would answer for the wrong repository.
+    const result = await gitService.getBranches(repoPath);
     if (!result.success || !result.data) return false;
     return result.data.some((b) => b.isHead && b.name === develop);
   }
 
-  private openConflictDialog(squash: boolean, gitflowFinish: GitflowFinishContext): void {
+  private openConflictDialog(
+    squash: boolean,
+    gitflowFinish: GitflowFinishContext,
+    repositoryPath: string,
+  ): void {
     this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
       bubbles: true,
       composed: true,
@@ -622,7 +641,9 @@ export class LvGitflowPanel extends LitElement {
         operationType: 'merge',
         squash,
         gitflowFinish,
-        repositoryPath: this.repositoryPath,
+        // The caller's PRE-AWAIT capture — this.repositoryPath may have been
+        // rebound to another repo while the finish ran.
+        repositoryPath,
       },
     }));
   }

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -383,6 +383,10 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleStartFeature(): Promise<void> {
+    // Captured BEFORE the prompt: it is an in-app overlay, so Ctrl+Tab can
+    // switch the active repo (rebinding this prop) while it is open — the
+    // branch must be created in the repo the panel showed at click time.
+    const repoPath = this.repositoryPath;
     const name = await showPrompt('Start Feature', 'Enter feature name:');
     if (!name || !name.trim()) return;
 
@@ -390,7 +394,7 @@ export class LvGitflowPanel extends LitElement {
     this.operationInProgress = true;
 
     try {
-      const result = await gitService.gitFlowStartFeature(this.repositoryPath, name.trim());
+      const result = await gitService.gitFlowStartFeature(repoPath, name.trim());
       if (result.success) {
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
@@ -453,6 +457,7 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleStartRelease(): Promise<void> {
+    const repoPath = this.repositoryPath;
     const version = await showPrompt('Start Release', 'Enter release version:');
     if (!version || !version.trim()) return;
 
@@ -460,7 +465,7 @@ export class LvGitflowPanel extends LitElement {
     this.operationInProgress = true;
 
     try {
-      const result = await gitService.gitFlowStartRelease(this.repositoryPath, version.trim());
+      const result = await gitService.gitFlowStartRelease(repoPath, version.trim());
       if (result.success) {
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
@@ -480,13 +485,16 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleFinishRelease(item: ActiveItem): Promise<void> {
+    // Captured BEFORE the prompt (an in-app overlay — Ctrl+Tab can rebind
+    // this prop while it is open): the finish must run on the repo whose
+    // release the user clicked, and the conflict dialog must pin to it.
+    const repoPath = this.repositoryPath;
     const tagMessage = await showPrompt('Finish Release', `Enter tag message for release ${item.name}:`, `Release ${item.name}`);
     if (tagMessage === null) return;
 
     this.error = null;
     this.operationInProgress = true;
 
-    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.gitFlowFinishRelease(
         repoPath,
@@ -529,6 +537,7 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleStartHotfix(): Promise<void> {
+    const repoPath = this.repositoryPath;
     const version = await showPrompt('Start Hotfix', 'Enter hotfix version:');
     if (!version || !version.trim()) return;
 
@@ -536,7 +545,7 @@ export class LvGitflowPanel extends LitElement {
     this.operationInProgress = true;
 
     try {
-      const result = await gitService.gitFlowStartHotfix(this.repositoryPath, version.trim());
+      const result = await gitService.gitFlowStartHotfix(repoPath, version.trim());
       if (result.success) {
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
@@ -556,13 +565,13 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleFinishHotfix(item: ActiveItem): Promise<void> {
+    const repoPath = this.repositoryPath;
     const tagMessage = await showPrompt('Finish Hotfix', `Enter tag message for hotfix ${item.name}:`, `Hotfix ${item.name}`);
     if (tagMessage === null) return;
 
     this.error = null;
     this.operationInProgress = true;
 
-    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.gitFlowFinishHotfix(
         repoPath,

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -363,11 +363,15 @@ export class LvGitflowPanel extends LitElement {
     this.error = null;
     this.operationInProgress = true;
 
+    // Captured BEFORE the await — the host's refresh must target the repo
+    // the init actually ran on, even if the prop is rebound mid-flight.
+    const repoPath = this.repositoryPath;
     try {
-      const result = await gitService.initGitFlow(this.repositoryPath);
+      const result = await gitService.initGitFlow(repoPath);
       if (result.success) {
         await this.loadConfig();
         this.dispatchEvent(new CustomEvent('gitflow-initialized', {
+          detail: { repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -398,7 +402,7 @@ export class LvGitflowPanel extends LitElement {
       if (result.success) {
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
-          detail: { type: 'start-feature', name: name.trim() },
+          detail: { type: 'start-feature', name: name.trim(), repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -425,7 +429,7 @@ export class LvGitflowPanel extends LitElement {
       if (result.success) {
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
-          detail: { type: 'finish-feature', name: item.name },
+          detail: { type: 'finish-feature', name: item.name, repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -469,7 +473,7 @@ export class LvGitflowPanel extends LitElement {
       if (result.success) {
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
-          detail: { type: 'start-release', name: version.trim() },
+          detail: { type: 'start-release', name: version.trim(), repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -508,7 +512,7 @@ export class LvGitflowPanel extends LitElement {
       if (result.success) {
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
-          detail: { type: 'finish-release', name: item.name },
+          detail: { type: 'finish-release', name: item.name, repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -552,7 +556,7 @@ export class LvGitflowPanel extends LitElement {
       if (result.success) {
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
-          detail: { type: 'start-hotfix', name: version.trim() },
+          detail: { type: 'start-hotfix', name: version.trim(), repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -586,7 +590,7 @@ export class LvGitflowPanel extends LitElement {
       if (result.success) {
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
-          detail: { type: 'finish-hotfix', name: item.name },
+          detail: { type: 'finish-hotfix', name: item.name, repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -488,7 +488,10 @@ export class LvGitflowPanel extends LitElement {
     // Captured BEFORE the prompt (an in-app overlay — Ctrl+Tab can rebind
     // this prop while it is open): the finish must run on the repo whose
     // release the user clicked, and the conflict dialog must pin to it.
+    // The develop-branch NAME is per-repo config that reloads on switch —
+    // capture it with the path.
     const repoPath = this.repositoryPath;
+    const developBranch = this.config?.developBranch ?? 'develop';
     const tagMessage = await showPrompt('Finish Release', `Enter tag message for release ${item.name}:`, `Release ${item.name}`);
     if (tagMessage === null) return;
 
@@ -521,7 +524,7 @@ export class LvGitflowPanel extends LitElement {
             tagMessage: tagMessage || undefined,
             // The backend merges+tags master BEFORE the develop merge; a conflict
             // while HEAD is on develop means that master merge + tag already landed.
-            priorFinishCommitLanded: await this.isOnDevelopBranch(repoPath),
+            priorFinishCommitLanded: await this.isOnDevelopBranch(repoPath, developBranch),
           },
           repoPath,
         );
@@ -566,6 +569,7 @@ export class LvGitflowPanel extends LitElement {
 
   private async handleFinishHotfix(item: ActiveItem): Promise<void> {
     const repoPath = this.repositoryPath;
+    const developBranch = this.config?.developBranch ?? 'develop';
     const tagMessage = await showPrompt('Finish Hotfix', `Enter tag message for hotfix ${item.name}:`, `Hotfix ${item.name}`);
     if (tagMessage === null) return;
 
@@ -598,7 +602,7 @@ export class LvGitflowPanel extends LitElement {
             tagMessage: tagMessage || undefined,
             // The backend merges+tags master BEFORE the develop merge; a conflict
             // while HEAD is on develop means that master merge + tag already landed.
-            priorFinishCommitLanded: await this.isOnDevelopBranch(repoPath),
+            priorFinishCommitLanded: await this.isOnDevelopBranch(repoPath, developBranch),
           },
           repoPath,
         );
@@ -628,14 +632,16 @@ export class LvGitflowPanel extends LitElement {
    * conflict this means the backend already merged into master and created the
    * version tag (both happen before the develop merge), so those survive an abort.
    */
-  private async isOnDevelopBranch(repoPath: string): Promise<boolean> {
-    const develop = this.config?.developBranch ?? 'develop';
-    // The caller's PRE-AWAIT capture — this runs after the finish's awaits,
-    // when this.repositoryPath may already point at another repo whose HEAD
-    // would answer for the wrong repository.
+  private async isOnDevelopBranch(repoPath: string, developBranch: string): Promise<boolean> {
+    // BOTH parameters are the caller's PRE-AWAIT captures — this runs after
+    // the finish's awaits, when this.repositoryPath (and with it
+    // this.config, which reloads on repo switch) may already describe
+    // another repo. Reading the live config here would compare repo A's
+    // HEAD against repo B's develop-branch NAME and seed a dishonest
+    // priorFinishCommitLanded into the abort wording.
     const result = await gitService.getBranches(repoPath);
     if (!result.success || !result.data) return false;
-    return result.data.some((b) => b.isHead && b.name === develop);
+    return result.data.some((b) => b.isHead && b.name === developBranch);
   }
 
   private openConflictDialog(

--- a/src/components/sidebar/lv-left-panel.ts
+++ b/src/components/sidebar/lv-left-panel.ts
@@ -283,14 +283,12 @@ export class LvLeftPanel extends LitElement {
     this.forwardRefresh(e);
   }
 
-  private handleStashCreated(): void {
-    this.dispatchEvent(new CustomEvent('repository-changed', { bubbles: true, composed: true }));
-    window.dispatchEvent(new CustomEvent('repository-refresh'));
+  private handleStashCreated(e?: Event): void {
+    this.forwardRefresh(e);
   }
 
-  private handleStashDropped(): void {
-    this.dispatchEvent(new CustomEvent('repository-changed', { bubbles: true, composed: true }));
-    window.dispatchEvent(new CustomEvent('repository-refresh'));
+  private handleStashDropped(e?: Event): void {
+    this.forwardRefresh(e);
   }
 
   private handleTagCheckout(e?: Event): void {
@@ -305,10 +303,8 @@ export class LvLeftPanel extends LitElement {
     this.forwardRefresh(e);
   }
 
-  private handleTagsChanged(): void {
-    // Refresh repository state after tags changed
-    this.dispatchEvent(new CustomEvent('repository-changed', { bubbles: true, composed: true }));
-    window.dispatchEvent(new CustomEvent('repository-refresh'));
+  private handleTagsChanged(e?: Event): void {
+    this.forwardRefresh(e);
   }
 
   private toggleSection(section: string): void {

--- a/src/components/sidebar/lv-left-panel.ts
+++ b/src/components/sidebar/lv-left-panel.ts
@@ -269,9 +269,18 @@ export class LvLeftPanel extends LitElement {
     `;
   }
 
-  private handleStashApplied(): void {
+  /** Forward the originating repo path (captured pre-await by the sidebar
+   * handler) so the host pins the refresh to the repo the operation ran on,
+   * not whichever tab is active if the user switched mid-operation. */
+  private forwardRefresh(e?: Event): void {
+    const repoPath = (e as CustomEvent<{ repositoryPath?: string }> | undefined)?.detail
+      ?.repositoryPath;
     this.dispatchEvent(new CustomEvent('repository-changed', { bubbles: true, composed: true }));
-    window.dispatchEvent(new CustomEvent('repository-refresh'));
+    window.dispatchEvent(new CustomEvent('repository-refresh', { detail: { repoPath } }));
+  }
+
+  private handleStashApplied(e?: Event): void {
+    this.forwardRefresh(e);
   }
 
   private handleStashCreated(): void {
@@ -284,21 +293,16 @@ export class LvLeftPanel extends LitElement {
     window.dispatchEvent(new CustomEvent('repository-refresh'));
   }
 
-  private handleTagCheckout(): void {
-    this.dispatchEvent(new CustomEvent('repository-changed', { bubbles: true, composed: true }));
-    window.dispatchEvent(new CustomEvent('repository-refresh'));
+  private handleTagCheckout(e?: Event): void {
+    this.forwardRefresh(e);
   }
 
-  private handleBranchCheckout(): void {
-    // Refresh repository state after branch checkout
-    this.dispatchEvent(new CustomEvent('repository-changed', { bubbles: true, composed: true }));
-    window.dispatchEvent(new CustomEvent('repository-refresh'));
+  private handleBranchCheckout(e?: Event): void {
+    this.forwardRefresh(e);
   }
 
-  private handleBranchesChanged(): void {
-    // Refresh repository state after branches changed
-    this.dispatchEvent(new CustomEvent('repository-changed', { bubbles: true, composed: true }));
-    window.dispatchEvent(new CustomEvent('repository-refresh'));
+  private handleBranchesChanged(e?: Event): void {
+    this.forwardRefresh(e);
   }
 
   private handleTagsChanged(): void {

--- a/src/components/sidebar/lv-stash-list.ts
+++ b/src/components/sidebar/lv-stash-list.ts
@@ -324,6 +324,7 @@ export class LvStashList extends LitElement {
       if (result.success) {
         await this.loadStashes();
         this.dispatchEvent(new CustomEvent('stash-applied', {
+          detail: { repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -384,6 +385,7 @@ export class LvStashList extends LitElement {
       if (result.success) {
         await this.loadStashes();
         this.dispatchEvent(new CustomEvent('stash-applied', {
+          detail: { repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));

--- a/src/components/sidebar/lv-stash-list.ts
+++ b/src/components/sidebar/lv-stash-list.ts
@@ -368,6 +368,11 @@ export class LvStashList extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the confirm await: stash.index is from THIS repo's list,
+    // so the pop must run on this repo even if the user switches tabs while the
+    // confirm is up — applying stash.index against another repo pops the wrong
+    // stash.
+    const repoPath = this.repositoryPath;
     const confirmed = await showConfirm(
       'Pop Stash',
       `This will apply the stash "${stash.message}" and remove it from the stash list. Any conflicts will need to be resolved manually. Continue?`,
@@ -377,7 +382,6 @@ export class LvStashList extends LitElement {
 
     this.operationInProgress = true;
 
-    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.popStash({
         path: repoPath,
@@ -421,6 +425,11 @@ export class LvStashList extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the confirm await: dropping is irreversible and stash.index
+    // is from THIS repo's list, so it must target this repo even if the user
+    // switches tabs while the confirm is up — otherwise a different, unrelated
+    // stash is dropped in the wrong repo.
+    const repoPath = this.repositoryPath;
     const confirmed = await showConfirm(
       'Drop Stash',
       `Are you sure you want to drop "${stash.message}"?\n\nThis action cannot be undone.`,
@@ -431,7 +440,6 @@ export class LvStashList extends LitElement {
 
     this.operationInProgress = true;
 
-    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.dropStash({
         path: repoPath,

--- a/src/components/sidebar/lv-stash-list.ts
+++ b/src/components/sidebar/lv-stash-list.ts
@@ -262,9 +262,10 @@ export class LvStashList extends LitElement {
 
     this.isStashing = true;
 
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.createStash({
-        path: this.repositoryPath,
+        path: repoPath,
         message: undefined,
         includeUntracked: true,
       });
@@ -277,6 +278,7 @@ export class LvStashList extends LitElement {
         }
         await this.loadStashes();
         this.dispatchEvent(new CustomEvent('stash-created', {
+          detail: { repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -429,16 +431,17 @@ export class LvStashList extends LitElement {
 
     this.operationInProgress = true;
 
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.dropStash({
-        path: this.repositoryPath,
+        path: repoPath,
         index: stash.index,
       });
 
       if (result.success) {
         await this.loadStashes();
         this.dispatchEvent(new CustomEvent('stash-dropped', {
-          detail: { stash },
+          detail: { stash, repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));

--- a/src/components/sidebar/lv-stash-list.ts
+++ b/src/components/sidebar/lv-stash-list.ts
@@ -311,9 +311,12 @@ export class LvStashList extends LitElement {
     this.contextMenu = { ...this.contextMenu, visible: false };
     this.operationInProgress = true;
 
+    // Captured BEFORE the await: the conflict event must carry the repo the
+    // apply actually ran on, even if the prop is rebound mid-flight.
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.applyStash({
-        path: this.repositoryPath,
+        path: repoPath,
         index: stash.index,
         dropAfter: false,
       });
@@ -338,6 +341,7 @@ export class LvStashList extends LitElement {
               operationType: 'stash',
               stashIndex: stash.index,
               dropStashOnComplete: false,
+              repositoryPath: repoPath,
             },
           }));
         }
@@ -370,9 +374,10 @@ export class LvStashList extends LitElement {
 
     this.operationInProgress = true;
 
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.popStash({
-        path: this.repositoryPath,
+        path: repoPath,
         index: stash.index,
       });
 
@@ -396,6 +401,7 @@ export class LvStashList extends LitElement {
               operationType: 'stash',
               stashIndex: stash.index,
               dropStashOnComplete: true,
+              repositoryPath: repoPath,
             },
           }));
         }

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -580,15 +580,17 @@ export class LvTagList extends LitElement {
 
     this.operationInProgress = true;
 
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.deleteTag({
-        path: this.repositoryPath,
+        path: repoPath,
         name: tag.name,
       });
 
       if (result.success) {
         await this.loadTags();
         this.dispatchEvent(new CustomEvent('tags-changed', {
+          detail: { repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -623,6 +625,7 @@ export class LvTagList extends LitElement {
   private async handleTagCreated(): Promise<void> {
     await this.loadTags();
     this.dispatchEvent(new CustomEvent('tags-changed', {
+      detail: { repositoryPath: this.repositoryPath },
       bubbles: true,
       composed: true,
     }));

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -626,12 +626,15 @@ export class LvTagList extends LitElement {
     this.createTagDialog.open(tag?.targetOid);
   }
 
-  private async handleTagCreated(): Promise<void> {
-    // Captured BEFORE the loadTags await: the refresh must pin to the repo the
-    // tag was created on, not whichever tab is active if the user switches
-    // during the reload (which rebinds this.repositoryPath).
-    const repoPath = this.repositoryPath;
-    await this.loadTags();
+  private async handleTagCreated(e?: CustomEvent<{ repositoryPath?: string }>): Promise<void> {
+    // The dialog pins to the repo it was opened for and reports it here. The
+    // user may have switched tabs while the dialog was open (rebinding our live
+    // repositoryPath), so trust the event's repo — not our current prop — and
+    // only reload OUR view when it matches the repo we're showing.
+    const repoPath = e?.detail?.repositoryPath ?? this.repositoryPath;
+    if (repoPath === this.repositoryPath) {
+      await this.loadTags();
+    }
     this.dispatchEvent(new CustomEvent('tags-changed', {
       detail: { repositoryPath: repoPath },
       bubbles: true,

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -9,6 +9,7 @@ import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
+import { repositoryStore } from '../../stores/repository.store.ts';
 import type { Tag } from '../../types/git.types.ts';
 import '../dialogs/lv-create-tag-dialog.ts';
 import type { LvCreateTagDialog } from '../dialogs/lv-create-tag-dialog.ts';
@@ -322,12 +323,25 @@ export class LvTagList extends LitElement {
 
   @query('lv-create-tag-dialog') private createTagDialog!: LvCreateTagDialog;
 
+  private storeUnsubscribe?: () => void;
+
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
     // Keep in sync with app-level refreshes (e.g. a gitflow release finish
     // creating a tag completes inside the shared conflict dialog) — same
     // subscription as the sibling branch/stash/gitflow lists.
     window.addEventListener('repository-refresh', this.handleRepositoryRefresh);
+    // Close our OWN embedded create-tag dialog when its pinned repo's tab is
+    // closed — app-shell's guard only reaches app-shell's instance, not this
+    // one in the sidebar's shadow root. A create on a closed repo would be a
+    // silent mutation of a repo no longer in the tab bar.
+    this.storeUnsubscribe = repositoryStore.subscribe((state) => {
+      const pinned = this.createTagDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (pinned && !state.openRepositories.some((r) => r.repository.path === pinned)) {
+        this.createTagDialog.close();
+        showToast('The repository tab was closed — tag creation cancelled', 'warning');
+      }
+    });
     await this.loadTags();
     document.addEventListener('click', this.handleDocumentClick);
     document.addEventListener('keydown', this.handleKeydown);
@@ -338,6 +352,7 @@ export class LvTagList extends LitElement {
     window.removeEventListener('repository-refresh', this.handleRepositoryRefresh);
     document.removeEventListener('click', this.handleDocumentClick);
     document.removeEventListener('keydown', this.handleKeydown);
+    this.storeUnsubscribe?.();
   }
 
   private handleRepositoryRefresh = (): void => {
@@ -862,6 +877,23 @@ export class LvTagList extends LitElement {
   }
 
   render() {
+    // Single stable outer template: the create-tag dialog must live at ONE
+    // template position, or an open dialog would be destroyed (losing its
+    // pinned repo, in-progress input, and open modal) when the tag list flips
+    // empty<->non-empty (e.g. a watcher refresh after an external `git tag`).
+    // Lit re-clones a subtree when the enclosing template literal changes, so
+    // the varying content goes through renderBody() while the dialog stays put.
+    return html`
+      ${this.renderBody()}
+      ${this.renderContextMenu()}
+      <lv-create-tag-dialog
+        .repositoryPath=${this.repositoryPath}
+        @tag-created=${this.handleTagCreated}
+      ></lv-create-tag-dialog>
+    `;
+  }
+
+  private renderBody() {
     if (this.loading) {
       return html`<div class="loading">Loading tags...</div>`;
     }
@@ -870,10 +902,6 @@ export class LvTagList extends LitElement {
       return html`
         ${this.renderControls()}
         <div class="empty">No tags</div>
-        <lv-create-tag-dialog
-          .repositoryPath=${this.repositoryPath}
-          @tag-created=${this.handleTagCreated}
-        ></lv-create-tag-dialog>
       `;
     }
 
@@ -916,13 +944,6 @@ export class LvTagList extends LitElement {
                 ` : nothing}
               `;
             })}
-
-      ${this.renderContextMenu()}
-
-      <lv-create-tag-dialog
-        .repositoryPath=${this.repositoryPath}
-        @tag-created=${this.handleTagCreated}
-      ></lv-create-tag-dialog>
     `;
   }
 }

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -522,8 +522,11 @@ export class LvTagList extends LitElement {
 
     this.operationInProgress = true;
 
+    // Captured BEFORE the await: the conflict event must carry the repo the
+    // checkout actually ran on, even if the prop is rebound mid-flight.
+    const repoPath = this.repositoryPath;
     try {
-      const result = await gitService.checkoutWithAutoStash(this.repositoryPath, tag.name);
+      const result = await gitService.checkoutWithAutoStash(repoPath, tag.name);
 
       if (result.success && result.data?.success) {
         const data = result.data;
@@ -534,7 +537,12 @@ export class LvTagList extends LitElement {
           this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
             bubbles: true,
             composed: true,
-            detail: { operationType: 'stash', stashIndex: 0, dropStashOnComplete: true },
+            detail: {
+              operationType: 'stash',
+              stashIndex: 0,
+              dropStashOnComplete: true,
+              repositoryPath: repoPath,
+            },
           }));
         } else if (data.stashed && data.stashApplied) {
           showToast(data.message, data.message.includes('staged status was not preserved') ? 'warning' : 'info');

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -550,7 +550,7 @@ export class LvTagList extends LitElement {
           showToast(data.message, 'warning');
         }
         this.dispatchEvent(new CustomEvent('tag-checkout', {
-          detail: { tag },
+          detail: { tag, repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -513,6 +513,10 @@ export class LvTagList extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the confirm await: the checkout must run on the repo it
+    // was invoked on (and the conflict event must carry it), even if the user
+    // switches tabs while the confirm is up and the prop rebinds.
+    const repoPath = this.repositoryPath;
     const confirmed = await showConfirm(
       'Checkout Tag',
       `Checking out tag "${tag.name}" will put you in 'detached HEAD' state. Any new commits won't belong to any branch. Continue?`,
@@ -522,9 +526,6 @@ export class LvTagList extends LitElement {
 
     this.operationInProgress = true;
 
-    // Captured BEFORE the await: the conflict event must carry the repo the
-    // checkout actually ran on, even if the prop is rebound mid-flight.
-    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.checkoutWithAutoStash(repoPath, tag.name);
 
@@ -570,6 +571,10 @@ export class LvTagList extends LitElement {
 
     this.contextMenu = { ...this.contextMenu, visible: false };
 
+    // Captured BEFORE the confirm await: tag deletion is irreversible and must
+    // target the repo it was invoked on, even if the user switches tabs (to a
+    // repo that may have a same-named tag) while the confirm is up.
+    const repoPath = this.repositoryPath;
     const confirmed = await showConfirm(
       'Delete Tag',
       `Are you sure you want to delete tag "${tag.name}"?\n\nThis action cannot be undone.`,
@@ -580,7 +585,6 @@ export class LvTagList extends LitElement {
 
     this.operationInProgress = true;
 
-    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.deleteTag({
         path: repoPath,
@@ -623,9 +627,13 @@ export class LvTagList extends LitElement {
   }
 
   private async handleTagCreated(): Promise<void> {
+    // Captured BEFORE the loadTags await: the refresh must pin to the repo the
+    // tag was created on, not whichever tab is active if the user switches
+    // during the reload (which rebinds this.repositoryPath).
+    const repoPath = this.repositoryPath;
     await this.loadTags();
     this.dispatchEvent(new CustomEvent('tags-changed', {
-      detail: { repositoryPath: this.repositoryPath },
+      detail: { repositoryPath: repoPath },
       bubbles: true,
       composed: true,
     }));
@@ -638,9 +646,13 @@ export class LvTagList extends LitElement {
     this.contextMenu = { ...this.contextMenu, visible: false };
     this.operationInProgress = true;
 
+    // Captured BEFORE the push await: the push and its refresh must pin to the
+    // repo it was invoked on, even if the user switches tabs during the (often
+    // slow) network push, which rebinds this.repositoryPath.
+    const repoPath = this.repositoryPath;
     try {
       const result = await gitService.pushTag({
-        path: this.repositoryPath,
+        path: repoPath,
         name: tag.name,
       });
 
@@ -648,6 +660,7 @@ export class LvTagList extends LitElement {
         await this.loadTags();
         showToast(`Pushed tag ${tag.name} to remote`, 'success');
         this.dispatchEvent(new CustomEvent('tags-changed', {
+          detail: { repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));

--- a/src/styles/code-styles.ts
+++ b/src/styles/code-styles.ts
@@ -82,37 +82,6 @@ export const codeStyles = css`
     border-radius: 2px;
   }
 
-  /* Conflict buttons */
-  .code-conflict-btn-ours {
-    background: rgba(var(--color-success-rgb, 34, 197, 94), 0.15);
-    border: 1px solid var(--color-success);
-    color: var(--color-success);
-  }
-
-  .code-conflict-btn-ours:hover {
-    background: rgba(var(--color-success-rgb, 34, 197, 94), 0.25);
-  }
-
-  .code-conflict-btn-theirs {
-    background: rgba(var(--color-info-rgb, 59, 130, 246), 0.15);
-    border: 1px solid var(--color-info);
-    color: var(--color-info);
-  }
-
-  .code-conflict-btn-theirs:hover {
-    background: rgba(var(--color-info-rgb, 59, 130, 246), 0.25);
-  }
-
-  .code-conflict-btn-both {
-    background: rgba(168, 85, 247, 0.15);
-    border: 1px solid #a855f7;
-    color: #a855f7;
-  }
-
-  .code-conflict-btn-both:hover {
-    background: rgba(168, 85, 247, 0.25);
-  }
-
   /* Conflict block container */
   .code-conflict-block {
     border: 1px solid var(--color-warning);

--- a/src/types/git.types.ts
+++ b/src/types/git.types.ts
@@ -397,6 +397,23 @@ export interface ConflictFile {
    * silently lose lines.
    */
   conflictStyle?: 'merge' | 'diff3';
+  /**
+   * AUTHORITATIVE marker positions (0-based working-file line indices)
+   * from the backend's collision-free replay. When present the parser
+   * uses them directly — content quoting marker lines (even byte-identical
+   * to the real ones) can never confuse position-based parsing. Empty for
+   * hand-edited files (no replay match), where validated shape heuristics
+   * take over.
+   */
+  conflictHunks?: ConflictHunk[];
+}
+
+/** One conflict hunk's marker line positions in the working file. */
+export interface ConflictHunk {
+  start: number;
+  separator: number;
+  end: number;
+  base?: number | null;
 }
 
 export interface ConflictEntry {

--- a/src/types/git.types.ts
+++ b/src/types/git.types.ts
@@ -390,6 +390,13 @@ export interface ConflictFile {
    * the parser must use this exact size — never guess from content.
    */
   markerSize?: number;
+  /**
+   * Conflict style the hunks were written with. Only when this is 'diff3'
+   * may a `|||||||` run be treated as a base-section marker — in the
+   * default 'merge' style it is ours CONTENT, and discarding it would
+   * silently lose lines.
+   */
+  conflictStyle?: 'merge' | 'diff3';
 }
 
 export interface ConflictEntry {

--- a/src/types/git.types.ts
+++ b/src/types/git.types.ts
@@ -384,6 +384,12 @@ export interface ConflictFile {
   /** True when any side of the conflict is binary — must not be edited as text */
   isBinary: boolean;
   /**
+   * True when any side is a submodule (gitlink) pointer. Its entry OIDs
+   * are COMMITS, not blobs — no side content can be read, and resolving
+   * stages the chosen commit pointer directly.
+   */
+  isSubmodule?: boolean;
+  /**
    * Marker size the conflict hunks in this file were written with (git's
    * default is 7; the conflict-marker-size gitattribute raises it). The
    * backend verifies the attribute against the file's actual emission, so

--- a/src/types/git.types.ts
+++ b/src/types/git.types.ts
@@ -383,6 +383,13 @@ export interface ConflictFile {
   theirs: ConflictEntry | null;
   /** True when any side of the conflict is binary — must not be edited as text */
   isBinary: boolean;
+  /**
+   * Marker size the conflict hunks in this file were written with (git's
+   * default is 7; the conflict-marker-size gitattribute raises it). The
+   * backend verifies the attribute against the file's actual emission, so
+   * the parser must use this exact size — never guess from content.
+   */
+  markerSize?: number;
 }
 
 export interface ConflictEntry {

--- a/src/utils/__tests__/diff-utils-alignment.test.ts
+++ b/src/utils/__tests__/diff-utils-alignment.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Tests for the line-alignment utilities powering the merge editor's
+ * Beyond-Compare-style panes: computeLineAlignment (pairwise LCS) and
+ * alignThreeWay (base/ours/theirs shared display rows).
+ */
+
+import { expect } from '@open-wc/testing';
+import { computeLineAlignment, alignThreeWay } from '../diff-utils.ts';
+
+describe('computeLineAlignment', () => {
+  it('aligns identical arrays one-to-one', () => {
+    const rows = computeLineAlignment(['a', 'b'], ['a', 'b']);
+    expect(rows).to.deep.equal([[0, 0], [1, 1]]);
+  });
+
+  it('keeps lines after an insertion aligned', () => {
+    // b inserts "new" at the top; a's lines must still pair with themselves.
+    const rows = computeLineAlignment(['a', 'b'], ['new', 'a', 'b']);
+    expect(rows).to.deep.equal([[null, 0], [0, 1], [1, 2]]);
+  });
+
+  it('keeps lines after a deletion aligned', () => {
+    const rows = computeLineAlignment(['a', 'gone', 'b'], ['a', 'b']);
+    expect(rows).to.deep.equal([[0, 0], [1, null], [2, 1]]);
+  });
+
+  it('pairs replaced lines index-wise', () => {
+    const rows = computeLineAlignment(['a', 'old', 'b'], ['a', 'new', 'b']);
+    expect(rows).to.deep.equal([[0, 0], [1, 1], [2, 2]]);
+  });
+
+  it('pads an uneven replace block with fillers', () => {
+    const rows = computeLineAlignment(['a', 'x', 'b'], ['a', 'y1', 'y2', 'b']);
+    expect(rows).to.deep.equal([[0, 0], [1, 1], [null, 2], [2, 3]]);
+  });
+
+  it('handles empty inputs', () => {
+    expect(computeLineAlignment([], [])).to.deep.equal([]);
+    expect(computeLineAlignment(['a'], [])).to.deep.equal([[0, null]]);
+    expect(computeLineAlignment([], ['b'])).to.deep.equal([[null, 0]]);
+  });
+
+  it('produces a row for every index on both sides exactly once', () => {
+    const a = ['1', '2', '3', '4', '5'];
+    const b = ['0', '1', '3', 'x', '5', '6'];
+    const rows = computeLineAlignment(a, b);
+    const aIdx = rows.map(([x]) => x).filter((x) => x !== null);
+    const bIdx = rows.map(([, y]) => y).filter((y) => y !== null);
+    expect(aIdx).to.deep.equal([0, 1, 2, 3, 4]);
+    expect(bIdx).to.deep.equal([0, 1, 2, 3, 4, 5]);
+  });
+});
+
+describe('alignThreeWay', () => {
+  it('gives every pane the same row count', () => {
+    const rows = alignThreeWay(
+      ['a', 'b', 'c'],
+      ['x', 'y', 'a', 'b', 'c'],
+      ['a', 'c'],
+    );
+    // Row count is shared by construction; each pane index appears exactly once.
+    const ours = rows.map((r) => r.ours).filter((x) => x !== null);
+    const base = rows.map((r) => r.base).filter((x) => x !== null);
+    const theirs = rows.map((r) => r.theirs).filter((x) => x !== null);
+    expect(ours).to.deep.equal([0, 1, 2, 3, 4]);
+    expect(base).to.deep.equal([0, 1, 2]);
+    expect(theirs).to.deep.equal([0, 1]);
+  });
+
+  it('aligns unchanged lines across all three panes', () => {
+    const rows = alignThreeWay(['a', 'b'], ['a', 'b'], ['a', 'b']);
+    expect(rows).to.deep.equal([
+      { base: 0, ours: 0, theirs: 0 },
+      { base: 1, ours: 1, theirs: 1 },
+    ]);
+  });
+
+  it('shares insertion rows between ours and theirs at the same anchor', () => {
+    const rows = alignThreeWay(['a'], ['new-ours', 'a'], ['new-theirs', 'a']);
+    expect(rows).to.deep.equal([
+      { base: null, ours: 0, theirs: 0 },
+      { base: 0, ours: 1, theirs: 1 },
+    ]);
+  });
+
+  it('marks a side-deleted base line with null on that side', () => {
+    const rows = alignThreeWay(['a', 'gone', 'b'], ['a', 'b'], ['a', 'gone', 'b']);
+    expect(rows).to.deep.equal([
+      { base: 0, ours: 0, theirs: 0 },
+      { base: 1, ours: null, theirs: 1 },
+      { base: 2, ours: 1, theirs: 2 },
+    ]);
+  });
+
+  it('anchors trailing insertions after the last base line', () => {
+    const rows = alignThreeWay(['a'], ['a', 'tail'], ['a']);
+    expect(rows).to.deep.equal([
+      { base: 0, ours: 0, theirs: 0 },
+      { base: null, ours: 1, theirs: null },
+    ]);
+  });
+});

--- a/src/utils/__tests__/diff-utils-alignment.test.ts
+++ b/src/utils/__tests__/diff-utils-alignment.test.ts
@@ -40,6 +40,23 @@ describe('computeLineAlignment', () => {
     expect(computeLineAlignment([], ['b'])).to.deep.equal([[null, 0]]);
   });
 
+  it('stays index-complete when the middle exceeds the LCS cell limit', () => {
+    // 1100 x 1100 fully-distinct middles exceed the 1M-cell DP guard, forcing
+    // the replace-block fallback — it must still emit every index exactly once.
+    const a = ['same-head', ...Array.from({ length: 1100 }, (_, i) => `a-${i}`), 'same-tail'];
+    const b = ['same-head', ...Array.from({ length: 1100 }, (_, i) => `b-${i}`), 'same-tail'];
+    const rows = computeLineAlignment(a, b);
+
+    const aIdx = rows.map(([x]) => x).filter((x) => x !== null);
+    const bIdx = rows.map(([, y]) => y).filter((y) => y !== null);
+    expect(aIdx).to.deep.equal(Array.from({ length: a.length }, (_, i) => i));
+    expect(bIdx).to.deep.equal(Array.from({ length: b.length }, (_, i) => i));
+    // Equal-length replace middles pair index-wise; head/tail stay matched.
+    expect(rows[0]).to.deep.equal([0, 0]);
+    expect(rows[rows.length - 1]).to.deep.equal([a.length - 1, b.length - 1]);
+    expect(rows.length).to.equal(a.length);
+  });
+
   it('produces a row for every index on both sides exactly once', () => {
     const a = ['1', '2', '3', '4', '5'];
     const b = ['0', '1', '3', 'x', '5', '6'];

--- a/src/utils/diff-utils.ts
+++ b/src/utils/diff-utils.ts
@@ -76,6 +76,173 @@ export function computeInlineWhitespaceDiff(
 }
 
 /**
+ * One display row of a pairwise line alignment.
+ * `a`/`b` are indices into the respective line arrays, or null when the row
+ * is a filler on that side (insertion/deletion).
+ */
+export type AlignedPair = [a: number | null, b: number | null];
+
+/**
+ * A single display row aligning the three merge panes. Each field is an index
+ * into that pane's line array, or null when the pane shows a filler row.
+ */
+export interface ThreeWayRow {
+  base: number | null;
+  ours: number | null;
+  theirs: number | null;
+}
+
+/** Above this many DP cells the LCS falls back to index pairing (perf guard). */
+const LCS_CELL_LIMIT = 1_000_000;
+
+/**
+ * Align two arrays of lines using an LCS diff, so equal lines share a row and
+ * changed regions are paired index-wise (k-th removed line with k-th added
+ * line), with null fillers for the unpaired remainder.
+ *
+ * Unlike naive index pairing, a single insertion/deletion does not misalign
+ * everything after it.
+ */
+export function computeLineAlignment(a: string[], b: string[]): AlignedPair[] {
+  // Trim common prefix/suffix so the DP only covers the changed middle.
+  let prefix = 0;
+  while (prefix < a.length && prefix < b.length && a[prefix] === b[prefix]) prefix++;
+  let suffix = 0;
+  while (
+    suffix < a.length - prefix &&
+    suffix < b.length - prefix &&
+    a[a.length - 1 - suffix] === b[b.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+
+  const rows: AlignedPair[] = [];
+  for (let i = 0; i < prefix; i++) rows.push([i, i]);
+
+  const midA = a.slice(prefix, a.length - suffix);
+  const midB = b.slice(prefix, b.length - suffix);
+
+  // Matched index pairs (relative to the middle) in ascending order.
+  let matches: Array<[number, number]>;
+  if (midA.length * midB.length > LCS_CELL_LIMIT) {
+    // Too large for DP — treat the whole middle as one replace block.
+    matches = [];
+  } else {
+    matches = lcsMatches(midA, midB);
+  }
+
+  let ai = 0;
+  let bi = 0;
+  const emitReplaceBlock = (aEnd: number, bEnd: number): void => {
+    // Pair the k-th removed line with the k-th added line; pad the rest.
+    const aRun = aEnd - ai;
+    const bRun = bEnd - bi;
+    const paired = Math.min(aRun, bRun);
+    for (let k = 0; k < paired; k++) rows.push([prefix + ai + k, prefix + bi + k]);
+    for (let k = paired; k < aRun; k++) rows.push([prefix + ai + k, null]);
+    for (let k = paired; k < bRun; k++) rows.push([null, prefix + bi + k]);
+    ai = aEnd;
+    bi = bEnd;
+  };
+
+  for (const [ma, mb] of matches) {
+    emitReplaceBlock(ma, mb);
+    rows.push([prefix + ma, prefix + mb]);
+    ai = ma + 1;
+    bi = mb + 1;
+  }
+  emitReplaceBlock(midA.length, midB.length);
+
+  for (let i = 0; i < suffix; i++) {
+    rows.push([a.length - suffix + i, b.length - suffix + i]);
+  }
+
+  return rows;
+}
+
+/** Standard DP LCS returning the matched index pairs in order. */
+function lcsMatches(a: string[], b: string[]): Array<[number, number]> {
+  const m = a.length;
+  const n = b.length;
+  if (m === 0 || n === 0) return [];
+
+  // dp[i][j] = LCS length of a[i..] and b[j..], flattened row-major.
+  const width = n + 1;
+  const dp = new Int32Array((m + 1) * width);
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i * width + j] =
+        a[i] === b[j]
+          ? dp[(i + 1) * width + j + 1] + 1
+          : Math.max(dp[(i + 1) * width + j], dp[i * width + j + 1]);
+    }
+  }
+
+  const matches: Array<[number, number]> = [];
+  let i = 0;
+  let j = 0;
+  while (i < m && j < n) {
+    if (a[i] === b[j]) {
+      matches.push([i, j]);
+      i++;
+      j++;
+    } else if (dp[(i + 1) * width + j] >= dp[i * width + j + 1]) {
+      i++;
+    } else {
+      j++;
+    }
+  }
+  return matches;
+}
+
+/**
+ * Align OURS and THEIRS against BASE into shared display rows, so all three
+ * merge-editor panes render the same number of rows and equal content lines
+ * up horizontally (Beyond Compare style). Insertions from ours and theirs
+ * anchored at the same base position share rows.
+ */
+export function alignThreeWay(
+  base: string[],
+  ours: string[],
+  theirs: string[],
+): ThreeWayRow[] {
+  const sideForBase = (side: string[]) => {
+    const matched = new Array<number | null>(base.length).fill(null);
+    // Insertions keyed by the base index they precede (base.length = trailing).
+    const insertions = new Map<number, number[]>();
+    let baseCursor = 0;
+    for (const [b, s] of computeLineAlignment(base, side)) {
+      if (b !== null) {
+        matched[b] = s;
+        baseCursor = b + 1;
+      } else if (s !== null) {
+        const list = insertions.get(baseCursor);
+        if (list) list.push(s);
+        else insertions.set(baseCursor, [s]);
+      }
+    }
+    return { matched, insertions };
+  };
+
+  const o = sideForBase(ours);
+  const t = sideForBase(theirs);
+
+  const rows: ThreeWayRow[] = [];
+  for (let b = 0; b <= base.length; b++) {
+    const oIns = o.insertions.get(b) ?? [];
+    const tIns = t.insertions.get(b) ?? [];
+    const insRows = Math.max(oIns.length, tIns.length);
+    for (let k = 0; k < insRows; k++) {
+      rows.push({ base: null, ours: oIns[k] ?? null, theirs: tIns[k] ?? null });
+    }
+    if (b < base.length) {
+      rows.push({ base: b, ours: o.matched[b], theirs: t.matched[b] });
+    }
+  }
+  return rows;
+}
+
+/**
  * Scan hunk lines for consecutive deletion→addition pairs that differ only in whitespace.
  * Returns a Map from deletion line index to its paired addition line index.
  */


### PR DESCRIPTION
Reviewing the conflicts workflow surfaced that raw git conflict markers
(`<<<<<<<` / `=======` / `>>>>>>>`) leaked into the UI in several places and that
a duplicate, broken conflict-resolution path lived in the diff view. This PR
reworks the whole flow so markers are an internal representation only, then
hardens it — through many rounds of multi-model adversarial review to
convergence — against two defect classes that surfaced along the way: raw-marker
leaks under unusual `conflict-marker-size` configurations, and wrong-repo
mutations when a git operation is running and the user switches repository tabs.

40 files, ~14k insertions. All work is covered by tests; the full gate (lint,
typecheck, unit, Rust fmt/clippy/tests, e2e) is green.

## Marker-free merge editor

- **lv-merge-editor**: replace the marker-string output model with structured
  segments. Conflict blocks render ours/theirs side by side with Use
  Ours/Theirs/Both, per-block free-text Edit (prefilled from both sides),
  per-block Reset, and AI suggest; resolved text is editable in place and
  gutter-colored by origin. The raw-edit textarea is gone. **Mark Resolved is
  disabled until every block is resolved**, so marker text can never be written
  back as a resolution.
- Replace the naive index-based pane comparison with **LCS alignment**
  (`computeLineAlignment`/`alignThreeWay` in diff-utils): all three source panes
  share row geometry with filler rows, an insertion no longer flags the whole
  rest of the file as changed, and scroll sync is bidirectional across all panes.
- Drop the fabricated-marker fallback merge; a failed working-dir read shows an
  error state with **Retry** instead of a wrong invented merge, and an empty
  merged file is treated as valid content.
- Side labels adapt to the operation (rebase swaps ours/theirs meaning; stash
  labels working tree vs stashed changes).
- Complete terminal states for every conflict shape — binary, symlink,
  submodule/gitlink, type-change, delete/modify, add/add, non-UTF-8 path, and
  read-failure — each with an actionable path (chooser, verbatim take-side, or
  `resolvedInPlace`/`resolvedAsDeleted`), no forever-Retry and no
  disabled-forever Complete.

## Never leak raw markers (marker-size detection)

The editor parses markers as structure and never emits them as content, backed
by layered defenses so this holds at **any** `conflict-marker-size` (1–12) and
for adversarial files (quoted markers, hand-broken structures, stale/reverted
attributes, hostile decoys):

- Backend `detect_conflict_emission` verifies the marker size and hunk positions
  by **replaying the merge** (collision-free re-replay for authoritative
  positions); hand-edited files with no replay match fall back to a structural
  scan that reports the **smallest demonstrated complete size** (folding in an
  explicit non-default attribute, floored at 3) — the safe direction, since the
  frontend's exact-match parser plus its `>=`-size orphan safety-net catch any
  real marker that is *larger* than the reported size, whereas over-reporting is
  what leaks.
- Frontend `enforceNoOrphanMarkers` is a final backstop on both parser paths:
  any marker-shaped line not present in any source blob collapses the file to a
  single whole-file conflict rather than rendering the marker.
- Writes are confirm-gated: `handleMarkResolved` and inline edits confirm before
  writing marker-shaped content; AI output hard-blocks on markers; the backend
  refuses non-UTF-8 filenames and text-writes over symlink/submodule modes.
- lv-diff-view no longer parses conflicts at all — conflicted files render a
  redirect to the merge editor and are excluded from diff loading and edit mode.

## Multi-repo operation pinning

Leviathan is multi-tab. An operation started on repo A must complete **and**
refresh against A even if the user switches tabs mid-operation, and a dialog
pinned to a repo must not act on a different one. This PR makes that hold across
the entire git-operations surface:

- Every mutating handler (branch/tag/stash/file-status/gitflow, and app-shell's
  context-menu / ref-menu / toolbar / command-palette handlers — reset, revert,
  fixup/squash, reword, merge, rebase, cherry-pick, checkout, delete, push,
  fetch, stash, reflog undo) captures its repo path **before** any yielding await
  and uses it for both the operation and the refresh. Several were wrong-repo
  *mutation* bugs, including a hard-reset and a force-delete that could hit the
  wrong repository.
- All six long-lived mutating dialogs — conflict, cherry-pick, interactive-rebase,
  create-branch, create-tag, and branch-cleanup — pin their repo at open and are
  correct on all three axes: **operation**, **refresh event payload**, and
  **self-close when their pinned tab is closed** (for both the app-shell and the
  sidebar-embedded instances).
- Refresh handlers reload the sidebar only when the completed operation's repo
  matches the shown one, and background repos are marked stale / badge-hydrated
  rather than refreshed against the active tab.
- Fixes a template-identity bug that destroyed an open create-tag dialog when the
  tag list flipped empty↔non-empty.

## app-shell / dialog integration

- Clicking a conflicted file opens the conflict dialog instead of the diff view;
  the operation type is derived from repository state, including state-clean stash
  conflicts (which previously had no way back into resolution after a restart)
  with safe don't-drop-stash semantics.
- Conflict dialog: operationType passed to the editor, wrap-around
  next-unresolved navigation, directory hints for same-named files, honest
  stash-abort/drop-failure completion, and pinned refresh on completion.
- cherry-pick dialog detects conflicts by structured error code (message match as
  fallback); AI resolve-all stops on first failure; AI explanations are keyed per
  block and cleared per file.

## Accepted residual

One narrow marker-size case is explicitly documented and accepted: if the
attribute has drifted back to the default 7 **and** the real markers are sub-7
**and** a hand edit broke their structure, no signal of the true size survives.
Closing it would require lowering the frontend echo-net floor below 7, which
would false-positive on ordinary `===`/`>>>` prose dividers — a worse tradeoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)