### PR TITLE
Fix dialog Escape handling and overlay stacking bugs

### DIFF
--- a/.claude/commands/bug-hunt.md
+++ b/.claude/commands/bug-hunt.md
@@ -1,0 +1,137 @@
+---
+description: Hunt for bugs, bad implementations, and incoherent UX across a feature area (not diff-scoped)
+argument-hint: "[feature area, path, or 'recent' — e.g. 'stash', 'src/components/dialogs/lv-github-dialog.ts', 'recent']"
+---
+
+# Bug Hunt: $ARGUMENTS
+
+You are hunting for **real defects a user would actually hit** in Leviathan. This is not a diff review — you are auditing a *feature area as it exists today*, including code nobody has touched in months.
+
+Three classes of defect are in scope, weighted equally:
+
+1. **Bugs** — wrong behaviour, crashes, data loss, races, unhandled failures.
+2. **Bad implementations** — code that "works" but is wired wrong: duplicated logic that has drifted, state that can't be reached, contracts held together by coincidence, error handling that swallows.
+3. **Incorrect or incoherent UX** — flows that dead-end, silent failures, the same operation behaving differently depending on where the user invoked it, missing empty/loading/error states, confirmations that lie about what they do.
+
+## Ground rules
+
+- **Prove it or drop it.** Every finding must cite `file:line` and be traceable in the code you actually read. If you cannot state a concrete repro — "user does X with Y state, gets Z, should get W" — it is not a finding.
+- **No invented nitpicks.** Style, naming preferences, "could be more idiomatic", missing comments, hypothetical futures — all out of scope unless they cause a defect.
+- **A pattern that looks wrong may be deliberate.** `CODE_REVIEW.md` documents past false positives (escaped-then-highlighted HTML, listener cleanup in `disconnectedCallback`, OAuth public-client secrets, broad `$HOME` fs scope). Check it before reporting anything in those areas, and check for `SAFETY:` comments.
+- **Read the whole path before judging.** A missing `.catch()` may be caught upstream; a missing toast may be shown by the caller. Follow the call chain to both ends.
+- **Do not fix anything yet.** This command produces a ranked findings report. Fixes happen after the user picks.
+
+## Phase 0 — Scope and inventory
+
+Establish the surface before reading line by line.
+
+- If `$ARGUMENTS` names a feature (e.g. "stash", "rebase", "worktrees"), find every layer it touches: `src-tauri/src/commands/*.rs`, `src/services/*.ts`, `src/types/api.types.ts`, the owning component(s), the store slice, and its tests.
+- If `$ARGUMENTS` is `recent`, use `git log --since="3 weeks ago" --name-only --pretty=format:` to rank files by churn and hunt the top ~15.
+- If `$ARGUMENTS` is empty, ask which area — do not audit 76 Rust command files at once.
+
+Write a short inventory: every **user-reachable entry point** into this area. Leviathan exposes the same operation from many places — toolbar buttons, context menus, the command palette (`lv-command-palette.ts`), keyboard shortcuts (`keyboard.service.ts`), dialogs, and drag-and-drop. Enumerate them all; divergence between them is one of the richest defect sources here.
+
+## Phase 1 — Trace each flow end to end
+
+For each entry point, walk the full stack and note where it breaks:
+
+```
+user gesture → component handler → service (git.service.ts / *.service.ts)
+  → invokeCommand → Rust command → git2 / process
+  → Result → TS return type → store mutation → re-render → user feedback
+```
+
+Bugs in this codebase concentrate at the **seams**. At each arrow ask: what happens on failure, on empty, on slow, and on the second concurrent call?
+
+## Phase 2 — Defect taxonomy
+
+Hunt these deliberately. Each is a pattern that has produced real bugs in this repo.
+
+### A. Contract seams (TS ↔ Rust)
+- snake_case leaking into an `invokeCommand` argument object or `gitService.*` call — Tauri will silently pass `undefined` and the command fails or misbehaves. Sweep:
+  ```bash
+  grep -rn "_[a-z]*:" src/types/api.types.ts src/services/ src/app-shell.ts src/components/ --include="*.ts" | grep -v __tests__
+  ```
+- TS interface in `api.types.ts` disagreeing with the Rust struct it mirrors — extra field, wrong optionality, renamed field, field the backend never populates.
+- `Option<T>` → `T | null` vs `T | undefined` mismatches; code checking `if (x)` where `0`/`""` is legitimate.
+- Rust returning `Ok(vec![])` where the caller renders "error", or returning `Err` where empty is the normal case.
+
+### B. Event wiring
+- A `CustomEvent` dispatched with **no listener anywhere** — dead code, and the user's action silently does nothing. For each event name found, grep for the matching `@name=` / `addEventListener`.
+- **Sibling asymmetry**: `handleAdd` dispatches `foo-changed` but `handleRemove`/`handleUpdate` don't, so the UI goes stale after one of three operations.
+- State-modifying handlers in `app-shell.ts` calling only `graphCanvas?.refresh?.()` instead of `handleRefresh()` — graph updates but the store, search index, and `repository-refresh` listeners don't.
+- Window-level events (`ai-settings-changed` and friends) dispatched by some handlers that change the state but not all of them.
+
+### C. Feedback and states
+- **Silent error paths**: `if (result.success) {...}` with no `else`, or an `else` that only does `console.error`. Sweep:
+  ```bash
+  grep -rn "console.error" src --include="*.ts" | grep -v __tests__
+  ```
+  For each, ask whether the user sees anything. If not, that's a finding.
+- Missing **empty / loading / disabled** states: a list that renders nothing with no "no branches yet" message; a button clickable while the operation is in flight (double-submit); a long git operation with no progress indication.
+- Dialogs that close on failure and lose the user's input, or stay open with no message.
+- Toast vs inline (`this.error`/`this.success`) chosen inconsistently between sibling handlers.
+
+### D. Cross-provider coherence
+`github` / `gitlab` / `bitbucket` / `azure_devops` (and their dialogs, OAuth flows, and Rust commands) should behave the same. Diff them against each other and report where one provider is missing pagination, error mapping, a rate-limit path, token refresh, an empty state, or a confirm that the others have.
+
+### E. Async, races, staleness
+- Unawaited promises and `.then()` without `.catch()`.
+- **Concurrent-flow state**: a single module-level mutable variable serving flows that can overlap (this is exactly how the OAuth `pendingAuth` bug happened — it needed to be a Map keyed by provider). Look for any shared "pending"/"current"/"inFlight" singleton.
+- **Stale results**: an async call that resolves *after* the user switched repository, branch, or commit, then writes its result into the now-wrong context. The repository store is `openRepositories[]` + `activeIndex` — any code that captured a repo path or index before an `await` is suspect.
+- Anything assuming a single open repository, or indexing `openRepositories` without bounds checks on both ends.
+- Watchers/intervals/listeners registered in `connectedCallback` (or a service `init`) with no matching teardown.
+
+### F. Rust backend
+- `Path::join` on user-supplied paths without `validate_path_within_repo()` from `path_utils.rs` — path traversal.
+- `.unwrap()` / `.expect()` on anything derived from user input, repo state, or IO, outside `#[cfg(test)]` — a panic across the Tauri boundary is a hung UI, not an error message.
+- Raw `git2` / IO error strings surfaced straight to the user with no translation.
+- Operations that mutate the repo without the network-permission check its siblings perform, or without honouring the repo pin.
+- Missing validation on refs/branch names/remote names before shelling out or calling git2.
+
+### G. Destructive operations
+For anything that can lose work — `clean`, force branch delete, hard reset, discard changes, stash drop, rebase, force push — verify: an explicit confirm exists, the confirm text names *exactly* what will be destroyed (count and scope), the operation is actually blocked when the user declines, and there is a stated recovery path where one exists.
+
+### H. Dead ends and half-wired features
+- Buttons/menu items that call a handler that does nothing, or a command that isn't registered.
+- `TODO` / `FIXME` / `not implemented` on a user-reachable path.
+- Features present in one surface but absent from the command palette or keyboard map, with no reason.
+- Settings that are persisted but never read, or read but never applied without a restart the UI never mentions.
+
+## Phase 3 — Verify before reporting
+
+For every candidate, run an adversarial pass against yourself: **try to refute it.** Re-read the surrounding code and the call sites looking for the thing that makes it *not* a bug — the upstream guard, the caller's error handling, the `SAFETY:` comment, the test that covers it. Default to dropping the finding when you can't close the gap.
+
+Then classify what survives:
+- **CONFIRMED** — you traced the full path and can state the repro concretely.
+- **PLAUSIBLE** — the defect is real in the code you read, but one link (e.g. runtime data shape) you could not verify statically. Say which link.
+
+Drop everything else. A short report of real bugs beats a long one padded with maybes.
+
+## Phase 4 — Report
+
+Rank by severity — user-visible data loss and crashes first, then wrong behaviour, then incoherent UX, then bad-implementation risk. For each finding:
+
+```
+### [SEVERITY] Short title
+**Where:** src/path/file.ts:123 (+ any other sites)
+**Verdict:** CONFIRMED | PLAUSIBLE
+**What breaks:** concrete repro — state, gesture, observed result, expected result.
+**Why:** the mechanism, in one or two sentences.
+**Minimal fix:** the smallest change that resolves it. No refactors.
+**Test gap:** which existing test should have caught this and why it didn't, or the test to add.
+```
+
+End with exactly one line: `VERDICT: N issues found` or `VERDICT: NO ISSUES FOUND`.
+
+Do **not** write findings to a file in the repo — report them in your message. Do not commit anything.
+
+## Scaling up
+
+For a scope larger than ~5 files, fan out: run three independent hunters in parallel on three different models (Opus, Sonnet, Haiku), each auditing the **entire** scope holistically with this same prompt — do not assign each one a lens or a subset. Dedupe their findings, keep what survives Phase 3, and report the union. If the user asks for a fix pass afterwards, apply the fixes with tests and re-run all three hunters until every one returns `NO ISSUES FOUND` in the same round.
+
+Before handing back any fixes:
+
+```bash
+npm run lint && npm run typecheck && npm test && cd src-tauri && cargo fmt --check && cargo clippy -- -D warnings
+```

--- a/e2e/fixtures/test-helpers.ts
+++ b/e2e/fixtures/test-helpers.ts
@@ -172,6 +172,33 @@ export async function injectCommandMock(
 }
 
 /**
+ * Make a command hang forever, so the caller stays in its "in flight" state
+ * for the rest of the test. Use this to exercise mid-operation guards — the
+ * affordances a component must refuse while a destructive command is running.
+ */
+export async function injectCommandHang(page: Page, command: string): Promise<void> {
+  await page.evaluate((cmd) => {
+    const internals = (window as unknown as {
+      __TAURI_INTERNALS__: { invoke: (c: string, args?: unknown) => Promise<unknown> };
+    }).__TAURI_INTERNALS__;
+    const originalInvoke = internals.invoke;
+
+    internals.invoke = (c: string, args?: unknown) => {
+      if (c === cmd) {
+        const captured = (window as unknown as {
+          __INVOKED_COMMANDS__?: { command: string; args: unknown }[];
+        }).__INVOKED_COMMANDS__;
+        if (captured) {
+          captured.push({ command: c, args });
+        }
+        return new Promise<unknown>(() => {});
+      }
+      return originalInvoke(c, args);
+    };
+  }, command);
+}
+
+/**
  * Wait for a specific Tauri command to be invoked.
  * Useful when you need to wait for an async action to trigger a backend call.
  */

--- a/e2e/fixtures/test-helpers.ts
+++ b/e2e/fixtures/test-helpers.ts
@@ -196,6 +196,10 @@ export async function autoConfirmDialogs(page: Page): Promise<void> {
   await injectCommandMock(page, {
     'plugin:dialog|confirm': true,
     'plugin:dialog|ask': true,
+    // plugin-dialog 2.x routes confirm() through `message` and resolves true
+    // only when the command returns the OK button label. Without this, every
+    // showConfirm() in the app reads as "declined" under test.
+    'plugin:dialog|message': 'Ok',
   });
 }
 

--- a/e2e/tests/context-menus.spec.ts
+++ b/e2e/tests/context-menus.spec.ts
@@ -207,6 +207,9 @@ test.describe('Operation Banner', () => {
       },
     });
 
+    // Aborting discards every conflict resolution, so it is gated by a confirm.
+    await autoConfirmDialogs(page);
+
     const banner = page.locator('.operation-banner');
     await expect(banner).toBeVisible();
     await expect(banner).toContainText('Cherry-pick in progress');
@@ -220,6 +223,28 @@ test.describe('Operation Banner', () => {
     const successToast = page.locator('.toast').first();
     await expect(successToast).toBeVisible({ timeout: 5000 });
     await expect(successToast).toContainText(/Aborted|abort/i);
+  });
+
+  test('declining the abort confirm does not abort', async ({ page }) => {
+    app = new AppPage(page);
+
+    await setupOpenRepository(page, {
+      repository: {
+        ...defaultMockData.repository,
+        state: 'cherrypick',
+      },
+    });
+    await startCommandCapture(page);
+
+    // Decline: plugin-dialog treats any non-OK label as "cancel".
+    await injectCommandMock(page, { 'plugin:dialog|message': 'Cancel' });
+
+    const abortBtn = page.locator('.operation-abort-btn');
+    await expect(abortBtn).toBeEnabled();
+    await abortBtn.click();
+
+    await expect(page.locator('.operation-banner')).toBeVisible();
+    expect(await findCommand(page, 'abort_cherry_pick')).toHaveLength(0);
   });
 
   test('should show Resolve Conflicts button for cherry-pick state', async ({ page }) => {

--- a/e2e/tests/context-menus.spec.ts
+++ b/e2e/tests/context-menus.spec.ts
@@ -225,6 +225,23 @@ test.describe('Operation Banner', () => {
     await expect(successToast).toContainText(/Aborted|abort/i);
   });
 
+  test('no Abort button for states that have no abort command', async ({ page }) => {
+    // The banner used to render Abort for every non-clean state, so during a
+    // bisect it was a permanent dead end — clicking it could only ever produce
+    // "Cannot abort operation: bisect".
+    app = new AppPage(page);
+
+    await setupOpenRepository(page, {
+      repository: {
+        ...defaultMockData.repository,
+        state: 'bisect',
+      },
+    });
+
+    await expect(page.locator('.operation-banner')).toBeVisible();
+    await expect(page.locator('.operation-abort-btn')).toHaveCount(0);
+  });
+
   test('declining the abort confirm does not abort', async ({ page }) => {
     app = new AppPage(page);
 

--- a/e2e/tests/create-tag-dialog.spec.ts
+++ b/e2e/tests/create-tag-dialog.spec.ts
@@ -256,7 +256,13 @@ test.describe('Create Tag Dialog', () => {
     const messageTextarea = dialog.locator('#message-input');
     await messageTextarea.fill('Duplicate tag');
 
+    // Assert the field actually took the value before clicking. The button is
+    // disabled while the name is empty, so a lost fill() surfaced as a 30s
+    // timeout on a disabled button rather than saying what went wrong.
+    await expect(nameInput).toHaveValue('v1.0.0');
+
     const createBtn = dialog.locator('button.btn-primary', { hasText: /Create Tag/ });
+    await expect(createBtn).toBeEnabled();
     await createBtn.click();
 
     const errorMessage = dialog.locator('.error-message');

--- a/e2e/tests/create-tag-dialog.spec.ts
+++ b/e2e/tests/create-tag-dialog.spec.ts
@@ -203,7 +203,13 @@ test.describe('Create Tag Dialog', () => {
     const messageTextarea = dialog.locator('#message-input');
     await messageTextarea.fill('Release v4.0.0');
 
+    // Assert the field took the value first: the button is disabled while the
+    // name is empty, so a lost fill() surfaces as a 30s timeout on a disabled
+    // button instead of saying what actually went wrong.
+    await expect(nameInput).toHaveValue('v4.0.0');
+
     const createBtn = dialog.locator('button.btn-primary', { hasText: /Create Tag/ });
+    await expect(createBtn).toBeEnabled();
     await createBtn.click();
 
     await page.waitForFunction(

--- a/e2e/tests/gitflow-panel.spec.ts
+++ b/e2e/tests/gitflow-panel.spec.ts
@@ -474,7 +474,7 @@ test.describe('GitFlow Panel - Operations', () => {
   });
 
   test('clicking Finish on a feature should call gitflow_finish_feature', async ({ page }) => {
-    await page.locator('lv-gitflow-panel#e2e-gitflow .item-finish-btn').first().click();
+    await page.locator('lv-gitflow-panel#e2e-gitflow .item-finish-btn:not(.item-squash-btn)').first().click();
 
     await expect
       .poll(async () => {
@@ -529,7 +529,7 @@ test.describe('GitFlow Panel - Operations', () => {
       ).__TAURI_INTERNALS__.invoke = newInvoke;
     });
 
-    await page.locator('lv-gitflow-panel#e2e-gitflow .item-finish-btn').first().click();
+    await page.locator('lv-gitflow-panel#e2e-gitflow .item-finish-btn:not(.item-squash-btn)').first().click();
 
     // After finishing, the feature should be removed and empty message shown
     await expect(page.locator('lv-gitflow-panel#e2e-gitflow .section').first().locator('.empty-section')).toHaveText(
@@ -620,7 +620,7 @@ test.describe('GitFlow Panel - Finish Feature Failure', () => {
   });
 
   test('should show error message when finish feature fails', async ({ page }) => {
-    await page.locator('lv-gitflow-panel#e2e-gitflow .item-finish-btn').first().click();
+    await page.locator('lv-gitflow-panel#e2e-gitflow .item-finish-btn:not(.item-squash-btn)').first().click();
 
     await expect(page.locator('lv-gitflow-panel#e2e-gitflow .error-banner')).toBeVisible();
   });

--- a/e2e/tests/keyboard.spec.ts
+++ b/e2e/tests/keyboard.spec.ts
@@ -37,6 +37,21 @@ test.describe('Keyboard Shortcuts', () => {
     await page.keyboard.press('?');
     await expect(dialogs.keyboardShortcuts.dialog).toBeVisible();
   });
+
+  // Closing the palette used to leave document focus inside its hidden search
+  // input, so every keydown's composedPath still contained an INPUT and
+  // keyboard.service's in-input bail swallowed every single-key shortcut until
+  // the user clicked something.
+  test('single-key shortcuts still work after closing the command palette', async ({ page }) => {
+    await page.keyboard.press('Meta+p');
+    await expect(dialogs.commandPalette.palette).toBeVisible();
+
+    await page.keyboard.press('Escape');
+    await expect(dialogs.commandPalette.palette).not.toBeVisible();
+
+    await page.keyboard.press('?');
+    await expect(dialogs.keyboardShortcuts.dialog).toBeVisible();
+  });
 });
 
 test.describe('Command Palette', () => {

--- a/e2e/tests/keyboard.spec.ts
+++ b/e2e/tests/keyboard.spec.ts
@@ -42,6 +42,32 @@ test.describe('Keyboard Shortcuts', () => {
   // input, so every keydown's composedPath still contained an INPUT and
   // keyboard.service's in-input bail swallowed every single-key shortcut until
   // the user clicked something.
+  // The palette restores focus to wherever it was when it opened. When the
+  // command it ran opens a dialog, that restore must NOT yank focus back out
+  // of the new dialog — lv-modal focuses in a rAF, which lands after the
+  // palette's restore, but the ordering is worth pinning down.
+  test('a dialog opened from the palette keeps focus', async ({ page }) => {
+    await page.keyboard.press('Meta+p');
+    await expect(page.locator('lv-command-palette[open]')).toBeVisible();
+
+    await page.locator('lv-command-palette input').fill('Create tag');
+    await page.keyboard.press('Enter');
+    await expect(page.locator('lv-create-tag-dialog lv-modal[open]')).toBeVisible();
+
+    const focusPath = await page.evaluate(() => {
+      const path: string[] = [];
+      let el: Element | null = document.activeElement;
+      while (el) {
+        path.push(el.tagName);
+        el = (el as HTMLElement & { shadowRoot?: ShadowRoot }).shadowRoot?.activeElement ?? null;
+      }
+      return path.join(' > ');
+    });
+
+    expect(focusPath, 'focus must stay inside the dialog the command opened')
+      .toContain('LV-CREATE-TAG-DIALOG');
+  });
+
   test('single-key shortcuts still work after closing the command palette', async ({ page }) => {
     await page.keyboard.press('Meta+p');
     await expect(dialogs.commandPalette.palette).toBeVisible();

--- a/e2e/tests/reflog-dialog.spec.ts
+++ b/e2e/tests/reflog-dialog.spec.ts
@@ -5,6 +5,7 @@ import {
   findCommand,
   injectCommandError,
   openViaCommandPalette,
+  autoConfirmDialogs,
 } from '../fixtures/test-helpers';
 
 /**
@@ -52,6 +53,8 @@ async function openReflogDialog(page: import('@playwright/test').Page): Promise<
 test.describe('Reflog Dialog', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // Every reset mode is confirm-gated now, not just hard.
+    await autoConfirmDialogs(page);
 
     await startCommandCaptureWithMocks(page, {
       get_reflog: REFLOG_ENTRIES,
@@ -166,6 +169,8 @@ test.describe('Reflog Dialog', () => {
 test.describe('Reflog Dialog - repository-refresh after undo', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // Every reset mode is confirm-gated now, not just hard.
+    await autoConfirmDialogs(page);
 
     await startCommandCaptureWithMocks(page, {
       get_reflog: REFLOG_ENTRIES,
@@ -195,6 +200,8 @@ test.describe('Reflog Dialog - repository-refresh after undo', () => {
 test.describe('Reflog Dialog - Error handling', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // Every reset mode is confirm-gated now, not just hard.
+    await autoConfirmDialogs(page);
 
     await startCommandCaptureWithMocks(page, {
       get_reflog: REFLOG_ENTRIES,
@@ -214,6 +221,8 @@ test.describe('Reflog Dialog - Error handling', () => {
 test.describe('Reflog Dialog - Injected reset_to_reflog error', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // Every reset mode is confirm-gated now, not just hard.
+    await autoConfirmDialogs(page);
 
     await startCommandCaptureWithMocks(page, {
       get_reflog: REFLOG_ENTRIES,
@@ -238,6 +247,8 @@ test.describe('Reflog Dialog - Injected reset_to_reflog error', () => {
 test.describe('Reflog Dialog - Extended Tests', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // Every reset mode is confirm-gated now, not just hard.
+    await autoConfirmDialogs(page);
 
     await startCommandCaptureWithMocks(page, {
       get_reflog: REFLOG_ENTRIES,

--- a/e2e/tests/reflog-dialog.spec.ts
+++ b/e2e/tests/reflog-dialog.spec.ts
@@ -4,8 +4,10 @@ import {
   startCommandCaptureWithMocks,
   findCommand,
   injectCommandError,
+  injectCommandHang,
   openViaCommandPalette,
   autoConfirmDialogs,
+  waitForCommand,
 } from '../fixtures/test-helpers';
 
 /**
@@ -151,6 +153,25 @@ test.describe('Reflog Dialog', () => {
     await page.keyboard.press('Escape');
 
     await expect(page.locator('lv-reflog-dialog[open]')).not.toBeAttached();
+  });
+
+  // The dialog's own dismiss() refuses to close mid-reset, but the keyboard
+  // service registers a SEPARATE document-level Escape handler that reaches
+  // app-shell and flips the dialog's `open` binding directly. That second path
+  // has to honour the same guard, or the reset carries on with no visible
+  // surface and its success path later slams shut whatever the user reopened.
+  test('Escape must not close the dialog while a reset is in flight', async ({ page }) => {
+    await injectCommandHang(page, 'reset_to_reflog');
+
+    await page.locator('lv-reflog-dialog .reset-btn:not(.hard)').first().click();
+    await waitForCommand(page, 'reset_to_reflog');
+
+    await page.keyboard.press('Escape');
+
+    await expect(page.locator('lv-reflog-dialog[open]')).toBeAttached();
+    // Still mid-reset (so the guard is what kept it open, not a stalled test):
+    // the reset affordances stay disabled for the same reason.
+    await expect(page.locator('lv-reflog-dialog .reset-btn').first()).toBeDisabled();
   });
 
   test('dialog should close when clicking the close button', async ({ page }) => {

--- a/e2e/tests/repository-health-dialog.spec.ts
+++ b/e2e/tests/repository-health-dialog.spec.ts
@@ -8,6 +8,7 @@ import {
   injectCommandMock,
   injectCommandError,
   openViaCommandPalette,
+  autoConfirmDialogs,
 } from '../fixtures/test-helpers';
 
 async function openHealthDialog(page: import('@playwright/test').Page): Promise<void> {
@@ -22,6 +23,8 @@ async function openHealthDialog(page: import('@playwright/test').Page): Promise<
 test.describe('Repository Health Dialog - Statistics', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // GC and prune destroy unreachable objects, so both are confirm-gated.
+    await autoConfirmDialogs(page);
 
     await injectCommandMock(page, {
       get_repository_stats: {
@@ -94,6 +97,8 @@ test.describe('Repository Health Dialog - Statistics', () => {
 test.describe('Repository Health Dialog - Maintenance Actions', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // GC and prune destroy unreachable objects, so both are confirm-gated.
+    await autoConfirmDialogs(page);
 
     await injectCommandMock(page, {
       get_repository_stats: {
@@ -167,6 +172,8 @@ test.describe('Repository Health Dialog - Maintenance Actions', () => {
 test.describe('Repository Health Dialog - Recommendations', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // GC and prune destroy unreachable objects, so both are confirm-gated.
+    await autoConfirmDialogs(page);
 
     await injectCommandMock(page, {
       get_repository_stats: {
@@ -209,6 +216,8 @@ test.describe('Repository Health Dialog - Recommendations', () => {
 test.describe('Repository Health Dialog - Healthy State', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // GC and prune destroy unreachable objects, so both are confirm-gated.
+    await autoConfirmDialogs(page);
 
     await injectCommandMock(page, {
       get_repository_stats: {
@@ -236,6 +245,8 @@ test.describe('Repository Health Dialog - Healthy State', () => {
 test.describe('Repository Health Dialog - Footer', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // GC and prune destroy unreachable objects, so both are confirm-gated.
+    await autoConfirmDialogs(page);
 
     await injectCommandMock(page, {
       get_repository_stats: {
@@ -276,6 +287,8 @@ test.describe('Repository Health Dialog - Footer', () => {
 test.describe('Repository Health Dialog - GC E2E', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // GC and prune destroy unreachable objects, so both are confirm-gated.
+    await autoConfirmDialogs(page);
   });
 
   test('run GC should invoke run_gc and show success feedback', async ({ page }) => {
@@ -392,6 +405,8 @@ test.describe('Repository Health Dialog - GC E2E', () => {
 test.describe('Repository Health Dialog - Error Scenarios', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // GC and prune destroy unreachable objects, so both are confirm-gated.
+    await autoConfirmDialogs(page);
 
     await injectCommandMock(page, {
       get_repository_stats: {
@@ -440,6 +455,33 @@ test.describe('Repository Health Dialog - Error Scenarios', () => {
 test.describe('Repository Health - Extended Tests', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
+    // GC and prune destroy unreachable objects, so both are confirm-gated.
+    await autoConfirmDialogs(page);
+  });
+
+  test('declining the GC confirm does not run gc', async ({ page }) => {
+    // This dialog reaches the same irreversible run_gc as the command palette,
+    // so it must be gated the same way rather than being the unguarded route.
+    await startCommandCaptureWithMocks(page, {
+      get_repository_stats: { count: 1250, loose: 600, sizeKb: 5120 },
+      get_pack_info: { packCount: 15, packSizeKb: 4096 },
+      run_gc: { success: true, message: 'Garbage collection completed' },
+    });
+
+    await openHealthDialog(page);
+
+    // Decline: plugin-dialog treats any non-OK label as cancel.
+    await injectCommandMock(page, { 'plugin:dialog|message': 'Cancel' });
+
+    const healthDialog = page.locator('lv-repository-health-dialog');
+    const gcButton = healthDialog
+      .locator('.action-btn', { hasText: /Garbage Collection/i })
+      .first();
+    await expect(gcButton).toBeVisible();
+    await gcButton.click();
+
+    await expect(healthDialog).toBeVisible();
+    expect(await findCommand(page, 'run_gc')).toHaveLength(0);
   });
 
   test('clicking Aggressive GC should invoke run_gc command', async ({ page }) => {

--- a/e2e/tests/worktree-clean.spec.ts
+++ b/e2e/tests/worktree-clean.spec.ts
@@ -7,6 +7,7 @@ import {
   injectCommandError,
   injectCommandMock,
   openViaCommandPalette,
+  autoConfirmDialogs,
 } from '../fixtures/test-helpers';
 
 /**
@@ -535,6 +536,23 @@ test.describe('Clean Dialog - Operations', () => {
       ],
       clean_files: 2,
     });
+
+    // Deleting untracked files is confirm-gated: they exist in no git object
+    // and there is no recovery path.
+    await autoConfirmDialogs(page);
+  });
+
+  test('declining the delete confirm does not clean', async ({ page }) => {
+    // Untracked files are unlinked with no recovery path anywhere, so the
+    // dialog's checkbox list is a selection UI, not a confirmation.
+    await startCommandCapture(page);
+    await injectCommandMock(page, { 'plugin:dialog|message': 'Cancel' });
+    await openCleanDialog(page);
+
+    await page.locator('lv-clean-dialog .btn-danger').click();
+
+    await expect(page.locator('lv-clean-dialog[open] .dialog')).toBeVisible();
+    expect(await findCommand(page, 'clean_files')).toHaveLength(0);
   });
 
   test('clicking Delete Selected calls clean_files with selected paths', async ({ page }) => {

--- a/eslint-rules/overlay-stack-membership.mjs
+++ b/eslint-rules/overlay-stack-membership.mjs
@@ -22,9 +22,11 @@ const rule = {
     schema: [],
     messages: {
       missingPush:
-        'This dialog adds a document-level keydown listener but never calls pushOverlay(). ' +
-        'A dialog opened over another one will then dismiss BOTH on a single Escape. ' +
-        'Register with src/utils/overlay-stack.ts (push on open, remove on close and disconnect).',
+        'This component dismisses on Escape from a global keydown listener but never ' +
+        'consults isTopOverlay(). Every such listener fires on the same keypress, so a ' +
+        'dialog opened over this one will dismiss BOTH. Gate the Escape branch on ' +
+        'isTopOverlay(this) from src/utils/overlay-stack.ts; if this component is itself ' +
+        'an overlay, also push on open and remove on close and disconnect.',
       missingRemove:
         'This dialog calls pushOverlay() but never removeOverlay(). A leaked entry sits on ' +
         'top of the stack forever and takes Escape away from every dialog below it.',
@@ -36,6 +38,8 @@ const rule = {
     if (filename.endsWith('lv-modal.ts')) return {};
 
     let addsDocumentKeydown = false;
+    let handlesEscape = false;
+    let consultsStack = false;
     let pushes = false;
     let removes = false;
     let firstNode = null;
@@ -49,7 +53,10 @@ const rule = {
         if (
           callee.type === 'MemberExpression' &&
           callee.object.type === 'Identifier' &&
-          callee.object.name === 'document' &&
+          // `window` counts too. The first version matched only `document`,
+          // so a window+capture listener — which pre-empts every document
+          // listener in the app — sailed straight past the rule.
+          (callee.object.name === 'document' || callee.object.name === 'window') &&
           callee.property.type === 'Identifier' &&
           callee.property.name === 'addEventListener' &&
           node.arguments[0]?.type === 'Literal' &&
@@ -59,9 +66,17 @@ const rule = {
         }
         if (callee.type === 'Identifier' && callee.name === 'pushOverlay') pushes = true;
         if (callee.type === 'Identifier' && callee.name === 'removeOverlay') removes = true;
+        if (callee.type === 'Identifier' && callee.name === 'isTopOverlay') consultsStack = true;
+      },
+      Literal(node) {
+        if (node.value === 'Escape') handlesEscape = true;
       },
       'Program:exit'() {
-        if (addsDocumentKeydown && !pushes) {
+        // The invariant is about DISMISSAL, not about listening. A component
+        // that listens for navigation keys only (j/k, arrows) is not an
+        // overlay and must not be dragged into the stack; one that acts on
+        // Escape must first check that the key is aimed at it.
+        if (addsDocumentKeydown && handlesEscape && !consultsStack) {
           context.report({ node: firstNode, messageId: 'missingPush' });
         }
         if (pushes && !removes) {

--- a/eslint-rules/overlay-stack-membership.mjs
+++ b/eslint-rules/overlay-stack-membership.mjs
@@ -66,10 +66,36 @@ const rule = {
         }
         if (callee.type === 'Identifier' && callee.name === 'pushOverlay') pushes = true;
         if (callee.type === 'Identifier' && callee.name === 'removeOverlay') removes = true;
-        if (callee.type === 'Identifier' && callee.name === 'isTopOverlay') consultsStack = true;
+        // NOTE: a bare call is deliberately NOT enough — see IfStatement below.
       },
       Literal(node) {
         if (node.value === 'Escape') handlesEscape = true;
+      },
+      /**
+       * The guard must actually GUARD. Counting any call to isTopOverlay let a
+       * component satisfy the rule with `void isTopOverlay(this);` and then
+       * close on Escape unconditionally — reintroducing the exact double
+       * dismissal the stack exists to prevent, with a green lint. Require the
+       * call to sit in the test of an `if` that bails.
+       */
+      IfStatement(node) {
+        const testMentionsGuard = (n) => {
+          if (!n || typeof n !== 'object') return false;
+          if (n.type === 'CallExpression' && n.callee?.name === 'isTopOverlay') return true;
+          return ['argument', 'left', 'right', 'expression', 'test', 'consequent', 'alternate']
+            .some((k) => testMentionsGuard(n[k]));
+        };
+        // Any `if` whose TEST consults the stack counts, whichever way round
+        // it is written — both of these are correct and both appear in the
+        // codebase:
+        //   if (!this.open || !isTopOverlay(this)) return;      // bail form
+        //   if (e.key === 'Escape' && isTopOverlay(this)) {...} // inline form
+        // What this rejects is the call appearing only as a standalone
+        // expression whose result is thrown away, which "consults" the stack
+        // without letting it decide anything.
+        if (testMentionsGuard(node.test)) {
+          consultsStack = true;
+        }
       },
       'Program:exit'() {
         // The invariant is about DISMISSAL, not about listening. A component

--- a/eslint-rules/overlay-stack-membership.mjs
+++ b/eslint-rules/overlay-stack-membership.mjs
@@ -1,0 +1,75 @@
+/**
+ * The overlay stack (src/utils/overlay-stack.ts) decides which dialog owns
+ * Escape. It only works if EVERY dialog that can close on Escape joins it.
+ *
+ * That membership started as a hand-written list and went stale immediately:
+ * fourteen dialogs own a document-level Escape listener, ten were migrated,
+ * and the three that were missed reproduced the exact bug the stack exists to
+ * prevent — a dialog opened over another dismissed both, taking the clean
+ * dialog's file selection with it.
+ *
+ * So the invariant is enforced here instead of remembered. A dialog that
+ * listens for keydown on `document` must also register with the stack.
+ */
+
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'dialogs listening for keydown on document must join the overlay stack',
+    },
+    schema: [],
+    messages: {
+      missingPush:
+        'This dialog adds a document-level keydown listener but never calls pushOverlay(). ' +
+        'A dialog opened over another one will then dismiss BOTH on a single Escape. ' +
+        'Register with src/utils/overlay-stack.ts (push on open, remove on close and disconnect).',
+      missingRemove:
+        'This dialog calls pushOverlay() but never removeOverlay(). A leaked entry sits on ' +
+        'top of the stack forever and takes Escape away from every dialog below it.',
+    },
+  },
+  create(context) {
+    const filename = context.filename ?? context.getFilename();
+    // The shared modal wrapper registers on behalf of its hosts.
+    if (filename.endsWith('lv-modal.ts')) return {};
+
+    let addsDocumentKeydown = false;
+    let pushes = false;
+    let removes = false;
+    let firstNode = null;
+
+    return {
+      Program(node) {
+        firstNode = node;
+      },
+      CallExpression(node) {
+        const callee = node.callee;
+        if (
+          callee.type === 'MemberExpression' &&
+          callee.object.type === 'Identifier' &&
+          callee.object.name === 'document' &&
+          callee.property.type === 'Identifier' &&
+          callee.property.name === 'addEventListener' &&
+          node.arguments[0]?.type === 'Literal' &&
+          node.arguments[0].value === 'keydown'
+        ) {
+          addsDocumentKeydown = true;
+        }
+        if (callee.type === 'Identifier' && callee.name === 'pushOverlay') pushes = true;
+        if (callee.type === 'Identifier' && callee.name === 'removeOverlay') removes = true;
+      },
+      'Program:exit'() {
+        if (addsDocumentKeydown && !pushes) {
+          context.report({ node: firstNode, messageId: 'missingPush' });
+        }
+        if (pushes && !removes) {
+          context.report({ node: firstNode, messageId: 'missingRemove' });
+        }
+      },
+    };
+  },
+};
+
+export default rule;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -31,7 +31,9 @@ export default tseslint.config(
     // Enforced rather than remembered: the overlay stack's membership was a
     // hand-written list once, and it went stale in the same round it was
     // written. See eslint-rules/overlay-stack-membership.mjs.
-    files: ['src/components/dialogs/*.ts'],
+    // Every component, not just dialogs: lv-toolbar owns a document capture
+    // Escape handler that stopPropagation()s, and sat outside the old glob.
+    files: ['src/components/**/*.ts'],
     plugins: { leviathan: { rules: { 'overlay-stack-membership': overlayStackMembership } } },
     rules: {
       'leviathan/overlay-stack-membership': 'error',

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import globals from 'globals';
 import tseslint from 'typescript-eslint';
+import overlayStackMembership from './eslint-rules/overlay-stack-membership.mjs';
 
 export default tseslint.config(
   {
@@ -24,6 +25,16 @@ export default tseslint.config(
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-unused-expressions': ['error', { allowShortCircuit: true, allowTernary: true }],
       'no-console': 'off',
+    },
+  },
+  {
+    // Enforced rather than remembered: the overlay stack's membership was a
+    // hand-written list once, and it went stale in the same round it was
+    // written. See eslint-rules/overlay-stack-membership.mjs.
+    files: ['src/components/dialogs/*.ts'],
+    plugins: { leviathan: { rules: { 'overlay-stack-membership': overlayStackMembership } } },
+    rules: {
+      'leviathan/overlay-stack-membership': 'error',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -3942,16 +3942,16 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.6",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
-      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
+      "version": "5.0.9",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+      "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "balanced-match": "^4.0.2"
       },
       "engines": {
-        "node": "18 || 20 || >=22"
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -5588,9 +5588,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
-      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "version": "10.4.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.4.0.tgz",
+      "integrity": "sha512-oSK96Grm3aP6OrS263xVxbNDGVL7rzBtYdpGqlDG8iQdoenDoTs/nkki+DflYbAEE8Xl6o5YxhxlrKvI3nqKXQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6671,9 +6671,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.12",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
-      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {
@@ -7083,9 +7083,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.25",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.25.tgz",
+      "integrity": "sha512-DTPx3RWSSnWyzLxQnlH0rJP+EW5ekl16ZU4/psbIhA0e53kJfdgaN5vKM+xP7yJtXVu+nfdVFmlgFDEKAe4Pyw==",
       "dev": true,
       "funding": [
         {
@@ -7103,7 +7103,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },

--- a/package.json
+++ b/package.json
@@ -16,8 +16,8 @@
     "test:e2e:ui": "playwright test --config=e2e/playwright.config.ts --ui",
     "test:e2e:headed": "playwright test --config=e2e/playwright.config.ts --headed",
     "typecheck": "tsc --noEmit",
-    "lint": "eslint src/**/*.ts",
-    "lint:fix": "eslint src/**/*.ts --fix",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
     "format": "prettier --write src",
     "format:check": "prettier --check src"
   },

--- a/src-tauri/src/commands/branch.rs
+++ b/src-tauri/src/commands/branch.rs
@@ -155,6 +155,19 @@ pub async fn delete_branch(path: String, name: String, force: Option<bool>) -> R
         .find_branch(&name, git2::BranchType::Local)
         .map_err(|_| LeviathanError::BranchNotFound(name.clone()))?;
 
+    // Enforce preventDeletion branch rules HERE rather than only in the cleanup
+    // dialog's candidate listing: the sidebar and the graph ref menu call this
+    // command directly, so a rule the UI displays as active was inert on both
+    // of those surfaces. Checked before the force branch so force cannot bypass
+    // an explicit protection rule.
+    let rules = super::branch_rules::load_rules(Path::new(&path)).unwrap_or_default();
+    if super::branch_rules::is_deletion_prevented(&rules, &name) {
+        return Err(LeviathanError::OperationFailed(format!(
+            "Branch \"{}\" is protected by a branch rule and cannot be deleted. Remove the rule first.",
+            name
+        )));
+    }
+
     if force.unwrap_or(false) {
         branch.delete()?;
     } else {
@@ -1042,6 +1055,92 @@ mod tests {
         assert!(git_repo
             .find_branch("at-head", git2::BranchType::Local)
             .is_err());
+    }
+
+    /// A preventDeletion rule must be enforced by the COMMAND, not only by the
+    /// cleanup dialog's listing — the sidebar and graph ref menu call
+    /// delete_branch directly and never load the rules.
+    #[tokio::test]
+    async fn test_delete_branch_refuses_protected_branch() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_branch("release/v1");
+
+        crate::commands::branch_rules::set_branch_rule(
+            repo.path_str(),
+            crate::commands::branch_rules::BranchRule {
+                pattern: "release/*".to_string(),
+                prevent_deletion: true,
+                prevent_force_push: false,
+                require_pull_request: false,
+                prevent_direct_push: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = delete_branch(repo.path_str(), "release/v1".to_string(), Some(false)).await;
+        assert!(result.is_err(), "protected branch must not be deleted");
+        assert!(result.unwrap_err().to_string().contains("protected"));
+
+        let git_repo = repo.repo();
+        assert!(
+            git_repo
+                .find_branch("release/v1", git2::BranchType::Local)
+                .is_ok(),
+            "branch must still exist"
+        );
+    }
+
+    /// Force must not be an escape hatch around an explicit protection rule.
+    #[tokio::test]
+    async fn test_delete_branch_force_cannot_bypass_protection() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_branch("protected-branch");
+
+        crate::commands::branch_rules::set_branch_rule(
+            repo.path_str(),
+            crate::commands::branch_rules::BranchRule {
+                pattern: "protected-branch".to_string(),
+                prevent_deletion: true,
+                prevent_force_push: false,
+                require_pull_request: false,
+                prevent_direct_push: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        let result =
+            delete_branch(repo.path_str(), "protected-branch".to_string(), Some(true)).await;
+        assert!(result.is_err(), "force must not bypass a protection rule");
+
+        let git_repo = repo.repo();
+        assert!(git_repo
+            .find_branch("protected-branch", git2::BranchType::Local)
+            .is_ok());
+    }
+
+    /// An unrelated branch must be unaffected by a rule that does not match it.
+    #[tokio::test]
+    async fn test_delete_branch_allows_unmatched_branch() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_branch("feature/x");
+
+        crate::commands::branch_rules::set_branch_rule(
+            repo.path_str(),
+            crate::commands::branch_rules::BranchRule {
+                pattern: "release/*".to_string(),
+                prevent_deletion: true,
+                prevent_force_push: false,
+                require_pull_request: false,
+                prevent_direct_push: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = delete_branch(repo.path_str(), "feature/x".to_string(), Some(true)).await;
+        assert!(result.is_ok(), "non-matching branch must still delete");
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/branch.rs
+++ b/src-tauri/src/commands/branch.rs
@@ -160,7 +160,14 @@ pub async fn delete_branch(path: String, name: String, force: Option<bool>) -> R
     // command directly, so a rule the UI displays as active was inert on both
     // of those surfaces. Checked before the force branch so force cannot bypass
     // an explicit protection rule.
-    let rules = super::branch_rules::load_rules(Path::new(&path)).unwrap_or_default();
+    // Propagated, NOT unwrap_or_default: load_rules errors both when the file
+    // is unreadable and when it fails to parse (save_rules is a non-atomic
+    // write, so a crash mid-save can truncate it). Defaulting to "no rules"
+    // would make an unreadable rule set indistinguishable from an empty one and
+    // silently disable every protection in the repo — a protection that fails
+    // open is worse than none, because the UI still shows the branch as
+    // protected.
+    let rules = super::branch_rules::load_rules(Path::new(&path))?;
     if super::branch_rules::is_deletion_prevented(&rules, &name) {
         return Err(LeviathanError::OperationFailed(format!(
             "Branch \"{}\" is protected by a branch rule and cannot be deleted. Remove the rule first.",

--- a/src-tauri/src/commands/branch_cleanup.rs
+++ b/src-tauri/src/commands/branch_cleanup.rs
@@ -75,24 +75,10 @@ pub async fn get_cleanup_candidates(
     // Load branch protection rules
     let rules = load_rules(Path::new(&path)).unwrap_or_default();
 
-    // Helper: check if a branch name matches any protection rule with prevent_deletion
+    // Shared with delete_branch's enforcement so the badge shown here and the
+    // rule actually applied at delete time can never diverge.
     let is_protected = |branch_name: &str| -> bool {
-        rules.iter().any(|rule| {
-            if !rule.prevent_deletion {
-                return false;
-            }
-            if rule.pattern.contains('*') {
-                // Simple glob matching: "release/*" matches "release/v1"
-                let parts: Vec<&str> = rule.pattern.split('*').collect();
-                if parts.len() == 2 {
-                    branch_name.starts_with(parts[0]) && branch_name.ends_with(parts[1])
-                } else {
-                    rule.pattern == branch_name
-                }
-            } else {
-                rule.pattern == branch_name
-            }
-        })
+        super::branch_rules::is_deletion_prevented(&rules, branch_name)
     };
 
     for branch_result in repo.branches(Some(git2::BranchType::Local))? {

--- a/src-tauri/src/commands/branch_rules.rs
+++ b/src-tauri/src/commands/branch_rules.rs
@@ -53,6 +53,33 @@ pub(crate) fn load_rules(repo_path: &Path) -> Result<Vec<BranchRule>> {
     })
 }
 
+/// Match a branch name against a rule pattern.
+///
+/// Supports a single `*` wildcard, e.g. `release/*` matches `release/v1`.
+pub(crate) fn pattern_matches(pattern: &str, branch_name: &str) -> bool {
+    if pattern.contains('*') {
+        // Simple glob matching: "release/*" matches "release/v1"
+        let parts: Vec<&str> = pattern.split('*').collect();
+        if parts.len() == 2 {
+            return branch_name.starts_with(parts[0]) && branch_name.ends_with(parts[1]);
+        }
+    }
+    pattern == branch_name
+}
+
+/// True when `branch_name` matches a rule that prevents deletion.
+///
+/// Shared by the cleanup dialog's candidate listing and by `delete_branch`
+/// itself. Enforcing it in the command rather than only where candidates are
+/// listed is what makes the rule real: the sidebar and the graph ref menu call
+/// `delete_branch` directly and never load the rules, so a rule the UI shows as
+/// "Protected" was previously inert on both of those surfaces.
+pub(crate) fn is_deletion_prevented(rules: &[BranchRule], branch_name: &str) -> bool {
+    rules
+        .iter()
+        .any(|rule| rule.prevent_deletion && pattern_matches(&rule.pattern, branch_name))
+}
+
 /// Save branch rules to the repository config
 fn save_rules(repo_path: &Path, rules: &[BranchRule]) -> Result<()> {
     let rules_path = get_rules_path(repo_path)?;

--- a/src-tauri/src/commands/gitflow.rs
+++ b/src-tauri/src/commands/gitflow.rs
@@ -182,6 +182,54 @@ pub async fn gitflow_start_feature(path: String, name: String) -> Result<Branch>
     })
 }
 
+/// Outcome of a git-flow finish.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitFlowFinishResult {
+    /// True when the source branch was deleted as part of the finish.
+    pub branch_deleted: bool,
+    /// Set when deletion was requested but skipped, explaining why.
+    pub branch_kept_reason: Option<String>,
+}
+
+/// Delete the finished branch unless a protection rule forbids it.
+///
+/// Branch rules are enforced here as well as in `delete_branch` because these
+/// finishes delete the branch themselves rather than going through that
+/// command — without this, a `preventDeletion` rule the UI displays as active
+/// is inert on every git-flow finish.
+///
+/// A protected branch must NOT fail the whole finish: the merge and tag have
+/// already landed by this point and deletion is the optional last step. Report
+/// what happened instead so the caller can explain why the branch is still
+/// there.
+fn delete_finished_branch(
+    repo: &git2::Repository,
+    repo_path: &str,
+    branch_name: &str,
+) -> Result<GitFlowFinishResult> {
+    let rules = super::branch_rules::load_rules(Path::new(repo_path))?;
+    if super::branch_rules::is_deletion_prevented(&rules, branch_name) {
+        return Ok(GitFlowFinishResult {
+            branch_deleted: false,
+            branch_kept_reason: Some(format!(
+                "\"{}\" is protected by a branch rule and was kept. The merge completed.",
+                branch_name
+            )),
+        });
+    }
+
+    let mut branch = repo
+        .find_branch(branch_name, git2::BranchType::Local)
+        .map_err(|_| LeviathanError::BranchNotFound(branch_name.to_string()))?;
+    branch.delete()?;
+
+    Ok(GitFlowFinishResult {
+        branch_deleted: true,
+        branch_kept_reason: None,
+    })
+}
+
 /// Finish a git flow feature branch (merge into develop)
 #[command]
 pub async fn gitflow_finish_feature(
@@ -189,7 +237,7 @@ pub async fn gitflow_finish_feature(
     name: String,
     delete_branch: Option<bool>,
     squash: Option<bool>,
-) -> Result<()> {
+) -> Result<GitFlowFinishResult> {
     let repo = git2::Repository::open(Path::new(&path))?;
     let config = repo.config()?;
 
@@ -280,13 +328,13 @@ pub async fn gitflow_finish_feature(
 
     // Delete feature branch if requested
     if delete_branch.unwrap_or(true) {
-        let mut branch = repo
-            .find_branch(&branch_name, git2::BranchType::Local)
-            .map_err(|_| LeviathanError::BranchNotFound(branch_name.clone()))?;
-        branch.delete()?;
+        return delete_finished_branch(&repo, &path, &branch_name);
     }
 
-    Ok(())
+    Ok(GitFlowFinishResult {
+        branch_deleted: false,
+        branch_kept_reason: None,
+    })
 }
 
 /// Start a git flow release branch
@@ -338,7 +386,7 @@ pub async fn gitflow_finish_release(
     version: String,
     tag_message: Option<String>,
     delete_branch: Option<bool>,
-) -> Result<()> {
+) -> Result<GitFlowFinishResult> {
     finish_release_like(
         path,
         version,
@@ -360,7 +408,7 @@ async fn finish_release_like(
     delete_branch: Option<bool>,
     prefix_key: &str,
     prefix_default: &str,
-) -> Result<()> {
+) -> Result<GitFlowFinishResult> {
     let repo = git2::Repository::open(Path::new(&path))?;
     let config = repo.config()?;
 
@@ -489,13 +537,13 @@ async fn finish_release_like(
 
     // Delete release branch
     if delete_branch.unwrap_or(true) {
-        let mut branch = repo
-            .find_branch(&branch_name, git2::BranchType::Local)
-            .map_err(|_| LeviathanError::BranchNotFound(branch_name.clone()))?;
-        branch.delete()?;
+        return delete_finished_branch(&repo, &path, &branch_name);
     }
 
-    Ok(())
+    Ok(GitFlowFinishResult {
+        branch_deleted: false,
+        branch_kept_reason: None,
+    })
 }
 
 /// Start a git flow hotfix branch
@@ -547,7 +595,7 @@ pub async fn gitflow_finish_hotfix(
     version: String,
     tag_message: Option<String>,
     delete_branch: Option<bool>,
-) -> Result<()> {
+) -> Result<GitFlowFinishResult> {
     // Same flow as release finish, but the branch lives under the hotfix
     // prefix — delegating with the release prefix made every hotfix finish
     // fail with BranchNotFound.
@@ -574,6 +622,74 @@ mod tests {
         assert!(result.is_ok());
         let config = result.unwrap();
         assert!(!config.initialized);
+    }
+
+    /// A preventDeletion rule must survive a git-flow finish. These finishes
+    /// delete the branch themselves rather than going through delete_branch, so
+    /// without an explicit check the rule is inert on this surface.
+    #[tokio::test]
+    async fn test_gitflow_finish_feature_respects_branch_rule() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        gitflow_start_feature(repo.path_str(), "protected-work".to_string())
+            .await
+            .unwrap();
+
+        crate::commands::branch_rules::set_branch_rule(
+            repo.path_str(),
+            crate::commands::branch_rules::BranchRule {
+                pattern: "feature/*".to_string(),
+                prevent_deletion: true,
+                prevent_force_push: false,
+                require_pull_request: false,
+                prevent_direct_push: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        let result = gitflow_finish_feature(
+            repo.path_str(),
+            "protected-work".to_string(),
+            Some(true),
+            None,
+        )
+        .await;
+
+        // The merge must still succeed — only the optional delete is skipped.
+        assert!(result.is_ok(), "finish should complete despite the rule");
+        let outcome = result.unwrap();
+        assert!(!outcome.branch_deleted, "protected branch must be kept");
+        assert!(
+            outcome.branch_kept_reason.is_some(),
+            "the caller must be told why the branch survived"
+        );
+
+        let git_repo = repo.repo();
+        assert!(git_repo
+            .find_branch("feature/protected-work", git2::BranchType::Local)
+            .is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_gitflow_finish_feature_deletes_unprotected_branch() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        gitflow_start_feature(repo.path_str(), "ordinary".to_string())
+            .await
+            .unwrap();
+
+        let outcome =
+            gitflow_finish_feature(repo.path_str(), "ordinary".to_string(), Some(true), None)
+                .await
+                .unwrap();
+
+        assert!(outcome.branch_deleted);
+        assert!(outcome.branch_kept_reason.is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/gitflow.rs
+++ b/src-tauri/src/commands/gitflow.rs
@@ -199,35 +199,69 @@ pub struct GitFlowFinishResult {
 /// command — without this, a `preventDeletion` rule the UI displays as active
 /// is inert on every git-flow finish.
 ///
-/// A protected branch must NOT fail the whole finish: the merge and tag have
-/// already landed by this point and deletion is the optional last step. Report
-/// what happened instead so the caller can explain why the branch is still
-/// there.
+/// NO failure here may fail the whole finish. The merge and (for release and
+/// hotfix) the tag have already been committed by the time this runs, so
+/// deletion is the optional last step — returning `Err` would report a finish
+/// that actually succeeded as failed, leave the item listed as active, and
+/// invite a retry. A squash retry is NOT idempotent (a squash commit never
+/// makes the feature an ancestor of develop), so each retry mints another
+/// duplicate commit. Every path therefore degrades to `branch_kept_reason`.
 fn delete_finished_branch(
     repo: &git2::Repository,
     repo_path: &str,
     branch_name: &str,
-) -> Result<GitFlowFinishResult> {
-    let rules = super::branch_rules::load_rules(Path::new(repo_path))?;
+) -> GitFlowFinishResult {
+    let kept = |reason: String| GitFlowFinishResult {
+        branch_deleted: false,
+        branch_kept_reason: Some(reason),
+    };
+
+    // Branch rules are enforced here as well as in `delete_branch` because
+    // these finishes delete the branch themselves rather than going through
+    // that command — without this, a `preventDeletion` rule the UI displays as
+    // active is inert on every git-flow finish.
+    let rules = match super::branch_rules::load_rules(Path::new(repo_path)) {
+        Ok(rules) => rules,
+        // Unreadable rules mean we cannot prove the branch is unprotected.
+        // Keep it: the merge is already safe, and deleting past an unverifiable
+        // protection is the one irreversible mistake available here.
+        Err(e) => {
+            return kept(format!(
+                "The merge completed, but \"{}\" was kept — its branch rules could not be read: {}",
+                branch_name, e
+            ))
+        }
+    };
+
     if super::branch_rules::is_deletion_prevented(&rules, branch_name) {
-        return Ok(GitFlowFinishResult {
-            branch_deleted: false,
-            branch_kept_reason: Some(format!(
-                "\"{}\" is protected by a branch rule and was kept. The merge completed.",
-                branch_name
-            )),
-        });
+        return kept(format!(
+            "\"{}\" is protected by a branch rule and was kept. The merge completed.",
+            branch_name
+        ));
     }
 
-    let mut branch = repo
-        .find_branch(branch_name, git2::BranchType::Local)
-        .map_err(|_| LeviathanError::BranchNotFound(branch_name.to_string()))?;
-    branch.delete()?;
+    let mut branch = match repo.find_branch(branch_name, git2::BranchType::Local) {
+        Ok(branch) => branch,
+        Err(e) => {
+            return kept(format!(
+                "The merge completed, but \"{}\" could not be opened for deletion: {}",
+                branch_name, e
+            ))
+        }
+    };
 
-    Ok(GitFlowFinishResult {
+    if let Err(e) = branch.delete() {
+        // e.g. the branch is checked out in a linked worktree.
+        return kept(format!(
+            "The merge completed, but \"{}\" could not be deleted: {}",
+            branch_name, e
+        ));
+    }
+
+    GitFlowFinishResult {
         branch_deleted: true,
         branch_kept_reason: None,
-    })
+    }
 }
 
 /// Finish a git flow feature branch (merge into develop)
@@ -328,7 +362,7 @@ pub async fn gitflow_finish_feature(
 
     // Delete feature branch if requested
     if delete_branch.unwrap_or(true) {
-        return delete_finished_branch(&repo, &path, &branch_name);
+        return Ok(delete_finished_branch(&repo, &path, &branch_name));
     }
 
     Ok(GitFlowFinishResult {
@@ -537,7 +571,7 @@ async fn finish_release_like(
 
     // Delete release branch
     if delete_branch.unwrap_or(true) {
-        return delete_finished_branch(&repo, &path, &branch_name);
+        return Ok(delete_finished_branch(&repo, &path, &branch_name));
     }
 
     Ok(GitFlowFinishResult {
@@ -671,6 +705,41 @@ mod tests {
         assert!(git_repo
             .find_branch("feature/protected-work", git2::BranchType::Local)
             .is_ok());
+    }
+
+    /// A delete failure must never fail the whole finish: the merge is already
+    /// committed, and a squash retry is not idempotent — it would mint a second
+    /// squash commit every time the user retried.
+    #[tokio::test]
+    async fn test_gitflow_finish_feature_survives_unreadable_branch_rules() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        gitflow_start_feature(repo.path_str(), "work".to_string())
+            .await
+            .unwrap();
+
+        // save_rules is a non-atomic write, so a crash mid-save can leave this
+        // truncated.
+        let git_repo = repo.repo();
+        let rules_dir = git_repo.path().join("leviathan");
+        std::fs::create_dir_all(&rules_dir).unwrap();
+        std::fs::write(rules_dir.join("branch_rules.json"), "{ not json").unwrap();
+
+        let result =
+            gitflow_finish_feature(repo.path_str(), "work".to_string(), Some(true), None).await;
+
+        assert!(
+            result.is_ok(),
+            "an unreadable rules file must not fail a finish whose merge already landed"
+        );
+        let outcome = result.unwrap();
+        assert!(!outcome.branch_deleted);
+        assert!(
+            outcome.branch_kept_reason.is_some(),
+            "the caller must be told the branch survived and why"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -280,6 +280,10 @@ pub async fn abort_merge(path: String) -> Result<()> {
     if !touched.is_empty() {
         let mut checkout = git2::build::CheckoutBuilder::new();
         checkout.force();
+        // Keeps "everything else is left alone" literally true: without this,
+        // CheckoutBuilder::path() glob-matches, so a touched path containing
+        // `*`, `?` or `[` would also force-restore unrelated dirty files.
+        checkout.disable_pathspec_match(true);
         for p in &touched {
             checkout.path(p);
         }

--- a/src-tauri/src/commands/reflog.rs
+++ b/src-tauri/src/commands/reflog.rs
@@ -104,6 +104,7 @@ pub async fn reset_to_reflog(
     path: String,
     reflog_index: usize,
     mode: String,
+    expected_oid: Option<String>,
 ) -> Result<ReflogEntry> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
@@ -118,6 +119,21 @@ pub async fn reset_to_reflog(
         })?;
 
         let oid_str = entry.id_new().to_string();
+
+        // `reflog_index` is a POSITION: anything that writes HEAD's reflog (a
+        // commit or checkout from a terminal, or a second window) shifts every
+        // entry down by one. The caller listed the reflog earlier and showed the
+        // user a specific commit, so verify the position still holds that commit
+        // before resetting — otherwise a hard reset discards uncommitted work to
+        // land somewhere the user never chose.
+        if let Some(expected) = &expected_oid {
+            if &oid_str != expected {
+                return Err(crate::error::LeviathanError::OperationFailed(
+                    "The reflog changed since this entry was listed — refresh and try again."
+                        .to_string(),
+                ));
+            }
+        }
         let msg = entry.message().ok().flatten().unwrap_or("").to_string();
         let committer = entry.committer();
         let ts = committer.when().seconds();
@@ -309,7 +325,7 @@ mod tests {
         assert_ne!(first_oid, second_oid);
 
         // Reset soft to first commit (reflog index 1)
-        let result = reset_to_reflog(repo.path_str(), 1, "soft".to_string()).await;
+        let result = reset_to_reflog(repo.path_str(), 1, "soft".to_string(), None).await;
         assert!(result.is_ok());
 
         let entry = result.unwrap();
@@ -334,7 +350,7 @@ mod tests {
         repo.create_commit("Second commit", &[("file2.txt", "content2")]);
 
         // Reset mixed to first commit
-        let result = reset_to_reflog(repo.path_str(), 1, "mixed".to_string()).await;
+        let result = reset_to_reflog(repo.path_str(), 1, "mixed".to_string(), None).await;
         assert!(result.is_ok());
 
         // HEAD should now point to first commit
@@ -350,7 +366,7 @@ mod tests {
         assert!(repo.path.join("file2.txt").exists());
 
         // Reset hard to first commit
-        let result = reset_to_reflog(repo.path_str(), 1, "hard".to_string()).await;
+        let result = reset_to_reflog(repo.path_str(), 1, "hard".to_string(), None).await;
         assert!(result.is_ok());
 
         // HEAD should point to first commit
@@ -368,7 +384,7 @@ mod tests {
         repo.create_commit("Second", &[("f.txt", "c")]);
 
         // Invalid mode should default to mixed
-        let result = reset_to_reflog(repo.path_str(), 1, "invalid".to_string()).await;
+        let result = reset_to_reflog(repo.path_str(), 1, "invalid".to_string(), None).await;
         assert!(result.is_ok());
         assert_eq!(repo.head_oid(), first_oid);
     }
@@ -378,7 +394,7 @@ mod tests {
         let repo = TestRepo::with_initial_commit();
 
         // Try to reset to a nonexistent reflog entry
-        let result = reset_to_reflog(repo.path_str(), 9999, "mixed".to_string()).await;
+        let result = reset_to_reflog(repo.path_str(), 9999, "mixed".to_string(), None).await;
         assert!(result.is_err());
 
         let err = result.unwrap_err();
@@ -386,11 +402,63 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_reset_to_reflog_refuses_when_entry_shifted() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Second", &[("f2.txt", "2")]);
+
+        // What the UI listed and showed the user at index 1.
+        let listed = get_reflog(repo.path_str(), None).await.unwrap();
+        let expected_oid = listed[1].oid.clone();
+
+        // A commit from a terminal / second window pushes every entry down one,
+        // so index 1 now names a DIFFERENT commit than the user selected.
+        repo.create_commit("Third", &[("f3.txt", "3")]);
+
+        let head_before = repo.head_oid();
+        let result = reset_to_reflog(
+            repo.path_str(),
+            1,
+            "hard".to_string(),
+            Some(expected_oid.clone()),
+        )
+        .await;
+
+        assert!(result.is_err(), "a shifted entry must not be reset to");
+        assert!(result.unwrap_err().to_string().contains("reflog changed"));
+        assert_eq!(
+            repo.head_oid(),
+            head_before,
+            "HEAD must be untouched when the guard trips"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_reset_to_reflog_proceeds_when_oid_matches() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Second", &[("f2.txt", "2")]);
+
+        let listed = get_reflog(repo.path_str(), None).await.unwrap();
+        let expected_oid = listed[1].oid.clone();
+
+        // Nothing shifted, so the pinned oid still matches index 1.
+        let result = reset_to_reflog(
+            repo.path_str(),
+            1,
+            "mixed".to_string(),
+            Some(expected_oid.clone()),
+        )
+        .await;
+
+        assert!(result.is_ok(), "a matching oid must not be blocked");
+        assert_eq!(result.unwrap().oid, expected_oid);
+    }
+
+    #[tokio::test]
     async fn test_reset_to_reflog_returns_correct_entry_info() {
         let repo = TestRepo::with_initial_commit();
         repo.create_commit("Second", &[("f2.txt", "2")]);
 
-        let result = reset_to_reflog(repo.path_str(), 1, "mixed".to_string()).await;
+        let result = reset_to_reflog(repo.path_str(), 1, "mixed".to_string(), None).await;
         assert!(result.is_ok());
 
         let entry = result.unwrap();
@@ -446,11 +514,11 @@ mod tests {
         assert_eq!(repo.repo().state(), git2::RepositoryState::Bisect);
 
         // Hard reset must be refused.
-        let hard = reset_to_reflog(repo.path_str(), 1, "hard".to_string()).await;
+        let hard = reset_to_reflog(repo.path_str(), 1, "hard".to_string(), None).await;
         assert!(hard.is_err(), "hard reset must refuse during a bisect");
 
         // Mixed reset must be refused.
-        let mixed = reset_to_reflog(repo.path_str(), 1, "mixed".to_string()).await;
+        let mixed = reset_to_reflog(repo.path_str(), 1, "mixed".to_string(), None).await;
         assert!(mixed.is_err(), "mixed reset must refuse during a bisect");
 
         // HEAD and the bisect state are both preserved.
@@ -466,7 +534,7 @@ mod tests {
         repo.create_commit("Second", &[("f.txt", "c")]);
 
         // Reset to index 0 (current HEAD) should be a no-op essentially
-        let result = reset_to_reflog(repo.path_str(), 0, "mixed".to_string()).await;
+        let result = reset_to_reflog(repo.path_str(), 0, "mixed".to_string(), None).await;
         assert!(result.is_ok());
 
         // Should point to the second commit (most recent)

--- a/src-tauri/src/commands/rewrite.rs
+++ b/src-tauri/src/commands/rewrite.rs
@@ -81,8 +81,12 @@ fn restore_after_abort(repo: &git2::Repository) -> Result<()> {
     }
 
     // Force-checkout only the affected paths; unrelated dirty files survive.
+    // disable_pathspec_match is what makes that true: CheckoutBuilder::path()
+    // takes a pathspec, so an affected file named e.g. `a[1].txt` would
+    // otherwise also force-restore `a1.txt` and destroy its uncommitted work.
     let mut checkout = git2::build::CheckoutBuilder::new();
     checkout.force();
+    checkout.disable_pathspec_match(true);
     for path in &affected {
         checkout.path(path.as_slice());
     }

--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -412,9 +412,16 @@ pub async fn discard_changes(path: String, paths: Vec<String>) -> Result<()> {
     // A path in HEAD but absent from the index is a staged deletion; there is
     // no worktree change to discard, so it is left untouched.
     let mut index_paths: Vec<&str> = Vec::new();
-    let mut untracked_paths: Vec<&str> = Vec::new();
+    let mut untracked_paths: Vec<std::path::PathBuf> = Vec::new();
 
     for file_path in &paths {
+        // Validate BEFORE any git2 lookup. git2's Index::get_path panics
+        // outright on a path beginning with `..`, so an unvalidated traversal
+        // crashes this command across the IPC boundary rather than returning an
+        // error. It also guards the untracked branch below, which is the only
+        // place in this file that deletes recursively.
+        let full_path = validate_path_within_repo(repo_path, file_path)?;
+
         let path_obj = Path::new(file_path);
 
         // Check if file exists in HEAD
@@ -431,7 +438,7 @@ pub async fn discard_changes(path: String, paths: Vec<String>) -> Result<()> {
             index_paths.push(file_path);
         } else if !in_head {
             // Untracked - need to delete it.
-            untracked_paths.push(file_path);
+            untracked_paths.push(full_path);
         }
         // in_head && !in_index: staged deletion, nothing to discard.
     }
@@ -441,6 +448,12 @@ pub async fn discard_changes(path: String, paths: Vec<String>) -> Result<()> {
         let mut checkout_opts = git2::build::CheckoutBuilder::new();
         checkout_opts.force();
         checkout_opts.remove_untracked(false);
+        // CheckoutBuilder::path() adds a PATHSPEC, not a literal path: without
+        // this, a filename containing a glob metacharacter (`*`, `?`, `[`, `\`)
+        // also matches its neighbours. Discarding `report[1].md` would then
+        // force-restore `report1.md` too, silently destroying uncommitted work
+        // in a file the confirm never named.
+        checkout_opts.disable_pathspec_match(true);
 
         for file_path in &index_paths {
             checkout_opts.path(file_path);
@@ -454,8 +467,8 @@ pub async fn discard_changes(path: String, paths: Vec<String>) -> Result<()> {
     // FOLLOW symlinks, so a dangling link would be skipped (left on disk)
     // and a link to a directory would be reported as a directory. The
     // symlink itself is what must go — never its target.
-    for file_path in untracked_paths {
-        let full_path = repo_path.join(file_path);
+    // Paths were containment-checked during classification above.
+    for full_path in untracked_paths {
         if let Ok(meta) = std::fs::symlink_metadata(&full_path) {
             if meta.file_type().is_dir() {
                 std::fs::remove_dir_all(&full_path)?;
@@ -1052,6 +1065,58 @@ mod tests {
 
         // Staged file should still exist (wasn't in discard list)
         assert!(repo.path.join("another.txt").exists());
+    }
+
+    #[tokio::test]
+    async fn test_discard_changes_rejects_path_outside_repo() {
+        let repo = TestRepo::with_initial_commit();
+
+        // A path that is in neither the index nor HEAD is classified untracked,
+        // which is the branch that DELETES. Without containment validation the
+        // traversal would escape the repo and remove an unrelated directory.
+        let outside = repo.path.parent().unwrap().join("outside-victim.txt");
+        std::fs::write(&outside, "must survive").unwrap();
+
+        let result =
+            discard_changes(repo.path_str(), vec!["../outside-victim.txt".to_string()]).await;
+
+        assert!(result.is_err(), "traversing path must be rejected");
+        assert!(
+            outside.exists(),
+            "file outside the repository must not be deleted"
+        );
+
+        std::fs::remove_file(&outside).ok();
+    }
+
+    #[tokio::test]
+    async fn test_discard_changes_does_not_glob_match_sibling() {
+        let repo = TestRepo::with_initial_commit();
+
+        // `a[1].txt` is a legitimate filename, but it is also a pathspec that
+        // matches `a1.txt`. Discarding the former must not restore the latter.
+        repo.create_file("a[1].txt", "original bracket");
+        repo.create_file("a1.txt", "original plain");
+        repo.stage_file("a[1].txt");
+        repo.stage_file("a1.txt");
+        repo.create_commit("add both", &[]);
+
+        repo.create_file("a[1].txt", "modified bracket");
+        repo.create_file("a1.txt", "UNSAVED WORK");
+
+        let result = discard_changes(repo.path_str(), vec!["a[1].txt".to_string()]).await;
+        assert!(result.is_ok());
+
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("a[1].txt")).unwrap(),
+            "original bracket",
+            "the named file should be restored"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("a1.txt")).unwrap(),
+            "UNSAVED WORK",
+            "a file that merely glob-matches must be left untouched"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/undo.rs
+++ b/src-tauri/src/commands/undo.rs
@@ -992,7 +992,7 @@ mod tests {
         repo.create_commit("Second", &[("f2.txt", "2")]);
         let second_oid = repo.head_oid();
 
-        crate::commands::reflog::reset_to_reflog(repo.path_str(), 1, "hard".to_string())
+        crate::commands::reflog::reset_to_reflog(repo.path_str(), 1, "hard".to_string(), None)
             .await
             .unwrap();
         let after_reset = repo.head_oid();

--- a/src/__tests__/app-shell-ref-context-menu.integration.test.ts
+++ b/src/__tests__/app-shell-ref-context-menu.integration.test.ts
@@ -144,6 +144,7 @@ describe('app-shell ref context menu handlers (integration)', () => {
   beforeEach(() => {
     clearHistory();
     setupDefaultMocks();
+    uiStore.setState({ toasts: [] });
   });
 
   describe('handleRefCheckout', () => {
@@ -362,6 +363,37 @@ describe('app-shell ref context menu handlers (integration)', () => {
       await (el as any).handleRefDeleteBranch();
 
       expect(findCommands('delete_branch')).to.have.length(0);
+    });
+  });
+
+  describe('maintenance commands', () => {
+    it('does not run gc or prune when the confirm is declined', async () => {
+      declineConfirms();
+      const el = createAppShell();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRunGc(false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRunPrune();
+
+      expect(findCommands('run_gc')).to.have.length(0);
+      expect(findCommands('run_prune')).to.have.length(0);
+    });
+
+    it('reports the outcome of gc, prune and fsck', async () => {
+      // Each of these previously discarded its result, so the palette entry
+      // produced no observable effect on success OR failure.
+      const el = createAppShell();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRunGc(false);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRunPrune();
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRunFsck();
+
+      const toasts = uiStore.getState().toasts;
+      expect(toasts.length, 'each maintenance command reports an outcome').to.be.greaterThan(2);
     });
   });
 

--- a/src/__tests__/app-shell-ref-context-menu.integration.test.ts
+++ b/src/__tests__/app-shell-ref-context-menu.integration.test.ts
@@ -72,9 +72,23 @@ function commandIndex(name: string): number {
   return invokeHistory.findIndex((h) => h.command === name);
 }
 
+/** Make every showConfirm() in the run resolve to "declined". */
+function declineConfirms(): void {
+  const previous = mockInvoke;
+  mockInvoke = (command: string, args?: unknown) =>
+    command === 'plugin:dialog|message'
+      ? Promise.resolve('Cancel')
+      : previous(command, args);
+}
+
 function setupDefaultMocks(): void {
   mockInvoke = async (command: string) => {
     switch (command) {
+      // Tauri confirm() resolves via plugin:dialog|message; truthy = confirmed.
+      // The destructive ref handlers (delete branch/tag) gate on this, matching
+      // their sidebar counterparts.
+      case 'plugin:dialog|message':
+        return 'Ok';
       case 'checkout_with_autostash':
         return { success: true, stashed: false, stashApplied: false, stashConflict: false, message: 'ok' };
       case 'open_repository':
@@ -336,9 +350,61 @@ describe('app-shell ref context menu handlers (integration)', () => {
 
       expect(findCommands('open_repository').length).to.be.greaterThan(0);
     });
+
+    it('does not delete when the confirm is declined', async () => {
+      // The graph ref menu deletes the same branch as the sidebar, which always
+      // confirms — this path must not be the unguarded shortcut.
+      declineConfirms();
+      const el = createAppShell();
+      setRefContextMenu(el, 'old-feature');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRefDeleteBranch();
+
+      expect(findCommands('delete_branch')).to.have.length(0);
+    });
+  });
+
+  describe('force delete from the error-suggestion toast', () => {
+    it('does not force delete when the confirm is declined', async () => {
+      // One click on a toast button must not discard unmerged commits.
+      declineConfirms();
+      const el = createAppShell();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).forceDeleteBranch('unmerged-feature');
+
+      expect(findCommands('delete_branch')).to.have.length(0);
+    });
+
+    it('force deletes once confirmed', async () => {
+      const el = createAppShell();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).forceDeleteBranch('unmerged-feature');
+
+      const calls = findCommands('delete_branch');
+      expect(calls).to.have.length(1);
+      expect(calls[0].args).to.deep.include({
+        path: REPO_PATH,
+        name: 'unmerged-feature',
+        force: true,
+      });
+    });
   });
 
   describe('handleRefDeleteTag', () => {
+    it('does not delete when the confirm is declined', async () => {
+      declineConfirms();
+      const el = createAppShell();
+      setRefContextMenu(el, 'v1.0.0', 'tag');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRefDeleteTag();
+
+      expect(findCommands('delete_tag')).to.have.length(0);
+    });
+
     it('calls delete_tag with the correct args', async () => {
       const el = createAppShell();
       setRefContextMenu(el, 'v1.0.0', 'tag');

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2167,25 +2167,39 @@ export class AppShell extends LitElement {
     // tabs (rebinding activeRepository) while the confirm is up.
     const repoPath = this.activeRepository.repository.path;
 
-    // Confirm reset based on mode
+    // Confirm reset based on mode.
+    //
+    // EVERY mode drops the commits after the target off this branch — that is
+    // what a reset is — so every confirm has to say so and name the recovery
+    // path. Describing only what happens to the working tree made soft/mixed
+    // read as harmless and understated hard, which is the loudest of them.
+    const droppedNote =
+      `Commits after "${commit.summary}" are removed from this branch and will be ` +
+      `recoverable only through the reflog.`;
+
     if (mode === 'hard') {
       const confirmed = await showConfirm(
         'Hard Reset',
-        `Are you sure you want to hard reset to "${commit.summary}"?\n\nThis will discard all uncommitted changes.`,
+        `Hard reset to "${commit.summary}"?\n\n${droppedNote}\n\n` +
+          `All uncommitted changes are also discarded permanently — those are not ` +
+          `in the reflog and cannot be recovered.`,
         'warning'
       );
       if (!confirmed) return;
     } else if (mode === 'mixed') {
       const confirmed = await showConfirm(
         'Mixed Reset',
-        `Reset to "${commit.summary}"?\n\nThis will move HEAD to the selected commit. Your changes will be unstaged but preserved in the working directory.`,
+        `Reset to "${commit.summary}"?\n\n${droppedNote}\n\n` +
+          `Your working-directory changes are kept, but unstaged.`,
         'warning'
       );
       if (!confirmed) return;
     } else if (mode === 'soft') {
       const confirmed = await showConfirm(
         'Soft Reset',
-        `Reset to "${commit.summary}"?\n\nThis will move HEAD to the selected commit. Your changes will remain staged.`
+        `Reset to "${commit.summary}"?\n\n${droppedNote}\n\n` +
+          `Your changes remain staged.`,
+        'warning'
       );
       if (!confirmed) return;
     }
@@ -2199,6 +2213,10 @@ export class AppShell extends LitElement {
     );
 
     if (result.success) {
+      // Without this the user cannot tell a completed reset from a click that
+      // did nothing — failure was reported, success was silent. Every sibling
+      // destructive handler in this file toasts on success.
+      showToast(`Reset to ${commit.shortId} (${mode})`, 'success');
       this.refreshConflictDialogRepo(repoPath);
     } else {
       log.error('Reset failed:', result.error);

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -83,6 +83,7 @@ import type { LvProfileManagerDialog } from './components/dialogs/lv-profile-man
 import type { LvReflogDialog } from './components/dialogs/lv-reflog-dialog.ts';
 import type { LvCleanDialog } from './components/dialogs/lv-clean-dialog.ts';
 import type { LvRemoteDialog } from './components/dialogs/lv-remote-dialog.ts';
+import type { LvRepositoryHealthDialog } from './components/dialogs/lv-repository-health-dialog.ts';
 import type { IntegrationOpenContext, IntegrationType } from './types/integration-accounts.types.ts';
 import type { Commit, RefInfo, StatusEntry, Tag, Branch, RepositoryState } from './types/git.types.ts';
 import type { SearchFilter } from './components/toolbar/lv-search-bar.ts';
@@ -177,6 +178,18 @@ export class AppShell extends LitElement {
         background: var(--color-bg-secondary);
         border-right: 1px solid var(--color-border);
         overflow: hidden;
+      }
+
+      /* Hidden, NOT unmounted. The panel owns the interactive-rebase,
+         branch-cleanup and create-branch dialogs; removing it from the
+         template tore down an in-progress rebase plan on Ctrl+B, and worse,
+         detached the subtree mid-execute, so the open-conflict-dialog event
+         it raises on REBASE_CONFLICT never reached app-shell's listener and
+         the repo was left mid-rebase with no conflict dialog. Keeping it
+         mounted also means lv-branch-list's window listeners stay registered. */
+      .left-panel.hidden,
+      .resize-handle-h.hidden {
+        display: none;
       }
 
       .center-panel {
@@ -630,7 +643,6 @@ export class AppShell extends LitElement {
   @state() private showLfs = false;
 
   // Changelog dialog
-  @state() private showChangelog = false;
 
   // GPG dialog
   @state() private showGpg = false;
@@ -710,6 +722,7 @@ export class AppShell extends LitElement {
   @query('lv-reflog-dialog') private reflogDialog?: LvReflogDialog;
   @query('lv-clean-dialog') private cleanDialog?: LvCleanDialog;
   @query('lv-remote-dialog') private remoteDialog?: LvRemoteDialog;
+  @query('lv-repository-health-dialog') private repositoryHealthDialog?: LvRepositoryHealthDialog;
 
   private unsubscribe?: () => void;
   private unsubscribeUi?: () => void;
@@ -1186,6 +1199,33 @@ export class AppShell extends LitElement {
         showToast('The repository tab was closed — remote management closed', 'warning');
       }
 
+      // The remaining pinned dialogs, swept the same way. Every one of these
+      // exposes pinnedRepositoryPathIfOpen but nothing read it, so Repository
+      // Health would still run `git gc --aggressive`, and the worktree /
+      // submodule dialogs still remove, against a repo whose tab is gone.
+      // Driven off the DOM element so a dialog cannot be added to the app and
+      // silently miss the sweep.
+      const pinnedFlagDialogs: Array<[string, () => void, string]> = [
+        ['lv-repository-health-dialog', () => { this.showRepositoryHealth = false; }, 'repository health closed'],
+        ['lv-worktree-dialog', () => { this.showWorktrees = false; }, 'worktrees closed'],
+        ['lv-submodule-dialog', () => { this.showSubmodules = false; }, 'submodules closed'],
+        ['lv-lfs-dialog', () => { this.showLfs = false; }, 'Git LFS closed'],
+        ['lv-gpg-dialog', () => { this.showGpg = false; }, 'signing settings closed'],
+        ['lv-config-dialog', () => { this.showConfig = false; }, 'configuration closed'],
+        ['lv-credentials-dialog', () => { this.showCredentials = false; }, 'credentials closed'],
+        ['lv-hooks-dialog', () => { this.showHooksDialog = false; }, 'hooks closed'],
+      ];
+      for (const [tag, close, label] of pinnedFlagDialogs) {
+        const el = this.renderRoot.querySelector(tag) as
+          | (Element & { pinnedRepositoryPathIfOpen?: string | null })
+          | null;
+        const pinned = el?.pinnedRepositoryPathIfOpen ?? null;
+        if (pinned && !repoOpen(pinned)) {
+          close();
+          showToast(`The repository tab was closed — ${label}`, 'warning');
+        }
+      }
+
       // The open diff binds a click-time StatusEntry snapshot. Re-derive it
       // from every status refresh so a file that became conflicted since the
       // click (e.g. a merge run in an external terminal) hits the diff view's
@@ -1565,38 +1605,55 @@ export class AppShell extends LitElement {
   }
 
   /**
-   * True when any dialog rendering a blocking overlay is open. Those dialogs
-   * handle their own Escape, so handleCloseOverlay must not keep walking its
-   * chain and dismiss something behind them. Excludes the flags that already
-   * have their own arm in that chain (shortcuts, command palette, reflog).
+   * True when any dialog is showing a blocking overlay.
+   *
+   * Asks the DOM rather than enumerating flags. The previous hand-maintained
+   * list drifted immediately: it covered only the flag-driven dialogs, so the
+   * seven opened by an .open() method call (cherry-pick, interactive-rebase,
+   * create-tag, create-branch, clone, init, changelog) still leaked Escape
+   * through to close the diff behind them — and it carried a `showChangelog`
+   * entry that is never set true, which is exactly why the list LOOKED
+   * complete. A dialog is open if it reflects `open` on its host (the
+   * self-overlay dialogs) or wraps an open lv-modal.
    */
   private hasModalDialogOpen(): boolean {
-    return (
-      this.showSettings ||
-      this.showConflictDialog ||
-      this.showRemotes ||
-      this.showClean ||
-      this.showRepositoryHealth ||
-      this.showBisect ||
-      this.showSubmodules ||
-      this.showWorktrees ||
-      this.showLfs ||
-      this.showChangelog ||
-      this.showGpg ||
-      this.showSsh ||
-      this.showConfig ||
-      this.showCredentials ||
-      this.showGitHub ||
-      this.showGitLab ||
-      this.showBitbucket ||
-      this.showAzureDevOps ||
-      this.showOidc ||
-      this.showProfileManager ||
-      this.showMigrationDialog ||
-      this.showWorkspaceManager ||
-      this.showHooksDialog
-    );
+    for (const el of this.renderRoot.querySelectorAll('*')) {
+      const tag = el.tagName;
+      if (!tag.startsWith('LV-') || !tag.endsWith('-DIALOG')) continue;
+      if (el.hasAttribute('open')) return true;
+      const modal = el.shadowRoot?.querySelector('lv-modal');
+      if (modal?.hasAttribute('open')) return true;
+    }
+    // The sidebar owns three more (interactive-rebase, branch-cleanup,
+    // create-branch) inside its own shadow root, which the sweep above
+    // cannot see through.
+    const panel = this.renderRoot.querySelector('lv-left-panel');
+    for (const el of panel?.shadowRoot?.querySelectorAll('*') ?? []) {
+      const nested = el.shadowRoot?.querySelectorAll('*') ?? [];
+      for (const inner of nested) {
+        if (!inner.tagName.endsWith('-DIALOG')) continue;
+        if (inner.hasAttribute('open')) return true;
+        if (inner.shadowRoot?.querySelector('lv-modal')?.hasAttribute('open')) return true;
+      }
+    }
+    return false;
   }
+
+  /**
+   * Closing this dialog DESTROYS it (its whole block is behind a conditional),
+   * so a dismissal mid-gc leaves `git gc --aggressive` running with no surface
+   * and lets a reopened, freshly-constructed dialog start a second one. Refuse
+   * while an action is in flight and re-assert the modal, mirroring the
+   * in-flight guards on the clean and reflog dialogs.
+   */
+  private handleRepositoryHealthClose = (): void => {
+    if (this.repositoryHealthDialog?.isRunning) {
+      const modal = this.renderRoot.querySelector('lv-modal[modalTitle="Repository Health"]');
+      if (modal) (modal as HTMLElement & { open: boolean }).open = true;
+      return;
+    }
+    this.showRepositoryHealth = false;
+  };
 
   private handleCloseOverlay(): void {
     // Close any open overlay in priority order
@@ -3780,23 +3837,21 @@ export class AppShell extends LitElement {
             ></lv-context-dashboard>
 
             <div class="main-content">
-              ${this.leftPanelVisible ? html`
-                <aside
-                  class="left-panel"
-                  style="width: ${this.leftPanelWidth}px"
-                  @tag-selected=${this.handleTagSelected}
-                  @branch-selected=${this.handleBranchSelected}
-                  @repository-changed=${() => this.handleRefresh()}
-                  @create-tag=${() => this.createTagDialog?.open()}
-                >
-                  <lv-left-panel></lv-left-panel>
-                </aside>
+              <aside
+                class="left-panel ${this.leftPanelVisible ? '' : 'hidden'}"
+                style="width: ${this.leftPanelWidth}px"
+                @tag-selected=${this.handleTagSelected}
+                @branch-selected=${this.handleBranchSelected}
+                @repository-changed=${() => this.handleRefresh()}
+                @create-tag=${() => this.createTagDialog?.open()}
+              >
+                <lv-left-panel></lv-left-panel>
+              </aside>
 
-                <div
-                  class="resize-handle-h ${this.resizing === 'left' ? 'dragging' : ''}"
-                  @mousedown=${(e: MouseEvent) => this.handleResizeStart(e, 'left')}
-                ></div>
-              ` : ''}
+              <div
+                class="resize-handle-h ${this.resizing === 'left' ? 'dragging' : ''} ${this.leftPanelVisible ? '' : 'hidden'}"
+                @mousedown=${(e: MouseEvent) => this.handleResizeStart(e, 'left')}
+              ></div>
 
               <main id="main-content" class="center-panel" tabindex="-1">
                 ${this.activeRepository.repository.state !== 'clean' || this.hasConflictedFiles
@@ -4256,7 +4311,6 @@ export class AppShell extends LitElement {
       ${this.activeRepository ? html`
         <lv-changelog-dialog
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showChangelog = false; }}
         ></lv-changelog-dialog>
       ` : ''}
 
@@ -4264,11 +4318,11 @@ export class AppShell extends LitElement {
         <lv-modal
           modalTitle="Repository Health"
           ?open=${this.showRepositoryHealth}
-          @close=${() => { this.showRepositoryHealth = false; }}
+          @close=${this.handleRepositoryHealthClose}
         >
           <lv-repository-health-dialog
             .repositoryPath=${this.activeRepository.repository.path}
-            @close=${() => { this.showRepositoryHealth = false; }}
+            @close=${this.handleRepositoryHealthClose}
           ></lv-repository-health-dialog>
         </lv-modal>
       ` : ''}

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -19,25 +19,6 @@ const log = loggers.app;
  *
  * Typed as RepositoryState so a typo or a renamed state is a compile error.
  */
-/**
- * Condense `git fsck` output for a toast.
- *
- * `git fsck --full` prints one line per dangling/unreachable object, which on a
- * repo with rebased or amended history is dozens of lines. A toast is ~400px
- * wide with no max-height and auto-dismisses, so dumping that raw makes it both
- * unreadable and large enough to cover the view. Lead with the count and point
- * at the surface that can show the detail.
- */
-function summariseFsck(message: string | undefined): string {
-  const text = (message ?? '').trim();
-  if (!text) return 'Repository integrity check completed';
-
-  const lines = text.split('\n').filter((l) => l.trim().length > 0);
-  if (lines.length <= 2 && text.length <= 200) return text;
-
-  return `Repository integrity check completed — ${lines.length} notes (${lines[0].trim()}, …). See Repository Health for the full output.`;
-}
-
 const ABORTABLE_STATES: readonly RepositoryState[] = [
   'cherrypick',
   'merge',
@@ -113,7 +94,7 @@ import { listenToEvent } from './services/tauri-api.ts';
 import { showToast, notifyWarning } from './services/notification.service.ts';
 import { showErrorWithSuggestion } from './services/error-suggestion.service.ts';
 import { showConfirm, showPrompt } from './services/dialog.service.ts';
-import { confirmGarbageCollection, confirmPrune } from './utils/maintenance-confirms.ts';
+import { confirmGarbageCollection, confirmPrune, summariseFsck } from './utils/maintenance-confirms.ts';
 import { searchIndexService } from './services/search-index.service.ts';
 import { embeddingIndexService } from './services/embedding-index.service.ts';
 import { initOAuthListener } from './services/oauth.service.ts';

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -3483,13 +3483,15 @@ export class AppShell extends LitElement {
     const repoPath = this.activeRepository.repository.path;
     const result = await gitService.runFsck({ path: repoPath, full: true });
 
-    // Reporting IS this command's purpose — without a toast the palette entry
-    // does nothing observable at all.
+    // Reporting IS this command's purpose, so report what git actually said.
+    // `git fsck` exits 0 while printing "dangling commit" / "unreachable blob"
+    // warnings, and run_fsck packs that output into `message` — asserting a
+    // clean bill of health from the exit code alone would hide it.
     showToast(
       result.success
-        ? 'Repository integrity check completed — no issues found'
-        : `Repository integrity check found issues: ${result.error?.message ?? 'Unknown error'}`,
-      result.success ? 'success' : 'warning'
+        ? (result.data?.message ?? 'Repository integrity check completed')
+        : `Repository integrity check failed: ${result.error?.message ?? 'Unknown error'}`,
+      result.success ? 'success' : 'error'
     );
   }
 
@@ -3704,6 +3706,16 @@ export class AppShell extends LitElement {
                             ? html`
                                 <button class="operation-abort-btn" @click=${this.handleAbortOperation}>
                                   Abort
+                                </button>
+                              `
+                            : ''}
+                          ${this.activeRepository.repository.state === 'bisect'
+                            ? html`
+                                <button
+                                  class="operation-btn operation-btn-primary"
+                                  @click=${() => { this.showBisect = true; }}
+                                >
+                                  Manage Bisect
                                 </button>
                               `
                             : ''}

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -105,6 +105,7 @@ import {
   summariseFsck,
   tryAcquireMaintenance,
   releaseMaintenance,
+  isMaintenanceRunning,
 } from './utils/maintenance-confirms.ts';
 import { searchIndexService } from './services/search-index.service.ts';
 import { embeddingIndexService } from './services/embedding-index.service.ts';
@@ -1233,9 +1234,17 @@ export class AppShell extends LitElement {
           if (!running || state.openRepositories.length === 0) {
             this.showRepositoryHealth = false;
           }
-          if (running) {
+          if (running && state.openRepositories.length > 0) {
             showToast(
               'The repository tab was closed — repository health will close when the current maintenance finishes',
+              'warning',
+            );
+          } else if (running) {
+            // Last tab: the force-close above already removed the dialog, so
+            // promising a later dismissal would describe something that just
+            // did not happen. The gc itself keeps running to completion.
+            showToast(
+              'The repository tab was closed — the maintenance operation will finish in the background',
               'warning',
             );
           }
@@ -1253,7 +1262,17 @@ export class AppShell extends LitElement {
         // Dismissing mid-generation hid a running AI call and then reported
         // "changelog closed", which was simply untrue.
         ['lv-changelog-dialog', () => {
-          if (this.changelogDialog?.generationInFlight) return false;
+          if (this.changelogDialog?.generationInFlight) {
+            // Say so. This block is also gated on activeRepository, so on the
+            // LAST tab the element is destroyed on the next render regardless
+            // and the generation completes into a detached component — the
+            // user would otherwise get silence: no changelog, no error.
+            showToast(
+              'The repository tab was closed — changelog generation was abandoned',
+              'warning',
+            );
+            return false;
+          }
           this.changelogDialog?.close();
           return true;
         }, 'changelog closed'],
@@ -1634,16 +1653,17 @@ export class AppShell extends LitElement {
     }
   }
 
-  private handleKeyDown(e: KeyboardEvent): void {
-    // Keyboard shortcuts are now handled by the keyboard service
-    // Only handle special cases here
-
-    // ? to show shortcuts help (need to handle separately due to shift key)
-    if (e.key === '?' && !e.ctrlKey && !e.metaKey && !e.altKey) {
-      e.preventDefault();
-      this.showShortcuts = true;
-      return;
-    }
+  private handleKeyDown(_e: KeyboardEvent): void {
+    // Keyboard shortcuts are handled by the keyboard service.
+    //
+    // There used to be a `?` arm here "because of the shift key". It matched
+    // with no input-focus check and called preventDefault(), so typing a
+    // question mark ANYWHERE — commit message, search, branch-rename prompt,
+    // hook editor — was impossible: the character was swallowed and the
+    // shortcuts dialog opened instead. keyboard.service registers the same
+    // shortcut and does bail inside inputs, but it bails by returning, and
+    // stopPropagation cannot suppress a sibling listener on the same node,
+    // so this copy always won. The guarded registration is the only one now.
   }
 
   /**
@@ -3709,6 +3729,13 @@ export class AppShell extends LitElement {
     // null activeRepository inside a floating promise.
     const repoPath = this.activeRepository.repository.path;
 
+    // Checked before the confirm so a destructive prompt is never shown for a
+    // run the shared claim below was always going to refuse.
+    if (isMaintenanceRunning(repoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
+
     // Shared with the Repository Health dialog so the two surfaces that reach
     // this command cannot drift apart on whether it is gated.
     if (!(await confirmGarbageCollection(aggressive))) return;
@@ -3770,6 +3797,11 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
 
     const repoPath = this.activeRepository.repository.path;
+
+    if (isMaintenanceRunning(repoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
 
     if (!(await confirmPrune())) return;
 

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1749,13 +1749,16 @@ export class AppShell extends LitElement {
 
   private handleCloseOverlay(): void {
     // Close any open overlay in priority order
-    if (this.showShortcuts) {
-      this.showShortcuts = false;
-    } else if (this.showCommandPalette) {
-      this.showCommandPalette = false;
-    } else if (this.hasModalDialogOpen()) {
+    if (this.hasModalDialogOpen()) {
       // A modal owns this Escape and dismisses itself, through lv-modal's
       // handler or its own — each now gated on being the TOPMOST overlay.
+      //
+      // This arm is FIRST. The showShortcuts and showCommandPalette arms used
+      // to precede it and closed unconditionally, without consulting the
+      // stack: opening the undo-history dialog over the shortcuts dialog and
+      // pressing Escape once closed BOTH. Both dialogs clear their own flag
+      // through their `close` event, so letting the topmost one dismiss itself
+      // is all that is needed.
       // Stop here so one keypress cannot also close the diff behind it, and
       // so a dialog that deliberately blocks dismissal mid-operation does not
       // leak the key either.

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -81,6 +81,8 @@ import type { LvCherryPickDialog } from './components/dialogs/lv-cherry-pick-dia
 import type { LvInteractiveRebaseDialog } from './components/dialogs/lv-interactive-rebase-dialog.ts';
 import type { LvProfileManagerDialog } from './components/dialogs/lv-profile-manager-dialog.ts';
 import type { LvReflogDialog } from './components/dialogs/lv-reflog-dialog.ts';
+import type { LvCleanDialog } from './components/dialogs/lv-clean-dialog.ts';
+import type { LvRemoteDialog } from './components/dialogs/lv-remote-dialog.ts';
 import type { IntegrationOpenContext, IntegrationType } from './types/integration-accounts.types.ts';
 import type { Commit, RefInfo, StatusEntry, Tag, Branch, RepositoryState } from './types/git.types.ts';
 import type { SearchFilter } from './components/toolbar/lv-search-bar.ts';
@@ -706,6 +708,8 @@ export class AppShell extends LitElement {
   @query('#app-rebase-dialog') private interactiveRebaseDialog?: LvInteractiveRebaseDialog;
   @query('lv-profile-manager-dialog') private profileManagerDialog?: LvProfileManagerDialog;
   @query('lv-reflog-dialog') private reflogDialog?: LvReflogDialog;
+  @query('lv-clean-dialog') private cleanDialog?: LvCleanDialog;
+  @query('lv-remote-dialog') private remoteDialog?: LvRemoteDialog;
 
   private unsubscribe?: () => void;
   private unsubscribeUi?: () => void;
@@ -764,6 +768,27 @@ export class AppShell extends LitElement {
   };
 
   // Cycle the active repository tab by offset (wraps around both ends)
+  /**
+   * Open the branch-cleanup dialog from the command palette.
+   *
+   * Unlike every sibling palette action, this one cannot just flip a flag on
+   * app-shell: the dialog is owned by `lv-branch-list`, which is rendered only
+   * while the left panel is visible. With the panel hidden (Ctrl+B) the
+   * `open-branch-cleanup` event had no listener at all and the command
+   * silently did nothing. Reveal the panel first, then wait for the panel AND
+   * its branch list to render — `lv-branch-list` registers the window listener
+   * in connectedCallback, so dispatching before it exists is the same dead end.
+   */
+  private async openBranchCleanup(): Promise<void> {
+    if (!this.leftPanelVisible) {
+      uiStore.getState().togglePanel('left');
+      await this.updateComplete;
+      const panel = this.renderRoot.querySelector('lv-left-panel') as LitElement | null;
+      await panel?.updateComplete;
+    }
+    window.dispatchEvent(new CustomEvent('open-branch-cleanup'));
+  }
+
   private cycleRepositoryTab(offset: number): void {
     const state = repositoryStore.getState();
     const count = state.openRepositories.length;
@@ -1139,6 +1164,26 @@ export class AppShell extends LitElement {
       if (cbPinned && !repoOpen(cbPinned)) {
         this.createBranchDialog?.close();
         showToast('The repository tab was closed — branch creation cancelled', 'warning');
+      }
+
+      // The repo-scoped dialogs hosted directly by app-shell pin their repo on
+      // open for the same reason, so they need the same sweep: the clean
+      // dialog would otherwise delete files from — and the reflog dialog reset
+      // — a repository that is no longer in the tab bar.
+      const cleanPinned = this.cleanDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (cleanPinned && !repoOpen(cleanPinned)) {
+        this.showClean = false;
+        showToast('The repository tab was closed — clean cancelled', 'warning');
+      }
+      const rfPinned = this.reflogDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (rfPinned && !repoOpen(rfPinned)) {
+        this.showReflog = false;
+        showToast('The repository tab was closed — undo history closed', 'warning');
+      }
+      const rmPinned = this.remoteDialog?.pinnedRepositoryPathIfOpen ?? null;
+      if (rmPinned && !repoOpen(rmPinned)) {
+        this.showRemotes = false;
+        showToast('The repository tab was closed — remote management closed', 'warning');
       }
 
       // The open diff binds a click-time StatusEntry snapshot. Re-derive it
@@ -1519,6 +1564,40 @@ export class AppShell extends LitElement {
     }
   }
 
+  /**
+   * True when any dialog rendering a blocking overlay is open. Those dialogs
+   * handle their own Escape, so handleCloseOverlay must not keep walking its
+   * chain and dismiss something behind them. Excludes the flags that already
+   * have their own arm in that chain (shortcuts, command palette, reflog).
+   */
+  private hasModalDialogOpen(): boolean {
+    return (
+      this.showSettings ||
+      this.showConflictDialog ||
+      this.showRemotes ||
+      this.showClean ||
+      this.showRepositoryHealth ||
+      this.showBisect ||
+      this.showSubmodules ||
+      this.showWorktrees ||
+      this.showLfs ||
+      this.showChangelog ||
+      this.showGpg ||
+      this.showSsh ||
+      this.showConfig ||
+      this.showCredentials ||
+      this.showGitHub ||
+      this.showGitLab ||
+      this.showBitbucket ||
+      this.showAzureDevOps ||
+      this.showOidc ||
+      this.showProfileManager ||
+      this.showMigrationDialog ||
+      this.showWorkspaceManager ||
+      this.showHooksDialog
+    );
+  }
+
   private handleCloseOverlay(): void {
     // Close any open overlay in priority order
     if (this.showShortcuts) {
@@ -1536,6 +1615,13 @@ export class AppShell extends LitElement {
       if (!this.reflogDialog?.isResetting) {
         this.showReflog = false;
       }
+    } else if (this.hasModalDialogOpen()) {
+      // A modal dialog owns this Escape and dismisses itself — through
+      // lv-modal's own document handler, or its own keydown listener. Stop
+      // here so one Escape cannot ALSO close the diff sitting behind it, and
+      // so a dialog that deliberately BLOCKS dismissal mid-operation doesn't
+      // leak the keypress to the diff either.
+      return;
     } else if (this.contextMenu.visible) {
       this.contextMenu = { ...this.contextMenu, visible: false };
     } else if (this.refContextMenu.visible) {
@@ -2958,7 +3044,7 @@ export class AppShell extends LitElement {
         label: 'Clean up branches',
         category: 'action',
         icon: 'git-branch',
-        action: this.requiresRepository(() => { window.dispatchEvent(new CustomEvent('open-branch-cleanup')); }),
+        action: this.requiresRepository(() => { void this.openBranchCleanup(); }),
       },
       {
         id: 'bisect',

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -99,7 +99,13 @@ import { listenToEvent } from './services/tauri-api.ts';
 import { showToast, notifyWarning } from './services/notification.service.ts';
 import { showErrorWithSuggestion } from './services/error-suggestion.service.ts';
 import { showConfirm, showPrompt } from './services/dialog.service.ts';
-import { confirmGarbageCollection, confirmPrune, summariseFsck } from './utils/maintenance-confirms.ts';
+import {
+  confirmGarbageCollection,
+  confirmPrune,
+  summariseFsck,
+  tryAcquireMaintenance,
+  releaseMaintenance,
+} from './utils/maintenance-confirms.ts';
 import { searchIndexService } from './services/search-index.service.ts';
 import { embeddingIndexService } from './services/embedding-index.service.ts';
 import { initOAuthListener } from './services/oauth.service.ts';
@@ -3707,24 +3713,46 @@ export class AppShell extends LitElement {
     // this command cannot drift apart on whether it is gated.
     if (!(await confirmGarbageCollection(aggressive))) return;
 
-    // silent: the service toasts by default; this handler owns the message.
-    const result = await gitService.runGc({ path: repoPath, aggressive, silent: true });
-    showToast(
-      result.success
-        ? aggressive
-          ? 'Aggressive garbage collection completed'
-          : 'Garbage collection completed'
-        : `Garbage collection failed: ${result.error?.message ?? 'Unknown error'}`,
-      result.success ? 'success' : 'error'
-    );
+    // Claimed AFTER the confirm (a declined confirm must not hold the slot) and
+    // shared with the Repository Health dialog, which reaches the same three
+    // commands. Only the dialog tracked concurrency, so a palette run could
+    // start a second gc over the dialog's — or race a prune against it on the
+    // objects directory, which git does not serialise at all.
+    if (!tryAcquireMaintenance(repoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
+
+    try {
+      // silent: the service toasts by default; this handler owns the message.
+      const result = await gitService.runGc({ path: repoPath, aggressive, silent: true });
+      showToast(
+        result.success
+          ? aggressive
+            ? 'Aggressive garbage collection completed'
+            : 'Garbage collection completed'
+          : `Garbage collection failed: ${result.error?.message ?? 'Unknown error'}`,
+        result.success ? 'success' : 'error'
+      );
+    } finally {
+      releaseMaintenance(repoPath);
+    }
   }
 
   private async handleRunFsck(): Promise<void> {
     if (!this.activeRepository) return;
 
     const repoPath = this.activeRepository.repository.path;
+
+    if (!tryAcquireMaintenance(repoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
+
     // silent: the service toasts by default; this handler owns the message.
-    const result = await gitService.runFsck({ path: repoPath, full: true, silent: true });
+    const result = await gitService
+      .runFsck({ path: repoPath, full: true, silent: true })
+      .finally(() => releaseMaintenance(repoPath));
 
     // Reporting IS this command's purpose, so report what git actually said.
     // `git fsck` exits 0 while printing "dangling commit" / "unreachable blob"
@@ -3745,8 +3773,15 @@ export class AppShell extends LitElement {
 
     if (!(await confirmPrune())) return;
 
+    if (!tryAcquireMaintenance(repoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
+
     // silent: the service toasts by default; this handler owns the message.
-    const result = await gitService.runPrune({ path: repoPath, silent: true });
+    const result = await gitService
+      .runPrune({ path: repoPath, silent: true })
+      .finally(() => releaseMaintenance(repoPath));
     showToast(
       result.success
         ? 'Pruned unreachable objects'

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -4122,7 +4122,10 @@ export class AppShell extends LitElement {
           ?open=${this.showReflog}
           .repositoryPath=${this.activeRepository.repository.path}
           @close=${() => { this.showReflog = false; }}
-          @undo-complete=${() => { this.showReflog = false; this.handleRefresh(); }}
+          @undo-complete=${(e: CustomEvent<{ repositoryPath?: string }>) => {
+            this.showReflog = false;
+            this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null);
+          }}
           @show-commit=${(e: CustomEvent<{ oid: string }>) => { this.showReflog = false; this.revealCommitInGraph(e.detail.oid); }}
         ></lv-reflog-dialog>
       ` : ''}
@@ -4148,7 +4151,8 @@ export class AppShell extends LitElement {
           ?open=${this.showClean}
           .repositoryPath=${this.activeRepository.repository.path}
           @close=${() => { this.showClean = false; }}
-          @files-cleaned=${() => this.handleRefresh()}
+          @files-cleaned=${(e: CustomEvent<{ repositoryPath?: string }>) =>
+            this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null)}
         ></lv-clean-dialog>
       ` : ''}
 

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1219,7 +1219,20 @@ export class AppShell extends LitElement {
           // once the first finished.
           const running = this.repositoryHealthDialog?.isRunning ?? false;
           this.repositoryHealthDialog?.closeWhenIdle();
-          if (!running) this.showRepositoryHealth = false;
+          // The flag must never outlive the element. Its render block is also
+          // gated on activeRepository, so closing the LAST tab removes the
+          // element regardless of the deferral — leaving showRepositoryHealth
+          // true meant the dialog sprang open unbidden over the next repo the
+          // user opened, freshly constructed with every button re-enabled.
+          if (!running || state.openRepositories.length === 0) {
+            this.showRepositoryHealth = false;
+          }
+          if (running) {
+            showToast(
+              'The repository tab was closed — repository health will close when the current maintenance finishes',
+              'warning',
+            );
+          }
           return !running;
         }, 'repository health closed'],
         ['lv-worktree-dialog', () => { this.showWorktrees = false; return true; }, 'worktrees closed'],
@@ -1229,7 +1242,15 @@ export class AppShell extends LitElement {
         ['lv-config-dialog', () => { this.showConfig = false; return true; }, 'configuration closed'],
         ['lv-credentials-dialog', () => { this.showCredentials = false; return true; }, 'credentials closed'],
         ['lv-hooks-dialog', () => { this.showHooksDialog = false; return true; }, 'hooks closed'],
-        ['lv-changelog-dialog', () => { this.changelogDialog?.close(); return true; }, 'changelog closed'],
+        // close() here is a bare modal.open = false — it does NOT apply the
+        // in-flight re-assert handleModalClose does for Escape/overlay/x.
+        // Dismissing mid-generation hid a running AI call and then reported
+        // "changelog closed", which was simply untrue.
+        ['lv-changelog-dialog', () => {
+          if (this.changelogDialog?.generationInFlight) return false;
+          this.changelogDialog?.close();
+          return true;
+        }, 'changelog closed'],
       ];
       for (const [tag, close, label] of pinnedFlagDialogs) {
         const el = this.renderRoot.querySelector(tag) as
@@ -1620,35 +1641,43 @@ export class AppShell extends LitElement {
   }
 
   /**
+   * Walk a DOM subtree, descending through shadow roots, for a blocking
+   * overlay: any open lv-modal, or any dialog reflecting `open`.
+   */
+  private static containsOpenModal(
+    root: ParentNode,
+    seen: Set<ShadowRoot>,
+    depth = 0,
+  ): boolean {
+    if (depth > 10) return false;
+    for (const el of root.querySelectorAll('*')) {
+      const tag = el.tagName;
+      if (tag === 'LV-MODAL' && el.hasAttribute('open')) return true;
+      if (tag.startsWith('LV-') && tag.endsWith('-DIALOG') && el.hasAttribute('open')) return true;
+      const shadow = el.shadowRoot;
+      if (shadow && !seen.has(shadow)) {
+        seen.add(shadow);
+        if (AppShell.containsOpenModal(shadow, seen, depth + 1)) return true;
+      }
+    }
+    return false;
+  }
+
+  /**
    * True when any dialog is showing a blocking overlay.
    *
-   * Walks every shadow root under app-shell rather than enumerating dialogs.
-   * Two earlier attempts drifted: a hand-written list of `show*` flags missed
-   * the seven dialogs opened by an .open() call, and a fixed two-level walk
-   * (renderRoot plus lv-left-panel) missed BOTH the toolbar's clone/init
-   * dialogs and the two dialogs wrapped by app-shell's OWN lv-modal — Settings
-   * and Repository Health, whose modal is their parent, not a child of their
-   * shadow root, and which declare no `open` property at all. Any fixed shape
-   * is the same bug waiting to happen, so this asks the whole tree: a blocking
-   * overlay is an open lv-modal anywhere, or a dialog reflecting `open`.
+   * Walks from document.body, not from this element. Two earlier attempts
+   * drifted by enumerating dialogs; the third fixed that but still hard-coded
+   * its ROOT as app-shell's renderRoot, which made lv-prompt-dialog invisible
+   * by construction — showPrompt appends that singleton to document.body, so
+   * it is app-shell's SIBLING. Escape then closed the diff behind an open
+   * prompt as soon as focus left its autofocused input (the keyboard service's
+   * composedPath bail only covers the input itself). Starting at the document
+   * subsumes app-shell, the sidebar, the toolbar and anything body-level, so
+   * the root is no longer a choice that can be wrong.
    */
   private hasModalDialogOpen(): boolean {
-    const seen = new Set<ShadowRoot>();
-    const walk = (root: ShadowRoot | Element, depth: number): boolean => {
-      if (depth > 8) return false;
-      for (const el of root.querySelectorAll('*')) {
-        const tag = el.tagName;
-        if (tag === 'LV-MODAL' && el.hasAttribute('open')) return true;
-        if (tag.startsWith('LV-') && tag.endsWith('-DIALOG') && el.hasAttribute('open')) return true;
-        const shadow = el.shadowRoot;
-        if (shadow && !seen.has(shadow)) {
-          seen.add(shadow);
-          if (walk(shadow, depth + 1)) return true;
-        }
-      }
-      return false;
-    };
-    return walk(this.renderRoot as ShadowRoot, 0);
+    return AppShell.containsOpenModal(document.body, new Set<ShadowRoot>());
   }
 
   /**
@@ -1659,23 +1688,9 @@ export class AppShell extends LitElement {
    */
   private hasSidebarDialogOpen(): boolean {
     const panel = this.renderRoot.querySelector('lv-left-panel');
-    if (!panel) return false;
-    const seen = new Set<ShadowRoot>();
-    const walk = (root: ShadowRoot | Element, depth: number): boolean => {
-      if (depth > 6) return false;
-      for (const el of root.querySelectorAll('*')) {
-        const tag = el.tagName;
-        if (tag === 'LV-MODAL' && el.hasAttribute('open')) return true;
-        if (tag.startsWith('LV-') && tag.endsWith('-DIALOG') && el.hasAttribute('open')) return true;
-        const shadow = el.shadowRoot;
-        if (shadow && !seen.has(shadow)) {
-          seen.add(shadow);
-          if (walk(shadow, depth + 1)) return true;
-        }
-      }
-      return false;
-    };
-    return panel.shadowRoot ? walk(panel.shadowRoot, 0) : false;
+    return panel?.shadowRoot
+      ? AppShell.containsOpenModal(panel.shadowRoot, new Set<ShadowRoot>())
+      : false;
   }
 
   /**
@@ -1712,23 +1727,17 @@ export class AppShell extends LitElement {
       this.showShortcuts = false;
     } else if (this.showCommandPalette) {
       this.showCommandPalette = false;
-    } else if (this.showReflog) {
-      // The keyboard service registers its own document-level Escape handler,
-      // so this path can flip the dialog's `open` binding without going
-      // through the dialog's dismiss() guard. Honour that guard here too:
-      // closing mid-reset hides a running operation whose success path then
-      // calls close() on whatever the user reopened. Swallow the Escape
-      // either way, so a blocked dismissal cannot fall through and close the
-      // diff sitting behind the dialog.
-      if (!this.reflogDialog?.isResetting) {
-        this.showReflog = false;
-      }
     } else if (this.hasModalDialogOpen()) {
-      // A modal dialog owns this Escape and dismisses itself — through
-      // lv-modal's own document handler, or its own keydown listener. Stop
-      // here so one Escape cannot ALSO close the diff sitting behind it, and
-      // so a dialog that deliberately BLOCKS dismissal mid-operation doesn't
-      // leak the keypress to the diff either.
+      // A modal owns this Escape and dismisses itself, through lv-modal's
+      // handler or its own — each now gated on being the TOPMOST overlay.
+      // Stop here so one keypress cannot also close the diff behind it, and
+      // so a dialog that deliberately blocks dismissal mid-operation does not
+      // leak the key either.
+      //
+      // This subsumes the old showReflog arm, which assumed reflog was always
+      // topmost: a dialog opened over it (via the palette) made Escape discard
+      // the reflog session underneath. The dialog's own handler applies the
+      // isResetting guard and its `close` event clears showReflog.
       return;
     } else if (this.contextMenu.visible) {
       this.contextMenu = { ...this.contextMenu, visible: false };

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -84,6 +84,7 @@ import type { LvReflogDialog } from './components/dialogs/lv-reflog-dialog.ts';
 import type { LvCleanDialog } from './components/dialogs/lv-clean-dialog.ts';
 import type { LvRemoteDialog } from './components/dialogs/lv-remote-dialog.ts';
 import type { LvRepositoryHealthDialog } from './components/dialogs/lv-repository-health-dialog.ts';
+import type { LvChangelogDialog } from './components/dialogs/lv-changelog-dialog.ts';
 import type { IntegrationOpenContext, IntegrationType } from './types/integration-accounts.types.ts';
 import type { Commit, RefInfo, StatusEntry, Tag, Branch, RepositoryState } from './types/git.types.ts';
 import type { SearchFilter } from './components/toolbar/lv-search-bar.ts';
@@ -723,6 +724,7 @@ export class AppShell extends LitElement {
   @query('lv-clean-dialog') private cleanDialog?: LvCleanDialog;
   @query('lv-remote-dialog') private remoteDialog?: LvRemoteDialog;
   @query('lv-repository-health-dialog') private repositoryHealthDialog?: LvRepositoryHealthDialog;
+  @query('lv-changelog-dialog') private changelogDialog?: LvChangelogDialog;
 
   private unsubscribe?: () => void;
   private unsubscribeUi?: () => void;
@@ -1205,23 +1207,31 @@ export class AppShell extends LitElement {
       // submodule dialogs still remove, against a repo whose tab is gone.
       // Driven off the DOM element so a dialog cannot be added to the app and
       // silently miss the sweep.
-      const pinnedFlagDialogs: Array<[string, () => void, string]> = [
-        ['lv-repository-health-dialog', () => { this.showRepositoryHealth = false; }, 'repository health closed'],
-        ['lv-worktree-dialog', () => { this.showWorktrees = false; }, 'worktrees closed'],
-        ['lv-submodule-dialog', () => { this.showSubmodules = false; }, 'submodules closed'],
-        ['lv-lfs-dialog', () => { this.showLfs = false; }, 'Git LFS closed'],
-        ['lv-gpg-dialog', () => { this.showGpg = false; }, 'signing settings closed'],
-        ['lv-config-dialog', () => { this.showConfig = false; }, 'configuration closed'],
-        ['lv-credentials-dialog', () => { this.showCredentials = false; }, 'credentials closed'],
-        ['lv-hooks-dialog', () => { this.showHooksDialog = false; }, 'hooks closed'],
+      // Each closer returns whether it actually closed: Repository Health
+      // refuses while gc/prune is in flight (closing DESTROYS the element and
+      // would leave the operation running with no surface), so the sweep must
+      // not announce a dismissal that did not happen.
+      const pinnedFlagDialogs: Array<[string, () => boolean, string]> = [
+        ['lv-repository-health-dialog', () => {
+          if (this.repositoryHealthDialog?.isRunning) return false;
+          this.showRepositoryHealth = false;
+          return true;
+        }, 'repository health closed'],
+        ['lv-worktree-dialog', () => { this.showWorktrees = false; return true; }, 'worktrees closed'],
+        ['lv-submodule-dialog', () => { this.showSubmodules = false; return true; }, 'submodules closed'],
+        ['lv-lfs-dialog', () => { this.showLfs = false; return true; }, 'Git LFS closed'],
+        ['lv-gpg-dialog', () => { this.showGpg = false; return true; }, 'signing settings closed'],
+        ['lv-config-dialog', () => { this.showConfig = false; return true; }, 'configuration closed'],
+        ['lv-credentials-dialog', () => { this.showCredentials = false; return true; }, 'credentials closed'],
+        ['lv-hooks-dialog', () => { this.showHooksDialog = false; return true; }, 'hooks closed'],
+        ['lv-changelog-dialog', () => { this.changelogDialog?.close(); return true; }, 'changelog closed'],
       ];
       for (const [tag, close, label] of pinnedFlagDialogs) {
         const el = this.renderRoot.querySelector(tag) as
           | (Element & { pinnedRepositoryPathIfOpen?: string | null })
           | null;
         const pinned = el?.pinnedRepositoryPathIfOpen ?? null;
-        if (pinned && !repoOpen(pinned)) {
-          close();
+        if (pinned && !repoOpen(pinned) && close()) {
           showToast(`The repository tab was closed — ${label}`, 'warning');
         }
       }
@@ -1418,7 +1428,7 @@ export class AppShell extends LitElement {
       search: () => this.handleToggleSearch(),
       openSettings: () => { this.showSettings = true; },
       openShortcuts: () => { this.showShortcuts = true; },
-      toggleLeftPanel: () => uiStore.getState().togglePanel('left'),
+      toggleLeftPanel: () => this.toggleLeftPanel(),
       toggleRightPanel: () => uiStore.getState().togglePanel('right'),
       openCommandPalette: () => this.openCommandPalette(),
       openReflog: () => { this.showReflog = true; },
@@ -1607,36 +1617,72 @@ export class AppShell extends LitElement {
   /**
    * True when any dialog is showing a blocking overlay.
    *
-   * Asks the DOM rather than enumerating flags. The previous hand-maintained
-   * list drifted immediately: it covered only the flag-driven dialogs, so the
-   * seven opened by an .open() method call (cherry-pick, interactive-rebase,
-   * create-tag, create-branch, clone, init, changelog) still leaked Escape
-   * through to close the diff behind them — and it carried a `showChangelog`
-   * entry that is never set true, which is exactly why the list LOOKED
-   * complete. A dialog is open if it reflects `open` on its host (the
-   * self-overlay dialogs) or wraps an open lv-modal.
+   * Walks every shadow root under app-shell rather than enumerating dialogs.
+   * Two earlier attempts drifted: a hand-written list of `show*` flags missed
+   * the seven dialogs opened by an .open() call, and a fixed two-level walk
+   * (renderRoot plus lv-left-panel) missed BOTH the toolbar's clone/init
+   * dialogs and the two dialogs wrapped by app-shell's OWN lv-modal — Settings
+   * and Repository Health, whose modal is their parent, not a child of their
+   * shadow root, and which declare no `open` property at all. Any fixed shape
+   * is the same bug waiting to happen, so this asks the whole tree: a blocking
+   * overlay is an open lv-modal anywhere, or a dialog reflecting `open`.
    */
   private hasModalDialogOpen(): boolean {
-    for (const el of this.renderRoot.querySelectorAll('*')) {
-      const tag = el.tagName;
-      if (!tag.startsWith('LV-') || !tag.endsWith('-DIALOG')) continue;
-      if (el.hasAttribute('open')) return true;
-      const modal = el.shadowRoot?.querySelector('lv-modal');
-      if (modal?.hasAttribute('open')) return true;
-    }
-    // The sidebar owns three more (interactive-rebase, branch-cleanup,
-    // create-branch) inside its own shadow root, which the sweep above
-    // cannot see through.
-    const panel = this.renderRoot.querySelector('lv-left-panel');
-    for (const el of panel?.shadowRoot?.querySelectorAll('*') ?? []) {
-      const nested = el.shadowRoot?.querySelectorAll('*') ?? [];
-      for (const inner of nested) {
-        if (!inner.tagName.endsWith('-DIALOG')) continue;
-        if (inner.hasAttribute('open')) return true;
-        if (inner.shadowRoot?.querySelector('lv-modal')?.hasAttribute('open')) return true;
+    const seen = new Set<ShadowRoot>();
+    const walk = (root: ShadowRoot | Element, depth: number): boolean => {
+      if (depth > 8) return false;
+      for (const el of root.querySelectorAll('*')) {
+        const tag = el.tagName;
+        if (tag === 'LV-MODAL' && el.hasAttribute('open')) return true;
+        if (tag.startsWith('LV-') && tag.endsWith('-DIALOG') && el.hasAttribute('open')) return true;
+        const shadow = el.shadowRoot;
+        if (shadow && !seen.has(shadow)) {
+          seen.add(shadow);
+          if (walk(shadow, depth + 1)) return true;
+        }
       }
+      return false;
+    };
+    return walk(this.renderRoot as ShadowRoot, 0);
+  }
+
+  /**
+   * True when a dialog owned by the LEFT PANEL is open. Hiding the panel with
+   * one of those up makes it invisible without closing it — the overlay is
+   * inside the `display: none` subtree — while it still owns Escape, so the
+   * key goes dead app-wide with no visible cause.
+   */
+  private hasSidebarDialogOpen(): boolean {
+    const panel = this.renderRoot.querySelector('lv-left-panel');
+    if (!panel) return false;
+    const seen = new Set<ShadowRoot>();
+    const walk = (root: ShadowRoot | Element, depth: number): boolean => {
+      if (depth > 6) return false;
+      for (const el of root.querySelectorAll('*')) {
+        const tag = el.tagName;
+        if (tag === 'LV-MODAL' && el.hasAttribute('open')) return true;
+        if (tag.startsWith('LV-') && tag.endsWith('-DIALOG') && el.hasAttribute('open')) return true;
+        const shadow = el.shadowRoot;
+        if (shadow && !seen.has(shadow)) {
+          seen.add(shadow);
+          if (walk(shadow, depth + 1)) return true;
+        }
+      }
+      return false;
+    };
+    return panel.shadowRoot ? walk(panel.shadowRoot, 0) : false;
+  }
+
+  /**
+   * Hiding the left panel is refused while it hosts an open dialog — see
+   * hasSidebarDialogOpen. Revealing it is always allowed.
+   */
+  private toggleLeftPanel(): void {
+    if (this.leftPanelVisible && this.hasSidebarDialogOpen()) {
+      showToast('Close the open dialog before hiding the sidebar', 'info');
+      return;
     }
-    return false;
+    uiStore.getState().togglePanel('left');
   }
 
   /**
@@ -3264,7 +3310,7 @@ export class AppShell extends LitElement {
         label: 'Toggle left panel',
         category: 'navigation',
         shortcut: `${mod}B`,
-        action: () => uiStore.getState().togglePanel('left'),
+        action: () => this.toggleLeftPanel(),
       },
       {
         id: 'toggle-right-panel',

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1213,9 +1213,14 @@ export class AppShell extends LitElement {
       // not announce a dismissal that did not happen.
       const pinnedFlagDialogs: Array<[string, () => boolean, string]> = [
         ['lv-repository-health-dialog', () => {
-          if (this.repositoryHealthDialog?.isRunning) return false;
-          this.showRepositoryHealth = false;
-          return true;
+          // Hands the close to the dialog: it dismisses now if idle, or after
+          // the running gc/prune lands. Merely refusing left it open and
+          // pinned to a repo with no tab, where a SECOND gc could be started
+          // once the first finished.
+          const running = this.repositoryHealthDialog?.isRunning ?? false;
+          this.repositoryHealthDialog?.closeWhenIdle();
+          if (!running) this.showRepositoryHealth = false;
+          return !running;
         }, 'repository health closed'],
         ['lv-worktree-dialog', () => { this.showWorktrees = false; return true; }, 'worktrees closed'],
         ['lv-submodule-dialog', () => { this.showSubmodules = false; return true; }, 'submodules closed'],

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2173,9 +2173,15 @@ export class AppShell extends LitElement {
     // what a reset is — so every confirm has to say so and name the recovery
     // path. Describing only what happens to the working tree made soft/mixed
     // read as harmless and understated hard, which is the loudest of them.
+    // Phrased for ANY target. The graph context menu offers Reset on every
+    // node, so the target may be a descendant of HEAD (nothing is dropped) or
+    // sit on a diverged branch (the dropped set is not a simple "after X").
+    // Saying "commits after X are removed" is false in the first case and
+    // mischaracterises the second — and a confirm that overstates trains users
+    // to dismiss the one that matters.
     const droppedNote =
-      `Commits after "${commit.summary}" are removed from this branch and will be ` +
-      `recoverable only through the reflog.`;
+      `This branch will point at ${commit.shortId}. Any commit no longer reachable ` +
+      `from it is recoverable only through the reflog.`;
 
     if (mode === 'hard') {
       const confirmed = await showConfirm(
@@ -2904,8 +2910,11 @@ export class AppShell extends LitElement {
 
             const confirmed = await showConfirm(
               'Smart Undo',
-              `${match.description}\n\nReset to ${target.shortId} (HEAD@{${match.index}})? ` +
-                `(soft reset — changes preserved as staged)`
+              `${match.description}\n\nReset to ${target.shortId} (HEAD@{${match.index}})?\n\n` +
+                `This branch will point at ${target.shortId}. Any commit no longer ` +
+                `reachable from it is recoverable only through the reflog. Your ` +
+                `changes remain staged.`,
+              'warning'
             );
             if (confirmed) {
               const resetResult = await git.resetToReflog(

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -505,6 +505,8 @@ export class AppShell extends LitElement {
 
   // Settings dialog
   @state() private showSettings = false;
+  /** True while an abort is in flight — blocks a double-click firing two. */
+  @state() private abortInProgress = false;
 
   // Search/filter
   @state() private searchFilter: SearchFilter | null = null;
@@ -1672,6 +1674,17 @@ export class AppShell extends LitElement {
     const repoPath = this.activeRepository.repository.path;
     this.refContextMenu = { ...this.refContextMenu, visible: false };
 
+    // Deleting from the graph's ref menu destroys the same branch as the
+    // sidebar's delete, so it must be gated the same way (lv-branch-list.ts
+    // handleDeleteBranch). Without this, one click on a graph label is enough.
+    const confirmed = await showConfirm(
+      'Delete Branch',
+      `Are you sure you want to delete the branch "${branchName}"?`,
+      'warning'
+    );
+
+    if (!confirmed) return;
+
     const result = await gitService.deleteBranch(
       repoPath,
       branchName,
@@ -1695,6 +1708,16 @@ export class AppShell extends LitElement {
     // the repo it was invoked on, even if the user switches tabs mid-operation.
     const repoPath = this.activeRepository.repository.path;
     this.refContextMenu = { ...this.refContextMenu, visible: false };
+
+    // Gated to match the sidebar's tag delete (lv-tag-list.ts) — the graph ref
+    // menu deletes the same tag and must not be the one unguarded path.
+    const confirmed = await showConfirm(
+      'Delete Tag',
+      `Are you sure you want to delete the tag "${tagName}"?`,
+      'warning'
+    );
+
+    if (!confirmed) return;
 
     const result = await gitService.deleteTag({
       path: repoPath,
@@ -1903,40 +1926,67 @@ export class AppShell extends LitElement {
   }
 
   private async handleAbortOperation(): Promise<void> {
-    if (!this.activeRepository) return;
+    if (!this.activeRepository || this.abortInProgress) return;
 
     const state = this.activeRepository.repository.state;
     const path = this.activeRepository.repository.path;
     let result;
 
-    switch (state) {
-      case 'cherrypick':
-        result = await gitService.abortCherryPick({ path });
-        break;
-      case 'merge':
-        result = await gitService.abortMerge({ path });
-        break;
-      case 'rebase':
-      case 'rebase-interactive':
-      case 'rebase-merge':
-        result = await gitService.abortRebase({ path });
-        break;
-      case 'revert':
-        result = await gitService.abortRevert({ path });
-        break;
-      default:
-        showToast(`Cannot abort operation: ${state}`, 'error');
-        return;
+    // Reject an unabortable state BEFORE prompting — otherwise the user
+    // confirms a destructive action that was never going to run.
+    const ABORTABLE = ['cherrypick', 'merge', 'rebase', 'rebase-interactive', 'rebase-merge', 'revert'];
+    if (!ABORTABLE.includes(state)) {
+      showToast(`Cannot abort operation: ${state}`, 'error');
+      return;
     }
 
-    if (result.success) {
-      showToast(`Aborted ${state}`, 'success');
-      // `path` was captured before the abort await — pin the refresh to it so a
-      // mid-abort tab switch doesn't refresh the wrong repo.
-      this.refreshConflictDialogRepo(path);
-    } else {
-      log.error('Abort failed:', result.error);
-      showToast(result.error?.message || 'Abort failed', 'error');
+    // Aborting throws away every conflict resolution made so far and restores
+    // the pre-operation working tree. The conflict dialog's own Abort button
+    // gates this behind an explicit confirmation panel; the banner button
+    // reaches the same command, so it needs the same gate rather than being a
+    // one-click path to the identical loss.
+    const confirmed = await showConfirm(
+      `Abort ${state}?`,
+      `This discards all conflict resolutions and restores the working tree to ` +
+        `its state before the ${state} began. This cannot be undone.`,
+      'warning'
+    );
+
+    if (!confirmed) return;
+
+    // Guards against a double-click firing two aborts: the second would run
+    // against an already-restored tree and surface a confusing failure.
+    this.abortInProgress = true;
+
+    try {
+      switch (state) {
+        case 'cherrypick':
+          result = await gitService.abortCherryPick({ path });
+          break;
+        case 'merge':
+          result = await gitService.abortMerge({ path });
+          break;
+        case 'rebase':
+        case 'rebase-interactive':
+        case 'rebase-merge':
+          result = await gitService.abortRebase({ path });
+          break;
+        default:
+          result = await gitService.abortRevert({ path });
+          break;
+      }
+
+      if (result.success) {
+        showToast(`Aborted ${state}`, 'success');
+        // `path` was captured before the abort await — pin the refresh to it so
+        // a mid-abort tab switch doesn't refresh the wrong repo.
+        this.refreshConflictDialogRepo(path);
+      } else {
+        log.error('Abort failed:', result.error);
+        showToast(result.error?.message || 'Abort failed', 'error');
+      }
+    } finally {
+      this.abortInProgress = false;
     }
   }
 
@@ -1947,21 +1997,46 @@ export class AppShell extends LitElement {
 
   private handleForceDeleteBranch = (e: CustomEvent<{ branchName?: string }>): void => {
     const branchName = e.detail?.branchName;
-    if (!branchName || !this.activeRepository) return;
+    if (branchName) void this.forceDeleteBranch(branchName);
+  };
 
-    // Captured before the delete: the force-delete and its refresh must target
+  private async forceDeleteBranch(branchName: string): Promise<void> {
+    if (!this.activeRepository) return;
+
+    // Captured before the confirm: the force-delete and its refresh must target
     // the repo it was invoked on, even if the user switches tabs mid-operation.
     const repoPath = this.activeRepository.repository.path;
-    gitService.deleteBranch(repoPath, branchName, true).then(async (result) => {
+
+    // This fires from the "Force Delete" action on an error-suggestion toast,
+    // i.e. one click away from an ordinary delete that just failed as unmerged.
+    // Force-deleting discards commits that exist on no other ref, so it needs
+    // its own gate — the sidebar escalation (lv-branch-list.ts) re-confirms
+    // here too, and the toast button must not be the cheaper route to the same
+    // irreversible outcome.
+    const confirmed = await showConfirm(
+      'Force Delete Branch',
+      `"${branchName}" has commits that are not merged anywhere else. ` +
+        `Force deleting it discards those commits permanently — they will be ` +
+        `recoverable only through the reflog. Continue?`,
+      'warning'
+    );
+
+    if (!confirmed) return;
+
+    try {
+      const result = await gitService.deleteBranch(repoPath, branchName, true);
       if (result.success) {
         this.refreshConflictDialogRepo(repoPath);
         showToast(`Force deleted branch ${branchName}`, 'success');
       } else {
         showToast(result.error?.message || 'Force delete failed', 'error');
       }
-    }).catch((e) => {
-      showToast(`Force delete failed: ${e instanceof Error ? e.message : 'Unknown error'}`, 'error');
-    });
+    } catch (err) {
+      showToast(
+        `Force delete failed: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        'error'
+      );
+    }
   };
 
   private handleOpenSettings = (): void => {
@@ -2768,10 +2843,32 @@ export class AppShell extends LitElement {
 
           if (result.success && result.data) {
             const match = result.data;
-            const confirmed = await showConfirm('Smart Undo', `${match.description}\n\nReset to HEAD@{${match.index}}? (soft reset — changes preserved as staged)`);
+
+            // Resolve the index to a commit BEFORE the confirm. An AI round
+            // trip plus a prompt plus a confirm all elapse between the reflog
+            // being read and the reset firing, and any commit or checkout in
+            // that window renumbers every entry. Pinning the oid means the
+            // reset either lands on the commit named here or is refused.
+            const git = await import('./services/git.service.ts');
+            const reflog = await git.getReflog(repoPath);
+            const target = reflog.success ? reflog.data?.[match.index] : undefined;
+
+            if (!target) {
+              showToast('Could not resolve that reflog entry — try again', 'error');
+              return;
+            }
+
+            const confirmed = await showConfirm(
+              'Smart Undo',
+              `${match.description}\n\nReset to ${target.shortId} (HEAD@{${match.index}})? ` +
+                `(soft reset — changes preserved as staged)`
+            );
             if (confirmed) {
-              const resetResult = await import('./services/git.service.ts').then(m =>
-                m.resetToReflog(repoPath, match.index, 'soft')
+              const resetResult = await git.resetToReflog(
+                repoPath,
+                match.index,
+                'soft',
+                target.oid
               );
               if (resetResult.success) {
                 showToast('Undo successful', 'success');
@@ -3310,7 +3407,14 @@ export class AppShell extends LitElement {
     // Pinned: if the user switches tabs while the stash is being created, the
     // refresh must target the repo that was stashed, not the active tab.
     const repoPath = this.activeRepository.repository.path;
-    const result = await gitService.createStash({ path: repoPath });
+    // includeUntracked matches the stash-list button (lv-stash-list.ts): both
+    // surfaces report an identical "Stash created", so they must stash the same
+    // set — otherwise the shortcut silently leaves untracked files behind and
+    // the divergence only surfaces during a later checkout or clean.
+    const result = await gitService.createStash({
+      path: repoPath,
+      includeUntracked: true,
+    });
     if (result.success) {
       if (result.data === null) {
         // Clean working tree: nothing to stash — informational, not an error.
@@ -3326,6 +3430,21 @@ export class AppShell extends LitElement {
 
   private async handleRunGc(aggressive = false): Promise<void> {
     if (!this.activeRepository) return;
+
+    // GC prunes unreachable objects, which is exactly the set that keeps
+    // dropped stashes, deleted branches, amended commits and hard resets
+    // recoverable. From the command palette this is two keystrokes, so it needs
+    // the same gate every other destructive palette entry has.
+    const confirmed = await showConfirm(
+      aggressive ? 'Run Garbage Collection (Aggressive)' : 'Run Garbage Collection',
+      'This permanently removes unreachable objects. Work recoverable only ' +
+        'through the reflog — dropped stashes, deleted branches, amended ' +
+        'commits — will become unrecoverable. Continue?',
+      'warning'
+    );
+
+    if (!confirmed) return;
+
     await gitService.runGc({
       path: this.activeRepository.repository.path,
       aggressive,
@@ -3342,6 +3461,20 @@ export class AppShell extends LitElement {
 
   private async handleRunPrune(): Promise<void> {
     if (!this.activeRepository) return;
+
+    // Same irreversibility as GC — see handleRunGc. `Ctrl+P → "prune" → Enter`
+    // must not be a shorter path to destroying the reflog safety net than any
+    // of the operations that net exists to protect.
+    const confirmed = await showConfirm(
+      'Prune Unreachable Objects',
+      'This permanently deletes unreachable objects. Work recoverable only ' +
+        'through the reflog — dropped stashes, deleted branches, amended ' +
+        'commits — will become unrecoverable. Continue?',
+      'warning'
+    );
+
+    if (!confirmed) return;
+
     await gitService.runPrune({
       path: this.activeRepository.repository.path,
     });

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -7,6 +7,26 @@ import { loggers } from './utils/logger.ts';
 import * as watcherService from './services/watcher.service.ts';
 
 const log = loggers.app;
+
+/**
+ * Repository states that have a working abort command.
+ *
+ * The operation banner's Abort button and handleAbortOperation BOTH read this,
+ * so the UI can never offer an abort the handler will refuse. The banner used
+ * to render for every non-clean state, which made Abort a permanent dead end
+ * during a bisect or an in-progress mailbox apply — those have no abort command
+ * here (a bisect exits via the bisect dialog's Reset).
+ *
+ * Typed as RepositoryState so a typo or a renamed state is a compile error.
+ */
+const ABORTABLE_STATES: readonly RepositoryState[] = [
+  'cherrypick',
+  'merge',
+  'rebase',
+  'rebase-interactive',
+  'rebase-merge',
+  'revert',
+];
 import './components/toolbar/lv-toolbar.ts';
 import './components/welcome/lv-welcome.ts';
 import './components/graph/lv-graph-canvas.ts';
@@ -61,7 +81,7 @@ import type { LvCherryPickDialog } from './components/dialogs/lv-cherry-pick-dia
 import type { LvInteractiveRebaseDialog } from './components/dialogs/lv-interactive-rebase-dialog.ts';
 import type { LvProfileManagerDialog } from './components/dialogs/lv-profile-manager-dialog.ts';
 import type { IntegrationOpenContext, IntegrationType } from './types/integration-accounts.types.ts';
-import type { Commit, RefInfo, StatusEntry, Tag, Branch } from './types/git.types.ts';
+import type { Commit, RefInfo, StatusEntry, Tag, Branch, RepositoryState } from './types/git.types.ts';
 import type { SearchFilter } from './components/toolbar/lv-search-bar.ts';
 import type { PaletteCommand } from './components/dialogs/lv-command-palette.ts';
 import * as gitService from './services/git.service.ts';
@@ -74,6 +94,7 @@ import { listenToEvent } from './services/tauri-api.ts';
 import { showToast, notifyWarning } from './services/notification.service.ts';
 import { showErrorWithSuggestion } from './services/error-suggestion.service.ts';
 import { showConfirm, showPrompt } from './services/dialog.service.ts';
+import { confirmGarbageCollection, confirmPrune } from './utils/maintenance-confirms.ts';
 import { searchIndexService } from './services/search-index.service.ts';
 import { embeddingIndexService } from './services/embedding-index.service.ts';
 import { initOAuthListener } from './services/oauth.service.ts';
@@ -1934,8 +1955,7 @@ export class AppShell extends LitElement {
 
     // Reject an unabortable state BEFORE prompting — otherwise the user
     // confirms a destructive action that was never going to run.
-    const ABORTABLE = ['cherrypick', 'merge', 'rebase', 'rebase-interactive', 'rebase-merge', 'revert'];
-    if (!ABORTABLE.includes(state)) {
+    if (!ABORTABLE_STATES.includes(state)) {
       showToast(`Cannot abort operation: ${state}`, 'error');
       return;
     }
@@ -1971,9 +1991,15 @@ export class AppShell extends LitElement {
         case 'rebase-merge':
           result = await gitService.abortRebase({ path });
           break;
-        default:
+        case 'revert':
           result = await gitService.abortRevert({ path });
           break;
+        default:
+          // Unreachable while ABORTABLE_STATES gates entry above. Kept explicit
+          // so that adding a state to that list without adding a case here
+          // fails loudly instead of silently running an unrelated abort.
+          showToast(`Cannot abort operation: ${state}`, 'error');
+          return;
       }
 
       if (result.success) {
@@ -3431,53 +3457,56 @@ export class AppShell extends LitElement {
   private async handleRunGc(aggressive = false): Promise<void> {
     if (!this.activeRepository) return;
 
-    // GC prunes unreachable objects, which is exactly the set that keeps
-    // dropped stashes, deleted branches, amended commits and hard resets
-    // recoverable. From the command palette this is two keystrokes, so it needs
-    // the same gate every other destructive palette entry has.
-    const confirmed = await showConfirm(
-      aggressive ? 'Run Garbage Collection (Aggressive)' : 'Run Garbage Collection',
-      'This permanently removes unreachable objects. Work recoverable only ' +
-        'through the reflog — dropped stashes, deleted branches, amended ' +
-        'commits — will become unrecoverable. Continue?',
-      'warning'
+    // Pinned before the confirm await, like every other destructive handler —
+    // and because reading it afterwards would also re-dereference a possibly
+    // null activeRepository inside a floating promise.
+    const repoPath = this.activeRepository.repository.path;
+
+    // Shared with the Repository Health dialog so the two surfaces that reach
+    // this command cannot drift apart on whether it is gated.
+    if (!(await confirmGarbageCollection(aggressive))) return;
+
+    const result = await gitService.runGc({ path: repoPath, aggressive });
+    showToast(
+      result.success
+        ? aggressive
+          ? 'Aggressive garbage collection completed'
+          : 'Garbage collection completed'
+        : `Garbage collection failed: ${result.error?.message ?? 'Unknown error'}`,
+      result.success ? 'success' : 'error'
     );
-
-    if (!confirmed) return;
-
-    await gitService.runGc({
-      path: this.activeRepository.repository.path,
-      aggressive,
-    });
   }
 
   private async handleRunFsck(): Promise<void> {
     if (!this.activeRepository) return;
-    await gitService.runFsck({
-      path: this.activeRepository.repository.path,
-      full: true,
-    });
+
+    const repoPath = this.activeRepository.repository.path;
+    const result = await gitService.runFsck({ path: repoPath, full: true });
+
+    // Reporting IS this command's purpose — without a toast the palette entry
+    // does nothing observable at all.
+    showToast(
+      result.success
+        ? 'Repository integrity check completed — no issues found'
+        : `Repository integrity check found issues: ${result.error?.message ?? 'Unknown error'}`,
+      result.success ? 'success' : 'warning'
+    );
   }
 
   private async handleRunPrune(): Promise<void> {
     if (!this.activeRepository) return;
 
-    // Same irreversibility as GC — see handleRunGc. `Ctrl+P → "prune" → Enter`
-    // must not be a shorter path to destroying the reflog safety net than any
-    // of the operations that net exists to protect.
-    const confirmed = await showConfirm(
-      'Prune Unreachable Objects',
-      'This permanently deletes unreachable objects. Work recoverable only ' +
-        'through the reflog — dropped stashes, deleted branches, amended ' +
-        'commits — will become unrecoverable. Continue?',
-      'warning'
+    const repoPath = this.activeRepository.repository.path;
+
+    if (!(await confirmPrune())) return;
+
+    const result = await gitService.runPrune({ path: repoPath });
+    showToast(
+      result.success
+        ? 'Pruned unreachable objects'
+        : `Prune failed: ${result.error?.message ?? 'Unknown error'}`,
+      result.success ? 'success' : 'error'
     );
-
-    if (!confirmed) return;
-
-    await gitService.runPrune({
-      path: this.activeRepository.repository.path,
-    });
   }
 
   private async handleCheckoutBranch(e: CustomEvent<{ branch: string }>): Promise<void> {
@@ -3671,7 +3700,7 @@ export class AppShell extends LitElement {
                                 </button>
                               `
                             : ''}
-                          ${this.activeRepository.repository.state !== 'clean'
+                          ${ABORTABLE_STATES.includes(this.activeRepository.repository.state)
                             ? html`
                                 <button class="operation-abort-btn" @click=${this.handleAbortOperation}>
                                   Abort

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -19,6 +19,25 @@ const log = loggers.app;
  *
  * Typed as RepositoryState so a typo or a renamed state is a compile error.
  */
+/**
+ * Condense `git fsck` output for a toast.
+ *
+ * `git fsck --full` prints one line per dangling/unreachable object, which on a
+ * repo with rebased or amended history is dozens of lines. A toast is ~400px
+ * wide with no max-height and auto-dismisses, so dumping that raw makes it both
+ * unreadable and large enough to cover the view. Lead with the count and point
+ * at the surface that can show the detail.
+ */
+function summariseFsck(message: string | undefined): string {
+  const text = (message ?? '').trim();
+  if (!text) return 'Repository integrity check completed';
+
+  const lines = text.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length <= 2 && text.length <= 200) return text;
+
+  return `Repository integrity check completed — ${lines.length} notes (${lines[0].trim()}, …). See Repository Health for the full output.`;
+}
+
 const ABORTABLE_STATES: readonly RepositoryState[] = [
   'cherrypick',
   'merge',
@@ -3466,7 +3485,8 @@ export class AppShell extends LitElement {
     // this command cannot drift apart on whether it is gated.
     if (!(await confirmGarbageCollection(aggressive))) return;
 
-    const result = await gitService.runGc({ path: repoPath, aggressive });
+    // silent: the service toasts by default; this handler owns the message.
+    const result = await gitService.runGc({ path: repoPath, aggressive, silent: true });
     showToast(
       result.success
         ? aggressive
@@ -3481,7 +3501,8 @@ export class AppShell extends LitElement {
     if (!this.activeRepository) return;
 
     const repoPath = this.activeRepository.repository.path;
-    const result = await gitService.runFsck({ path: repoPath, full: true });
+    // silent: the service toasts by default; this handler owns the message.
+    const result = await gitService.runFsck({ path: repoPath, full: true, silent: true });
 
     // Reporting IS this command's purpose, so report what git actually said.
     // `git fsck` exits 0 while printing "dangling commit" / "unreachable blob"
@@ -3489,7 +3510,7 @@ export class AppShell extends LitElement {
     // clean bill of health from the exit code alone would hide it.
     showToast(
       result.success
-        ? (result.data?.message ?? 'Repository integrity check completed')
+        ? summariseFsck(result.data?.message)
         : `Repository integrity check failed: ${result.error?.message ?? 'Unknown error'}`,
       result.success ? 'success' : 'error'
     );
@@ -3502,7 +3523,8 @@ export class AppShell extends LitElement {
 
     if (!(await confirmPrune())) return;
 
-    const result = await gitService.runPrune({ path: repoPath });
+    // silent: the service toasts by default; this handler owns the message.
+    const result = await gitService.runPrune({ path: repoPath, silent: true });
     showToast(
       result.success
         ? 'Pruned unreachable objects'

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -80,6 +80,7 @@ import type { LvCreateBranchDialog } from './components/dialogs/lv-create-branch
 import type { LvCherryPickDialog } from './components/dialogs/lv-cherry-pick-dialog.ts';
 import type { LvInteractiveRebaseDialog } from './components/dialogs/lv-interactive-rebase-dialog.ts';
 import type { LvProfileManagerDialog } from './components/dialogs/lv-profile-manager-dialog.ts';
+import type { LvReflogDialog } from './components/dialogs/lv-reflog-dialog.ts';
 import type { IntegrationOpenContext, IntegrationType } from './types/integration-accounts.types.ts';
 import type { Commit, RefInfo, StatusEntry, Tag, Branch, RepositoryState } from './types/git.types.ts';
 import type { SearchFilter } from './components/toolbar/lv-search-bar.ts';
@@ -704,6 +705,7 @@ export class AppShell extends LitElement {
   @query('lv-cherry-pick-dialog') private cherryPickDialog?: LvCherryPickDialog;
   @query('#app-rebase-dialog') private interactiveRebaseDialog?: LvInteractiveRebaseDialog;
   @query('lv-profile-manager-dialog') private profileManagerDialog?: LvProfileManagerDialog;
+  @query('lv-reflog-dialog') private reflogDialog?: LvReflogDialog;
 
   private unsubscribe?: () => void;
   private unsubscribeUi?: () => void;
@@ -1524,7 +1526,16 @@ export class AppShell extends LitElement {
     } else if (this.showCommandPalette) {
       this.showCommandPalette = false;
     } else if (this.showReflog) {
-      this.showReflog = false;
+      // The keyboard service registers its own document-level Escape handler,
+      // so this path can flip the dialog's `open` binding without going
+      // through the dialog's dismiss() guard. Honour that guard here too:
+      // closing mid-reset hides a running operation whose success path then
+      // calls close() on whatever the user reopened. Swallow the Escape
+      // either way, so a blocked dismissal cannot fall through and close the
+      // diff sitting behind the dialog.
+      if (!this.reflogDialog?.isResetting) {
+        this.showReflog = false;
+      }
     } else if (this.contextMenu.visible) {
       this.contextMenu = { ...this.contextMenu, visible: false };
     } else if (this.refContextMenu.visible) {
@@ -4181,8 +4192,12 @@ export class AppShell extends LitElement {
           ?open=${this.showBisect}
           .repositoryPath=${this.activeRepository.repository.path}
           @close=${() => { this.showBisect = false; }}
-          @bisect-step=${() => this.handleRefresh()}
-          @bisect-complete=${() => { this.showBisect = false; this.handleRefresh(); }}
+          @bisect-step=${(e: CustomEvent<{ repositoryPath?: string }>) =>
+            this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null)}
+          @bisect-complete=${(e: CustomEvent<{ repositoryPath?: string }>) => {
+            this.showBisect = false;
+            this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null);
+          }}
         ></lv-bisect-dialog>
       ` : ''}
 

--- a/src/components/dialogs/__tests__/lv-bisect-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-bisect-dialog.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Regression tests for lv-bisect-dialog.
+ *
+ * The dialog's `repositoryPath` is live-bound to the ACTIVE repository, and
+ * repo switching is a document-level keyboard shortcut that fires straight
+ * through the dialog's own overlay. That makes two things mandatory:
+ *
+ *  - every event the dialog dispatches must name the repository the operation
+ *    actually ran against, or app-shell refreshes whichever tab happens to be
+ *    active instead (every other destructive dialog already does this);
+ *  - a mid-session repo switch must re-read status and drop the previous
+ *    repo's session, or the dialog displays repo A while its buttons target
+ *    repo B — "Bad" would mark a commit bad in the repo the user is not
+ *    looking at.
+ *
+ * `git bisect start` also checks out the midpoint, so starting a bisect moves
+ * HEAD exactly as good/bad/skip do and must announce it.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeCalls: Array<{ command: string; args?: unknown }> = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeCalls.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-bisect-dialog.ts';
+
+const REPO_A = '/repo/a';
+const REPO_B = '/repo/b';
+
+interface BisectStatus {
+  active: boolean;
+  currentCommit?: string | null;
+  badCommit?: string | null;
+  goodCommits?: string[];
+  remaining?: number | null;
+  currentStep?: number | null;
+  totalSteps?: number | null;
+}
+
+function status(overrides: Partial<BisectStatus> = {}): BisectStatus {
+  return {
+    active: true,
+    currentCommit: 'aaaaaaaaaaaa',
+    badCommit: 'bbbbbbbbbbbb',
+    goodCommits: ['cccccccccccc'],
+    remaining: 3,
+    currentStep: 1,
+    totalSteps: 2,
+    ...overrides,
+  };
+}
+
+/** Status per repository path, so a tab switch yields a different session. */
+let statusByPath: Record<string, BisectStatus> = {};
+
+function installMock(): void {
+  mockInvoke = (command: string, args?: unknown) => {
+    const path = (args as { path?: string } | undefined)?.path ?? '';
+    switch (command) {
+      case 'get_bisect_status':
+        return Promise.resolve(statusByPath[path] ?? { active: false });
+      case 'get_commit':
+        return Promise.resolve({ oid: 'aaaaaaaaaaaa', shortId: 'aaaaaaa', summary: `commit in ${path}` });
+      case 'bisect_start':
+      case 'bisect_good':
+      case 'bisect_bad':
+      case 'bisect_skip':
+        return Promise.resolve({ status: statusByPath[path] ?? status(), message: 'ok', culprit: null });
+      case 'bisect_reset':
+        return Promise.resolve(null);
+      default:
+        return Promise.resolve(null);
+    }
+  };
+}
+
+async function settle(el: HTMLElement & { updateComplete: Promise<unknown> }): Promise<void> {
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 0));
+  await el.updateComplete;
+}
+
+type Dialog = HTMLElement & {
+  updateComplete: Promise<unknown>;
+  repositoryPath: string;
+  open: boolean;
+};
+
+async function openOn(path: string): Promise<Dialog> {
+  const el = await fixture<Dialog>(
+    html`<lv-bisect-dialog .repositoryPath=${path} .open=${true}></lv-bisect-dialog>`
+  );
+  await settle(el);
+  return el;
+}
+
+function clickAction(el: Dialog, label: string): void {
+  const buttons = [...el.shadowRoot!.querySelectorAll('.action-btn')];
+  const btn = buttons.find((b) => b.textContent?.includes(label));
+  expect(btn, `"${label}" button present`).to.not.be.undefined;
+  (btn as HTMLButtonElement).click();
+}
+
+describe('lv-bisect-dialog repository targeting', () => {
+  beforeEach(() => {
+    invokeCalls.length = 0;
+    statusByPath = { [REPO_A]: status(), [REPO_B]: { active: false } };
+    installMock();
+  });
+
+  it('names the repository the step ran against in bisect-step', async () => {
+    const el = await openOn(REPO_A);
+
+    const seen: Array<string | undefined> = [];
+    el.addEventListener('bisect-step', (e) => {
+      seen.push((e as CustomEvent<{ repositoryPath?: string }>).detail?.repositoryPath);
+    });
+
+    clickAction(el, 'Bad');
+    await settle(el);
+
+    expect(seen).to.deep.equal([REPO_A]);
+  });
+
+  it('names the repository in bisect-complete when the session is reset', async () => {
+    const el = await openOn(REPO_A);
+
+    let detailPath: string | undefined;
+    el.addEventListener('bisect-complete', (e) => {
+      detailPath = (e as CustomEvent<{ repositoryPath?: string }>).detail?.repositoryPath;
+    });
+
+    const resetBtn = [...el.shadowRoot!.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Abort Bisect')
+    );
+    expect(resetBtn, 'Abort Bisect button present').to.not.be.undefined;
+    resetBtn!.click();
+    await settle(el);
+
+    expect(detailPath).to.equal(REPO_A);
+  });
+
+  // `git bisect start` checks out the midpoint: HEAD has moved, so the graph
+  // and branch list are stale until something refreshes them. Its three
+  // siblings announced the move; this one silently did not.
+  it('announces the HEAD move when a bisect is started', async () => {
+    statusByPath = { [REPO_A]: { active: false } };
+    const el = await openOn(REPO_A);
+
+    let detailPath: string | undefined;
+    let fired = 0;
+    el.addEventListener('bisect-step', (e) => {
+      fired++;
+      detailPath = (e as CustomEvent<{ repositoryPath?: string }>).detail?.repositoryPath;
+    });
+
+    const inputs = el.shadowRoot!.querySelectorAll<HTMLInputElement>('.commit-input input');
+    inputs[0].value = 'HEAD';
+    inputs[0].dispatchEvent(new Event('input'));
+    inputs[1].value = 'v1.0';
+    inputs[1].dispatchEvent(new Event('input'));
+    await el.updateComplete;
+
+    statusByPath[REPO_A] = status();
+    const startBtn = [...el.shadowRoot!.querySelectorAll('button')].find((b) =>
+      b.textContent?.includes('Start Bisect')
+    );
+    expect(startBtn, 'Start Bisect button present').to.not.be.undefined;
+    startBtn!.click();
+    await settle(el);
+
+    expect(fired, 'bisect-step dispatched after start').to.equal(1);
+    expect(detailPath).to.equal(REPO_A);
+  });
+
+  // Repo switching (Ctrl+Tab) is a document-level shortcut and is not blocked
+  // by this dialog's overlay, so the binding really does change underneath it.
+  it('re-reads status and drops the old session when the repository switches', async () => {
+    const el = await openOn(REPO_A);
+    expect(el.shadowRoot!.querySelector('.current-commit'), 'repo A session shown').to.not.be.null;
+
+    invokeCalls.length = 0;
+    el.repositoryPath = REPO_B;
+    await settle(el);
+
+    const statusCalls = invokeCalls.filter((c) => c.command === 'get_bisect_status');
+    expect(statusCalls.length, 'status re-read for the new repo').to.be.greaterThan(0);
+    expect((statusCalls[0].args as { path: string }).path).to.equal(REPO_B);
+
+    // Repo B has no bisect in progress, so the in-progress surface for repo A
+    // must be gone rather than left on screen driving buttons at repo B.
+    expect(el.shadowRoot!.querySelector('.current-commit')).to.be.null;
+  });
+
+  it('sends the step to the repository shown, not one bound mid-flight', async () => {
+    const el = await openOn(REPO_A);
+    invokeCalls.length = 0;
+
+    clickAction(el, 'Good');
+    // Switch tabs while the command is in flight.
+    el.repositoryPath = REPO_B;
+    await settle(el);
+
+    const good = invokeCalls.find((c) => c.command === 'bisect_good');
+    expect(good, 'bisect_good issued').to.not.be.undefined;
+    expect((good!.args as { path: string }).path).to.equal(REPO_A);
+  });
+});

--- a/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
@@ -355,6 +355,21 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
       expect(warningBadge!.textContent).to.include('Warning');
     });
 
+    it('merged branch with no upstream stays .risk-badge.safe', async () => {
+      // The backend proved it merged (graph_descendant_of) to put it in the
+      // 'merged' category; a missing upstream comparison must not override that
+      // and label it risky.
+      const mergedNoUpstream = createCandidate('feature/done', 'merged', {
+        aheadBehind: null,
+        upstream: null,
+      });
+      const el = await renderAndOpen([mergedNoUpstream]);
+
+      const safeBadge = el.shadowRoot!.querySelector('.risk-badge.safe');
+      expect(safeBadge, 'merged branch must stay safe').to.not.be.null;
+      expect(safeBadge!.textContent).to.include('Safe');
+    });
+
     it('branch with unmeasurable divergence shows .risk-badge.warning, not "safe"', async () => {
       // aheadBehind is null when the backend could not compare at all — a
       // branch that neither tracks an upstream nor is gone. Treating that as
@@ -545,6 +560,58 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
       const deleteBtn = el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement;
       expect(deleteBtn).to.not.be.null;
       expect(deleteBtn.disabled).to.be.true;
+    });
+
+    it('does NOT force-delete a branch whose divergence could not be measured', async () => {
+      // Regression guard. `force` must not be derived from the risk LABEL:
+      // a branch is labelled 'warning' precisely BECAUSE its ahead/behind is
+      // unknown, and force-deleting it bypasses delete_branch's merged-check —
+      // turning the backend's safe refusal into permanent commit loss.
+      const unknownDivergence = createCandidate('spike/old-idea', 'stale', {
+        aheadBehind: null,
+        upstream: null,
+      });
+      const el = await renderAndOpen([unknownDivergence]);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const staleTab = Array.from(tabs).find((t) => t.textContent!.includes('Stale'));
+      staleTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle(el);
+
+      const checkbox = el.shadowRoot!.querySelector(
+        '.branch-item input[type="checkbox"]',
+      ) as HTMLInputElement;
+      checkbox.click();
+      await settle(el);
+      clearHistory();
+
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      const calls = findCommands('delete_branch');
+      expect(calls, 'delete_branch invoked').to.have.length(1);
+      expect(
+        (calls[0].args as { force?: boolean }).force,
+        'unknown divergence must fall through to the backend merged-check',
+      ).to.not.equal(true);
+    });
+
+    it('force-deletes only when unpushed commits were actually measured', async () => {
+      const el = await renderAndOpen([mergedWarning]);
+
+      const checkbox = el.shadowRoot!.querySelector(
+        '.branch-item input[type="checkbox"]',
+      ) as HTMLInputElement;
+      checkbox.click();
+      await settle(el);
+      clearHistory();
+
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      const calls = findCommands('delete_branch');
+      expect(calls).to.have.length(1);
+      expect((calls[0].args as { force?: boolean }).force).to.equal(true);
     });
 
     it('clicking delete calls delete_branch for each selected branch', async () => {

--- a/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
@@ -24,6 +24,7 @@ let mockInvoke: MockInvoke = () => Promise.resolve(null);
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
 import { expect, fixture, html } from '@open-wc/testing';
 import { settingsStore } from '../../../stores/settings.store.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
 import type { CleanupCandidate } from '../../../types/git.types.ts';
 
 // Import the actual component — registers <lv-branch-cleanup-dialog>
@@ -161,6 +162,7 @@ const allCandidates: CleanupCandidate[] = [
 describe('lv-branch-cleanup-dialog (fixture)', () => {
   beforeEach(() => {
     clearHistory();
+    uiStore.setState({ toasts: [] });
     // Ensure settings store has staleBranchDays set
     settingsStore.setState({ staleBranchDays: 90 });
   });
@@ -612,6 +614,80 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
       expect(deleteBtn.disabled).to.be.true;
     });
 
+    it('never issues a force delete without a confirm', async () => {
+      // Invariant guard. force=true skips delete_branch's merged-check, so it
+      // must never happen on a path the user was not asked about. A merged
+      // branch with upstream drift is labelled Safe (correctly) and therefore
+      // bypasses the risky-branch confirm — it must not be forced.
+      const el = await renderAndOpen([
+        createCandidate('feature/merged-drift', 'merged', {
+          aheadBehind: { ahead: 5, behind: 0 },
+          upstream: 'origin/feature/merged-drift',
+        }),
+      ]);
+      clearHistory();
+
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      const forced = findCommands('delete_branch').filter(
+        (c) => (c.args as { force?: boolean }).force === true,
+      );
+      expect(
+        forced.length === 0 || confirmMessages().length > 0,
+        'a forced delete must be preceded by a confirm',
+      ).to.be.true;
+      expect(forced, 'a Safe branch must never be force-deleted').to.have.length(0);
+    });
+
+    it('reports declining the escalation as kept, not as a failure', async () => {
+      const el = await renderAndOpen([
+        createCandidate('spike/idea', 'stale', { aheadBehind: null, upstream: null }),
+      ]);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const staleTab = Array.from(tabs).find((t) => t.textContent!.includes('Stale'));
+      staleTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle(el);
+      (el.shadowRoot!.querySelector(
+        '.branch-item input[type="checkbox"]',
+      ) as HTMLInputElement).click();
+      await settle(el);
+
+      // Confirm the delete, then DECLINE the force escalation.
+      let confirms = 0;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_cleanup_candidates') return [];
+        if (command === 'plugin:dialog|message') {
+          confirms++;
+          return confirms === 1 ? 'Ok' : 'Cancel';
+        }
+        if (command === 'delete_branch') {
+          throw {
+            code: 'COMMAND_ERROR',
+            message: 'Branch is not fully merged. Use force to delete anyway.',
+          };
+        }
+        return null;
+      };
+
+      clearHistory();
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      const forced = findCommands('delete_branch').filter(
+        (c) => (c.args as { force?: boolean }).force === true,
+      );
+      expect(forced, 'declining must not force-delete').to.have.length(0);
+
+      const toasts = uiStore.getState().toasts;
+      expect(
+        toasts.some((t) => t.type === 'error'),
+        "the user's own decision must not be reported as an error",
+      ).to.be.false;
+      expect(toasts.some((t) => /kept/i.test(t.message))).to.be.true;
+    });
+
     it('never shows a confirm with an empty clause', async () => {
       // A branch emitted as BOTH merged and stale used to get two labels; the
       // gate read the un-deduplicated union (saw 'warning') while the message
@@ -674,9 +750,55 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
       expect((calls[0].args as { force?: boolean }).force).to.not.equal(true);
       expect((calls[1].args as { force?: boolean }).force).to.equal(true);
       expect(
-        confirmMessages().some((m) => /not fully merged/i.test(m)),
+        confirmMessages().some((m) => /not merged into the current branch/i.test(m)),
         'the escalation must be confirmed explicitly',
       ).to.be.true;
+    });
+
+    it('does not claim commits "exist nowhere else" for a pushed branch', async () => {
+      // "not fully merged" is measured against HEAD; the Safe badge is measured
+      // against the UPSTREAM. A branch can be refused here while its commits
+      // sit safely on its remote, so the confirm must not overstate the loss.
+      const el = await renderAndOpen([
+        createCandidate('feature/pushed', 'stale', {
+          aheadBehind: { ahead: 0, behind: 0 },
+          upstream: 'origin/feature/pushed',
+        }),
+      ]);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const staleTab = Array.from(tabs).find((t) => t.textContent!.includes('Stale'));
+      staleTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle(el);
+      (el.shadowRoot!.querySelector(
+        '.branch-item input[type="checkbox"]',
+      ) as HTMLInputElement).click();
+      await settle(el);
+
+      mockInvoke = async (command: string) => {
+        if (command === 'get_cleanup_candidates') return [];
+        if (command === 'plugin:dialog|message') return 'Cancel';
+        if (command === 'delete_branch') {
+          throw {
+            code: 'COMMAND_ERROR',
+            message: 'Branch is not fully merged. Use force to delete anyway.',
+          };
+        }
+        return null;
+      };
+
+      clearHistory();
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      const escalation = confirmMessages().find((m) =>
+        /not merged into the current branch/i.test(m),
+      );
+      expect(escalation, 'escalation confirm shown').to.not.be.undefined;
+      expect(escalation!).to.not.match(/nowhere else/i);
+      expect(escalation!, 'should name where the commits actually are').to.include(
+        'origin/feature/pushed',
+      );
     });
 
     it('does NOT force-delete a branch whose divergence could not be measured', async () => {

--- a/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
@@ -84,7 +84,7 @@ async function renderAndOpen(
       case 'delete_branch':
         return undefined;
       case 'prune_remote_tracking_branches':
-        return { success: true, pruned: [], count: 0 };
+        return { success: true, branchesPruned: ['origin/gone'] };
       case 'plugin:notification|is_permission_granted':
         return false;
       // plugin-dialog 2.7 routes confirm() through `message` and returns the
@@ -787,7 +787,7 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
           };
         }
         if (command === 'prune_remote_tracking_branches') {
-          return { success: true, pruned: ['origin/gone'], count: 1 };
+          return { success: true, branchesPruned: ['origin/gone'] };
         }
         return null;
       };

--- a/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
@@ -755,6 +755,137 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
       ).to.be.true;
     });
 
+    it('reports a failed remote prune instead of claiming it succeeded', async () => {
+      // pruneRemoteTrackingBranches goes through invokeCommand, which never
+      // throws — it resolves { success: false }. The old try/catch was dead
+      // code, so an offline prune was reported as "(remotes pruned)".
+      const el = await renderAndOpen([mergedSafe]);
+
+      mockInvoke = async (command: string) => {
+        if (command === 'get_cleanup_candidates') return [];
+        if (command === 'plugin:dialog|message') return 'Ok';
+        if (command === 'delete_branch') return undefined;
+        if (command === 'prune_remote_tracking_branches') {
+          throw { code: 'COMMAND_ERROR', message: 'could not connect to origin' };
+        }
+        return null;
+      };
+
+      uiStore.setState({ toasts: [] });
+      clearHistory();
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      const messages = uiStore.getState().toasts.map((t) => t.message);
+      expect(
+        messages.some((m) => /Failed to prune remote branches/i.test(m)),
+        'a failed prune must be reported',
+      ).to.be.true;
+      expect(
+        messages.some((m) => /remotes pruned/i.test(m)),
+        'must not claim a prune that did not happen',
+      ).to.be.false;
+    });
+
+    it('warns of permanent loss for a branch with no remote copy', async () => {
+      // Mirror of the pushed case. A branch with NO upstream loses everything
+      // on a force delete, so the confirm must not imply an upstream fallback.
+      const el = await renderAndOpen([
+        createCandidate('spike/idea', 'stale', { aheadBehind: null, upstream: null }),
+      ]);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const staleTab = Array.from(tabs).find((t) => t.textContent!.includes('Stale'));
+      staleTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle(el);
+      (el.shadowRoot!.querySelector(
+        '.branch-item input[type="checkbox"]',
+      ) as HTMLInputElement).click();
+      await settle(el);
+
+      // This branch is 'warning', so the risky-branch confirm fires first —
+      // accept it, then decline the escalation.
+      let confirms = 0;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_cleanup_candidates') return [];
+        if (command === 'plugin:dialog|message') {
+          confirms++;
+          return confirms === 1 ? 'Ok' : 'Cancel';
+        }
+        if (command === 'delete_branch') {
+          throw {
+            code: 'COMMAND_ERROR',
+            message: 'Branch is not fully merged. Use force to delete anyway.',
+          };
+        }
+        return null;
+      };
+
+      clearHistory();
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      const escalation = confirmMessages().find((m) =>
+        /not merged into the current branch/i.test(m),
+      );
+      expect(escalation, 'escalation confirm shown').to.not.be.undefined;
+      expect(escalation!).to.include('no remote copy');
+      expect(escalation!).to.include('discarded permanently');
+      expect(escalation!, 'must not imply an upstream fallback').to.not.match(
+        /can be restored from the remote/i,
+      );
+    });
+
+    it('reports failed and kept outcomes together', async () => {
+      // These were mutually exclusive `else if` arms, so a branch the user
+      // chose to keep went unmentioned whenever another branch also failed —
+      // leaving them to assume it had been deleted.
+      const el = await renderAndOpen([
+        createCandidate('a/fails', 'stale', { aheadBehind: { ahead: 2, behind: 0 } }),
+        createCandidate('b/kept', 'stale', { aheadBehind: null, upstream: null }),
+      ]);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const staleTab = Array.from(tabs).find((t) => t.textContent!.includes('Stale'));
+      staleTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle(el);
+      for (const box of Array.from(
+        el.shadowRoot!.querySelectorAll('.branch-item input[type="checkbox"]'),
+      )) {
+        (box as HTMLInputElement).click();
+      }
+      await settle(el);
+
+      let confirms = 0;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_cleanup_candidates') return [];
+        if (command === 'plugin:dialog|message') {
+          confirms++;
+          // Confirm the delete, decline the force escalation.
+          return confirms === 1 ? 'Ok' : 'Cancel';
+        }
+        if (command === 'delete_branch') {
+          const name = (args as { name: string }).name;
+          throw name === 'a/fails'
+            ? { code: 'COMMAND_ERROR', message: 'locked by another worktree' }
+            : {
+                code: 'COMMAND_ERROR',
+                message: 'Branch is not fully merged. Use force to delete anyway.',
+              };
+        }
+        return null;
+      };
+
+      uiStore.setState({ toasts: [] });
+      clearHistory();
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      const messages = uiStore.getState().toasts.map((t) => t.message);
+      expect(messages.some((m) => /a\/fails/.test(m)), 'the failure is named').to.be.true;
+      expect(messages.some((m) => /kept/i.test(m)), 'the kept branch is named').to.be.true;
+    });
+
     it('does not claim commits "exist nowhere else" for a pushed branch', async () => {
       // "not fully merged" is measured against HEAD; the Safe badge is measured
       // against the UPSTREAM. A branch can be refused here while its commits

--- a/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
@@ -55,6 +55,13 @@ function clearHistory(): void {
   invokeHistory.length = 0;
 }
 
+/** Messages passed to showConfirm(), in order. */
+function confirmMessages(): string[] {
+  return invokeHistory
+    .filter((h) => h.command === 'plugin:dialog|message')
+    .map((h) => (h.args as { message?: string })?.message ?? '');
+}
+
 function findCommands(name: string): Array<{ command: string; args?: unknown }> {
   return invokeHistory.filter((h) => h.command === name);
 }
@@ -126,6 +133,11 @@ const goneDanger = createCandidate('feature/gone-danger', 'gone', {
   upstream: 'origin/feature/gone-danger',
 });
 
+const protectedMainStale = createCandidate('main', 'stale', {
+  aheadBehind: { ahead: 0, behind: 0 },
+  lastCommitTimestamp: 1600000000,
+});
+
 const protectedMain = createCandidate('main', 'merged', {
   aheadBehind: { ahead: 0, behind: 0 },
 });
@@ -190,8 +202,9 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
     });
 
     it('risk badges render with correct class (.risk-badge.safe, .risk-badge.warning, .risk-badge.danger)', async () => {
-      // Put one of each risk in merged tab
-      const el = await renderAndOpen([mergedSafe, mergedWarning]);
+      // A merged branch is always safe (the backend proved HEAD descends from
+      // it), so 'warning' is only reachable outside that category — use stale.
+      const el = await renderAndOpen([staleSafe, staleWarning]);
 
       const safeBadge = el.shadowRoot!.querySelector('.risk-badge.safe');
       const warningBadge = el.shadowRoot!.querySelector('.risk-badge.warning');
@@ -347,12 +360,48 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
       expect(safeBadge!.textContent).to.include('Safe');
     });
 
-    it('branch with ahead: 5 shows .risk-badge.warning', async () => {
-      const el = await renderAndOpen([mergedWarning]);
+    it('unmerged branch with unpushed commits shows .risk-badge.warning', async () => {
+      const el = await renderAndOpen([staleWarning]);
 
       const warningBadge = el.shadowRoot!.querySelector('.risk-badge.warning');
       expect(warningBadge).to.not.be.null;
       expect(warningBadge!.textContent).to.include('Warning');
+    });
+
+    it('merged branch with measured unpushed commits stays .risk-badge.safe', async () => {
+      // `ahead` measures distance from the UPSTREAM, which says nothing about
+      // whether deleting the local ref loses work. The backend already proved
+      // HEAD descends from this branch, so nothing is lost.
+      const mergedUnpushed = createCandidate('feature/x', 'merged', {
+        aheadBehind: { ahead: 3, behind: 0 },
+        upstream: 'origin/feature/x',
+      });
+      const el = await renderAndOpen([mergedUnpushed]);
+
+      const safeBadge = el.shadowRoot!.querySelector('.risk-badge.safe');
+      expect(safeBadge, 'a merged branch is safe regardless of upstream drift').to.not.be.null;
+    });
+
+    it('gives one branch the same risk in every tab it appears in', async () => {
+      // The backend emits a branch once per qualifying category. Risk belongs
+      // to the branch, so the merged proof must win in the Stale tab too —
+      // otherwise the same branch reads green on one tab and amber on another.
+      const name = 'feature/old-and-merged';
+      const el = await renderAndOpen([
+        createCandidate(name, 'merged', { aheadBehind: null, upstream: null }),
+        createCandidate(name, 'stale', { aheadBehind: null, upstream: null }),
+      ]);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const staleTab = Array.from(tabs).find((t) => t.textContent!.includes('Stale'));
+      staleTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle(el);
+
+      expect(
+        el.shadowRoot!.querySelector('.risk-badge.warning'),
+        'the merged proof must apply in the Stale tab too',
+      ).to.be.null;
+      expect(el.shadowRoot!.querySelector('.risk-badge.safe')).to.not.be.null;
     });
 
     it('merged branch with no upstream stays .risk-badge.safe', async () => {
@@ -502,7 +551,8 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
     });
 
     it('select-all checkbox toggles all selectable branches', async () => {
-      const el = await renderAndOpen([mergedSafe, mergedWarning, protectedMain]);
+      // Stale branches are never auto-selected, so select-all has something to do.
+      const el = await renderAndOpen([staleSafe, staleWarning, protectedMainStale]);
 
       // Find select-all checkbox
       const selectAllCheckbox = el.shadowRoot!.querySelector(
@@ -554,12 +604,79 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
     });
 
     it('delete button disabled when nothing selected', async () => {
-      // Use a warning branch that won't be auto-selected
-      const el = await renderAndOpen([mergedWarning]);
+      // Stale branches are never auto-selected.
+      const el = await renderAndOpen([staleWarning]);
 
       const deleteBtn = el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement;
       expect(deleteBtn).to.not.be.null;
       expect(deleteBtn.disabled).to.be.true;
+    });
+
+    it('never shows a confirm with an empty clause', async () => {
+      // A branch emitted as BOTH merged and stale used to get two labels; the
+      // gate read the un-deduplicated union (saw 'warning') while the message
+      // read the deduplicated set (saw only 'safe'), producing the text
+      // "Of the selected branches, .".
+      const name = 'feature/old-and-merged';
+      const el = await renderAndOpen([
+        createCandidate(name, 'merged', { aheadBehind: null, upstream: null }),
+        createCandidate(name, 'stale', { aheadBehind: null, upstream: null }),
+      ]);
+      clearHistory();
+
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      for (const message of confirmMessages()) {
+        expect(message, `malformed confirm: ${message}`).to.not.match(/,\s*\./);
+      }
+      expect(findCommands('delete_branch'), 'the delete still runs').to.have.length(1);
+    });
+
+    it('offers a force escalation when the backend refuses an unmerged branch', async () => {
+      // force is withheld for unmeasurable divergence (that is the safe
+      // outcome), but git's "use force to delete anyway" is unactionable
+      // unless the dialog offers it.
+      const el = await renderAndOpen([
+        createCandidate('spike/idea', 'stale', { aheadBehind: null, upstream: null }),
+      ]);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const staleTab = Array.from(tabs).find((t) => t.textContent!.includes('Stale'));
+      staleTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle(el);
+      (el.shadowRoot!.querySelector(
+        '.branch-item input[type="checkbox"]',
+      ) as HTMLInputElement).click();
+      await settle(el);
+
+      // First delete_branch call is refused as unmerged; the retry succeeds.
+      let deleteCalls = 0;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_cleanup_candidates') return [];
+        if (command === 'plugin:dialog|message') return 'Ok';
+        if (command === 'delete_branch') {
+          deleteCalls++;
+          if (deleteCalls === 1) {
+            throw { code: 'COMMAND_ERROR', message: 'Branch is not fully merged. Use force to delete anyway.' };
+          }
+          return undefined;
+        }
+        return null;
+      };
+
+      clearHistory();
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      const calls = findCommands('delete_branch');
+      expect(calls.length, 'should retry after the escalation confirm').to.equal(2);
+      expect((calls[0].args as { force?: boolean }).force).to.not.equal(true);
+      expect((calls[1].args as { force?: boolean }).force).to.equal(true);
+      expect(
+        confirmMessages().some((m) => /not fully merged/i.test(m)),
+        'the escalation must be confirmed explicitly',
+      ).to.be.true;
     });
 
     it('does NOT force-delete a branch whose divergence could not be measured', async () => {
@@ -597,7 +714,8 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
     });
 
     it('force-deletes only when unpushed commits were actually measured', async () => {
-      const el = await renderAndOpen([mergedWarning]);
+      // staleWarning has a measured ahead of 3, so force is justified.
+      const el = await renderAndOpen([staleWarning]);
 
       const checkbox = el.shadowRoot!.querySelector(
         '.branch-item input[type="checkbox"]',
@@ -615,17 +733,9 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
     });
 
     it('clicking delete calls delete_branch for each selected branch', async () => {
+      // Both are merged and therefore safe, so both are auto-selected.
       const candidates = [mergedSafe, mergedWarning];
       const el = await renderAndOpen(candidates);
-      clearHistory();
-
-      // Select the warning branch too (safe is auto-selected)
-      const branchItems = el.shadowRoot!.querySelectorAll('.branch-item');
-      const warningItem = Array.from(branchItems).find(
-        (item) => item.querySelector('.branch-name')?.textContent?.trim() === 'feature/wip',
-      );
-      const warningCheckbox = warningItem!.querySelector('input[type="checkbox"]') as HTMLInputElement;
-      warningCheckbox.click();
       await settle(el);
 
       clearHistory();
@@ -749,8 +859,8 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
   // ── Footer ─────────────────────────────────────────────────────────────
   describe('Footer', () => {
     it('shows "No branches selected" when none selected', async () => {
-      // Use only a warning branch so nothing is auto-selected
-      const el = await renderAndOpen([mergedWarning]);
+      // Stale branches are never auto-selected.
+      const el = await renderAndOpen([staleWarning]);
 
       const footer = el.shadowRoot!.querySelector('.footer-summary');
       expect(footer).to.not.be.null;

--- a/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
@@ -755,6 +755,73 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
       ).to.be.true;
     });
 
+    it('reloads its list when it stays open after a successful prune', async () => {
+      // The prune removes remote-tracking refs that the risk badges and the
+      // Gone Upstream tab are derived from. The dialog now survives that
+      // (deleted === 0), so what it shows must be refreshed — otherwise the
+      // next Delete click acts on labels the prune already invalidated.
+      const el = await renderAndOpen([
+        createCandidate('spike/idea', 'stale', { aheadBehind: null, upstream: null }),
+      ]);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const staleTab = Array.from(tabs).find((t) => t.textContent!.includes('Stale'));
+      staleTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle(el);
+      (el.shadowRoot!.querySelector(
+        '.branch-item input[type="checkbox"]',
+      ) as HTMLInputElement).click();
+      await settle(el);
+
+      let confirms = 0;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_cleanup_candidates') return [];
+        if (command === 'plugin:dialog|message') {
+          confirms++;
+          return confirms === 1 ? 'Ok' : 'Cancel';
+        }
+        if (command === 'delete_branch') {
+          throw {
+            code: 'COMMAND_ERROR',
+            message: 'Branch is not fully merged. Use force to delete anyway.',
+          };
+        }
+        if (command === 'prune_remote_tracking_branches') {
+          return { success: true, pruned: ['origin/gone'], count: 1 };
+        }
+        return null;
+      };
+
+      clearHistory();
+      (el.shadowRoot!.querySelector('.btn-danger') as HTMLButtonElement).click();
+      await settle(el);
+
+      expect(
+        findCommands('get_cleanup_candidates'),
+        'the visible list must be refreshed after the prune',
+      ).to.have.length.greaterThan(0);
+    });
+
+    it('ignores open() while a delete is in flight', async () => {
+      // The command palette can dispatch open-branch-cleanup over the modal.
+      // reset() would clear `deleting`, re-enabling Delete mid-flight so a
+      // second concurrent loop could start, and re-pin the repo path.
+      const el = await renderAndOpen([mergedSafe]);
+      (el as unknown as { deleting: boolean }).deleting = true;
+      (el as unknown as { selectedBranches: Set<string> }).selectedBranches = new Set(['keep/me']);
+
+      await el.open();
+
+      expect(
+        (el as unknown as { deleting: boolean }).deleting,
+        'an in-flight delete must not be cleared',
+      ).to.equal(true);
+      expect(
+        (el as unknown as { selectedBranches: Set<string> }).selectedBranches.has('keep/me'),
+        'the in-flight selection must survive',
+      ).to.be.true;
+    });
+
     it('reports a failed remote prune instead of claiming it succeeded', async () => {
       // pruneRemoteTrackingBranches goes through invokeCommand, which never
       // throws — it resolves { success: false }. The old try/catch was dead

--- a/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-branch-cleanup-dialog.test.ts
@@ -355,6 +355,29 @@ describe('lv-branch-cleanup-dialog (fixture)', () => {
       expect(warningBadge!.textContent).to.include('Warning');
     });
 
+    it('branch with unmeasurable divergence shows .risk-badge.warning, not "safe"', async () => {
+      // aheadBehind is null when the backend could not compare at all — a
+      // branch that neither tracks an upstream nor is gone. Treating that as
+      // ahead: 0 claimed "Fully merged into current branch" about a branch
+      // whose unmerged work is simply unknown, and cleared the delete confirm.
+      const unknownDivergence = createCandidate('spike/old-idea', 'stale', {
+        aheadBehind: null,
+        upstream: null,
+      });
+      const el = await renderAndOpen([unknownDivergence]);
+
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const staleTab = Array.from(tabs).find((t) => t.textContent!.includes('Stale'));
+      staleTab!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+      await settle(el);
+
+      expect(el.shadowRoot!.querySelector('.risk-badge.safe'), 'must not be labelled safe').to.be
+        .null;
+      const warningBadge = el.shadowRoot!.querySelector('.risk-badge.warning');
+      expect(warningBadge).to.not.be.null;
+      expect(warningBadge!.textContent).to.include('Warning');
+    });
+
     it('gone branch with ahead: 3 shows .risk-badge.danger', async () => {
       const el = await renderAndOpen([goneDanger]);
 

--- a/src/components/dialogs/__tests__/lv-clean-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-clean-dialog.test.ts
@@ -5,6 +5,7 @@
  */
 
 import { expect, fixture, html } from '@open-wc/testing';
+import { pushOverlay, removeOverlay, resetOverlayStack } from '../../../utils/overlay-stack.ts';
 
 let failingCommands: Set<string> = new Set();
 let cleanableEntries: unknown[] = [];
@@ -160,6 +161,36 @@ describe('lv-clean-dialog', () => {
       await new Promise(r => setTimeout(r, 0));
     }
   }
+
+  // Every dialog listens for Escape on `document`, so before the overlay stack
+  // one keypress ran all of them: dismissing the command palette opened over
+  // this dialog also dismissed this dialog, discarding the user's selection.
+  it('ignores Escape while another overlay is on top', async () => {
+    cleanableEntries = [
+      { path: 'a.txt', isDirectory: false, isIgnored: false, isNestedRepo: false, size: 1 },
+    ];
+
+    const el = await fixture<LvCleanDialog>(
+      html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
+    );
+    await waitForEntries(el);
+
+    // Something opens over it (the command palette registers the same way).
+    const palette = {};
+    pushOverlay(palette);
+
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await el.updateComplete;
+
+    expect(el.open, 'dialog underneath must survive the palette dismissal').to.be.true;
+
+    // Once the overlay above closes, Escape belongs to this dialog again.
+    removeOverlay(palette);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await el.updateComplete;
+
+    expect(el.open, 'dialog closes once it is topmost').to.be.false;
+  });
 
   // `repositoryPath` is live-bound to the ACTIVE repository and rebinds the
   // instant the user Ctrl+Tabs — a document-level shortcut this dialog's

--- a/src/components/dialogs/__tests__/lv-clean-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-clean-dialog.test.ts
@@ -161,6 +161,56 @@ describe('lv-clean-dialog', () => {
     }
   }
 
+  // `repositoryPath` is live-bound to the ACTIVE repository and rebinds the
+  // instant the user Ctrl+Tabs — a document-level shortcut this dialog's
+  // overlay does not block. The listed files belong to the repo that was
+  // active at OPEN, so the delete must target that repo. Pinning only at click
+  // time (the previous fix) still deleted from the wrong repository whenever
+  // the switch happened before the click. Untracked files have no trash and no
+  // recovery path, so this is the one deletion in the app that cannot be undone.
+  it('deletes from the repository the listed files were read from, not the newly active one', async () => {
+    cleanableEntries = [
+      { path: 'dist/', isDirectory: true, isIgnored: true, isNestedRepo: false, size: 100 },
+    ];
+
+    const el = await fixture<LvCleanDialog>(
+      html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/repo/a'}></lv-clean-dialog>`,
+    );
+    await waitForEntries(el);
+
+    // The user Ctrl+Tabs to another repo; the dialog stays open showing A's files.
+    el.repositoryPath = '/repo/b';
+    await el.updateComplete;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleClean();
+
+    expect(lastCleanFilesArgs).to.not.be.null;
+    expect(lastCleanFilesArgs!.path).to.equal('/repo/a');
+  });
+
+  it('reads the file list from the repo active at open, ignoring a later rebind', async () => {
+    cleanableEntries = [
+      { path: 'a.txt', isDirectory: false, isIgnored: false, isNestedRepo: false, size: 1 },
+    ];
+
+    const el = await fixture<LvCleanDialog>(
+      html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/repo/a'}></lv-clean-dialog>`,
+    );
+    await waitForEntries(el);
+
+    el.repositoryPath = '/repo/b';
+    await el.updateComplete;
+    await new Promise(r => setTimeout(r, 0));
+
+    // A tab switch must not silently swap the list out from under the
+    // selection the user already made.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect(((el as any).entries as unknown[]).length).to.equal(1);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).pinnedRepositoryPathIfOpen).to.equal('/repo/a');
+  });
+
   it('does not pre-select untracked nested repositories', async () => {
     cleanableEntries = [
       { path: 'untracked.txt', isDirectory: false, isIgnored: false, isNestedRepo: false, size: 100 },

--- a/src/components/dialogs/__tests__/lv-clean-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-clean-dialog.test.ts
@@ -13,6 +13,8 @@ let lastCleanFilesArgs: Record<string, unknown> | null = null;
 // confirm() routes through `plugin:dialog|message` and treats a truthy return
 // as "confirmed").
 let confirmResult = true;
+/** When set, clean_files reports this many removed instead of all requested. */
+let partialCleanCount: number | null = null;
 
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
 
@@ -39,6 +41,9 @@ const mockInvoke: MockInvoke = async (command: string, args?: unknown) => {
 
   if (command === 'clean_files') {
     lastCleanFilesArgs = args as Record<string, unknown>;
+    // partialCleanCount simulates the backend skipping entries it cannot
+    // remove, which it reports by returning a count lower than the request.
+    if (partialCleanCount !== null) return partialCleanCount;
     return (args as { paths?: unknown[] }).paths?.length ?? 1;
   }
 
@@ -60,6 +65,7 @@ describe('lv-clean-dialog', () => {
     cleanableEntries = [];
     lastCleanFilesArgs = null;
     confirmResult = true;
+    partialCleanCount = null;
     const state = uiStore.getState();
     state.toasts.forEach(t => state.removeToast(t.id));
   });
@@ -87,6 +93,44 @@ describe('lv-clean-dialog', () => {
     await (el as any).handleClean();
 
     expect(eventFired).to.be.true;
+  });
+
+  it('toasts what was deleted on success', async () => {
+    const el = await fixture<LvCleanDialog>(
+      html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any).selectedPaths = new Set(['a.txt', 'b.txt']);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleClean();
+
+    const toast = uiStore.getState().toasts.find(t => t.type === 'success');
+    expect(toast, 'success toast shown').to.not.be.undefined;
+    expect(toast!.message).to.include('2');
+  });
+
+  it('warns when clean_files removed fewer items than were selected', async () => {
+    // clean_files silently skips nested repos without force, directories with
+    // tracked content, and locked files. The dialog closes immediately, so the
+    // shortfall must be surfaced or the user assumes everything was deleted.
+    cleanableEntries = [];
+    const el = await fixture<LvCleanDialog>(
+      html`<lv-clean-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-clean-dialog>`,
+    );
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any).selectedPaths = new Set(['a.txt', 'b.txt', 'c.txt']);
+    // Backend reports only 1 of the 3 actually removed.
+    partialCleanCount = 1;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleClean();
+    partialCleanCount = null;
+
+    const toast = uiStore.getState().toasts.find(t => t.type === 'warning');
+    expect(toast, 'warning toast shown').to.not.be.undefined;
+    expect(toast!.message).to.include('1 of 3');
+    expect(toast!.message).to.include('2 could not be removed');
   });
 
   it('shows error toast on API failure', async () => {

--- a/src/components/dialogs/__tests__/lv-clone-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-clone-dialog.test.ts
@@ -469,4 +469,44 @@ describe('lv-clone-dialog', () => {
       expect(internal.url).to.equal('');
     });
   });
+
+  describe('re-entrancy guard', () => {
+    // open() refuses while a clone is in flight, so the in-flight flag MUST be
+    // cleared on every terminating path. The success branch closes via
+    // setTimeout and never cleared it, and open()'s guard returns before
+    // reset() can — so one successful clone made "Clone Repository" a silent
+    // no-op for the rest of the session.
+    it('can be reopened after a clone succeeds', async () => {
+      const internal = el as unknown as {
+        url: string;
+        destination: string;
+        isCloning: boolean;
+        handleClone: () => Promise<void>;
+      };
+
+      mockInvoke = (command: string) => {
+        if (command === 'clone_repository') {
+          return Promise.resolve({ path: '/cloned/repo', name: 'repo' });
+        }
+        return Promise.resolve(null);
+      };
+
+      internal.url = 'https://github.com/user/repo.git';
+      internal.destination = '/dest';
+      await internal.handleClone();
+      await el.updateComplete;
+
+      // The success path schedules close() on a 500ms timer.
+      await new Promise((r) => setTimeout(r, 600));
+      await el.updateComplete;
+
+      expect(internal.isCloning, 'in-flight flag cleared after success').to.be.false;
+
+      el.open();
+      await el.updateComplete;
+
+      const modal = el.shadowRoot!.querySelector('lv-modal') as HTMLElement & { open: boolean };
+      expect(modal.open, 'dialog reopens after a successful clone').to.be.true;
+    });
+  });
 });

--- a/src/components/dialogs/__tests__/lv-hooks-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-hooks-dialog.test.ts
@@ -53,11 +53,13 @@ const mockHooks: GitHook[] = [
 ];
 
 let lastInvokedCommand: string | null = null;
+const invokeCalls: Array<{ command: string; args?: unknown }> = [];
 
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
 
 const mockInvoke: MockInvoke = async (command: string, args?: unknown) => {
   lastInvokedCommand = command;
+  invokeCalls.push({ command, args });
   const params = args as Record<string, unknown> | undefined;
 
   switch (command) {
@@ -287,5 +289,54 @@ describe('lv-hooks-dialog', () => {
 
     const saveBtn = el.shadowRoot!.querySelector('.btn-primary');
     expect(saveBtn).to.not.be.null;
+  });
+
+  // `repoPath` is live-bound to the ACTIVE repository and rebinds on a
+  // Ctrl+Tab this dialog's overlay does not block. The hook list on screen
+  // belongs to the repo active at open, so saving or deleting must target THAT
+  // repo — .git/hooks is untracked, so a wrong-repo delete is unrecoverable.
+  it('saves to the repository the hook list was read from, not the newly active one', async () => {
+    const el = await fixture<LvHooksDialog>(
+      html`<lv-hooks-dialog ?open=${true} .repoPath=${'/repo/a'}></lv-hooks-dialog>`,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    await el.updateComplete;
+
+    (el.shadowRoot!.querySelectorAll('.hook-item')[0] as HTMLElement).click();
+    await new Promise((r) => setTimeout(r, 50));
+    await el.updateComplete;
+
+    // The user Ctrl+Tabs; the dialog stays open showing repo A's hooks.
+    el.repoPath = '/repo/b';
+    await el.updateComplete;
+
+    invokeCalls.length = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleSave();
+
+    const save = invokeCalls.find((c) => c.command === 'save_hook');
+    expect(save, 'save_hook issued').to.not.be.undefined;
+    expect((save!.args as { path: string }).path).to.equal('/repo/a');
+  });
+
+  it('deletes from the repository the hook list was read from', async () => {
+    const el = await fixture<LvHooksDialog>(
+      html`<lv-hooks-dialog ?open=${true} .repoPath=${'/repo/a'}></lv-hooks-dialog>`,
+    );
+    await new Promise((r) => setTimeout(r, 50));
+    await el.updateComplete;
+
+    el.repoPath = '/repo/b';
+    await el.updateComplete;
+
+    invokeCalls.length = 0;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any).confirmingDelete = 'pre-commit';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).confirmDelete();
+
+    const del = invokeCalls.find((c) => c.command === 'delete_hook');
+    expect(del, 'delete_hook issued').to.not.be.undefined;
+    expect((del!.args as { path: string }).path).to.equal('/repo/a');
   });
 });

--- a/src/components/dialogs/__tests__/lv-interactive-rebase-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-interactive-rebase-dialog.test.ts
@@ -494,6 +494,54 @@ describe('lv-interactive-rebase-dialog (fixture)', () => {
       await el.updateComplete;
     });
 
+    // Cancel is disabled during execution, but Escape and the overlay reached
+    // lv-modal.close() directly — which sets open=false BEFORE dispatching, so
+    // the rebase carried on with no visible surface and wrote any failure into
+    // `error` on a hidden dialog. Reopening then called reset(), clearing
+    // `executing` and re-enabling Start Rebase for a second concurrent rebase.
+    it('cannot be dismissed while the rebase is executing', async () => {
+      let resolveExec!: (value: unknown) => void;
+      mockInvoke = async (command: string) => {
+        switch (command) {
+          case 'get_rebase_commits':
+            return mockCommits;
+          case 'execute_interactive_rebase':
+            return new Promise((resolve) => { resolveExec = resolve; });
+          default:
+            return null;
+        }
+      };
+
+      const el = await createDialog();
+      await openAndWait(el);
+
+      (el.shadowRoot!.querySelector('.btn-primary') as HTMLButtonElement).click();
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 10));
+      await el.updateComplete;
+
+      const modal = el.shadowRoot!.querySelector('lv-modal') as HTMLElement & { open: boolean };
+      expect(modal.open, 'modal open while rebasing').to.be.true;
+
+      // Escape reaches lv-modal's own document listener.
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 0));
+      await el.updateComplete;
+
+      expect(modal.open, 'modal stays open mid-rebase').to.be.true;
+
+      // And a second open() must not restart the session under the running one.
+      await el.open('main');
+      await el.updateComplete;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      expect((el as any).executing, 'still executing after a re-open attempt').to.be.true;
+
+      resolveExec(undefined);
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+    });
+
     it('execute calls execute_interactive_rebase with correct path, onto, and todo string', async () => {
       const el = await createDialog();
       await openAndWait(el);

--- a/src/components/dialogs/__tests__/lv-keyboard-shortcuts-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-keyboard-shortcuts-dialog.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for lv-keyboard-shortcuts-dialog's key-recording mode.
+ *
+ * KeyboardService registers its `document` keydown listener at MODULE
+ * evaluation, so it always runs before this dialog's (registered in
+ * connectedCallback) — and stopPropagation() cannot suppress a listener on the
+ * same node. So the key being recorded was executed first: pressing "s" to
+ * rebind a shortcut staged the whole working tree, Ctrl+Shift+S stashed
+ * including untracked files, Ctrl+Shift+U pushed. It also swallowed the
+ * "Esc to cancel" the dialog advertises, closing the entire dialog instead.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+const mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import { keyboardService } from '../../../services/keyboard.service.ts';
+import type { LvKeyboardShortcutsDialog } from '../lv-keyboard-shortcuts-dialog.ts';
+import '../lv-keyboard-shortcuts-dialog.ts';
+
+interface Internal {
+  editingId: string | null;
+  startEditing: (id: string) => void;
+  cancelEditing: () => void;
+}
+
+function internalOf(el: LvKeyboardShortcutsDialog): Internal {
+  return el as unknown as Internal;
+}
+
+async function openDialog(): Promise<LvKeyboardShortcutsDialog> {
+  const el = await fixture<LvKeyboardShortcutsDialog>(
+    html`<lv-keyboard-shortcuts-dialog ?open=${true}></lv-keyboard-shortcuts-dialog>`
+  );
+  await el.updateComplete;
+  return el;
+}
+
+describe('lv-keyboard-shortcuts-dialog recording mode', () => {
+  afterEach(() => {
+    // Never leave the service disabled for the next test.
+    keyboardService.setEnabled(true);
+  });
+
+  it('does not run a shortcut while capturing its replacement', async () => {
+    let fired = 0;
+    keyboardService.register('test-destructive', {
+      key: 'y',
+      action: () => { fired++; },
+      description: 'destructive probe',
+      category: 'Test',
+    });
+
+    const el = await openDialog();
+    try {
+      internalOf(el).startEditing('test-destructive');
+      await el.updateComplete;
+
+      // The key the user is recording must be captured, NOT executed. This is
+      // the whole bug: "s" staged the working tree before being recorded.
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
+
+      expect(fired, 'the shortcut must not run while being rebound').to.equal(0);
+    } finally {
+      keyboardService.unregister('test-destructive');
+    }
+  });
+
+  it('re-enables shortcuts once recording is cancelled', async () => {
+    let fired = 0;
+    keyboardService.register('test-restore', {
+      key: 'y',
+      action: () => { fired++; },
+      description: 'restore probe',
+      category: 'Test',
+    });
+
+    const el = await openDialog();
+    try {
+      internalOf(el).startEditing('test-restore');
+      await el.updateComplete;
+      internalOf(el).cancelEditing();
+      await el.updateComplete;
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
+
+      expect(fired, 'shortcuts work again after cancelling').to.equal(1);
+    } finally {
+      keyboardService.unregister('test-restore');
+    }
+  });
+
+  // The inverse failure: leaving the service disabled kills every shortcut in
+  // the app with no way back.
+  it('re-enables shortcuts if torn down mid-recording', async () => {
+    let fired = 0;
+    keyboardService.register('test-teardown', {
+      key: 'y',
+      action: () => { fired++; },
+      description: 'teardown probe',
+      category: 'Test',
+    });
+
+    const el = await openDialog();
+    try {
+      internalOf(el).startEditing('test-teardown');
+      await el.updateComplete;
+
+      el.remove();
+      await new Promise((r) => setTimeout(r, 0));
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
+
+      expect(fired, 'shortcuts must survive a mid-recording teardown').to.equal(1);
+    } finally {
+      keyboardService.unregister('test-teardown');
+    }
+  });
+});

--- a/src/components/dialogs/__tests__/lv-lfs-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-lfs-dialog.test.ts
@@ -7,11 +7,22 @@
 import { expect, fixture, html } from '@open-wc/testing';
 
 let failingCommands: Set<string> = new Set();
+/** Result of the app's showConfirm(); prune is gated behind it. */
+let confirmResult = true;
 
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
 
 const mockInvoke: MockInvoke = async (command: string) => {
   if (command === 'plugin:notification|is_permission_granted') return false;
+
+  if (
+    command === 'plugin:dialog|message' ||
+    command === 'plugin:dialog|confirm' ||
+    command === 'plugin:dialog|ask'
+  ) {
+    // plugin-dialog's confirm() resolves true only for the OK button label.
+    return confirmResult ? 'Ok' : 'Cancel';
+  }
 
   if (failingCommands.has(command)) {
     throw { code: 'COMMAND_ERROR', message: 'Operation failed' };
@@ -48,6 +59,7 @@ import type { LvLfsDialog } from '../lv-lfs-dialog.ts';
 describe('lv-lfs-dialog', () => {
   beforeEach(() => {
     failingCommands = new Set();
+    confirmResult = true;
   });
 
   it('renders when open', async () => {
@@ -98,6 +110,24 @@ describe('lv-lfs-dialog', () => {
     await (el as any).handlePrune();
 
     expect(eventFired).to.be.true;
+  });
+
+  it('does not prune when the confirm is declined', async () => {
+    // `git lfs prune` deletes local LFS objects; blobs from a commit that was
+    // never pushed have no copy anywhere else.
+    confirmResult = false;
+
+    const el = await fixture<LvLfsDialog>(
+      html`<lv-lfs-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-lfs-dialog>`,
+    );
+
+    let eventFired = false;
+    el.addEventListener('lfs-changed', () => { eventFired = true; });
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handlePrune();
+
+    expect(eventFired, 'declining must not prune').to.be.false;
   });
 
   it('does not dispatch lfs-changed on pull failure', async () => {

--- a/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
@@ -59,4 +59,59 @@ describe('lv-reflog-dialog', () => {
     const toasts = uiStore.getState().toasts;
     expect(toasts.some((t) => t.type === 'error' && /copy hash/i.test(t.message))).to.be.true;
   });
+
+  // `repositoryPath` is live-bound to the ACTIVE repository and rebinds on a
+  // Ctrl+Tab this dialog's overlay does not block. The entries on screen (and
+  // the oid named in the confirm) belong to the repo active at OPEN, so the
+  // reset must target that repo — not whichever tab the user switched to.
+  it('resets the repository the entries were read from, not the newly active one', async () => {
+    const calls: Array<{ command: string; args?: unknown }> = [];
+    mockInvoke = async (command, args) => {
+      calls.push({ command, args });
+      if (command === 'get_reflog') return [mockEntry];
+      if (command === 'plugin:dialog|message') return 'Ok';
+      return null;
+    };
+
+    const el = await fixture<LvReflogDialog>(
+      html`<lv-reflog-dialog ?open=${true} .repositoryPath=${'/repo/a'}></lv-reflog-dialog>`
+    );
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+
+    // The reflog was read from repo A.
+    const load = calls.find((c) => c.command === 'get_reflog');
+    expect((load?.args as { path?: string })?.path).to.equal('/repo/a');
+
+    // User Ctrl+Tabs; the dialog stays open still showing A's entries.
+    el.repositoryPath = '/repo/b';
+    await el.updateComplete;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleReset(mockEntry, 'hard');
+
+    const reset = calls.find((c) => c.command === 'reset_to_reflog');
+    expect(reset, 'reset_to_reflog issued').to.not.be.undefined;
+    expect((reset!.args as { path: string }).path).to.equal('/repo/a');
+  });
+
+  // Only handleDocumentClick cleared this, and Escape is not a click — so the
+  // menu was repainted over the next session's list still holding the OLD
+  // entry, and clicking it ran a reset the user never re-selected.
+  it('clears the context menu when the dialog closes', async () => {
+    const el = await fixture<LvReflogDialog>(
+      html`<lv-reflog-dialog ?open=${true} .repositoryPath=${'/test/repo'}></lv-reflog-dialog>`
+    );
+    await el.updateComplete;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any).contextMenu = { visible: true, x: 10, y: 10, entry: mockEntry };
+    el.close();
+    await el.updateComplete;
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).contextMenu.visible).to.be.false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).contextMenu.entry).to.be.null;
+  });
 });

--- a/src/components/dialogs/__tests__/lv-repository-health-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-repository-health-dialog.test.ts
@@ -15,7 +15,7 @@ const invokeHistory: Array<{ command: string; args?: unknown }> = [];
 /** plugin-dialog's confirm() resolves true only for the OK button label. */
 let confirmResult = true;
 
-let mockInvoke: MockInvoke = async (command: string) => {
+const defaultMockInvoke: MockInvoke = async (command: string) => {
   if (command === 'plugin:notification|is_permission_granted') return false;
   if (
     command === 'plugin:dialog|message' ||
@@ -30,6 +30,8 @@ let mockInvoke: MockInvoke = async (command: string) => {
   return null;
 };
 
+let mockInvoke: MockInvoke = defaultMockInvoke;
+
 (globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
   invoke: (command: string, args?: unknown) => {
     invokeHistory.push({ command, args });
@@ -41,6 +43,11 @@ let mockInvoke: MockInvoke = async (command: string) => {
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
 import { expect, fixture, html } from '@open-wc/testing';
 import '../lv-repository-health-dialog.ts';
+import {
+  tryAcquireMaintenance,
+  releaseMaintenance,
+  resetMaintenanceLocks,
+} from '../../../utils/maintenance-confirms.ts';
 import type { LvRepositoryHealthDialog } from '../lv-repository-health-dialog.ts';
 
 const REPO_PATH = '/test/repo';
@@ -158,5 +165,42 @@ describe('lv-repository-health-dialog deferred close', () => {
     await el.updateComplete;
 
     expect(closed, 'closed once the gc landed').to.equal(1);
+  });
+});
+
+describe('lv-repository-health-dialog maintenance lock', () => {
+  beforeEach(() => {
+    resetMaintenanceLocks();
+    // An earlier suite swaps in a hanging gc mock; restore the default so
+    // these tests are not left waiting on it.
+    mockInvoke = defaultMockInvoke;
+  });
+
+  // gc/prune/fsck have two implementations — this dialog and the command
+  // palette — and only this one tracked concurrency, so a palette run could
+  // start a second maintenance command against the same repo. git's pid lock
+  // catches gc-vs-gc with a raw error; it does not serialise gc-vs-prune.
+  it('refuses to start when the palette already holds the repo', async () => {
+    const el = await render();
+    invokeHistory.length = 0;
+
+    // The palette claims the slot first.
+    expect(tryAcquireMaintenance(REPO_PATH)).to.be.true;
+
+    await internalOf(el).runGc(true);
+
+    expect(findCommands('run_gc'), 'no second gc while one is running').to.have.length(0);
+  });
+
+  it('releases the slot so the next run is allowed', async () => {
+    const el = await render();
+    invokeHistory.length = 0;
+
+    await internalOf(el).runGc(false);
+    expect(findCommands('run_gc')).to.have.length(1);
+
+    // Slot released in the finally, so the palette can claim it afterwards.
+    expect(tryAcquireMaintenance(REPO_PATH), 'slot free after the run').to.be.true;
+    releaseMaintenance(REPO_PATH);
   });
 });

--- a/src/components/dialogs/__tests__/lv-repository-health-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-repository-health-dialog.test.ts
@@ -1,0 +1,113 @@
+/**
+ * Repository Health Dialog — destructive action gating.
+ *
+ * `run_gc` and `run_prune` are reachable from BOTH this dialog and the command
+ * palette. They remove unreachable objects irreversibly, so both surfaces must
+ * gate them behind the same confirmation — a gate on only one surface just
+ * moves the unguarded route rather than closing it.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+const invokeHistory: Array<{ command: string; args?: unknown }> = [];
+/** plugin-dialog's confirm() resolves true only for the OK button label. */
+let confirmResult = true;
+
+const mockInvoke: MockInvoke = async (command: string) => {
+  if (command === 'plugin:notification|is_permission_granted') return false;
+  if (
+    command === 'plugin:dialog|message' ||
+    command === 'plugin:dialog|confirm' ||
+    command === 'plugin:dialog|ask'
+  ) {
+    return confirmResult ? 'Ok' : 'Cancel';
+  }
+  if (command === 'get_repository_health') {
+    return { objectCount: 10, packCount: 1, looseObjectCount: 9, repositorySize: 1024, hasReflog: true };
+  }
+  return null;
+};
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-repository-health-dialog.ts';
+import type { LvRepositoryHealthDialog } from '../lv-repository-health-dialog.ts';
+
+const REPO_PATH = '/test/repo';
+
+function findCommands(name: string): Array<{ command: string; args?: unknown }> {
+  return invokeHistory.filter((h) => h.command === name);
+}
+
+async function render(): Promise<LvRepositoryHealthDialog> {
+  const el = await fixture<LvRepositoryHealthDialog>(html`
+    <lv-repository-health-dialog .repositoryPath=${REPO_PATH} ?open=${true}></lv-repository-health-dialog>
+  `);
+  await el.updateComplete;
+  return el;
+}
+
+interface Internal {
+  runGc: (aggressive: boolean) => Promise<void>;
+  runPrune: () => Promise<void>;
+}
+
+function internalOf(el: LvRepositoryHealthDialog): Internal {
+  return el as unknown as Internal;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+describe('lv-repository-health-dialog destructive actions', () => {
+  beforeEach(() => {
+    invokeHistory.length = 0;
+    confirmResult = true;
+  });
+
+  it('does not run GC when the confirm is declined', async () => {
+    confirmResult = false;
+    const el = await render();
+    invokeHistory.length = 0;
+
+    await internalOf(el).runGc(false);
+
+    expect(findCommands('run_gc')).to.have.length(0);
+  });
+
+  it('runs GC once confirmed', async () => {
+    const el = await render();
+    invokeHistory.length = 0;
+
+    await internalOf(el).runGc(false);
+
+    expect(findCommands('run_gc')).to.have.length(1);
+  });
+
+  it('does not run prune when the confirm is declined', async () => {
+    confirmResult = false;
+    const el = await render();
+    invokeHistory.length = 0;
+
+    await internalOf(el).runPrune();
+
+    expect(findCommands('run_prune')).to.have.length(0);
+  });
+
+  it('runs prune once confirmed', async () => {
+    const el = await render();
+    invokeHistory.length = 0;
+
+    await internalOf(el).runPrune();
+
+    expect(findCommands('run_prune')).to.have.length(1);
+  });
+});

--- a/src/components/dialogs/__tests__/lv-repository-health-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-repository-health-dialog.test.ts
@@ -15,7 +15,7 @@ const invokeHistory: Array<{ command: string; args?: unknown }> = [];
 /** plugin-dialog's confirm() resolves true only for the OK button label. */
 let confirmResult = true;
 
-const mockInvoke: MockInvoke = async (command: string) => {
+let mockInvoke: MockInvoke = async (command: string) => {
   if (command === 'plugin:notification|is_permission_granted') return false;
   if (
     command === 'plugin:dialog|message' ||
@@ -109,5 +109,54 @@ describe('lv-repository-health-dialog destructive actions', () => {
     await internalOf(el).runPrune();
 
     expect(findCommands('run_prune')).to.have.length(1);
+  });
+});
+
+describe('lv-repository-health-dialog deferred close', () => {
+  // Closing this dialog DESTROYS the element, so the host refuses while gc is
+  // in flight. Refusing alone left it open and pinned to a repo whose tab was
+  // gone — and its own guard (!pinnedRepoPath || runningAction) then allowed a
+  // SECOND gc against that repo once the first finished.
+  it('closes immediately when idle', async () => {
+    const el = await render();
+    let closed = 0;
+    el.addEventListener('close', () => { closed++; });
+
+    el.closeWhenIdle();
+
+    expect(closed).to.equal(1);
+  });
+
+  it('defers the close until the running action lands, and blocks new ones', async () => {
+    let resolveGc!: (v: unknown) => void;
+    mockInvoke = async (command: string) => {
+      if (command === 'run_gc') return new Promise((r) => { resolveGc = r; });
+      if (command === 'plugin:dialog|message') return 'Ok';
+      return null;
+    };
+
+    const el = await render();
+    let closed = 0;
+    el.addEventListener('close', () => { closed++; });
+
+    const gc = internalOf(el).runGc(true);
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+    expect(el.isRunning, 'gc in flight').to.be.true;
+
+    el.closeWhenIdle();
+    await el.updateComplete;
+    expect(closed, 'not closed while gc runs').to.equal(0);
+
+    // A second action must be refused while the close is pending.
+    invokeHistory.length = 0;
+    await internalOf(el).runPrune();
+    expect(findCommands('run_prune'), 'no new action once closing').to.have.length(0);
+
+    resolveGc(null);
+    await gc;
+    await el.updateComplete;
+
+    expect(closed, 'closed once the gc landed').to.equal(1);
   });
 });

--- a/src/components/dialogs/lv-bisect-dialog.ts
+++ b/src/components/dialogs/lv-bisect-dialog.ts
@@ -433,11 +433,29 @@ export class LvBisectDialog extends LitElement {
   @state() private message = '';
   @state() private currentCommitInfo: Commit | null = null;
 
+  /**
+   * This dialog renders its own overlay rather than using lv-modal, so it got
+   * no Escape handling at all — the one dialog in the app that Escape could
+   * not dismiss. Worse, app-shell's Escape chain then fell through and closed
+   * the diff behind it while this stayed put.
+   */
+  private handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this.open && !this.loading) {
+      this.handleClose();
+    }
+  };
+
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
+    document.addEventListener('keydown', this.handleKeyDown);
     if (this.open) {
       await this.checkBisectStatus();
     }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener('keydown', this.handleKeyDown);
   }
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
@@ -550,11 +568,14 @@ export class LvBisectDialog extends LitElement {
     // `git bisect start` checks out the midpoint, so HEAD has moved just as
     // surely as it does on good/bad/skip. Without this the graph, branch list
     // and status all keep showing the pre-bisect HEAD.
-    if (result.success) {
-      this.dispatchEvent(
-        new CustomEvent('bisect-step', { detail: { repositoryPath: repoPath } })
-      );
-    }
+    //
+    // Dispatched even on failure, matching good/bad/skip: the command can fail
+    // partway through having already moved HEAD, and the handler only triggers
+    // an idempotent refresh. (bisect-complete is different — it also CLOSES
+    // the dialog, so it stays gated on success or the error is never read.)
+    this.dispatchEvent(
+      new CustomEvent('bisect-step', { detail: { repositoryPath: repoPath } })
+    );
   }
 
   private async handleBad(): Promise<void> {

--- a/src/components/dialogs/lv-bisect-dialog.ts
+++ b/src/components/dialogs/lv-bisect-dialog.ts
@@ -9,6 +9,7 @@ import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import type { BisectStatus, CulpritCommit } from '../../services/git.service.ts';
 import type { Commit } from '../../types/git.types.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 type BisectStep = 'setup' | 'in-progress' | 'complete';
 
@@ -440,7 +441,10 @@ export class LvBisectDialog extends LitElement {
    * the diff behind it while this stayed put.
    */
   private handleKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape' && this.open && !this.loading) {
+    // Only the topmost overlay owns Escape: every dialog listens on
+    // `document`, so without this one keypress ran all of them.
+    if (!this.open || !isTopOverlay(this)) return;
+    if (e.key === 'Escape' && !this.loading) {
       this.handleClose();
     }
   };
@@ -455,10 +459,15 @@ export class LvBisectDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProperties.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     // `repositoryPath` is live-bound to the ACTIVE repository, and repo
     // switching (Ctrl+Tab / Ctrl+1-9) is a document-level shortcut that fires
     // straight through this dialog's own overlay. Without re-reading status on

--- a/src/components/dialogs/lv-bisect-dialog.ts
+++ b/src/components/dialogs/lv-bisect-dialog.ts
@@ -441,16 +441,42 @@ export class LvBisectDialog extends LitElement {
   }
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
-    if (changedProperties.has('open') && this.open) {
+    // `repositoryPath` is live-bound to the ACTIVE repository, and repo
+    // switching (Ctrl+Tab / Ctrl+1-9) is a document-level shortcut that fires
+    // straight through this dialog's own overlay. Without re-reading status on
+    // that change the dialog keeps displaying repo A's session while every
+    // button now targets repo B — "Bad" would mark a commit bad in the repo
+    // the user is not looking at.
+    if (this.open && (changedProperties.has('open') || changedProperties.has('repositoryPath'))) {
+      if (changedProperties.has('repositoryPath')) {
+        this.resetSessionState();
+      }
       await this.checkBisectStatus();
     }
   }
 
+  /** Drop every field describing the previous repository's session. */
+  private resetSessionState(): void {
+    this.step = 'setup';
+    this.status = null;
+    this.culprit = null;
+    this.currentCommitInfo = null;
+    this.badCommitInput = '';
+    this.goodCommitInput = '';
+    this.message = '';
+    this.error = '';
+  }
+
   private async checkBisectStatus(): Promise<void> {
+    const loadedPath = this.repositoryPath;
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.getBisectStatus(this.repositoryPath);
+    const result = await gitService.getBisectStatus(loadedPath);
+
+    // The tab may have switched while the fetch was in flight; a stale result
+    // must not be painted over the now-active repository's session.
+    if (this.repositoryPath !== loadedPath) return;
 
     if (result.success && result.data) {
       this.status = result.data;
@@ -468,11 +494,14 @@ export class LvBisectDialog extends LitElement {
       this.error = result.error?.message || 'Failed to get bisect status';
     }
 
+    if (this.repositoryPath !== loadedPath) return;
     this.loading = false;
   }
 
   private async fetchCurrentCommitInfo(oid: string): Promise<void> {
-    const result = await gitService.getCommit(this.repositoryPath, oid);
+    const loadedPath = this.repositoryPath;
+    const result = await gitService.getCommit(loadedPath, oid);
+    if (this.repositoryPath !== loadedPath) return;
     if (result.success && result.data) {
       this.currentCommitInfo = result.data;
     } else {
@@ -488,121 +517,162 @@ export class LvBisectDialog extends LitElement {
       return;
     }
 
+    const repoPath = this.repositoryPath;
     this.loading = true;
     this.error = '';
 
     const result = await gitService.bisectStart(
-      this.repositoryPath,
+      repoPath,
       this.badCommitInput,
       this.goodCommitInput
     );
 
-    if (result.success && result.data) {
-      this.status = result.data.status;
-      this.message = result.data.message;
+    if (this.repositoryPath === repoPath) {
+      if (result.success && result.data) {
+        this.status = result.data.status;
+        this.message = result.data.message;
 
-      if (result.data.status.active) {
-        this.step = 'in-progress';
-        if (result.data.status.currentCommit) {
-          await this.fetchCurrentCommitInfo(result.data.status.currentCommit);
+        if (result.data.status.active) {
+          this.step = 'in-progress';
+          if (result.data.status.currentCommit) {
+            await this.fetchCurrentCommitInfo(result.data.status.currentCommit);
+          }
         }
+      } else {
+        this.error = result.error?.message || 'Failed to start bisect';
       }
-    } else {
-      this.error = result.error?.message || 'Failed to start bisect';
+
+      if (this.repositoryPath === repoPath) {
+        this.loading = false;
+      }
     }
 
-    this.loading = false;
+    // `git bisect start` checks out the midpoint, so HEAD has moved just as
+    // surely as it does on good/bad/skip. Without this the graph, branch list
+    // and status all keep showing the pre-bisect HEAD.
+    if (result.success) {
+      this.dispatchEvent(
+        new CustomEvent('bisect-step', { detail: { repositoryPath: repoPath } })
+      );
+    }
   }
 
   private async handleBad(): Promise<void> {
+    const repoPath = this.repositoryPath;
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.bisectBad(this.repositoryPath);
+    const result = await gitService.bisectBad(repoPath);
 
-    if (result.success && result.data) {
-      this.status = result.data.status;
-      this.message = result.data.message;
+    if (this.repositoryPath === repoPath) {
+      if (result.success && result.data) {
+        this.status = result.data.status;
+        this.message = result.data.message;
 
-      if (result.data.culprit) {
-        this.culprit = result.data.culprit;
-        this.step = 'complete';
-      } else if (result.data.status.currentCommit) {
-        await this.fetchCurrentCommitInfo(result.data.status.currentCommit);
+        if (result.data.culprit) {
+          this.culprit = result.data.culprit;
+          this.step = 'complete';
+        } else if (result.data.status.currentCommit) {
+          await this.fetchCurrentCommitInfo(result.data.status.currentCommit);
+        }
+      } else {
+        this.error = result.error?.message || 'Failed to mark as bad';
       }
-    } else {
-      this.error = result.error?.message || 'Failed to mark as bad';
+
+      if (this.repositoryPath === repoPath) {
+        this.loading = false;
+      }
     }
 
-    this.loading = false;
-    this.dispatchEvent(new CustomEvent('bisect-step'));
+    this.dispatchEvent(
+      new CustomEvent('bisect-step', { detail: { repositoryPath: repoPath } })
+    );
   }
 
   private async handleGood(): Promise<void> {
+    const repoPath = this.repositoryPath;
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.bisectGood(this.repositoryPath);
+    const result = await gitService.bisectGood(repoPath);
 
-    if (result.success && result.data) {
-      this.status = result.data.status;
-      this.message = result.data.message;
+    if (this.repositoryPath === repoPath) {
+      if (result.success && result.data) {
+        this.status = result.data.status;
+        this.message = result.data.message;
 
-      if (result.data.culprit) {
-        this.culprit = result.data.culprit;
-        this.step = 'complete';
-      } else if (result.data.status.currentCommit) {
-        await this.fetchCurrentCommitInfo(result.data.status.currentCommit);
+        if (result.data.culprit) {
+          this.culprit = result.data.culprit;
+          this.step = 'complete';
+        } else if (result.data.status.currentCommit) {
+          await this.fetchCurrentCommitInfo(result.data.status.currentCommit);
+        }
+      } else {
+        this.error = result.error?.message || 'Failed to mark as good';
       }
-    } else {
-      this.error = result.error?.message || 'Failed to mark as good';
+
+      if (this.repositoryPath === repoPath) {
+        this.loading = false;
+      }
     }
 
-    this.loading = false;
-    this.dispatchEvent(new CustomEvent('bisect-step'));
+    this.dispatchEvent(
+      new CustomEvent('bisect-step', { detail: { repositoryPath: repoPath } })
+    );
   }
 
   private async handleSkip(): Promise<void> {
+    const repoPath = this.repositoryPath;
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.bisectSkip(this.repositoryPath);
+    const result = await gitService.bisectSkip(repoPath);
 
-    if (result.success && result.data) {
-      this.status = result.data.status;
-      this.message = result.data.message;
+    if (this.repositoryPath === repoPath) {
+      if (result.success && result.data) {
+        this.status = result.data.status;
+        this.message = result.data.message;
 
-      if (result.data.status.currentCommit) {
-        await this.fetchCurrentCommitInfo(result.data.status.currentCommit);
+        if (result.data.status.currentCommit) {
+          await this.fetchCurrentCommitInfo(result.data.status.currentCommit);
+        }
+      } else {
+        this.error = result.error?.message || 'Failed to skip commit';
       }
-    } else {
-      this.error = result.error?.message || 'Failed to skip commit';
+
+      if (this.repositoryPath === repoPath) {
+        this.loading = false;
+      }
     }
 
-    this.loading = false;
-    this.dispatchEvent(new CustomEvent('bisect-step'));
+    this.dispatchEvent(
+      new CustomEvent('bisect-step', { detail: { repositoryPath: repoPath } })
+    );
   }
 
   private async handleReset(): Promise<void> {
+    const repoPath = this.repositoryPath;
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.bisectReset(this.repositoryPath);
+    const result = await gitService.bisectReset(repoPath);
 
-    if (result.success) {
-      this.step = 'setup';
-      this.status = null;
-      this.culprit = null;
-      this.currentCommitInfo = null;
-      this.badCommitInput = '';
-      this.goodCommitInput = '';
-      this.message = '';
-      this.dispatchEvent(new CustomEvent('bisect-complete'));
-    } else {
-      this.error = result.error?.message || 'Failed to reset bisect';
+    if (this.repositoryPath === repoPath) {
+      if (result.success) {
+        this.resetSessionState();
+      } else {
+        this.error = result.error?.message || 'Failed to reset bisect';
+      }
+      this.loading = false;
     }
 
-    this.loading = false;
+    // `git bisect reset` checks the original HEAD back out, so the refresh has
+    // to land on the repo the reset ran against, not whichever tab is active.
+    if (result.success) {
+      this.dispatchEvent(
+        new CustomEvent('bisect-complete', { detail: { repositoryPath: repoPath } })
+      );
+    }
   }
 
   private handleClose(): void {

--- a/src/components/dialogs/lv-branch-cleanup-dialog.ts
+++ b/src/components/dialogs/lv-branch-cleanup-dialog.ts
@@ -424,31 +424,46 @@ export class LvBranchCleanupDialog extends LitElement {
   }
 
   private assessRisk(candidate: CleanupCandidate): { risk: RiskLevel; riskReason: string } {
-    const ahead = candidate.aheadBehind?.ahead ?? 0;
-
-    if (ahead === 0) {
-      return { risk: 'safe', riskReason: 'Fully merged into current branch' };
+    // `aheadBehind` is null when the backend could not measure divergence at
+    // all — a branch that neither tracks an upstream nor is "gone". Coercing
+    // that to 0 would claim "fully merged" about a branch whose unmerged work
+    // is simply unknown, which is a false safety claim in the unsafe direction:
+    // it also clears the confirm gate in handleDelete. Unknown is a warning.
+    if (!candidate.aheadBehind) {
+      return {
+        risk: 'warning',
+        riskReason: candidate.upstream
+          ? 'Unpushed work unknown — no upstream comparison available'
+          : 'No upstream configured — may contain unmerged work',
+      };
     }
 
-    if (candidate.category === 'gone' && ahead > 0) {
+    const ahead = candidate.aheadBehind.ahead;
+
+    if (ahead === 0) {
+      // A 'gone' branch is measured against HEAD (its upstream is gone), so
+      // ahead === 0 genuinely means merged; anything else is measured against
+      // its upstream, where it means nothing left to push.
+      return {
+        risk: 'safe',
+        riskReason:
+          candidate.category === 'gone'
+            ? 'Fully merged into current branch'
+            : 'No unpushed work',
+      };
+    }
+
+    if (candidate.category === 'gone') {
       return {
         risk: 'danger',
         riskReason: `Remote deleted with ${ahead} unpushed commit${ahead !== 1 ? 's' : ''}`,
       };
     }
 
-    if (ahead > 0) {
-      return {
-        risk: 'warning',
-        riskReason: `Has ${ahead} unpushed commit${ahead !== 1 ? 's' : ''}`,
-      };
-    }
-
-    if (!candidate.upstream) {
-      return { risk: 'warning', riskReason: 'No upstream configured' };
-    }
-
-    return { risk: 'safe', riskReason: 'No unpushed work' };
+    return {
+      risk: 'warning',
+      riskReason: `Has ${ahead} unpushed commit${ahead !== 1 ? 's' : ''}`,
+    };
   }
 
   private isBuiltinProtected(name: string): boolean {
@@ -564,6 +579,7 @@ export class LvBranchCleanupDialog extends LitElement {
     this.deleting = true;
     let deleted = 0;
     let failed = 0;
+    const failures: string[] = [];
 
     // Pinned at open(): these irreversible force-deletes and the remote prune
     // must target the repo the cleanup was invoked on, even if the user
@@ -578,6 +594,9 @@ export class LvBranchCleanupDialog extends LitElement {
         deleted++;
       } else {
         failed++;
+        // Keep the reason: a bare "Failed to delete N branches" leaves the user
+        // with no idea why and no way forward.
+        failures.push(`${cb.branch.name}: ${result.error?.message ?? 'unknown error'}`);
         console.error(`Failed to delete ${cb.branch.name}:`, result.error);
       }
     }
@@ -611,7 +630,10 @@ export class LvBranchCleanupDialog extends LitElement {
       );
       this.close();
     } else if (failed > 0) {
-      showToast(`Failed to delete ${failed} branch${failed !== 1 ? 'es' : ''}`, 'error');
+      showToast(
+        `Failed to delete ${failed} branch${failed !== 1 ? 'es' : ''} — ${failures.join('; ')}`,
+        'error'
+      );
     }
   }
 

--- a/src/components/dialogs/lv-branch-cleanup-dialog.ts
+++ b/src/components/dialogs/lv-branch-cleanup-dialog.ts
@@ -351,6 +351,23 @@ export class LvBranchCleanupDialog extends LitElement {
       const stale: CleanupBranch[] = [];
       const gone: CleanupBranch[] = [];
 
+      // Group by branch name FIRST. The backend emits the same branch once per
+      // category it qualifies for (merged AND stale is common for an old
+      // finished feature branch), but risk is a property of the BRANCH, not of
+      // the tab it happens to be listed under. Assessing each entry separately
+      // gave one branch two different badges — green on Merged, amber on Stale
+      // — and let the delete gate fire on a label the deletion path had already
+      // deduplicated away.
+      const byName = new Map<string, CleanupCandidate[]>();
+      for (const candidate of result.data) {
+        const group = byName.get(candidate.name);
+        if (group) {
+          group.push(candidate);
+        } else {
+          byName.set(candidate.name, [candidate]);
+        }
+      }
+
       for (const candidate of result.data) {
         const branch: Branch = {
           name: candidate.name,
@@ -366,7 +383,7 @@ export class LvBranchCleanupDialog extends LitElement {
 
         const isProtected = candidate.isProtected || this.isBuiltinProtected(candidate.name);
         const protectedReason = isProtected ? this.getProtectedReason(candidate) : undefined;
-        const risk = this.assessRisk(candidate);
+        const risk = this.assessRisk(byName.get(candidate.name) ?? [candidate]);
 
         const entry: CleanupBranch = {
           branch,
@@ -423,20 +440,33 @@ export class LvBranchCleanupDialog extends LitElement {
     }
   }
 
-  private assessRisk(candidate: CleanupCandidate): { risk: RiskLevel; riskReason: string } {
-    // `aheadBehind` is null when the backend could not measure divergence at
-    // all — a branch that neither tracks an upstream nor is "gone". Coercing
-    // that to 0 would claim "fully merged" about a branch whose unmerged work
-    // is simply unknown, which is a false safety claim in the unsafe direction:
-    // it also clears the confirm gate in handleDelete. Unknown is a warning.
+  /**
+   * Canonical risk for a branch, computed from EVERY category the backend
+   * listed it under.
+   *
+   * Takes the whole group rather than one entry because the backend emits a
+   * branch once per qualifying category, and risk belongs to the branch: a
+   * branch that is both merged and stale is still merged, and deleting it
+   * loses nothing.
+   */
+  private assessRisk(group: CleanupCandidate[]): { risk: RiskLevel; riskReason: string } {
+    // The backend proved this merged — HEAD descends from its tip, or the two
+    // are equal (branch_cleanup.rs). Every commit on it is therefore reachable
+    // from HEAD and deleting the ref loses nothing. That proof outranks any
+    // upstream comparison, measured or missing: `ahead` counts distance from
+    // the UPSTREAM, which says nothing about whether local deletion loses work.
+    if (group.some((c) => c.category === 'merged')) {
+      return { risk: 'safe', riskReason: 'Fully merged into current branch' };
+    }
+
+    // Prefer an entry that actually carries a measurement; the categories a
+    // branch appears in do not all populate aheadBehind.
+    const candidate = group.find((c) => c.aheadBehind) ?? group[0];
+
+    // aheadBehind is null when divergence could not be measured at all — a
+    // branch that neither tracks an upstream nor is "gone". Coercing that to 0
+    // would claim "fully merged" about work we simply cannot see.
     if (!candidate.aheadBehind) {
-      // The backend independently proved this branch merged (graph_descendant_of
-      // / tip equality, branch_cleanup.rs) to put it in the 'merged' category.
-      // That is a stronger signal than the missing upstream comparison, so
-      // trust it rather than warning about work we know is already merged.
-      if (candidate.category === 'merged') {
-        return { risk: 'safe', riskReason: 'Fully merged into current branch' };
-      }
       return {
         risk: 'warning',
         riskReason: candidate.upstream
@@ -446,21 +476,19 @@ export class LvBranchCleanupDialog extends LitElement {
     }
 
     const ahead = candidate.aheadBehind.ahead;
+    const isGone = group.some((c) => c.category === 'gone');
 
     if (ahead === 0) {
       // A 'gone' branch is measured against HEAD (its upstream is gone), so
-      // ahead === 0 genuinely means merged; anything else is measured against
-      // its upstream, where it means nothing left to push.
+      // ahead === 0 genuinely means merged; otherwise it is measured against
+      // the upstream, where it means nothing left to push.
       return {
         risk: 'safe',
-        riskReason:
-          candidate.category === 'gone'
-            ? 'Fully merged into current branch'
-            : 'No unpushed work',
+        riskReason: isGone ? 'Fully merged into current branch' : 'No unpushed work',
       };
     }
 
-    if (candidate.category === 'gone') {
+    if (isGone) {
       return {
         risk: 'danger',
         riskReason: `Remote deleted with ${ahead} unpushed commit${ahead !== 1 ? 's' : ''}`,
@@ -537,51 +565,50 @@ export class LvBranchCleanupDialog extends LitElement {
     return this.selectedBranches.size;
   }
 
-  private get hasWarningOrDanger(): boolean {
-    const allBranches = [
-      ...this.mergedBranches,
-      ...this.staleBranches,
-      ...this.goneUpstreamBranches,
-    ];
-    return allBranches.some(
-      (cb) =>
-        this.selectedBranches.has(cb.branch.name) &&
-        (cb.risk === 'warning' || cb.risk === 'danger'),
-    );
-  }
-
-  private async handleDelete(): Promise<void> {
-    if (this.totalSelected === 0) return;
-
-    // Build list of selected branches with their categories
+  /**
+   * The selected branches, one entry per branch.
+   *
+   * Single source of truth for the delete flow: the confirm gate, the confirm
+   * text, and the force flag are all derived from THIS list. Deriving the gate
+   * from the un-deduplicated union while the message used the deduplicated set
+   * let them disagree, producing a confirm with an empty clause.
+   */
+  private selectedForDeletion(): CleanupBranch[] {
     const allBranches = [
       ...this.mergedBranches,
       ...this.staleBranches,
       ...this.goneUpstreamBranches,
     ];
 
-    // Deduplicate (a branch could appear in both stale and gone)
     const selectedMap = new Map<string, CleanupBranch>();
     for (const cb of allBranches) {
       if (this.selectedBranches.has(cb.branch.name) && !selectedMap.has(cb.branch.name)) {
         selectedMap.set(cb.branch.name, cb);
       }
     }
+    return Array.from(selectedMap.values());
+  }
 
-    const toDelete = Array.from(selectedMap.values());
+  private async handleDelete(): Promise<void> {
+    if (this.totalSelected === 0) return;
 
-    // Confirm if any are warning/danger. Distinguish MEASURED unpushed commits
-    // from unmeasurable divergence — claiming "has unpushed commits" about a
-    // branch we could not compare is the same false-precision the risk badge
-    // used to have, just in the other direction.
-    if (this.hasWarningOrDanger) {
-      const risky = toDelete.filter((cb) => cb.risk === 'warning' || cb.risk === 'danger');
+    const toDelete = this.selectedForDeletion();
+
+    // Gate on the SAME deduplicated list the message and the deletes use.
+    // Distinguish MEASURED unpushed commits from unmeasurable divergence —
+    // claiming "has unpushed commits" about a branch we could not compare is
+    // the same false precision the risk badge used to have, reversed.
+    const risky = toDelete.filter((cb) => cb.risk === 'warning' || cb.risk === 'danger');
+
+    if (risky.length > 0) {
       const unpushed = risky.filter((cb) => (cb.branch.aheadBehind?.ahead ?? 0) > 0).length;
       const unknown = risky.length - unpushed;
 
       const parts: string[] = [];
       if (unpushed > 0) {
-        parts.push(`${unpushed} have unpushed commits that will be lost`);
+        parts.push(
+          `${unpushed} ${unpushed === 1 ? 'has' : 'have'} unpushed commits that will be lost`,
+        );
       }
       if (unknown > 0) {
         parts.push(
@@ -607,6 +634,12 @@ export class LvBranchCleanupDialog extends LitElement {
     // switches tabs during the confirm or across the delete loop's awaits
     // (which rebinds the live repositoryPath prop).
     const repoPath = this.pinnedRepoPath;
+    // Branches the backend refused as unmerged. Force was withheld because we
+    // could not measure their divergence, so the refusal is the SAFE outcome —
+    // but leaving it there strands the user with an error telling them to force
+    // and no way to do it. Collect them and offer one escalation below.
+    const unmergedRefusals: CleanupBranch[] = [];
+
     for (const cb of toDelete) {
       // Force only when we have MEASURED unpushed commits. Deriving this from
       // the risk label instead would mean any branch labelled 'warning' — including
@@ -618,12 +651,44 @@ export class LvBranchCleanupDialog extends LitElement {
       const result = await gitService.deleteBranch(repoPath, cb.branch.name, force);
       if (result.success) {
         deleted++;
+      } else if (!force && /not fully merged/i.test(result.error?.message ?? '')) {
+        unmergedRefusals.push(cb);
       } else {
         failed++;
         // Keep the reason: a bare "Failed to delete N branches" leaves the user
         // with no idea why and no way forward.
         failures.push(`${cb.branch.name}: ${result.error?.message ?? 'unknown error'}`);
         console.error(`Failed to delete ${cb.branch.name}:`, result.error);
+      }
+    }
+
+    // Escalation, mirroring the sidebar's force path (lv-branch-list.ts): the
+    // user already confirmed the delete, so ask once about the subset git
+    // refused rather than reporting a failure they cannot act on.
+    if (unmergedRefusals.length > 0) {
+      const names = unmergedRefusals.map((cb) => cb.branch.name).join(', ');
+      const forceConfirmed = await showConfirm(
+        'Branches Not Fully Merged',
+        `${unmergedRefusals.length} branch${unmergedRefusals.length !== 1 ? 'es' : ''} ` +
+          `(${names}) ${unmergedRefusals.length === 1 ? 'is' : 'are'} not fully merged, so ` +
+          `deleting ${unmergedRefusals.length === 1 ? 'it' : 'them'} discards commits that ` +
+          `exist nowhere else. Force delete anyway?`,
+        'warning',
+      );
+
+      for (const cb of unmergedRefusals) {
+        if (!forceConfirmed) {
+          failed++;
+          failures.push(`${cb.branch.name}: not fully merged (kept)`);
+          continue;
+        }
+        const retry = await gitService.deleteBranch(repoPath, cb.branch.name, true);
+        if (retry.success) {
+          deleted++;
+        } else {
+          failed++;
+          failures.push(`${cb.branch.name}: ${retry.error?.message ?? 'unknown error'}`);
+        }
       }
     }
 

--- a/src/components/dialogs/lv-branch-cleanup-dialog.ts
+++ b/src/components/dialogs/lv-branch-cleanup-dialog.ts
@@ -337,7 +337,7 @@ export class LvBranchCleanupDialog extends LitElement {
     this.pruneRemotes = true;
   }
 
-  private async loadCleanupData(): Promise<void> {
+  private async loadCleanupData(preserveSelection = false): Promise<void> {
     this.loading = true;
 
     try {
@@ -416,18 +416,34 @@ export class LvBranchCleanupDialog extends LitElement {
       this.staleBranches = stale;
       this.goneUpstreamBranches = gone;
 
-      // Auto-select safe branches in merged and gone categories
-      for (const cb of this.mergedBranches) {
-        if (!cb.isProtected && cb.risk === 'safe') {
-          this.selectedBranches.add(cb.branch.name);
+      if (preserveSelection) {
+        // Reload of an ALREADY-OPEN dialog. Auto-select must not run: it only
+        // ever adds, so it would silently re-check a branch the user
+        // deliberately unchecked, and the next Delete would remove it without
+        // a confirm (safe branches skip the risky-branch gate). Keep exactly
+        // what the user chose, minus anything no longer listed.
+        const stillListed = new Set(
+          [...this.mergedBranches, ...this.staleBranches, ...this.goneUpstreamBranches].map(
+            (cb) => cb.branch.name,
+          ),
+        );
+        this.selectedBranches = new Set(
+          [...this.selectedBranches].filter((name) => stillListed.has(name)),
+        );
+      } else {
+        // Auto-select safe branches in merged and gone categories
+        for (const cb of this.mergedBranches) {
+          if (!cb.isProtected && cb.risk === 'safe') {
+            this.selectedBranches.add(cb.branch.name);
+          }
         }
-      }
-      for (const cb of this.goneUpstreamBranches) {
-        if (!cb.isProtected && cb.risk === 'safe') {
-          this.selectedBranches.add(cb.branch.name);
+        for (const cb of this.goneUpstreamBranches) {
+          if (!cb.isProtected && cb.risk === 'safe') {
+            this.selectedBranches.add(cb.branch.name);
+          }
         }
+        // Don't auto-select stale branches (they require more deliberate action)
       }
-      // Don't auto-select stale branches (they require more deliberate action)
 
       // Select the first non-empty tab
       if (this.mergedBranches.length > 0) {
@@ -566,7 +582,10 @@ export class LvBranchCleanupDialog extends LitElement {
   }
 
   private get totalSelected(): number {
-    return this.selectedBranches.size;
+    // Derived from the branches actually listed, not the raw Set: after a
+    // reload the Set can hold names that are no longer candidates, and a
+    // Delete click on those would run an empty loop and report nothing.
+    return this.selectedForDeletion().length;
   }
 
   /**
@@ -712,7 +731,14 @@ export class LvBranchCleanupDialog extends LitElement {
       const anyWithoutRemoteCopy = unmergedRefusals.some(
         (cb) => !cb.branch.upstream || !cb.branch.aheadBehind || cb.branch.aheadBehind.ahead > 0,
       );
-      const forceConfirmed = await showConfirm(
+      // showConfirm is the only throw source inside the `deleting` window
+      // (invokeCommand never throws). An unhandled rejection here would unwind
+      // with `deleting` stuck true, and since open() refuses to re-show the
+      // dialog while that is set, Branch Cleanup would be dead for the rest of
+      // the session with no error anywhere. Treat a failed prompt as declined.
+      let forceConfirmed = false;
+      try {
+        forceConfirmed = await showConfirm(
         'Branches Not Fully Merged',
         `${unmergedRefusals.length} branch${plural ? 'es' : ''} (${names}) ` +
           `${plural ? 'are' : 'is'} not merged into the current branch.\n\n` +
@@ -723,7 +749,10 @@ export class LvBranchCleanupDialog extends LitElement {
               `from the remote.`) +
           `\n\nForce delete anyway?`,
         'warning',
-      );
+        );
+      } catch {
+        forceConfirmed = false;
+      }
 
       for (const cb of unmergedRefusals) {
         if (!forceConfirmed) {
@@ -751,7 +780,10 @@ export class LvBranchCleanupDialog extends LitElement {
     let pruned = false;
     if (this.pruneRemotes) {
       const pruneResult = await gitService.pruneRemoteTrackingBranches(repoPath);
-      pruned = pruneResult.success;
+      // Ok with an empty list means there was nothing to prune — reporting
+      // "remotes pruned" for that overstates, and it forced a reload after
+      // every zero-delete attempt.
+      pruned = pruneResult.success && (pruneResult.data?.branchesPruned.length ?? 0) > 0;
       if (!pruneResult.success) {
         showToast(
           `Failed to prune remote branches: ${pruneResult.error?.message ?? 'Unknown error'}`,
@@ -802,15 +834,22 @@ export class LvBranchCleanupDialog extends LitElement {
     // has since changed — either way the list on screen is no longer what the
     // next Delete click would act on.
     if (pruned || failed > 0) {
-      await this.loadCleanupData();
+      await this.loadCleanupData(true);
     }
   }
 
   private handleModalClose(): void {
-    this.isOpen = false;
-    if (!this.deleting) {
-      this.reset();
+    // Cancel is disabled while deleting; Escape, the overlay and the × must
+    // honour the same rule. Dismissing mid-loop left it force-deleting and
+    // pruning with no visible surface, and open() now refuses to re-show the
+    // dialog while `deleting`, so the user could not get back to it.
+    if (this.deleting) {
+      this.modal.open = true;
+      return;
     }
+
+    this.isOpen = false;
+    this.reset();
   }
 
   private formatTimeAgo(timestamp: number): string {
@@ -976,7 +1015,7 @@ export class LvBranchCleanupDialog extends LitElement {
               <button
                 class="btn btn-danger"
                 @click=${this.handleDelete}
-                ?disabled=${this.totalSelected === 0 || this.deleting}
+                ?disabled=${this.totalSelected === 0 || this.deleting || this.loading}
               >
                 ${this.deleting
                   ? 'Deleting...'

--- a/src/components/dialogs/lv-branch-cleanup-dialog.ts
+++ b/src/components/dialogs/lv-branch-cleanup-dialog.ts
@@ -430,6 +430,13 @@ export class LvBranchCleanupDialog extends LitElement {
     // is simply unknown, which is a false safety claim in the unsafe direction:
     // it also clears the confirm gate in handleDelete. Unknown is a warning.
     if (!candidate.aheadBehind) {
+      // The backend independently proved this branch merged (graph_descendant_of
+      // / tip equality, branch_cleanup.rs) to put it in the 'merged' category.
+      // That is a stronger signal than the missing upstream comparison, so
+      // trust it rather than warning about work we know is already merged.
+      if (candidate.category === 'merged') {
+        return { risk: 'safe', riskReason: 'Fully merged into current branch' };
+      }
       return {
         risk: 'warning',
         riskReason: candidate.upstream
@@ -563,14 +570,28 @@ export class LvBranchCleanupDialog extends LitElement {
 
     const toDelete = Array.from(selectedMap.values());
 
-    // Confirm if any are warning/danger
+    // Confirm if any are warning/danger. Distinguish MEASURED unpushed commits
+    // from unmeasurable divergence — claiming "has unpushed commits" about a
+    // branch we could not compare is the same false-precision the risk badge
+    // used to have, just in the other direction.
     if (this.hasWarningOrDanger) {
-      const dangerCount = toDelete.filter(
-        (cb) => cb.risk === 'warning' || cb.risk === 'danger',
-      ).length;
+      const risky = toDelete.filter((cb) => cb.risk === 'warning' || cb.risk === 'danger');
+      const unpushed = risky.filter((cb) => (cb.branch.aheadBehind?.ahead ?? 0) > 0).length;
+      const unknown = risky.length - unpushed;
+
+      const parts: string[] = [];
+      if (unpushed > 0) {
+        parts.push(`${unpushed} have unpushed commits that will be lost`);
+      }
+      if (unknown > 0) {
+        parts.push(
+          `${unknown} could not be checked for unmerged work (no upstream to compare against)`,
+        );
+      }
+
       const confirmed = await showConfirm(
         'Delete Branches with Unpushed Work?',
-        `${dangerCount} of the selected branches have unpushed commits that may be lost.\n\nThis action cannot be undone. Continue?`,
+        `Of the selected branches, ${parts.join(', and ')}.\n\nThis action cannot be undone. Continue?`,
         'warning',
       );
       if (!confirmed) return;
@@ -587,8 +608,13 @@ export class LvBranchCleanupDialog extends LitElement {
     // (which rebinds the live repositoryPath prop).
     const repoPath = this.pinnedRepoPath;
     for (const cb of toDelete) {
-      // Use force delete for warning/danger branches (not fully merged)
-      const force = cb.risk === 'warning' || cb.risk === 'danger';
+      // Force only when we have MEASURED unpushed commits. Deriving this from
+      // the risk label instead would mean any branch labelled 'warning' — including
+      // one labelled that way precisely BECAUSE its divergence could not be
+      // measured — bypasses delete_branch's merged-check (branch.rs), turning a
+      // safe refusal into permanent commit loss. Unknown divergence must fall
+      // through to the backend and let it refuse.
+      const force = cb.risk === 'danger' || (cb.branch.aheadBehind?.ahead ?? 0) > 0;
       const result = await gitService.deleteBranch(repoPath, cb.branch.name, force);
       if (result.success) {
         deleted++;

--- a/src/components/dialogs/lv-branch-cleanup-dialog.ts
+++ b/src/components/dialogs/lv-branch-cleanup-dialog.ts
@@ -445,13 +445,18 @@ export class LvBranchCleanupDialog extends LitElement {
         // Don't auto-select stale branches (they require more deliberate action)
       }
 
-      // Select the first non-empty tab
-      if (this.mergedBranches.length > 0) {
-        this.activeTab = 'merged';
-      } else if (this.staleBranches.length > 0) {
-        this.activeTab = 'stale';
-      } else if (this.goneUpstreamBranches.length > 0) {
-        this.activeTab = 'gone';
+      // Select the first non-empty tab — only on a fresh open(). On a reload
+      // the user is mid-task on a tab they chose; snapping back to 'merged'
+      // showed them an empty selection while the footer still counted it, and
+      // the next Delete would act on branches they could not see.
+      if (!preserveSelection) {
+        if (this.mergedBranches.length > 0) {
+          this.activeTab = 'merged';
+        } else if (this.staleBranches.length > 0) {
+          this.activeTab = 'stale';
+        } else if (this.goneUpstreamBranches.length > 0) {
+          this.activeTab = 'gone';
+        }
       }
 
       this.requestUpdate();

--- a/src/components/dialogs/lv-branch-cleanup-dialog.ts
+++ b/src/components/dialogs/lv-branch-cleanup-dialog.ts
@@ -307,6 +307,13 @@ export class LvBranchCleanupDialog extends LitElement {
   @query('lv-modal') private modal!: LvModal;
 
   public async open(): Promise<void> {
+    // Re-entry while a delete loop is running would reset() away `deleting`
+    // (re-enabling the Delete button mid-flight, so a second concurrent loop
+    // can start), clear the selection, and re-pin pinnedRepoPath from the live
+    // prop. The command palette can dispatch open-branch-cleanup over the open
+    // modal, so this is reachable.
+    if (this.deleting) return;
+
     this.reset();
     this.pinnedRepoPath = this.repositoryPath;
     this.isOpen = true;
@@ -688,6 +695,16 @@ export class LvBranchCleanupDialog extends LitElement {
           if (!upstream) {
             return `${cb.branch.name} (no remote copy)`;
           }
+          // Measured and non-zero: say how much is at risk rather than
+          // falling through to "unknown", which understates a loss we can
+          // quantify. Reachable when the Safe label went stale (e.g. an
+          // external reset while this modal sat open) and the backend then
+          // refused the delete — exactly the case the withheld force exists
+          // to catch.
+          if (aheadBehind && aheadBehind.ahead > 0) {
+            const n = aheadBehind.ahead;
+            return `${cb.branch.name} (${n} commit${n === 1 ? '' : 's'} not on ${upstream})`;
+          }
           return `${cb.branch.name} (unpushed work unknown)`;
         })
         .join(', ');
@@ -774,10 +791,18 @@ export class LvBranchCleanupDialog extends LitElement {
       );
     }
 
-    // Only close when something was actually deleted; otherwise leave the
-    // dialog up so the user can act on what is still listed.
     if (deleted > 0) {
       this.close();
+      return;
+    }
+
+    // The dialog stays open, so refresh what it shows. A successful prune
+    // removes remote-tracking refs that the risk badges and the Gone Upstream
+    // tab are derived from, and a failure may have been caused by state that
+    // has since changed — either way the list on screen is no longer what the
+    // next Delete click would act on.
+    if (pruned || failed > 0) {
+      await this.loadCleanupData();
     }
   }
 

--- a/src/components/dialogs/lv-branch-cleanup-dialog.ts
+++ b/src/components/dialogs/lv-branch-cleanup-dialog.ts
@@ -296,6 +296,8 @@ export class LvBranchCleanupDialog extends LitElement {
   }
 
   @state() private loading = true;
+  /** The candidate scan failed — render that, not "nothing to clean up". */
+  @state() private loadFailed = false;
   @state() private mergedBranches: CleanupBranch[] = [];
   @state() private staleBranches: CleanupBranch[] = [];
   @state() private goneUpstreamBranches: CleanupBranch[] = [];
@@ -349,9 +351,16 @@ export class LvBranchCleanupDialog extends LitElement {
 
       if (!result.success || !result.data) {
         showToast('Failed to load cleanup candidates', 'error');
+        // Distinct from "no candidates": leaving the three lists empty made
+        // every tab assert "No merged branches found", i.e. claim there is
+        // nothing to clean up when the scan simply could not tell us. The
+        // sidebar badge stopped telling that lie; the surface it opens must
+        // not repeat it.
+        this.loadFailed = true;
         this.loading = false;
         return;
       }
+      this.loadFailed = false;
 
       // Build CleanupBranch entries from backend candidates
       const merged: CleanupBranch[] = [];
@@ -936,6 +945,22 @@ export class LvBranchCleanupDialog extends LitElement {
   }
 
   private renderBranchList(branches: CleanupBranch[]) {
+    if (this.loadFailed) {
+      return html`
+        <div class="empty-state">
+          <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+            <circle cx="12" cy="12" r="10"></circle>
+            <line x1="12" y1="8" x2="12" y2="12"></line>
+            <line x1="12" y1="16" x2="12.01" y2="16"></line>
+          </svg>
+          <span>Could not load cleanup candidates</span>
+          <button class="btn btn-secondary" @click=${() => void this.loadCleanupData()}>
+            Retry
+          </button>
+        </div>
+      `;
+    }
+
     if (branches.length === 0) {
       const messages: Record<CleanupTab, string> = {
         merged: 'No merged branches found',

--- a/src/components/dialogs/lv-branch-cleanup-dialog.ts
+++ b/src/components/dialogs/lv-branch-cleanup-dialog.ts
@@ -671,27 +671,40 @@ export class LvBranchCleanupDialog extends LitElement {
     // user already confirmed the delete, so ask once about the subset git
     // refused rather than reporting a failure they cannot act on.
     if (unmergedRefusals.length > 0) {
-      // Name each branch's actual exposure. "not fully merged" is measured
+      // State each branch's ACTUAL exposure. "not fully merged" is measured
       // against HEAD, while the Safe/Warning badge is measured against the
-      // UPSTREAM — so a branch can be refused here while its commits sit safely
-      // on its remote. Claiming they "exist nowhere else" would be false for
-      // exactly those, and a confirm that overstates trains users to dismiss it.
+      // UPSTREAM, so this set mixes three genuinely different situations and a
+      // single blanket sentence is wrong for two of them:
+      //   - no upstream at all  -> the commits exist on no other ref (total loss)
+      //   - upstream, ahead === 0 -> the commits are on the remote (recoverable)
+      //   - upstream, unmeasured  -> unknown; never coerce that to "pushed"
+      // Overstating trains users to dismiss confirms; understating loses work.
       const names = unmergedRefusals
         .map((cb) => {
-          const pushed =
-            cb.branch.upstream && (cb.branch.aheadBehind?.ahead ?? 0) === 0
-              ? ` (pushed to ${cb.branch.upstream})`
-              : '';
-          return `${cb.branch.name}${pushed}`;
+          const { upstream, aheadBehind } = cb.branch;
+          if (upstream && aheadBehind && aheadBehind.ahead === 0) {
+            return `${cb.branch.name} (pushed to ${upstream})`;
+          }
+          if (!upstream) {
+            return `${cb.branch.name} (no remote copy)`;
+          }
+          return `${cb.branch.name} (unpushed work unknown)`;
         })
         .join(', ');
       const plural = unmergedRefusals.length !== 1;
+      const anyWithoutRemoteCopy = unmergedRefusals.some(
+        (cb) => !cb.branch.upstream || !cb.branch.aheadBehind || cb.branch.aheadBehind.ahead > 0,
+      );
       const forceConfirmed = await showConfirm(
         'Branches Not Fully Merged',
         `${unmergedRefusals.length} branch${plural ? 'es' : ''} (${names}) ` +
-          `${plural ? 'are' : 'is'} not merged into the current branch. Any commits ` +
-          `not also on their upstream will be discarded permanently.\n\n` +
-          `Force delete anyway?`,
+          `${plural ? 'are' : 'is'} not merged into the current branch.\n\n` +
+          (anyWithoutRemoteCopy
+            ? `Commits that are not on a remote will be discarded permanently and ` +
+              `cannot be recovered.`
+            : `Their commits are on their upstreams, so the branches can be restored ` +
+              `from the remote.`) +
+          `\n\nForce delete anyway?`,
         'warning',
       );
 
@@ -713,32 +726,45 @@ export class LvBranchCleanupDialog extends LitElement {
       }
     }
 
-    // Prune remote tracking branches if requested
+    // Prune remote tracking branches if requested.
+    //
+    // invokeCommand NEVER throws — it resolves to { success: false, error } —
+    // so a try/catch here is dead code and the outcome must be read off the
+    // result. Without that, an offline or auth-failed prune reported success.
+    let pruned = false;
     if (this.pruneRemotes) {
-      try {
-        await gitService.pruneRemoteTrackingBranches(repoPath);
-      } catch (err) {
-        console.error('Failed to prune remote tracking branches:', err);
-        showToast(`Failed to prune remote branches: ${err instanceof Error ? err.message : String(err)}`, 'error');
+      const pruneResult = await gitService.pruneRemoteTrackingBranches(repoPath);
+      pruned = pruneResult.success;
+      if (!pruneResult.success) {
+        showToast(
+          `Failed to prune remote branches: ${pruneResult.error?.message ?? 'Unknown error'}`,
+          'error',
+        );
       }
     }
 
     this.deleting = false;
 
-    if (deleted > 0) {
-      const pruneNote = this.pruneRemotes ? ' (remotes pruned)' : '';
-      const notes: string[] = [];
-      // Carry the per-branch reasons into the PARTIAL outcome too — this is the
-      // common case, and the dialog closes straight after, so a bare count
-      // leaves the user with no way to find out what happened.
-      if (failed > 0) notes.push(`${failed} failed — ${failures.join('; ')}`);
-      if (kept > 0) notes.push(`${kept} kept (not fully merged)`);
+    // ONE composite message covering every combination. Reporting deleted /
+    // failed / kept in mutually exclusive branches silently dropped whichever
+    // outcomes did not match the arm that fired — e.g. a branch the user chose
+    // to keep went unmentioned whenever any other branch also failed, so they
+    // reasonably concluded it had been deleted.
+    // `pruned` is gated on the actual prune result, not on the checkbox.
+    const notes: string[] = [];
+    if (deleted > 0) notes.push(`Deleted ${deleted} branch${deleted !== 1 ? 'es' : ''}`);
+    if (failed > 0) notes.push(`${failed} failed — ${failures.join('; ')}`);
+    if (kept > 0) notes.push(`${kept} kept (not fully merged)`);
+    if (pruned) notes.push('remotes pruned');
 
-      const message =
-        `Deleted ${deleted} branch${deleted !== 1 ? 'es' : ''}${pruneNote}` +
-        (notes.length > 0 ? `, ${notes.join(', ')}` : '');
-      showToast(message, failed > 0 || kept > 0 ? 'warning' : 'success');
+    if (notes.length > 0) {
+      showToast(notes.join(', '), failed > 0 ? 'error' : kept > 0 ? 'warning' : 'success');
+    }
 
+    // The prune mutates the repo on its own, so the refresh must fire for it
+    // too — not only when a branch was deleted. Otherwise the sidebar keeps
+    // listing remote-tracking refs that no longer exist.
+    if (deleted > 0 || pruned) {
       this.dispatchEvent(
         new CustomEvent('cleanup-complete', {
           detail: { repositoryPath: repoPath },
@@ -746,19 +772,12 @@ export class LvBranchCleanupDialog extends LitElement {
           composed: true,
         }),
       );
+    }
+
+    // Only close when something was actually deleted; otherwise leave the
+    // dialog up so the user can act on what is still listed.
+    if (deleted > 0) {
       this.close();
-    } else if (failed > 0) {
-      showToast(
-        `Failed to delete ${failed} branch${failed !== 1 ? 'es' : ''} — ${failures.join('; ')}`,
-        'error'
-      );
-    } else if (kept > 0) {
-      // Nothing deleted because the user declined the escalation — that is an
-      // outcome, not an error.
-      showToast(
-        `${kept} branch${kept !== 1 ? 'es' : ''} kept (not fully merged)`,
-        'info'
-      );
     }
   }
 

--- a/src/components/dialogs/lv-branch-cleanup-dialog.ts
+++ b/src/components/dialogs/lv-branch-cleanup-dialog.ts
@@ -383,7 +383,7 @@ export class LvBranchCleanupDialog extends LitElement {
 
         const isProtected = candidate.isProtected || this.isBuiltinProtected(candidate.name);
         const protectedReason = isProtected ? this.getProtectedReason(candidate) : undefined;
-        const risk = this.assessRisk(byName.get(candidate.name) ?? [candidate]);
+        const risk = this.assessRisk(byName.get(candidate.name)!);
 
         const entry: CleanupBranch = {
           branch,
@@ -459,9 +459,9 @@ export class LvBranchCleanupDialog extends LitElement {
       return { risk: 'safe', riskReason: 'Fully merged into current branch' };
     }
 
-    // Prefer an entry that actually carries a measurement; the categories a
-    // branch appears in do not all populate aheadBehind.
-    const candidate = group.find((c) => c.aheadBehind) ?? group[0];
+    // branch_cleanup.rs computes ahead_behind once per branch and clones it
+    // into every category entry, so any entry of the group carries it.
+    const candidate = group[0];
 
     // aheadBehind is null when divergence could not be measured at all — a
     // branch that neither tracks an upstream nor is "gone". Coercing that to 0
@@ -479,13 +479,10 @@ export class LvBranchCleanupDialog extends LitElement {
     const isGone = group.some((c) => c.category === 'gone');
 
     if (ahead === 0) {
-      // A 'gone' branch is measured against HEAD (its upstream is gone), so
-      // ahead === 0 genuinely means merged; otherwise it is measured against
-      // the upstream, where it means nothing left to push.
-      return {
-        risk: 'safe',
-        riskReason: isGone ? 'Fully merged into current branch' : 'No unpushed work',
-      };
+      // A 'gone' branch with ahead === 0 is measured against HEAD, so it is
+      // also emitted as 'merged' and the early return above already fired —
+      // reaching here always means "nothing left to push to the upstream".
+      return { risk: 'safe', riskReason: 'No unpushed work' };
     }
 
     if (isGone) {
@@ -627,6 +624,7 @@ export class LvBranchCleanupDialog extends LitElement {
     this.deleting = true;
     let deleted = 0;
     let failed = 0;
+    let kept = 0;
     const failures: string[] = [];
 
     // Pinned at open(): these irreversible force-deletes and the remote prune
@@ -641,13 +639,20 @@ export class LvBranchCleanupDialog extends LitElement {
     const unmergedRefusals: CleanupBranch[] = [];
 
     for (const cb of toDelete) {
-      // Force only when we have MEASURED unpushed commits. Deriving this from
-      // the risk label instead would mean any branch labelled 'warning' — including
-      // one labelled that way precisely BECAUSE its divergence could not be
-      // measured — bypasses delete_branch's merged-check (branch.rs), turning a
-      // safe refusal into permanent commit loss. Unknown divergence must fall
-      // through to the backend and let it refuse.
-      const force = cb.risk === 'danger' || (cb.branch.aheadBehind?.ahead ?? 0) > 0;
+      // NEVER force a branch the dialog labelled Safe. Two reasons: a merged
+      // branch deletes fine without force, and the confirm above only fires for
+      // risky branches — so forcing a safe one would be an UNCONFIRMED force
+      // delete. Withholding force also keeps delete_branch's merged-check,
+      // which is the only thing that catches the label having gone stale (an
+      // external reset or checkout while this modal sat open).
+      //
+      // Among risky branches, force only on MEASURED unpushed commits. Deriving
+      // it from the label alone would force-delete a branch labelled 'warning'
+      // precisely BECAUSE its divergence could not be measured, turning the
+      // backend's safe refusal into permanent commit loss.
+      const force =
+        cb.risk !== 'safe' &&
+        (cb.risk === 'danger' || (cb.branch.aheadBehind?.ahead ?? 0) > 0);
       const result = await gitService.deleteBranch(repoPath, cb.branch.name, force);
       if (result.success) {
         deleted++;
@@ -666,20 +671,36 @@ export class LvBranchCleanupDialog extends LitElement {
     // user already confirmed the delete, so ask once about the subset git
     // refused rather than reporting a failure they cannot act on.
     if (unmergedRefusals.length > 0) {
-      const names = unmergedRefusals.map((cb) => cb.branch.name).join(', ');
+      // Name each branch's actual exposure. "not fully merged" is measured
+      // against HEAD, while the Safe/Warning badge is measured against the
+      // UPSTREAM — so a branch can be refused here while its commits sit safely
+      // on its remote. Claiming they "exist nowhere else" would be false for
+      // exactly those, and a confirm that overstates trains users to dismiss it.
+      const names = unmergedRefusals
+        .map((cb) => {
+          const pushed =
+            cb.branch.upstream && (cb.branch.aheadBehind?.ahead ?? 0) === 0
+              ? ` (pushed to ${cb.branch.upstream})`
+              : '';
+          return `${cb.branch.name}${pushed}`;
+        })
+        .join(', ');
+      const plural = unmergedRefusals.length !== 1;
       const forceConfirmed = await showConfirm(
         'Branches Not Fully Merged',
-        `${unmergedRefusals.length} branch${unmergedRefusals.length !== 1 ? 'es' : ''} ` +
-          `(${names}) ${unmergedRefusals.length === 1 ? 'is' : 'are'} not fully merged, so ` +
-          `deleting ${unmergedRefusals.length === 1 ? 'it' : 'them'} discards commits that ` +
-          `exist nowhere else. Force delete anyway?`,
+        `${unmergedRefusals.length} branch${plural ? 'es' : ''} (${names}) ` +
+          `${plural ? 'are' : 'is'} not merged into the current branch. Any commits ` +
+          `not also on their upstream will be discarded permanently.\n\n` +
+          `Force delete anyway?`,
         'warning',
       );
 
       for (const cb of unmergedRefusals) {
         if (!forceConfirmed) {
-          failed++;
-          failures.push(`${cb.branch.name}: not fully merged (kept)`);
+          // Declining is the safe choice the dialog just offered — counting it
+          // as a failure would report the user's own decision back to them as
+          // a red error.
+          kept++;
           continue;
         }
         const retry = await gitService.deleteBranch(repoPath, cb.branch.name, true);
@@ -706,11 +727,17 @@ export class LvBranchCleanupDialog extends LitElement {
 
     if (deleted > 0) {
       const pruneNote = this.pruneRemotes ? ' (remotes pruned)' : '';
+      const notes: string[] = [];
+      // Carry the per-branch reasons into the PARTIAL outcome too — this is the
+      // common case, and the dialog closes straight after, so a bare count
+      // leaves the user with no way to find out what happened.
+      if (failed > 0) notes.push(`${failed} failed — ${failures.join('; ')}`);
+      if (kept > 0) notes.push(`${kept} kept (not fully merged)`);
+
       const message =
-        failed > 0
-          ? `Deleted ${deleted} branch${deleted !== 1 ? 'es' : ''}, ${failed} failed${pruneNote}`
-          : `Deleted ${deleted} branch${deleted !== 1 ? 'es' : ''}${pruneNote}`;
-      showToast(message, failed > 0 ? 'warning' : 'success');
+        `Deleted ${deleted} branch${deleted !== 1 ? 'es' : ''}${pruneNote}` +
+        (notes.length > 0 ? `, ${notes.join(', ')}` : '');
+      showToast(message, failed > 0 || kept > 0 ? 'warning' : 'success');
 
       this.dispatchEvent(
         new CustomEvent('cleanup-complete', {
@@ -724,6 +751,13 @@ export class LvBranchCleanupDialog extends LitElement {
       showToast(
         `Failed to delete ${failed} branch${failed !== 1 ? 'es' : ''} — ${failures.join('; ')}`,
         'error'
+      );
+    } else if (kept > 0) {
+      // Nothing deleted because the user declined the escalation — that is an
+      // outcome, not an error.
+      showToast(
+        `${kept} branch${kept !== 1 ? 'es' : ''} kept (not fully merged)`,
+        'info'
       );
     }
   }

--- a/src/components/dialogs/lv-changelog-dialog.ts
+++ b/src/components/dialogs/lv-changelog-dialog.ts
@@ -172,8 +172,26 @@ export class LvChangelogDialog extends LitElement {
 
   @query('lv-modal') private modal!: HTMLElement & { open: boolean };
 
+  /**
+   * Repo captured at open. `repositoryPath` is live-bound to the ACTIVE
+   * repository and rebinds on a Ctrl+Tab this dialog's overlay does not block,
+   * so generating after a switch ran repo B against repo A's tag refs —
+   * an unresolvable-revision error, or worse a silently wrong changelog when
+   * both repos use conventional tags like v1.0.0.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.modal?.open ? this.pinnedRepoPath : null;
+  }
+
   public async open(): Promise<void> {
+    // A generation already running owns this component; reset() would clear
+    // isGenerating and re-enable Generate for a second concurrent run.
+    if (this.isGenerating) return;
     this.reset();
+    this.pinnedRepoPath = this.repositoryPath;
     (this.modal as HTMLElement & { open: boolean }).open = true;
     await this.loadTags();
     this.aiAvailable = await aiService.isAiAvailable();
@@ -192,7 +210,7 @@ export class LvChangelogDialog extends LitElement {
   }
 
   private async loadTags(): Promise<void> {
-    const result = await gitService.getTags(this.repositoryPath);
+    const result = await gitService.getTags(this.pinnedRepoPath);
     if (result.success && result.data) {
       this.tags = result.data;
       // Default baseRef to the second most recent tag (previous release)
@@ -217,7 +235,7 @@ export class LvChangelogDialog extends LitElement {
     this.result = '';
 
     const changelogResult = await aiService.generateChangelog(
-      this.repositoryPath,
+      this.pinnedRepoPath,
       this.baseRef,
       this.compareRef,
     );

--- a/src/components/dialogs/lv-changelog-dialog.ts
+++ b/src/components/dialogs/lv-changelog-dialog.ts
@@ -197,6 +197,11 @@ export class LvChangelogDialog extends LitElement {
     this.aiAvailable = await aiService.isAiAvailable();
   }
 
+  /** True while the AI call is in flight, for the host's tab-close sweep. */
+  public get generationInFlight(): boolean {
+    return this.isGenerating;
+  }
+
   public close(): void {
     this.modal.open = false;
   }

--- a/src/components/dialogs/lv-changelog-dialog.ts
+++ b/src/components/dialogs/lv-changelog-dialog.ts
@@ -260,7 +260,15 @@ export class LvChangelogDialog extends LitElement {
   }
 
   private handleModalClose(): void {
-    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+    // The `close` event this used to dispatch had no listener anywhere — the
+    // one binding was removed with the dead showChangelog flag. Rather than
+    // re-adding a no-op listener, this handler now does the job its siblings'
+    // do: lv-modal.close() clears `open` BEFORE dispatching, so dismissing
+    // mid-generation left the AI request running with no visible surface, and
+    // its result landed on a hidden dialog.
+    if (this.isGenerating) {
+      this.modal.open = true;
+    }
   }
 
   render() {

--- a/src/components/dialogs/lv-cherry-pick-dialog.ts
+++ b/src/components/dialogs/lv-cherry-pick-dialog.ts
@@ -4,10 +4,11 @@
  */
 
 import { LitElement, html, css, nothing } from 'lit';
-import { customElement, state, property } from 'lit/decorators.js';
+import { customElement, state, property, query } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import { cherryPick } from '../../services/git.service.ts';
 import './lv-modal.ts';
+import type { LvModal } from './lv-modal.ts';
 import type { Commit } from '../../types/git.types.ts';
 
 @customElement('lv-cherry-pick-dialog')
@@ -199,6 +200,8 @@ export class LvCherryPickDialog extends LitElement {
   @property({ type: String }) repositoryPath = '';
   @property({ type: String }) currentBranch = '';
 
+  @query('lv-modal') private modal!: LvModal;
+
   @state() private commit: Commit | null = null;
   @state() private noCommit = false;
   @state() private mainline = 1;
@@ -217,6 +220,10 @@ export class LvCherryPickDialog extends LitElement {
   @state() private pinnedCurrentBranch = '';
 
   public open(commit: Commit): void {
+    // A cherry-pick already running owns this component; reset() would clear
+    // isExecuting and re-enable the button for a second concurrent run against
+    // the same repo.
+    if (this.isExecuting) return;
     this.reset();
     this.commit = commit;
     this.pinnedRepoPath = this.repositoryPath;
@@ -327,9 +334,16 @@ export class LvCherryPickDialog extends LitElement {
   }
 
   private handleModalClose(): void {
-    if (!this.isExecuting) {
-      this.close();
+    // Cancel is disabled while the cherry-pick runs; Escape, the overlay and
+    // the × must honour the same rule. lv-modal.close() sets open=false BEFORE
+    // dispatching, so without re-asserting it the operation kept running with
+    // no visible surface and reported failure into a hidden dialog.
+    if (this.isExecuting) {
+      this.modal.open = true;
+      return;
     }
+
+    this.close();
   }
 
   private formatDate(timestamp: number): string {

--- a/src/components/dialogs/lv-clean-dialog.ts
+++ b/src/components/dialogs/lv-clean-dialog.ts
@@ -10,6 +10,7 @@ import * as gitService from '../../services/git.service.ts';
 import type { CleanEntry } from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 @customElement('lv-clean-dialog')
 export class LvCleanDialog extends LitElement {
@@ -355,6 +356,10 @@ export class LvCleanDialog extends LitElement {
   }
 
   async updated(changedProps: Map<string, unknown>): Promise<void> {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProps.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProps.has('open') && this.open) {
       // A prior operation may still be running against this component; its
       // completion handler will close the dialog, so do not start a fresh
@@ -417,6 +422,9 @@ export class LvCleanDialog extends LitElement {
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
+    // Only the topmost overlay owns Escape: every dialog listens on
+    // `document`, so without this one keypress ran all of them.
+    if (!this.open || !isTopOverlay(this)) return;
     if (e.key === 'Escape') {
       this.dismiss();
     }
@@ -429,6 +437,7 @@ export class LvCleanDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 

--- a/src/components/dialogs/lv-clean-dialog.ts
+++ b/src/components/dialogs/lv-clean-dialog.ts
@@ -338,18 +338,35 @@ export class LvCleanDialog extends LitElement {
   @state() private includeIgnored = false;
   @state() private includeDirectories = true;
 
+  /**
+   * Repo captured when the dialog opened. `repositoryPath` is live-bound to
+   * the ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this dialog's overlay does not block. The file
+   * list on screen belongs to the repo that was active at open, so every
+   * operation must use THIS value: reading the live prop deleted the listed
+   * paths out of whichever repo the user had switched to, and untracked files
+   * have no trash and no recovery path.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
   async updated(changedProps: Map<string, unknown>): Promise<void> {
     if (changedProps.has('open') && this.open) {
       // A prior operation may still be running against this component; its
       // completion handler will close the dialog, so do not start a fresh
       // session on top of it.
       if (this.cleaning) return;
+      this.pinnedRepoPath = this.repositoryPath;
       await this.loadFiles();
     }
   }
 
   private async loadFiles(): Promise<void> {
-    if (!this.repositoryPath) return;
+    if (!this.pinnedRepoPath) return;
 
     this.loading = true;
     this.entries = [];
@@ -357,7 +374,7 @@ export class LvCleanDialog extends LitElement {
 
     try {
       const result = await gitService.getCleanableFiles(
-        this.repositoryPath,
+        this.pinnedRepoPath,
         this.includeIgnored,
         this.includeDirectories
       );
@@ -445,10 +462,10 @@ export class LvCleanDialog extends LitElement {
   private async handleClean(): Promise<void> {
     if (this.selectedPaths.size === 0) return;
 
-    // Captured BEFORE the nested-repo confirm await: this dialog is bound to
-    // the active repository and rebinds live, so a mid-confirm tab switch would
-    // otherwise delete files from the repo the user switched TO.
-    const repoPath = this.repositoryPath;
+    // The repo the listed files were read from — NOT the live prop. Pinning
+    // only at click time still deleted from the wrong repository whenever the
+    // tab switch happened before the click rather than during the confirm.
+    const repoPath = this.pinnedRepoPath;
 
     // Captured BEFORE the confirms too. loadFiles() reassigns selectedPaths on
     // every option change and on its own initial load, so reading it after an

--- a/src/components/dialogs/lv-clean-dialog.ts
+++ b/src/components/dialogs/lv-clean-dialog.ts
@@ -340,6 +340,10 @@ export class LvCleanDialog extends LitElement {
 
   async updated(changedProps: Map<string, unknown>): Promise<void> {
     if (changedProps.has('open') && this.open) {
+      // A prior operation may still be running against this component; its
+      // completion handler will close the dialog, so do not start a fresh
+      // session on top of it.
+      if (this.cleaning) return;
       await this.loadFiles();
     }
   }
@@ -377,15 +381,27 @@ export class LvCleanDialog extends LitElement {
     }
   }
 
+  /**
+   * User-initiated dismissal. Blocked while the operation is in flight:
+   * closing mid-delete leaves it running with no visible surface, and when it
+   * finishes its success path calls close() — yanking shut whatever session
+   * the user had reopened in the meantime and discarding their new selection.
+   * close() itself stays unguarded because that success path needs it.
+   */
+  private dismiss(): void {
+    if (this.cleaning) return;
+    this.close();
+  }
+
   private handleOverlayClick(e: MouseEvent): void {
     if (e.target === e.currentTarget) {
-      this.close();
+      this.dismiss();
     }
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
     if (e.key === 'Escape') {
-      this.close();
+      this.dismiss();
     }
   };
 
@@ -498,7 +514,9 @@ export class LvCleanDialog extends LitElement {
         );
 
         this.dispatchEvent(new CustomEvent('files-cleaned', {
-          detail: { count: removed },
+          // repositoryPath so the host refreshes the repo the clean ran on —
+          // the user may have switched tabs during the IPC await.
+          detail: { count: removed, repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -583,7 +601,7 @@ export class LvCleanDialog extends LitElement {
             </svg>
             <span class="title">Clean Working Directory</span>
           </div>
-          <button class="close-btn" @click=${this.close}>
+          <button class="close-btn" @click=${this.dismiss}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="18" y1="6" x2="6" y2="18"></line>
               <line x1="6" y1="6" x2="18" y2="18"></line>
@@ -669,7 +687,7 @@ export class LvCleanDialog extends LitElement {
             ` : html`No files selected`}
           </div>
           <div class="footer-right">
-            <button class="btn btn-secondary" @click=${this.close}>Cancel</button>
+            <button class="btn btn-secondary" ?disabled=${this.cleaning} @click=${this.dismiss}>Cancel</button>
             <button
               class="btn btn-danger"
               ?disabled=${!someSelected || this.cleaning}

--- a/src/components/dialogs/lv-clean-dialog.ts
+++ b/src/components/dialogs/lv-clean-dialog.ts
@@ -434,12 +434,34 @@ export class LvCleanDialog extends LitElement {
     // otherwise delete files from the repo the user switched TO.
     const repoPath = this.repositoryPath;
 
-    // If any selected entry is an untracked nested git repository, require an
-    // explicit confirmation before force-deleting it (this destroys the nested
-    // repo's history, which `git clean` guards behind a second `-f`).
+    // Captured BEFORE the confirms too. loadFiles() reassigns selectedPaths on
+    // every option change and on its own initial load, so reading it after an
+    // await can yield a set the user never chose — or an empty one. Pinning it
+    // also guarantees the count named in the confirm is exactly what gets
+    // deleted.
+    const paths = Array.from(this.selectedPaths);
     const nestedRepos = this.entries.filter(
-      e => this.selectedPaths.has(e.path) && e.isNestedRepo
+      e => paths.includes(e.path) && e.isNestedRepo
     );
+
+    // Untracked files are unlinked outright: they exist in no git object and
+    // there is no trash, so this is the one deletion in the app with no
+    // recovery path at all. Discarding a SINGLE untracked file from the file
+    // list raises a confirm the user cannot even switch off
+    // (lv-file-status.ts confirmDiscard), so deleting 200 of them here must
+    // not be the ungated route. The dialog's checkboxes are a selection UI,
+    // not a confirmation.
+    const confirmedDelete = await showConfirm(
+      'Delete Untracked Files',
+      `Permanently delete ${paths.length} item${paths.length === 1 ? '' : 's'}? ` +
+        `They are not in Git and cannot be recovered.`,
+      'warning'
+    );
+    if (!confirmedDelete) return;
+
+    // A nested git repository additionally destroys that repo's whole history,
+    // which `git clean` itself guards behind a second `-f` — so it gets its own
+    // gate on top of the deletion confirm above.
     if (nestedRepos.length > 0) {
       const names = nestedRepos.map(e => e.path).join(', ');
       const confirmed = await showConfirm(
@@ -458,7 +480,6 @@ export class LvCleanDialog extends LitElement {
     this.cleaning = true;
 
     try {
-      const paths = Array.from(this.selectedPaths);
       const result = await gitService.cleanFiles(repoPath, paths, forceNested);
 
       if (result.success) {

--- a/src/components/dialogs/lv-clean-dialog.ts
+++ b/src/components/dialogs/lv-clean-dialog.ts
@@ -429,6 +429,11 @@ export class LvCleanDialog extends LitElement {
   private async handleClean(): Promise<void> {
     if (this.selectedPaths.size === 0) return;
 
+    // Captured BEFORE the nested-repo confirm await: this dialog is bound to
+    // the active repository and rebinds live, so a mid-confirm tab switch would
+    // otherwise delete files from the repo the user switched TO.
+    const repoPath = this.repositoryPath;
+
     // If any selected entry is an untracked nested git repository, require an
     // explicit confirmation before force-deleting it (this destroys the nested
     // repo's history, which `git clean` guards behind a second `-f`).
@@ -454,11 +459,25 @@ export class LvCleanDialog extends LitElement {
 
     try {
       const paths = Array.from(this.selectedPaths);
-      const result = await gitService.cleanFiles(this.repositoryPath, paths, forceNested);
+      const result = await gitService.cleanFiles(repoPath, paths, forceNested);
 
       if (result.success) {
+        // clean_files skips entries it cannot remove — nested repos without
+        // force, directories holding tracked content, locked files — and
+        // reports how many it actually deleted. The dialog closes immediately,
+        // so without this the user sees no feedback at all and assumes every
+        // selected file is gone.
+        const removed = result.data ?? 0;
+        const shortfall = paths.length - removed;
+        showToast(
+          shortfall > 0
+            ? `Deleted ${removed} of ${paths.length} items — ${shortfall} could not be removed`
+            : `Deleted ${removed} item${removed === 1 ? '' : 's'}`,
+          shortfall > 0 ? 'warning' : 'success'
+        );
+
         this.dispatchEvent(new CustomEvent('files-cleaned', {
-          detail: { count: result.data },
+          detail: { count: removed },
           bubbles: true,
           composed: true,
         }));

--- a/src/components/dialogs/lv-clone-dialog.ts
+++ b/src/components/dialogs/lv-clone-dialog.ts
@@ -204,6 +204,12 @@ export class LvCloneDialog extends LitElement {
 
   public close(): void {
     this.modal.open = false;
+    // Cleared HERE, not just on the failure paths. The success branch closes
+    // via setTimeout without clearing it, so `isCloning` stayed true for the
+    // life of the component — and open()'s re-entrancy guard returns before
+    // reset() can clear it, which made "Clone Repository" silently dead for
+    // the rest of the session after the first successful clone.
+    this.isCloning = false;
     this.cleanupListener();
   }
 

--- a/src/components/dialogs/lv-clone-dialog.ts
+++ b/src/components/dialogs/lv-clone-dialog.ts
@@ -193,6 +193,10 @@ export class LvCloneDialog extends LitElement {
   private unlistenProgress?: UnlistenFn;
 
   public open(): void {
+    // A clone already in flight owns this component; reset() would
+    // clear `isCloning` and re-enable the button for a second concurrent run,
+    // and the first run's close() would then yank shut the reopened session.
+    if (this.isCloning) return;
     this.reset();
     this.destination = settingsStore.getState().defaultClonePath;
     this.modal.open = true;

--- a/src/components/dialogs/lv-clone-dialog.ts
+++ b/src/components/dialogs/lv-clone-dialog.ts
@@ -349,9 +349,17 @@ export class LvCloneDialog extends LitElement {
   }
 
   private handleModalClose(): void {
-    if (!this.isCloning) {
-      this.reset();
+    // Cancel is disabled while isCloning is in flight; Escape, the overlay and the
+    // × must honour the same rule. lv-modal.close() sets open=false BEFORE
+    // dispatching, so without re-asserting it here the clone kept running with no
+    // visible surface — and reported any failure into `error` on a hidden
+    // dialog. Mirrors lv-branch-cleanup-dialog.handleModalClose.
+    if (this.isCloning) {
+      this.modal.open = true;
+      return;
     }
+
+    this.reset();
   }
 
   private get fullPath(): string {

--- a/src/components/dialogs/lv-command-palette.ts
+++ b/src/components/dialogs/lv-command-palette.ts
@@ -198,6 +198,9 @@ export class LvCommandPalette extends LitElement {
   ];
 
   @property({ type: Boolean, reflect: true }) open = false;
+
+  /** Focus owner at open time, restored on close. */
+  private previouslyFocused: HTMLElement | null = null;
   @property({ type: Array }) commands: PaletteCommand[] = [];
   @property({ type: Array }) branches: Branch[] = [];
   @property({ type: Array }) files: string[] = [];
@@ -234,12 +237,26 @@ export class LvCommandPalette extends LitElement {
       if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
     }
     if (changedProps.has('open') && this.open) {
+      // Remembered so focus can go back where it was. Leaving it in the
+      // search input after closing left document focus inside a hidden field:
+      // every keydown's composedPath still contained an INPUT, so
+      // keyboard.service's in-input bail swallowed EVERY single-key shortcut
+      // app-wide until the user happened to click something.
+      this.previouslyFocused = document.activeElement as HTMLElement | null;
       this.searchQuery = '';
       this.selectedIndex = 0;
       this.updateFilteredCommands();
       requestAnimationFrame(() => {
         this.searchInput?.focus();
       });
+    }
+    if (changedProps.has('open') && !this.open) {
+      this.searchInput?.blur();
+      const restore = this.previouslyFocused;
+      this.previouslyFocused = null;
+      if (restore && restore.isConnected) {
+        restore.focus();
+      }
     }
     if (
       changedProps.has('commands') ||

--- a/src/components/dialogs/lv-command-palette.ts
+++ b/src/components/dialogs/lv-command-palette.ts
@@ -8,6 +8,7 @@ import { customElement, property, state, query } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import { fuzzyScore, highlightMatch } from '../../utils/fuzzy-search.ts';
 import type { Branch, Commit } from '../../types/git.types.ts';
+import { pushOverlay, removeOverlay } from '../../utils/overlay-stack.ts';
 
 export interface PaletteCommand {
   id: string;
@@ -218,6 +219,12 @@ export class LvCommandPalette extends LitElement {
   }
 
   updated(changedProps: Map<string, unknown>): void {
+    // The palette opens OVER other dialogs, so it must take ownership of
+    // Escape while it is up — otherwise dismissing it also dismissed the
+    // dialog underneath, discarding whatever the user had built there.
+    if (changedProps.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProps.has('open') && this.open) {
       this.searchQuery = '';
       this.selectedIndex = 0;

--- a/src/components/dialogs/lv-command-palette.ts
+++ b/src/components/dialogs/lv-command-palette.ts
@@ -8,7 +8,7 @@ import { customElement, property, state, query } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import { fuzzyScore, highlightMatch } from '../../utils/fuzzy-search.ts';
 import type { Branch, Commit } from '../../types/git.types.ts';
-import { pushOverlay, removeOverlay } from '../../utils/overlay-stack.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 export interface PaletteCommand {
   id: string;
@@ -216,13 +216,33 @@ export class LvCommandPalette extends LitElement {
 
   private recentCommands: string[] = [];
 
+  /**
+   * Escape at the document level, gated on being the topmost overlay.
+   *
+   * The palette's other key handling hangs off @keydown on the search input,
+   * so it only fires once that input has focus — which happens in a rAF after
+   * open. app-shell used to paper over the gap with an unconditional
+   * `showCommandPalette = false` arm ahead of every other check, but that arm
+   * closed the palette even when it was NOT the overlay the user was aiming
+   * at. Owning Escape here, stack-gated, is what every other overlay does.
+   */
+  private handleDocumentKeyDown = (e: KeyboardEvent): void => {
+    if (!this.open || !isTopOverlay(this)) return;
+    if (e.key === 'Escape') {
+      e.preventDefault();
+      this.close();
+    }
+  };
+
   connectedCallback(): void {
     super.connectedCallback();
+    document.addEventListener('keydown', this.handleDocumentKeyDown);
     this.loadRecentCommands();
   }
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    document.removeEventListener('keydown', this.handleDocumentKeyDown);
     // Withdraw on teardown as every sibling does. Unreachable while the
     // palette is rendered unconditionally, but a leaked entry sits on top
     // of the stack forever and takes Escape away from every dialog below.

--- a/src/components/dialogs/lv-command-palette.ts
+++ b/src/components/dialogs/lv-command-palette.ts
@@ -218,6 +218,14 @@ export class LvCommandPalette extends LitElement {
     this.loadRecentCommands();
   }
 
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    // Withdraw on teardown as every sibling does. Unreachable while the
+    // palette is rendered unconditionally, but a leaked entry sits on top
+    // of the stack forever and takes Escape away from every dialog below.
+    removeOverlay(this);
+  }
+
   updated(changedProps: Map<string, unknown>): void {
     // The palette opens OVER other dialogs, so it must take ownership of
     // Escape while it is up — otherwise dismissing it also dismissed the

--- a/src/components/dialogs/lv-config-dialog.ts
+++ b/src/components/dialogs/lv-config-dialog.ts
@@ -380,8 +380,24 @@ export class LvConfigDialog extends LitElement {
     super.connectedCallback();
   }
 
+  /**
+   * Repo captured when the dialog opened. `repositoryPath` is live-bound to
+   * the ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this dialog's overlay does not block — while the
+   * data on screen still belongs to the repo that was active at open. Every
+   * read and every mutation must use THIS value, or the dialog acts on a
+   * repository the user is not looking at.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
   updated(changedProperties: Map<string, unknown>): void {
     if (changedProperties.has('open') && this.open) {
+      this.pinnedRepoPath = this.repositoryPath;
       this.loadData();
     }
   }
@@ -392,9 +408,9 @@ export class LvConfigDialog extends LitElement {
 
     try {
       const [identityResult, settingsResult, aliasesResult] = await Promise.all([
-        gitService.getUserIdentity(this.repositoryPath),
-        gitService.getCommonSettings(this.repositoryPath),
-        gitService.getAliases(this.repositoryPath),
+        gitService.getUserIdentity(this.pinnedRepoPath),
+        gitService.getCommonSettings(this.pinnedRepoPath),
+        gitService.getAliases(this.pinnedRepoPath),
       ]);
 
       if (identityResult.success && identityResult.data) {
@@ -427,7 +443,7 @@ export class LvConfigDialog extends LitElement {
 
     try {
       const result = await gitService.setUserIdentity(
-        this.saveScope === 'local' ? this.repositoryPath : null,
+        this.saveScope === 'local' ? this.pinnedRepoPath : null,
         this.editName,
         this.editEmail,
         this.saveScope === 'global'
@@ -451,7 +467,7 @@ export class LvConfigDialog extends LitElement {
 
     try {
       const result = await gitService.setConfigValue(
-        this.repositoryPath,
+        this.pinnedRepoPath,
         key,
         value,
         false // local
@@ -479,7 +495,7 @@ export class LvConfigDialog extends LitElement {
 
     try {
       const result = await gitService.setAlias(
-        this.saveScope === 'local' ? this.repositoryPath : null,
+        this.saveScope === 'local' ? this.pinnedRepoPath : null,
         this.newAliasName,
         this.newAliasCommand,
         this.saveScope === 'global'
@@ -506,7 +522,7 @@ export class LvConfigDialog extends LitElement {
 
     try {
       const result = await gitService.deleteAlias(
-        alias.isGlobal ? null : this.repositoryPath,
+        alias.isGlobal ? null : this.pinnedRepoPath,
         alias.name,
         alias.isGlobal
       );

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -1251,8 +1251,14 @@ export class LvConflictResolutionDialog extends LitElement {
       if (ctx.deleteBranch) {
         const del = await gitService.deleteBranch(this.repositoryPath, ctx.branchName, true);
         if (!del.success) {
-          showToast(del.error?.message ?? 'Failed to delete feature branch', 'error');
-          return false;
+          // The squash commit has already landed — deleting the branch is the
+          // optional last step. Treating its failure (e.g. a preventDeletion
+          // branch rule) as "finish incomplete" left the dialog stuck on a
+          // fully-resolved conflict list with no way forward but closing it.
+          showToast(
+            `${del.error?.message ?? 'Failed to delete feature branch'} — the squash commit landed`,
+            'warning',
+          );
         }
       }
       return true;
@@ -1262,7 +1268,7 @@ export class LvConflictResolutionDialog extends LitElement {
     // re-invoking the (now idempotent) backend finish skips the up-to-date
     // master/develop merges, creates the version tag (release/hotfix), and deletes
     // the branch.
-    let result: CommandResult<void>;
+    let result: CommandResult<gitService.GitFlowFinishResult>;
     switch (ctx.kind) {
       case 'feature':
         result = await gitService.gitFlowFinishFeature(
@@ -1319,6 +1325,12 @@ export class LvConflictResolutionDialog extends LitElement {
       }
       showToast(result.error?.message ?? 'Failed to complete Git Flow finish', 'error');
       return false;
+    }
+
+    // The finish can succeed while a branch rule blocks its branch deletion —
+    // say so, or the branch silently survives the finish.
+    if (result.data?.branchKeptReason) {
+      showToast(result.data.branchKeptReason, 'warning');
     }
     return true;
   }

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -13,6 +13,7 @@ import type { LvMergeEditor } from '../panels/lv-merge-editor.ts';
 import type { ConflictFile } from '../../types/git.types.ts';
 import type { CommandResult } from '../../types/api.types.ts';
 import '../panels/lv-merge-editor.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 /**
  * Context threaded through a conflicted git-flow finish so the dialog can COMPLETE
@@ -417,11 +418,19 @@ export class LvConflictResolutionDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 
   protected updated(changedProperties: Map<string, unknown>): void {
     super.updated(changedProperties);
+
+    // Announce/withdraw overlay ownership of Escape. Missing this made a
+    // dialog opened over another one dismiss BOTH on a single keypress: the
+    // one underneath was still stack-top, so its own guard passed.
+    if (changedProperties.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
 
     // When open changes to true, load conflicts
     if (changedProperties.has('open') && this.open) {
@@ -467,7 +476,9 @@ export class LvConflictResolutionDialog extends LitElement {
   private stashCaptureEpoch = 0;
 
   private handleKeyDown = (e: KeyboardEvent): void => {
-    if (!this.open) return;
+    // Only the topmost overlay owns Escape. This handler only swallows the
+    // key today, but it must not swallow one aimed at a dialog above it.
+    if (!this.open || !isTopOverlay(this)) return;
 
     if (e.key === 'Escape') {
       e.preventDefault();

--- a/src/components/dialogs/lv-create-branch-dialog.ts
+++ b/src/components/dialogs/lv-create-branch-dialog.ts
@@ -149,6 +149,10 @@ export class LvCreateBranchDialog extends LitElement {
   @query('#branch-name-input') private inputEl!: HTMLInputElement;
 
   public open(startPoint?: string): void {
+    // Branch creation already in flight owns this component; reset() would
+    // clear `isCreating` and re-enable the button for a second concurrent run,
+    // and the first run's close() would then yank shut the reopened session.
+    if (this.isCreating) return;
     this.reset();
     this.pinnedRepoPath = this.repositoryPath;
     this.isOpen = true;

--- a/src/components/dialogs/lv-create-branch-dialog.ts
+++ b/src/components/dialogs/lv-create-branch-dialog.ts
@@ -236,10 +236,17 @@ export class LvCreateBranchDialog extends LitElement {
   }
 
   private handleModalClose(): void {
-    this.isOpen = false;
-    if (!this.isCreating) {
-      this.reset();
+    // Escape, the overlay and the × must honour the same rule as the disabled
+    // Cancel button. lv-modal.close() sets open=false BEFORE dispatching, and
+    // this handler additionally dropped `isOpen`, so branch creation carried on with
+    // no visible surface and reported failure into a hidden dialog.
+    if (this.isCreating) {
+      this.modal.open = true;
+      return;
     }
+
+    this.isOpen = false;
+    this.reset();
   }
 
   private get canCreate(): boolean {

--- a/src/components/dialogs/lv-create-tag-dialog.ts
+++ b/src/components/dialogs/lv-create-tag-dialog.ts
@@ -313,10 +313,17 @@ export class LvCreateTagDialog extends LitElement {
   }
 
   private handleModalClose(): void {
-    this.isOpen = false;
-    if (!this.isCreating) {
-      this.reset();
+    // Escape, the overlay and the × must honour the same rule as the disabled
+    // Cancel button. lv-modal.close() sets open=false BEFORE dispatching, and
+    // this handler additionally dropped `isOpen`, so tag creation carried on with
+    // no visible surface and reported failure into a hidden dialog.
+    if (this.isCreating) {
+      this.modal.open = true;
+      return;
     }
+
+    this.isOpen = false;
+    this.reset();
   }
 
   private get canCreate(): boolean {

--- a/src/components/dialogs/lv-create-tag-dialog.ts
+++ b/src/components/dialogs/lv-create-tag-dialog.ts
@@ -206,6 +206,10 @@ export class LvCreateTagDialog extends LitElement {
   @query('#tag-name-input') private inputEl!: HTMLInputElement;
 
   public open(targetRef?: string): void {
+    // Tag creation already in flight owns this component; reset() would
+    // clear `isCreating` and re-enable the button for a second concurrent run,
+    // and the first run's close() would then yank shut the reopened session.
+    if (this.isCreating) return;
     this.reset();
     this.pinnedRepoPath = this.repositoryPath;
     this.isOpen = true;

--- a/src/components/dialogs/lv-credentials-dialog.ts
+++ b/src/components/dialogs/lv-credentials-dialog.ts
@@ -414,8 +414,24 @@ export class LvCredentialsDialog extends LitElement {
     super.connectedCallback();
   }
 
+  /**
+   * Repo captured when the dialog opened. `repositoryPath` is live-bound to
+   * the ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this dialog's overlay does not block — while the
+   * data on screen still belongs to the repo that was active at open. Every
+   * read and every mutation must use THIS value, or the dialog acts on a
+   * repository the user is not looking at.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
   updated(changedProperties: Map<string, unknown>): void {
     if (changedProperties.has('open') && this.open) {
+      this.pinnedRepoPath = this.repositoryPath;
       this.loadData();
     }
   }
@@ -426,9 +442,9 @@ export class LvCredentialsDialog extends LitElement {
 
     try {
       const [helpersResult, availableResult, remotesResult] = await Promise.all([
-        gitService.getCredentialHelpers(this.repositoryPath),
+        gitService.getCredentialHelpers(this.pinnedRepoPath),
         gitService.getAvailableHelpers(),
-        gitService.getRemotes(this.repositoryPath),
+        gitService.getRemotes(this.pinnedRepoPath),
       ]);
 
       if (helpersResult.success && helpersResult.data) {
@@ -449,7 +465,7 @@ export class LvCredentialsDialog extends LitElement {
       // Detect GCM status
       try {
         const { detectCredentialManager } = await import('../../services/credential.service.ts');
-        this.gcmStatus = await detectCredentialManager(this.repositoryPath);
+        this.gcmStatus = await detectCredentialManager(this.pinnedRepoPath);
       } catch {
         // GCM detection is best-effort
       }
@@ -471,7 +487,7 @@ export class LvCredentialsDialog extends LitElement {
 
     try {
       const result = await gitService.setCredentialHelper(
-        this.newHelperScope === 'local' ? this.repositoryPath : null,
+        this.newHelperScope === 'local' ? this.pinnedRepoPath : null,
         this.newHelper,
         this.newHelperScope === 'global'
       );
@@ -495,7 +511,7 @@ export class LvCredentialsDialog extends LitElement {
 
     try {
       const result = await gitService.unsetCredentialHelper(
-        helper.scope === 'local' ? this.repositoryPath : null,
+        helper.scope === 'local' ? this.pinnedRepoPath : null,
         helper.scope === 'global',
         helper.urlPattern ?? undefined
       );
@@ -519,7 +535,7 @@ export class LvCredentialsDialog extends LitElement {
 
     try {
       const result = await gitService.testCredentials(
-        this.repositoryPath,
+        this.pinnedRepoPath,
         this.selectedRemote.url
       );
 
@@ -549,7 +565,7 @@ export class LvCredentialsDialog extends LitElement {
 
     try {
       const result = await gitService.eraseCredentials(
-        this.repositoryPath,
+        this.pinnedRepoPath,
         this.testResult.host,
         this.testResult.protocol
       );

--- a/src/components/dialogs/lv-gpg-dialog.ts
+++ b/src/components/dialogs/lv-gpg-dialog.ts
@@ -657,8 +657,24 @@ export class LvGpgDialog extends LitElement {
     }
   }
 
+  /**
+   * Repo captured when the dialog opened. `repositoryPath` is live-bound to
+   * the ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this dialog's overlay does not block — while the
+   * data on screen still belongs to the repo that was active at open. Every
+   * read and every mutation must use THIS value, or the dialog acts on a
+   * repository the user is not looking at.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     if (changedProperties.has('open') && this.open) {
+      this.pinnedRepoPath = this.repositoryPath;
       await this.loadData();
     }
   }
@@ -669,8 +685,8 @@ export class LvGpgDialog extends LitElement {
     this.platform = getPlatform();
 
     const [configResult, keysResult] = await Promise.all([
-      gitService.getGpgConfig(this.repositoryPath),
-      gitService.getGpgKeys(this.repositoryPath),
+      gitService.getGpgConfig(this.pinnedRepoPath),
+      gitService.getGpgKeys(this.pinnedRepoPath),
     ]);
 
     if (configResult.success && configResult.data) {
@@ -737,7 +753,7 @@ export class LvGpgDialog extends LitElement {
     this.error = '';
 
     const result = await gitService.setCommitSigning(
-      this.repositoryPath,
+      this.pinnedRepoPath,
       !this.config.signCommits,
       this.globalScope
     );
@@ -760,7 +776,7 @@ export class LvGpgDialog extends LitElement {
     this.error = '';
 
     const result = await gitService.setTagSigning(
-      this.repositoryPath,
+      this.pinnedRepoPath,
       !this.config.signTags,
       this.globalScope
     );
@@ -781,7 +797,7 @@ export class LvGpgDialog extends LitElement {
     this.error = '';
 
     const result = await gitService.setSigningKey(
-      this.repositoryPath,
+      this.pinnedRepoPath,
       keyId,
       this.globalScope
     );

--- a/src/components/dialogs/lv-gpg-dialog.ts
+++ b/src/components/dialogs/lv-gpg-dialog.ts
@@ -10,6 +10,7 @@ import * as gitService from '../../services/git.service.ts';
 import type { GpgConfig, GpgKey } from '../../services/git.service.ts';
 import { getPlatform, type Platform } from '../../utils/platform.ts';
 import { openExternalUrl } from '../../utils/external-link.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 type SetupStep = 'install-guide' | 'generate-guide' | 'configure' | 'complete';
 
@@ -657,7 +658,10 @@ export class LvGpgDialog extends LitElement {
    * made Escape a completely dead key here. Dismiss like every sibling.
    */
   private handleKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape' && this.open) {
+    // Only the topmost overlay owns Escape: every dialog listens on
+    // `document`, so without this one keypress ran all of them.
+    if (!this.open || !isTopOverlay(this)) return;
+    if (e.key === 'Escape') {
       this.handleClose();
     }
   };
@@ -672,6 +676,7 @@ export class LvGpgDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 
@@ -691,6 +696,10 @@ export class LvGpgDialog extends LitElement {
   }
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProperties.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProperties.has('open') && this.open) {
       this.pinnedRepoPath = this.repositoryPath;
       await this.loadData();

--- a/src/components/dialogs/lv-gpg-dialog.ts
+++ b/src/components/dialogs/lv-gpg-dialog.ts
@@ -650,11 +650,29 @@ export class LvGpgDialog extends LitElement {
   @state() private platform: Platform = 'unknown';
   @state() private copyFeedback: string | null = null;
 
+  /**
+   * This dialog paints its own overlay instead of using lv-modal, so it had no
+   * Escape handling at all — and app-shell's Escape chain now stops at the
+   * dialog layer (so a keypress cannot also close the diff behind it), which
+   * made Escape a completely dead key here. Dismiss like every sibling.
+   */
+  private handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this.open) {
+      this.handleClose();
+    }
+  };
+
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
+    document.addEventListener('keydown', this.handleKeyDown);
     if (this.open) {
       await this.loadData();
     }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener('keydown', this.handleKeyDown);
   }
 
   /**

--- a/src/components/dialogs/lv-hooks-dialog.ts
+++ b/src/components/dialogs/lv-hooks-dialog.ts
@@ -10,6 +10,7 @@ import { getHooks, getHook, saveHook, deleteHook, toggleHook } from '../../servi
 import type { GitHook } from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 const HOOK_TEMPLATES: Record<string, string> = {
   'pre-commit': `#!/bin/sh
@@ -738,6 +739,10 @@ export class LvHooksDialog extends LitElement {
   }
 
   async updated(changedProps: Map<string, unknown>): Promise<void> {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProps.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProps.has('open') && this.open) {
       this.pinnedRepoPath = this.repoPath;
       await this.loadHooks();
@@ -936,6 +941,9 @@ export class LvHooksDialog extends LitElement {
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
+    // Only the topmost overlay owns Escape: every dialog listens on
+    // `document`, so without this one keypress ran all of them.
+    if (!this.open || !isTopOverlay(this)) return;
     if (e.key === 'Escape') {
       if (this.confirmingDelete) {
         this.cancelDelete();
@@ -952,6 +960,7 @@ export class LvHooksDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 
@@ -960,6 +969,11 @@ export class LvHooksDialog extends LitElement {
       const discard = await showConfirm('Unsaved Changes', 'You have unsaved changes. Discard them?', 'warning');
       if (!discard) return;
     }
+    // Cleared HERE: close() left them set, and the element stays mounted, so
+    // one discarded session made EVERY later Escape anywhere in the app pop
+    // the same native "Unsaved Changes" confirm out of nowhere.
+    this.hasUnsavedChanges = false;
+    this.confirmingDelete = null;
     this.open = false;
     this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
   }

--- a/src/components/dialogs/lv-hooks-dialog.ts
+++ b/src/components/dialogs/lv-hooks-dialog.ts
@@ -721,14 +721,31 @@ export class LvHooksDialog extends LitElement {
   @state() private hasUnsavedChanges = false;
   @state() private confirmingDelete: string | null = null;
 
+  /**
+   * Repo captured when the dialog opened. `repoPath` is live-bound to the
+   * ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this dialog's overlay does not block — while the
+   * hook list on screen still belongs to the repo active at open. Saving or
+   * deleting through the live prop wrote to, and `std::fs::remove_file`d,
+   * hooks in the other repository. `.git/hooks` is untracked: like the clean
+   * dialog's untracked files, there is no trash and no recovery path.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
   async updated(changedProps: Map<string, unknown>): Promise<void> {
     if (changedProps.has('open') && this.open) {
+      this.pinnedRepoPath = this.repoPath;
       await this.loadHooks();
     }
   }
 
   private async loadHooks(): Promise<void> {
-    if (!this.repoPath) return;
+    if (!this.pinnedRepoPath) return;
 
     this.loading = true;
     this.hooks = [];
@@ -738,7 +755,7 @@ export class LvHooksDialog extends LitElement {
     this.confirmingDelete = null;
 
     try {
-      const result = await getHooks(this.repoPath);
+      const result = await getHooks(this.pinnedRepoPath);
 
       if (result.success && result.data) {
         this.hooks = result.data;
@@ -761,7 +778,7 @@ export class LvHooksDialog extends LitElement {
 
     if (hook.exists) {
       try {
-        const result = await getHook(this.repoPath, hook.name);
+        const result = await getHook(this.pinnedRepoPath, hook.name);
         if (result.success && result.data) {
           this.selectedHook = result.data;
           this.editContent = result.data.content ?? '';
@@ -811,18 +828,18 @@ export class LvHooksDialog extends LitElement {
   }
 
   private async handleSave(): Promise<void> {
-    if (!this.selectedHook || !this.repoPath) return;
+    if (!this.selectedHook || !this.pinnedRepoPath) return;
 
     this.saving = true;
 
     try {
-      const result = await saveHook(this.repoPath, this.selectedHook.name, this.editContent);
+      const result = await saveHook(this.pinnedRepoPath, this.selectedHook.name, this.editContent);
 
       if (result.success) {
         showToast(`Hook "${this.selectedHook.name}" saved successfully`, 'success');
         this.hasUnsavedChanges = false;
         // Reload hooks to update status
-        const hooksResult = await getHooks(this.repoPath);
+        const hooksResult = await getHooks(this.pinnedRepoPath);
         if (hooksResult.success && hooksResult.data) {
           this.hooks = hooksResult.data;
           // Update selected hook reference
@@ -843,10 +860,10 @@ export class LvHooksDialog extends LitElement {
   }
 
   private async handleToggle(hook: GitHook): Promise<void> {
-    if (!this.repoPath || !hook.exists) return;
+    if (!this.pinnedRepoPath || !hook.exists) return;
 
     try {
-      const result = await toggleHook(this.repoPath, hook.name, !hook.enabled);
+      const result = await toggleHook(this.pinnedRepoPath, hook.name, !hook.enabled);
 
       if (result.success) {
         showToast(
@@ -854,7 +871,7 @@ export class LvHooksDialog extends LitElement {
           'success'
         );
         // Reload hooks
-        const hooksResult = await getHooks(this.repoPath);
+        const hooksResult = await getHooks(this.pinnedRepoPath);
         if (hooksResult.success && hooksResult.data) {
           this.hooks = hooksResult.data;
           if (this.selectedHook?.name === hook.name) {
@@ -882,13 +899,13 @@ export class LvHooksDialog extends LitElement {
   }
 
   private async confirmDelete(): Promise<void> {
-    if (!this.confirmingDelete || !this.repoPath) return;
+    if (!this.confirmingDelete || !this.pinnedRepoPath) return;
 
     const hookName = this.confirmingDelete;
     this.confirmingDelete = null;
 
     try {
-      const result = await deleteHook(this.repoPath, hookName);
+      const result = await deleteHook(this.pinnedRepoPath, hookName);
 
       if (result.success) {
         showToast(`Hook "${hookName}" deleted`, 'success');
@@ -899,7 +916,7 @@ export class LvHooksDialog extends LitElement {
           this.hasUnsavedChanges = false;
         }
         // Reload hooks
-        const hooksResult = await getHooks(this.repoPath);
+        const hooksResult = await getHooks(this.pinnedRepoPath);
         if (hooksResult.success && hooksResult.data) {
           this.hooks = hooksResult.data;
         }

--- a/src/components/dialogs/lv-init-dialog.ts
+++ b/src/components/dialogs/lv-init-dialog.ts
@@ -261,9 +261,17 @@ export class LvInitDialog extends LitElement {
   }
 
   private handleModalClose(): void {
-    if (!this.isInitializing) {
-      this.reset();
+    // Cancel is disabled while isInitializing is in flight; Escape, the overlay and the
+    // × must honour the same rule. lv-modal.close() sets open=false BEFORE
+    // dispatching, so without re-asserting it here the init kept running with no
+    // visible surface — and reported any failure into `error` on a hidden
+    // dialog. Mirrors lv-branch-cleanup-dialog.handleModalClose.
+    if (this.isInitializing) {
+      this.modal.open = true;
+      return;
     }
+
+    this.reset();
   }
 
   private get canInit(): boolean {

--- a/src/components/dialogs/lv-init-dialog.ts
+++ b/src/components/dialogs/lv-init-dialog.ts
@@ -187,6 +187,10 @@ export class LvInitDialog extends LitElement {
   @query('lv-modal') private modal!: LvModal;
 
   public open(): void {
+    // An init already in flight owns this component; reset() would
+    // clear `isInitializing` and re-enable the button for a second concurrent run,
+    // and the first run's close() would then yank shut the reopened session.
+    if (this.isInitializing) return;
     this.reset();
     this.modal.open = true;
   }

--- a/src/components/dialogs/lv-interactive-rebase-dialog.ts
+++ b/src/components/dialogs/lv-interactive-rebase-dialog.ts
@@ -512,6 +512,10 @@ export class LvInteractiveRebaseDialog extends LitElement {
   }
 
   public async open(onto: string, options?: { rewordCommitOid?: string }): Promise<void> {
+    // A rebase already running owns this component; reset() would clear
+    // `executing` and re-enable Start Rebase, allowing a second concurrent
+    // execute_interactive_rebase against the same repository.
+    if (this.executing) return;
     this.reset();
     this.onto = onto;
     this.pinnedRepoPath = this.repositoryPath;
@@ -880,9 +884,17 @@ export class LvInteractiveRebaseDialog extends LitElement {
   }
 
   private handleModalClose(): void {
-    if (!this.executing) {
-      this.reset();
+    // Cancel is disabled while executing is in flight; Escape, the overlay and the
+    // × must honour the same rule. lv-modal.close() sets open=false BEFORE
+    // dispatching, so without re-asserting it here the rebase kept running with no
+    // visible surface — and reported any failure into `error` on a hidden
+    // dialog. Mirrors lv-branch-cleanup-dialog.handleModalClose.
+    if (this.executing) {
+      this.modal.open = true;
+      return;
     }
+
+    this.reset();
   }
 
   private get canExecute(): boolean {

--- a/src/components/dialogs/lv-keyboard-shortcuts-dialog.ts
+++ b/src/components/dialogs/lv-keyboard-shortcuts-dialog.ts
@@ -375,8 +375,10 @@ export class LvKeyboardShortcutsDialog extends LitElement {
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
-    // Handle recording mode
-    if (this.editingId) {
+    // Handle recording mode. Gated on `open` as well as editingId: close()
+    // cancels recording, but a stale flag must never let a closed dialog eat
+    // keystrokes and rewrite bindings.
+    if (this.editingId && this.open) {
       e.preventDefault();
       e.stopPropagation();
 
@@ -464,6 +466,14 @@ export class LvKeyboardShortcutsDialog extends LitElement {
   }
 
   private close(): void {
+    // Recording MUST be cancelled here. The recording branch of handleKeyDown
+    // is gated on editingId alone, and this element is rendered
+    // unconditionally, so its document listener stays live forever. Dismissing
+    // mid-recording via the x or the backdrop (neither of which went through
+    // cancelEditing) left editingId set — and every subsequent keystroke
+    // anywhere in the app was then swallowed AND silently rebound that
+    // shortcut, persisted to localStorage, with no dialog on screen to show it.
+    this.cancelEditing();
     this.open = false;
     this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
   }

--- a/src/components/dialogs/lv-keyboard-shortcuts-dialog.ts
+++ b/src/components/dialogs/lv-keyboard-shortcuts-dialog.ts
@@ -369,6 +369,11 @@ export class LvKeyboardShortcutsDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    // Never leave the service disabled: being torn down mid-capture would
+    // otherwise kill every shortcut in the app with no way back.
+    if (this.editingId) {
+      keyboardService.setEnabled(true);
+    }
     removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
     this.settingsUnsubscribe?.();
@@ -404,6 +409,7 @@ export class LvKeyboardShortcutsDialog extends LitElement {
       // Try to rebind
       const success = keyboardService.rebind(this.editingId, binding);
       if (success) {
+        keyboardService.setEnabled(true);
         this.editingId = null;
         this.recordedBinding = null;
         this.conflictError = null;
@@ -434,12 +440,22 @@ export class LvKeyboardShortcutsDialog extends LitElement {
   };
 
   private startEditing(id: string): void {
+    // Silence the shortcut service for the duration of the capture. Its
+    // document listener is registered at MODULE EVALUATION, so it always runs
+    // before this dialog's (registered in connectedCallback) — and
+    // stopPropagation cannot suppress a listener on the same node. So the key
+    // being recorded was first EXECUTED: pressing "s" to rebind something
+    // staged the entire working tree, Ctrl+Shift+S stashed including
+    // untracked files, Ctrl+Shift+U pushed. It also ate the "Esc to cancel"
+    // this dialog advertises, closing the whole dialog instead.
+    keyboardService.setEnabled(false);
     this.editingId = id;
     this.recordedBinding = null;
     this.conflictError = null;
   }
 
   private cancelEditing(): void {
+    keyboardService.setEnabled(true);
     this.editingId = null;
     this.recordedBinding = null;
     this.conflictError = null;

--- a/src/components/dialogs/lv-keyboard-shortcuts-dialog.ts
+++ b/src/components/dialogs/lv-keyboard-shortcuts-dialog.ts
@@ -9,6 +9,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import { keyboardService, type Shortcut, type ShortcutBinding } from '../../services/keyboard.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 @customElement('lv-keyboard-shortcuts-dialog')
 export class LvKeyboardShortcutsDialog extends LitElement {
@@ -348,6 +349,15 @@ export class LvKeyboardShortcutsDialog extends LitElement {
 
   private settingsUnsubscribe?: () => void;
 
+  updated(changedProps: Map<string, unknown>): void {
+    // Announce/withdraw overlay ownership of Escape. Missing this made a
+    // dialog opened over another one dismiss BOTH on a single keypress:
+    // the one underneath was still stack-top, so its own guard passed.
+    if (changedProps.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
+  }
+
   connectedCallback(): void {
     super.connectedCallback();
     document.addEventListener('keydown', this.handleKeyDown);
@@ -359,6 +369,7 @@ export class LvKeyboardShortcutsDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
     this.settingsUnsubscribe?.();
   }
@@ -408,8 +419,14 @@ export class LvKeyboardShortcutsDialog extends LitElement {
       return;
     }
 
-    // Normal mode: close on Escape
-    if (e.key === 'Escape' && this.open) {
+    // Normal mode: close on Escape, but only when this dialog is the topmost
+    // overlay. Without that, pressing ? over the clean dialog and then Escape
+    // dismissed BOTH — the clean dialog was still stack-top, so its own guard
+    // passed and it discarded the user's file selection.
+    //
+    // The recording branch above is deliberately NOT gated: it is an explicit
+    // capture mode inside this dialog and already stops propagation.
+    if (e.key === 'Escape' && this.open && isTopOverlay(this)) {
       this.close();
     }
   };

--- a/src/components/dialogs/lv-lfs-dialog.ts
+++ b/src/components/dialogs/lv-lfs-dialog.ts
@@ -10,6 +10,7 @@ import * as gitService from '../../services/git.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
 import { handleExternalLink } from '../../utils/index.ts';
 import type { LfsStatus, LfsFile } from '../../services/git.service.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 @customElement('lv-lfs-dialog')
 export class LvLfsDialog extends LitElement {
@@ -394,7 +395,10 @@ export class LvLfsDialog extends LitElement {
    * made Escape a completely dead key here. Dismiss like every sibling.
    */
   private handleKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape' && this.open) {
+    // Only the topmost overlay owns Escape: every dialog listens on
+    // `document`, so without this one keypress ran all of them.
+    if (!this.open || !isTopOverlay(this)) return;
+    if (e.key === 'Escape') {
       this.handleClose();
     }
   };
@@ -409,6 +413,7 @@ export class LvLfsDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 
@@ -428,6 +433,10 @@ export class LvLfsDialog extends LitElement {
   }
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProperties.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProperties.has('open') && this.open) {
       this.pinnedRepoPath = this.repositoryPath;
       await this.loadStatus();

--- a/src/components/dialogs/lv-lfs-dialog.ts
+++ b/src/components/dialogs/lv-lfs-dialog.ts
@@ -7,6 +7,7 @@ import { LitElement, html, css } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
+import { showConfirm } from '../../services/dialog.service.ts';
 import { handleExternalLink } from '../../utils/index.ts';
 import type { LfsStatus, LfsFile } from '../../services/git.service.ts';
 
@@ -495,11 +496,28 @@ export class LvLfsDialog extends LitElement {
   }
 
   private async handlePrune(): Promise<void> {
+    // Captured BEFORE the confirm await: this dialog is bound to the active
+    // repository and rebinds live on a tab switch.
+    const repoPath = this.repositoryPath;
+
+    // `git lfs prune` deletes local LFS objects that recent commits don't
+    // reference. Unless lfs.pruneverifyremotealways is configured it does not
+    // verify the objects exist on the remote first, so blobs from a commit that
+    // was never pushed can be deleted with no copy left anywhere.
+    const confirmed = await showConfirm(
+      'Prune LFS Files',
+      'This permanently deletes local LFS objects that recent commits do not ' +
+        'reference. Objects that were never pushed cannot be recovered. Continue?',
+      'warning'
+    );
+
+    if (!confirmed) return;
+
     this.loading = true;
     this.error = '';
     this.success = '';
 
-    const result = await gitService.lfsPrune(this.repositoryPath);
+    const result = await gitService.lfsPrune(repoPath);
 
     if (result.success) {
       this.success = result.data || 'LFS files pruned';

--- a/src/components/dialogs/lv-lfs-dialog.ts
+++ b/src/components/dialogs/lv-lfs-dialog.ts
@@ -394,8 +394,24 @@ export class LvLfsDialog extends LitElement {
     }
   }
 
+  /**
+   * Repo captured when the dialog opened. `repositoryPath` is live-bound to
+   * the ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this dialog's overlay does not block — while the
+   * data on screen still belongs to the repo that was active at open. Every
+   * read and every mutation must use THIS value, or the dialog acts on a
+   * repository the user is not looking at.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     if (changedProperties.has('open') && this.open) {
+      this.pinnedRepoPath = this.repositoryPath;
       await this.loadStatus();
     }
   }
@@ -404,7 +420,7 @@ export class LvLfsDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.getLfsStatus(this.repositoryPath);
+    const result = await gitService.getLfsStatus(this.pinnedRepoPath);
 
     if (result.success && result.data) {
       this.status = result.data;
@@ -419,7 +435,7 @@ export class LvLfsDialog extends LitElement {
   }
 
   private async loadFiles(): Promise<void> {
-    const result = await gitService.getLfsFiles(this.repositoryPath);
+    const result = await gitService.getLfsFiles(this.pinnedRepoPath);
     if (result.success && result.data) {
       this.files = result.data;
     }
@@ -429,7 +445,7 @@ export class LvLfsDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.initLfs(this.repositoryPath);
+    const result = await gitService.initLfs(this.pinnedRepoPath);
 
     if (result.success) {
       this.success = 'Git LFS initialized';
@@ -448,7 +464,7 @@ export class LvLfsDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.lfsTrack(this.repositoryPath, this.newPattern);
+    const result = await gitService.lfsTrack(this.pinnedRepoPath, this.newPattern);
 
     if (result.success) {
       this.newPattern = '';
@@ -465,7 +481,7 @@ export class LvLfsDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.lfsUntrack(this.repositoryPath, pattern);
+    const result = await gitService.lfsUntrack(this.pinnedRepoPath, pattern);
 
     if (result.success) {
       await this.loadStatus();
@@ -482,7 +498,7 @@ export class LvLfsDialog extends LitElement {
     this.error = '';
     this.success = '';
 
-    const result = await gitService.lfsPull(this.repositoryPath);
+    const result = await gitService.lfsPull(this.pinnedRepoPath);
 
     if (result.success) {
       this.success = 'LFS files pulled successfully';
@@ -498,7 +514,7 @@ export class LvLfsDialog extends LitElement {
   private async handlePrune(): Promise<void> {
     // Captured BEFORE the confirm await: this dialog is bound to the active
     // repository and rebinds live on a tab switch.
-    const repoPath = this.repositoryPath;
+    const repoPath = this.pinnedRepoPath;
 
     // `git lfs prune` deletes local LFS objects that recent commits don't
     // reference. Unless lfs.pruneverifyremotealways is configured it does not

--- a/src/components/dialogs/lv-lfs-dialog.ts
+++ b/src/components/dialogs/lv-lfs-dialog.ts
@@ -387,11 +387,29 @@ export class LvLfsDialog extends LitElement {
   @state() private newPattern = '';
   @state() private showFiles = false;
 
+  /**
+   * This dialog paints its own overlay instead of using lv-modal, so it had no
+   * Escape handling at all — and app-shell's Escape chain now stops at the
+   * dialog layer (so a keypress cannot also close the diff behind it), which
+   * made Escape a completely dead key here. Dismiss like every sibling.
+   */
+  private handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this.open) {
+      this.handleClose();
+    }
+  };
+
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
+    document.addEventListener('keydown', this.handleKeyDown);
     if (this.open) {
       await this.loadStatus();
     }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener('keydown', this.handleKeyDown);
   }
 
   /**

--- a/src/components/dialogs/lv-migration-dialog.ts
+++ b/src/components/dialogs/lv-migration-dialog.ts
@@ -445,6 +445,28 @@ export class LvMigrationDialog extends LitElement {
     this.isLoading = false;
   }
 
+  /**
+   * This dialog paints its own overlay instead of using lv-modal, so it had no
+   * Escape handling at all — and app-shell's Escape chain stops at the dialog
+   * layer (so one keypress cannot also close the diff behind it), which left
+   * Escape completely dead here. handleClose already refuses mid-migration.
+   */
+  private handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this.open) {
+      this.handleClose();
+    }
+  };
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    document.addEventListener('keydown', this.handleKeyDown);
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener('keydown', this.handleKeyDown);
+  }
+
   private handleClose(): void {
     if (this.viewMode === 'migrating') return; // Don't allow closing during migration
     this.open = false;

--- a/src/components/dialogs/lv-migration-dialog.ts
+++ b/src/components/dialogs/lv-migration-dialog.ts
@@ -16,6 +16,7 @@ import type {
   UnifiedMigrationResult,
 } from '../../types/unified-profile.types.ts';
 import { INTEGRATION_TYPE_NAMES } from '../../types/unified-profile.types.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 type ViewMode = 'intro' | 'preview' | 'migrating' | 'complete';
 
@@ -432,6 +433,10 @@ export class LvMigrationDialog extends LitElement {
   @state() private migrationResult: UnifiedMigrationResult | null = null;
 
   updated(changedProperties: Map<string, unknown>): void {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProperties.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProperties.has('open') && this.open) {
       this.resetState();
     }
@@ -452,7 +457,10 @@ export class LvMigrationDialog extends LitElement {
    * Escape completely dead here. handleClose already refuses mid-migration.
    */
   private handleKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape' && this.open) {
+    // Only the topmost overlay owns Escape: every dialog listens on
+    // `document`, so without this one keypress ran all of them.
+    if (!this.open || !isTopOverlay(this)) return;
+    if (e.key === 'Escape') {
       this.handleClose();
     }
   };
@@ -464,6 +472,7 @@ export class LvMigrationDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 

--- a/src/components/dialogs/lv-modal.ts
+++ b/src/components/dialogs/lv-modal.ts
@@ -129,6 +129,19 @@ export class LvModal extends LitElement {
 
   private previouslyFocused: HTMLElement | null = null;
 
+  /**
+   * True when focus already sits inside this modal, following shadow
+   * boundaries. `document.activeElement` only ever names the outermost host,
+   * so a slotted input reads as its own dialog element, not as the input.
+   */
+  private containsDeepActiveElement(): boolean {
+    let el: Element | null = document.activeElement;
+    while (el?.shadowRoot?.activeElement) {
+      el = el.shadowRoot.activeElement;
+    }
+    return !!el && el !== document.body && this.contains(el);
+  }
+
   private handleOverlayClick(e: MouseEvent): void {
     if (e.target === e.currentTarget) {
       this.close();
@@ -210,6 +223,15 @@ export class LvModal extends LitElement {
         this.previouslyFocused = document.activeElement as HTMLElement;
         // Focus the dialog after render
         requestAnimationFrame(() => {
+          // Do not override a host that already focused something of its own.
+          // getFocusableElements queries this shadow root BEFORE walking the
+          // slot, so index 0 is our own header close button — and this rAF
+          // lands after a host's microtask focus, so it was silently stealing
+          // focus from every slotted field. lv-prompt-dialog focused its text
+          // input and lost it every time: typing a branch rename went to the
+          // global shortcut handler instead, where "s" ran Stage All Changes.
+          if (this.containsDeepActiveElement()) return;
+
           const dialog = this.shadowRoot?.querySelector('.dialog') as HTMLElement;
           if (dialog) {
             const focusable = this.getFocusableElements(dialog);

--- a/src/components/dialogs/lv-modal.ts
+++ b/src/components/dialogs/lv-modal.ts
@@ -135,6 +135,13 @@ export class LvModal extends LitElement {
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
+    // This listener lives on `document` for the element's whole lifetime, but
+    // host dialogs keep their <lv-modal> mounted while closed. Without this
+    // check every closed modal in the tree answered each Escape press by
+    // dispatching `close`, firing host handlers for dialogs the user was not
+    // looking at. The Tab trap below already guarded on `open`.
+    if (!this.open) return;
+
     if (e.key === 'Escape') {
       this.close();
     }

--- a/src/components/dialogs/lv-modal.ts
+++ b/src/components/dialogs/lv-modal.ts
@@ -6,6 +6,7 @@
 import { LitElement, html, css, type PropertyValues } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 @customElement('lv-modal')
 export class LvModal extends LitElement {
@@ -142,6 +143,12 @@ export class LvModal extends LitElement {
     // looking at. The Tab trap below already guarded on `open`.
     if (!this.open) return;
 
+    // Only the topmost overlay owns Escape. Every dialog listens on
+    // `document`, so without this one keypress ran all of them — dismissing
+    // the command palette opened over another dialog dismissed that dialog
+    // too, discarding whatever the user had built there.
+    if (!isTopOverlay(this)) return;
+
     if (e.key === 'Escape') {
       this.close();
     }
@@ -192,10 +199,12 @@ export class LvModal extends LitElement {
   disconnectedCallback(): void {
     super.disconnectedCallback();
     document.removeEventListener('keydown', this.handleKeyDown);
+    removeOverlay(this);
   }
 
   updated(changedProperties: PropertyValues): void {
     if (changedProperties.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
       if (this.open) {
         // Save the currently focused element for restoration
         this.previouslyFocused = document.activeElement as HTMLElement;

--- a/src/components/dialogs/lv-profile-manager-dialog.ts
+++ b/src/components/dialogs/lv-profile-manager-dialog.ts
@@ -14,6 +14,7 @@ import type { UnifiedProfile, IntegrationAccount, IntegrationType, IntegrationCo
 import { PROFILE_COLORS, ACCOUNT_COLORS, INTEGRATION_TYPE_NAMES } from '../../types/unified-profile.types.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 type ViewMode = 'list' | 'edit' | 'create' | 'select-account' | 'edit-account' | 'assign-repos' | 'accounts';
 
@@ -716,6 +717,7 @@ export class LvProfileManagerDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     this.unsubscribeStore?.();
     this.unsubscribeRepoStore?.();
     window.removeEventListener('keydown', this.handleKeyDown, true);
@@ -727,6 +729,11 @@ export class LvProfileManagerDialog extends LitElement {
     // is set via `?open=${...}` from the parent and reliably reflects there.
     const isOpen = this.hasAttribute('open');
     if (!isOpen || this.demoted) return;
+    // window + capture runs before EVERY document listener in the app, and
+    // this handler stopPropagation()s — so opening the command palette over
+    // this dialog and pressing Escape closed the dialog underneath while the
+    // palette, the actual topmost overlay, kept ignoring the key.
+    if (!isTopOverlay(this)) return;
     e.preventDefault();
     e.stopPropagation();
     if (this.viewMode === 'list') {
@@ -737,6 +744,10 @@ export class LvProfileManagerDialog extends LitElement {
   };
 
   willUpdate(changedProperties: Map<string, unknown>): void {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProperties.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     // Land on the requested view before render so opening doesn't flash the
     // list view first (and avoids a redundant update if set in updated()).
     if (changedProperties.has('open') && this.open) {

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -397,15 +397,30 @@ export class LvReflogDialog extends LitElement {
     // reset the repo the user switched TO.
     const repoPath = this.repositoryPath;
 
-    // Confirm hard reset
-    if (mode === 'hard') {
-      const confirmed = await showConfirm(
-        'Hard Reset',
-        `Are you sure you want to hard reset to ${entry.shortId}? This will discard all uncommitted changes.`,
-        'warning'
-      );
-      if (!confirmed) return;
-    }
+    // EVERY mode is a reset — the "Undo" button runs a mixed one — so every
+    // mode repoints the branch and drops commits off it. Gating the confirm on
+    // `hard` alone meant clicking Undo in a dialog opened just to LOOK at
+    // history silently reset the branch. The same operation from the graph
+    // context menu confirms for all three modes; this surface must match.
+    const droppedNote =
+      `This branch will point at ${entry.shortId}. Any commit no longer reachable ` +
+      `from it is recoverable only through the reflog.`;
+
+    const modeNote =
+      mode === 'hard'
+        ? 'All uncommitted changes are also discarded permanently — those are not in the reflog and cannot be recovered.'
+        : mode === 'mixed'
+          ? 'Your working-directory changes are kept, but unstaged.'
+          : 'Your changes remain staged.';
+
+    const titles = { hard: 'Hard Reset', mixed: 'Undo to This State', soft: 'Soft Reset' };
+
+    const confirmed = await showConfirm(
+      titles[mode],
+      `Reset to ${entry.shortId}?\n\n${droppedNote}\n\n${modeNote}`,
+      'warning'
+    );
+    if (!confirmed) return;
 
     this.resetting = true;
 

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -392,6 +392,11 @@ export class LvReflogDialog extends LitElement {
   private async handleReset(entry: ReflogEntry, mode: 'soft' | 'mixed' | 'hard'): Promise<void> {
     if (this.resetting) return;
 
+    // Captured BEFORE the confirm await: this dialog is bound to the active
+    // repository and rebinds live, so a mid-confirm tab switch would otherwise
+    // reset the repo the user switched TO.
+    const repoPath = this.repositoryPath;
+
     // Confirm hard reset
     if (mode === 'hard') {
       const confirmed = await showConfirm(
@@ -405,7 +410,10 @@ export class LvReflogDialog extends LitElement {
     this.resetting = true;
 
     try {
-      const result = await gitService.resetToReflog(this.repositoryPath, entry.index, mode);
+      // entry.oid pins the reset to the commit the user was actually shown:
+      // this dialog loads the reflog once and never reloads, so an external
+      // commit or checkout shifts entry.index onto a different commit.
+      const result = await gitService.resetToReflog(repoPath, entry.index, mode, entry.oid);
 
       if (result.success) {
         this.dispatchEvent(new CustomEvent('undo-complete', {

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -332,6 +332,10 @@ export class LvReflogDialog extends LitElement {
 
   async updated(changedProps: Map<string, unknown>): Promise<void> {
     if (changedProps.has('open') && this.open) {
+      // A prior operation may still be running against this component; its
+      // completion handler will close the dialog, so do not start a fresh
+      // session on top of it.
+      if (this.resetting) return;
       await this.loadReflog();
     }
   }
@@ -360,15 +364,27 @@ export class LvReflogDialog extends LitElement {
     }
   }
 
+  /**
+   * User-initiated dismissal. Blocked while the operation is in flight:
+   * closing mid-reset leaves it running with no visible surface, and when it
+   * finishes its success path calls close() — yanking shut whatever session
+   * the user had reopened in the meantime and discarding their new selection.
+   * close() itself stays unguarded because that success path needs it.
+   */
+  private dismiss(): void {
+    if (this.resetting) return;
+    this.close();
+  }
+
   private handleOverlayClick(e: MouseEvent): void {
     if (e.target === e.currentTarget) {
-      this.close();
+      this.dismiss();
     }
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
     if (e.key === 'Escape') {
-      this.close();
+      this.dismiss();
     }
   };
 
@@ -432,7 +448,9 @@ export class LvReflogDialog extends LitElement {
 
       if (result.success) {
         this.dispatchEvent(new CustomEvent('undo-complete', {
-          detail: { entry: result.data, mode },
+          // repositoryPath so the host refreshes the repo the reset ran on —
+          // the user may have switched tabs during the IPC await.
+          detail: { entry: result.data, mode, repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -577,7 +595,7 @@ export class LvReflogDialog extends LitElement {
               <div class="subtitle">Reflog - recover previous states</div>
             </div>
           </div>
-          <button class="close-btn" @click=${this.close}>
+          <button class="close-btn" @click=${this.dismiss}>
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="18" y1="6" x2="6" y2="18"></line>
               <line x1="6" y1="6" x2="18" y2="18"></line>

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -330,24 +330,41 @@ export class LvReflogDialog extends LitElement {
     }
   };
 
+  /**
+   * Repo captured when the dialog opened. `repositoryPath` is live-bound to
+   * the ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this dialog's overlay does not block. The entries
+   * on screen belong to the repo that was active at open, so a reset must
+   * target THAT repo: reading the live prop aimed the reset at whichever repo
+   * the user had switched to, while the confirm still named the old repo's
+   * commit.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
   async updated(changedProps: Map<string, unknown>): Promise<void> {
     if (changedProps.has('open') && this.open) {
       // A prior operation may still be running against this component; its
       // completion handler will close the dialog, so do not start a fresh
       // session on top of it.
       if (this.resetting) return;
+      this.pinnedRepoPath = this.repositoryPath;
       await this.loadReflog();
     }
   }
 
   private async loadReflog(): Promise<void> {
-    if (!this.repositoryPath) return;
+    if (!this.pinnedRepoPath) return;
 
     this.loading = true;
     this.entries = [];
 
     try {
-      const result = await gitService.getReflog(this.repositoryPath, 50);
+      const result = await gitService.getReflog(this.pinnedRepoPath, 50);
       if (result.success && result.data) {
         this.entries = result.data;
       } else if (!result.success) {
@@ -411,16 +428,21 @@ export class LvReflogDialog extends LitElement {
 
   public close(): void {
     this.open = false;
+    // Only handleDocumentClick clears this, and Escape is not a click — so a
+    // menu left open at dismissal was repainted at its old coordinates over
+    // the next session's freshly loaded list, still holding the PREVIOUS
+    // entry. Clicking it ran a reset the user never re-selected.
+    this.contextMenu = { visible: false, x: 0, y: 0, entry: null };
     this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
   }
 
   private async handleReset(entry: ReflogEntry, mode: 'soft' | 'mixed' | 'hard'): Promise<void> {
     if (this.resetting) return;
 
-    // Captured BEFORE the confirm await: this dialog is bound to the active
-    // repository and rebinds live, so a mid-confirm tab switch would otherwise
-    // reset the repo the user switched TO.
-    const repoPath = this.repositoryPath;
+    // The repo the listed entries were read from — NOT the live prop. Pinning
+    // only at click time still reset the wrong repository whenever the tab
+    // switch happened before the click rather than during the confirm.
+    const repoPath = this.pinnedRepoPath;
 
     // EVERY mode is a reset — the "Undo" button runs a mixed one — so every
     // mode repoints the branch and drops commits off it. Gating the confirm on
@@ -470,13 +492,9 @@ export class LvReflogDialog extends LitElement {
         // user to "refresh and try again" — but this dialog loads once and has
         // no refresh affordance, so without this the stale indices persist and
         // every retry fails identically. Reload so the advice is actionable.
-        //
-        // Skipped if the active repository changed while the reset was in
-        // flight: reloading would then replace the list with a DIFFERENT
-        // repo's reflog while the error still refers to this one.
-        if (this.repositoryPath === repoPath) {
-          await this.loadReflog();
-        }
+        // Safe unconditionally now the dialog is pinned: the reload reads the
+        // same repo the failed reset targeted, whichever tab is active.
+        await this.loadReflog();
       }
     } catch (err) {
       console.error('Reset failed:', err);

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -428,7 +428,13 @@ export class LvReflogDialog extends LitElement {
         // user to "refresh and try again" — but this dialog loads once and has
         // no refresh affordance, so without this the stale indices persist and
         // every retry fails identically. Reload so the advice is actionable.
-        await this.loadReflog();
+        //
+        // Skipped if the active repository changed while the reset was in
+        // flight: reloading would then replace the list with a DIFFERENT
+        // repo's reflog while the error still refers to this one.
+        if (this.repositoryPath === repoPath) {
+          await this.loadReflog();
+        }
       }
     } catch (err) {
       console.error('Reset failed:', err);

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -10,6 +10,7 @@ import * as gitService from '../../services/git.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import type { ReflogEntry } from '../../types/git.types.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 interface ReflogContextMenuState {
   visible: boolean;
@@ -347,6 +348,10 @@ export class LvReflogDialog extends LitElement {
   }
 
   async updated(changedProps: Map<string, unknown>): Promise<void> {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProps.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProps.has('open') && this.open) {
       // A prior operation may still be running against this component; its
       // completion handler will close the dialog, so do not start a fresh
@@ -382,15 +387,6 @@ export class LvReflogDialog extends LitElement {
   }
 
   /**
-   * True while a reset is in flight. Exposed so the app-shell-level Escape
-   * handler — a second, independent path that flips this dialog's `open`
-   * binding — can honour the same guard `dismiss()` applies.
-   */
-  public get isResetting(): boolean {
-    return this.resetting;
-  }
-
-  /**
    * User-initiated dismissal. Blocked while the operation is in flight:
    * closing mid-reset leaves it running with no visible surface, and when it
    * finishes its success path calls close() — yanking shut whatever session
@@ -409,6 +405,9 @@ export class LvReflogDialog extends LitElement {
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
+    // Only the topmost overlay owns Escape: every dialog listens on
+    // `document`, so without this one keypress ran all of them.
+    if (!this.open || !isTopOverlay(this)) return;
     if (e.key === 'Escape') {
       this.dismiss();
     }
@@ -422,6 +421,7 @@ export class LvReflogDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
     document.removeEventListener('click', this.handleDocumentClick);
   }

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -365,6 +365,15 @@ export class LvReflogDialog extends LitElement {
   }
 
   /**
+   * True while a reset is in flight. Exposed so the app-shell-level Escape
+   * handler — a second, independent path that flips this dialog's `open`
+   * binding — can honour the same guard `dismiss()` applies.
+   */
+  public get isResetting(): boolean {
+    return this.resetting;
+  }
+
+  /**
    * User-initiated dismissal. Blocked while the operation is in flight:
    * closing mid-reset leaves it running with no visible surface, and when it
    * finishes its success path calls close() — yanking shut whatever session

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -424,6 +424,11 @@ export class LvReflogDialog extends LitElement {
         this.close();
       } else {
         showToast(`Reset failed: ${result.error?.message ?? 'Unknown error'}`, 'error');
+        // The backend refuses when the reflog shifted under us and tells the
+        // user to "refresh and try again" — but this dialog loads once and has
+        // no refresh affordance, so without this the stale indices persist and
+        // every retry fails identically. Reload so the advice is actionable.
+        await this.loadReflog();
       }
     } catch (err) {
       console.error('Reset failed:', err);

--- a/src/components/dialogs/lv-remote-dialog.ts
+++ b/src/components/dialogs/lv-remote-dialog.ts
@@ -10,6 +10,7 @@ import * as gitService from '../../services/git.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import type { Remote } from '../../types/git.types.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 type DialogMode = 'list' | 'add' | 'edit' | 'rename';
 
@@ -399,6 +400,10 @@ export class LvRemoteDialog extends LitElement {
   }
 
   async updated(changedProps: Map<string, unknown>): Promise<void> {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProps.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProps.has('open') && this.open) {
       this.pinnedRepoPath = this.repositoryPath;
       await this.loadRemotes();
@@ -432,6 +437,9 @@ export class LvRemoteDialog extends LitElement {
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
+    // Only the topmost overlay owns Escape: every dialog listens on
+    // `document`, so without this one keypress ran all of them.
+    if (!this.open || !isTopOverlay(this)) return;
     if (e.key === 'Escape') {
       if (this.mode !== 'list') {
         this.resetForm();
@@ -448,6 +456,7 @@ export class LvRemoteDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 

--- a/src/components/dialogs/lv-remote-dialog.ts
+++ b/src/components/dialogs/lv-remote-dialog.ts
@@ -383,20 +383,36 @@ export class LvRemoteDialog extends LitElement {
   @state() private fetchingRemote: string | null = null;
   @state() private pruningRemote: string | null = null;
 
+  /**
+   * Repo captured when the dialog opened. `repositoryPath` is live-bound to
+   * the ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this dialog's overlay does not block. The remotes
+   * on screen belong to the repo that was active at open, so removing or
+   * pruning one must target THAT repo: reading the live prop removed "origin"
+   * from whichever repo the user had switched to.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
   async updated(changedProps: Map<string, unknown>): Promise<void> {
     if (changedProps.has('open') && this.open) {
+      this.pinnedRepoPath = this.repositoryPath;
       await this.loadRemotes();
     }
   }
 
   private async loadRemotes(): Promise<void> {
-    if (!this.repositoryPath) return;
+    if (!this.pinnedRepoPath) return;
 
     this.loading = true;
     this.error = null;
 
     try {
-      const result = await gitService.getRemotes(this.repositoryPath);
+      const result = await gitService.getRemotes(this.pinnedRepoPath);
       if (result.success && result.data) {
         this.remotes = result.data;
       } else {
@@ -483,7 +499,7 @@ export class LvRemoteDialog extends LitElement {
 
     try {
       const result = await gitService.addRemote(
-        this.repositoryPath,
+        this.pinnedRepoPath,
         this.formName.trim(),
         this.formUrl.trim()
       );
@@ -511,7 +527,7 @@ export class LvRemoteDialog extends LitElement {
     try {
       // Update fetch URL
       let result = await gitService.setRemoteUrl(
-        this.repositoryPath,
+        this.pinnedRepoPath,
         this.editingRemote.name,
         this.formUrl.trim(),
         false
@@ -525,7 +541,7 @@ export class LvRemoteDialog extends LitElement {
       // Update push URL if different
       if (this.formPushUrl.trim() && this.formPushUrl.trim() !== this.formUrl.trim()) {
         result = await gitService.setRemoteUrl(
-          this.repositoryPath,
+          this.pinnedRepoPath,
           this.editingRemote.name,
           this.formPushUrl.trim(),
           true
@@ -559,7 +575,7 @@ export class LvRemoteDialog extends LitElement {
 
     try {
       const result = await gitService.renameRemote(
-        this.repositoryPath,
+        this.pinnedRepoPath,
         this.editingRemote.name,
         this.formName.trim()
       );
@@ -582,7 +598,7 @@ export class LvRemoteDialog extends LitElement {
     this.fetchingRemote = remote.name;
     try {
       const result = await gitService.fetch({
-        path: this.repositoryPath,
+        path: this.pinnedRepoPath,
         remote: remote.name,
         silent: true,
       });
@@ -603,7 +619,7 @@ export class LvRemoteDialog extends LitElement {
     this.pruningRemote = remote.name;
     try {
       const result = await gitService.pruneRemoteTrackingBranches(
-        this.repositoryPath,
+        this.pinnedRepoPath,
         remote.name,
       );
       if (result.success && result.data) {
@@ -626,10 +642,10 @@ export class LvRemoteDialog extends LitElement {
   }
 
   private async handleRemove(remote: Remote): Promise<void> {
-    // Captured BEFORE the confirm await: this dialog is bound to the active
-    // repository and rebinds live, so a mid-confirm tab switch would otherwise
-    // remove the remote from the repo the user switched TO.
-    const repoPath = this.repositoryPath;
+    // The repo the listed remotes were read from — NOT the live prop, which
+    // rebinds on a tab switch and would remove "origin" from the repo the
+    // user switched to while this list still showed the old one's.
+    const repoPath = this.pinnedRepoPath;
 
     const confirmed = await showConfirm(
       'Remove Remote',

--- a/src/components/dialogs/lv-remote-dialog.ts
+++ b/src/components/dialogs/lv-remote-dialog.ts
@@ -626,6 +626,11 @@ export class LvRemoteDialog extends LitElement {
   }
 
   private async handleRemove(remote: Remote): Promise<void> {
+    // Captured BEFORE the confirm await: this dialog is bound to the active
+    // repository and rebinds live, so a mid-confirm tab switch would otherwise
+    // remove the remote from the repo the user switched TO.
+    const repoPath = this.repositoryPath;
+
     const confirmed = await showConfirm(
       'Remove Remote',
       `Are you sure you want to remove the remote "${remote.name}"?\n\nThis will not delete the remote repository, only the local reference.`,
@@ -640,7 +645,7 @@ export class LvRemoteDialog extends LitElement {
     this.error = null;
 
     try {
-      const result = await gitService.removeRemote(this.repositoryPath, remote.name);
+      const result = await gitService.removeRemote(repoPath, remote.name);
 
       if (result.success) {
         await this.loadRemotes();

--- a/src/components/dialogs/lv-repository-health-dialog.ts
+++ b/src/components/dialogs/lv-repository-health-dialog.ts
@@ -612,7 +612,15 @@ export class LvRepositoryHealthDialog extends LitElement {
       </div>
 
       <div class="footer">
-        <button class="primary" @click=${this.handleClose}>Done</button>
+        <!-- Disabled while an action runs: the host refuses to close mid-gc
+             (closing destroys this element and would orphan the operation), so
+             an enabled Done was a button that silently did nothing. Every
+             sibling dialog with this guard disables its cancel control too. -->
+        <button
+          class="primary"
+          ?disabled=${!!this.runningAction}
+          @click=${this.handleClose}
+        >Done</button>
       </div>
     `;
   }

--- a/src/components/dialogs/lv-repository-health-dialog.ts
+++ b/src/components/dialogs/lv-repository-health-dialog.ts
@@ -233,6 +233,17 @@ export class LvRepositoryHealthDialog extends LitElement {
    */
   private pinnedRepoPath = '';
 
+  /**
+   * True while gc / prune / fsck is running. The host must refuse to close on
+   * it: this dialog is inside an `${cond ? html : ''}` block, so dismissing it
+   * DESTROYS the element rather than hiding it — an aggressive gc kept running
+   * with no surface, and reopening built a fresh element with runningAction
+   * null, re-enabling every button for a second concurrent gc on the same repo.
+   */
+  public get isRunning(): boolean {
+    return this.runningAction !== null;
+  }
+
   /** The repo this dialog is pinned to, for the host's tab-close sweep. */
   public get pinnedRepositoryPathIfOpen(): string | null {
     return this.pinnedRepoPath || null;

--- a/src/components/dialogs/lv-repository-health-dialog.ts
+++ b/src/components/dialogs/lv-repository-health-dialog.ts
@@ -244,6 +244,33 @@ export class LvRepositoryHealthDialog extends LitElement {
     return this.runningAction !== null;
   }
 
+  /**
+   * The pinned repo's tab was closed while an action was in flight. We cannot
+   * close now — that destroys the element and orphans the running gc — so
+   * refuse any FURTHER action and dismiss as soon as the current one lands.
+   * Without this the host's refusal merely deferred the problem: the dialog
+   * stayed open pinned to a repo with no tab, and its guard
+   * (`!pinnedRepoPath || runningAction`) happily allowed a second gc on it
+   * once the first finished.
+   */
+  @state() private closePending = false;
+
+  public closeWhenIdle(): void {
+    if (!this.runningAction) {
+      this.handleClose();
+      return;
+    }
+    this.closePending = true;
+  }
+
+  /** Called from every action's finally: honour a deferred close. */
+  private settleClosePending(): void {
+    if (this.closePending && !this.runningAction) {
+      this.closePending = false;
+      this.handleClose();
+    }
+  }
+
   /** The repo this dialog is pinned to, for the host's tab-close sweep. */
   public get pinnedRepositoryPathIfOpen(): string | null {
     return this.pinnedRepoPath || null;
@@ -358,7 +385,7 @@ export class LvRepositoryHealthDialog extends LitElement {
   }
 
   private async runGc(aggressive: boolean): Promise<void> {
-    if (!this.pinnedRepoPath || this.runningAction) return;
+    if (!this.pinnedRepoPath || this.runningAction || this.closePending) return;
 
     // Pinned before the confirm await: this dialog is bound to the active
     // repository and rebinds live on a tab switch.
@@ -386,11 +413,12 @@ export class LvRepositoryHealthDialog extends LitElement {
       }
     } finally {
       this.runningAction = null;
+      this.settleClosePending();
     }
   }
 
   private async runFsck(): Promise<void> {
-    if (!this.pinnedRepoPath || this.runningAction) return;
+    if (!this.pinnedRepoPath || this.runningAction || this.closePending) return;
 
     this.runningAction = 'fsck';
 
@@ -412,11 +440,12 @@ export class LvRepositoryHealthDialog extends LitElement {
       }
     } finally {
       this.runningAction = null;
+      this.settleClosePending();
     }
   }
 
   private async runPrune(): Promise<void> {
-    if (!this.pinnedRepoPath || this.runningAction) return;
+    if (!this.pinnedRepoPath || this.runningAction || this.closePending) return;
 
     const repoPath = this.pinnedRepoPath;
 
@@ -439,6 +468,7 @@ export class LvRepositoryHealthDialog extends LitElement {
       }
     } finally {
       this.runningAction = null;
+      this.settleClosePending();
     }
   }
 

--- a/src/components/dialogs/lv-repository-health-dialog.ts
+++ b/src/components/dialogs/lv-repository-health-dialog.ts
@@ -366,9 +366,11 @@ export class LvRepositoryHealthDialog extends LitElement {
       });
 
       if (result.success) {
-        showToast('File system check completed - no issues found', 'success');
+        // `git fsck` exits 0 while reporting dangling/unreachable objects, so
+        // show its actual output rather than asserting "no issues found".
+        showToast(result.data?.message ?? 'File system check completed', 'success');
       } else {
-        showToast(`File system check found issues: ${result.error?.message}`, 'warning');
+        showToast(`File system check failed: ${result.error?.message}`, 'error');
       }
     } finally {
       this.runningAction = null;

--- a/src/components/dialogs/lv-repository-health-dialog.ts
+++ b/src/components/dialogs/lv-repository-health-dialog.ts
@@ -8,7 +8,11 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
-import { tryAcquireMaintenance, releaseMaintenance } from '../../utils/maintenance-confirms.ts';
+import {
+  tryAcquireMaintenance,
+  releaseMaintenance,
+  isMaintenanceRunning,
+} from '../../utils/maintenance-confirms.ts';
 import {
   confirmGarbageCollection,
   confirmPrune,
@@ -388,6 +392,15 @@ export class LvRepositoryHealthDialog extends LitElement {
   private async runGc(aggressive: boolean): Promise<void> {
     if (!this.pinnedRepoPath || this.runningAction || this.closePending) return;
 
+    // Checked BEFORE the confirm. The claim below is what actually
+    // serialises, but taking it only after the prompt meant the user read a
+    // full "this permanently deletes unreachable objects" warning, clicked
+    // through it, and only then got told the run was refused.
+    if (isMaintenanceRunning(this.pinnedRepoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
+
     // Pinned before the confirm await: this dialog is bound to the active
     // repository and rebinds live on a tab switch.
     const repoPath = this.pinnedRepoPath;
@@ -430,6 +443,15 @@ export class LvRepositoryHealthDialog extends LitElement {
   private async runFsck(): Promise<void> {
     if (!this.pinnedRepoPath || this.runningAction || this.closePending) return;
 
+    // Checked BEFORE the confirm. The claim below is what actually
+    // serialises, but taking it only after the prompt meant the user read a
+    // full "this permanently deletes unreachable objects" warning, clicked
+    // through it, and only then got told the run was refused.
+    if (isMaintenanceRunning(this.pinnedRepoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
+
     const repoPath = this.pinnedRepoPath;
     // Shared with the command palette, which reaches these same three
     // commands: runningAction only ever covered THIS dialog, so a palette run
@@ -466,6 +488,15 @@ export class LvRepositoryHealthDialog extends LitElement {
 
   private async runPrune(): Promise<void> {
     if (!this.pinnedRepoPath || this.runningAction || this.closePending) return;
+
+    // Checked BEFORE the confirm. The claim below is what actually
+    // serialises, but taking it only after the prompt meant the user read a
+    // full "this permanently deletes unreachable objects" warning, clicked
+    // through it, and only then got told the run was refused.
+    if (isMaintenanceRunning(this.pinnedRepoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
 
     const repoPath = this.pinnedRepoPath;
 

--- a/src/components/dialogs/lv-repository-health-dialog.ts
+++ b/src/components/dialogs/lv-repository-health-dialog.ts
@@ -8,7 +8,11 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
-import { confirmGarbageCollection, confirmPrune } from '../../utils/maintenance-confirms.ts';
+import {
+  confirmGarbageCollection,
+  confirmPrune,
+  summariseFsck,
+} from '../../utils/maintenance-confirms.ts';
 
 interface HealthStats {
   objectCount: number;
@@ -371,8 +375,9 @@ export class LvRepositoryHealthDialog extends LitElement {
 
       if (result.success) {
         // `git fsck` exits 0 while reporting dangling/unreachable objects, so
-        // show its actual output rather than asserting "no issues found".
-        showToast(result.data?.message ?? 'File system check completed', 'success');
+        // show its actual output rather than asserting "no issues found" —
+        // summarised, because that output can run to dozens of lines.
+        showToast(summariseFsck(result.data?.message), 'success');
       } else {
         showToast(`File system check failed: ${result.error?.message}`, 'error');
       }

--- a/src/components/dialogs/lv-repository-health-dialog.ts
+++ b/src/components/dialogs/lv-repository-health-dialog.ts
@@ -341,6 +341,8 @@ export class LvRepositoryHealthDialog extends LitElement {
       const result = await gitService.runGc({
         path: repoPath,
         aggressive,
+        // silent: the service toasts by default; this dialog owns the message.
+        silent: true,
       });
 
       if (result.success) {
@@ -363,6 +365,8 @@ export class LvRepositoryHealthDialog extends LitElement {
       const result = await gitService.runFsck({
         path: this.repositoryPath,
         full: true,
+        // silent: the service toasts by default; this dialog owns the message.
+        silent: true,
       });
 
       if (result.success) {
@@ -389,6 +393,8 @@ export class LvRepositoryHealthDialog extends LitElement {
     try {
       const result = await gitService.runPrune({
         path: repoPath,
+        // silent: the service toasts by default; this dialog owns the message.
+        silent: true,
       });
 
       if (result.success) {

--- a/src/components/dialogs/lv-repository-health-dialog.ts
+++ b/src/components/dialogs/lv-repository-health-dialog.ts
@@ -8,6 +8,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
+import { confirmGarbageCollection, confirmPrune } from '../../utils/maintenance-confirms.ts';
 
 interface HealthStats {
   objectCount: number;
@@ -326,11 +327,19 @@ export class LvRepositoryHealthDialog extends LitElement {
   private async runGc(aggressive: boolean): Promise<void> {
     if (!this.repositoryPath || this.runningAction) return;
 
+    // Pinned before the confirm await: this dialog is bound to the active
+    // repository and rebinds live on a tab switch.
+    const repoPath = this.repositoryPath;
+
+    // Same gate as the command palette (shared helper) — this dialog reaches
+    // the identical irreversible command and must not be the unguarded route.
+    if (!(await confirmGarbageCollection(aggressive))) return;
+
     this.runningAction = aggressive ? 'gc-aggressive' : 'gc';
 
     try {
       const result = await gitService.runGc({
-        path: this.repositoryPath,
+        path: repoPath,
         aggressive,
       });
 
@@ -369,11 +378,15 @@ export class LvRepositoryHealthDialog extends LitElement {
   private async runPrune(): Promise<void> {
     if (!this.repositoryPath || this.runningAction) return;
 
+    const repoPath = this.repositoryPath;
+
+    if (!(await confirmPrune())) return;
+
     this.runningAction = 'prune';
 
     try {
       const result = await gitService.runPrune({
-        path: this.repositoryPath,
+        path: repoPath,
       });
 
       if (result.success) {

--- a/src/components/dialogs/lv-repository-health-dialog.ts
+++ b/src/components/dialogs/lv-repository-health-dialog.ts
@@ -8,6 +8,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
+import { tryAcquireMaintenance, releaseMaintenance } from '../../utils/maintenance-confirms.ts';
 import {
   confirmGarbageCollection,
   confirmPrune,
@@ -395,6 +396,14 @@ export class LvRepositoryHealthDialog extends LitElement {
     // the identical irreversible command and must not be the unguarded route.
     if (!(await confirmGarbageCollection(aggressive))) return;
 
+    // Shared with the command palette, which reaches these same three
+    // commands: runningAction only ever covered THIS dialog, so a palette run
+    // could start a second maintenance command against the same repo.
+    if (!tryAcquireMaintenance(repoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
+
     this.runningAction = aggressive ? 'gc-aggressive' : 'gc';
 
     try {
@@ -413,12 +422,22 @@ export class LvRepositoryHealthDialog extends LitElement {
       }
     } finally {
       this.runningAction = null;
+      releaseMaintenance(repoPath);
       this.settleClosePending();
     }
   }
 
   private async runFsck(): Promise<void> {
     if (!this.pinnedRepoPath || this.runningAction || this.closePending) return;
+
+    const repoPath = this.pinnedRepoPath;
+    // Shared with the command palette, which reaches these same three
+    // commands: runningAction only ever covered THIS dialog, so a palette run
+    // could start a second maintenance command against the same repo.
+    if (!tryAcquireMaintenance(repoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
 
     this.runningAction = 'fsck';
 
@@ -440,6 +459,7 @@ export class LvRepositoryHealthDialog extends LitElement {
       }
     } finally {
       this.runningAction = null;
+      releaseMaintenance(repoPath);
       this.settleClosePending();
     }
   }
@@ -450,6 +470,14 @@ export class LvRepositoryHealthDialog extends LitElement {
     const repoPath = this.pinnedRepoPath;
 
     if (!(await confirmPrune())) return;
+
+    // Shared with the command palette, which reaches these same three
+    // commands: runningAction only ever covered THIS dialog, so a palette run
+    // could start a second maintenance command against the same repo.
+    if (!tryAcquireMaintenance(repoPath)) {
+      showToast('A maintenance operation is already running on this repository', 'warning');
+      return;
+    }
 
     this.runningAction = 'prune';
 
@@ -468,6 +496,7 @@ export class LvRepositoryHealthDialog extends LitElement {
       }
     } finally {
       this.runningAction = null;
+      releaseMaintenance(repoPath);
       this.settleClosePending();
     }
   }

--- a/src/components/dialogs/lv-repository-health-dialog.ts
+++ b/src/components/dialogs/lv-repository-health-dialog.ts
@@ -221,25 +221,43 @@ export class LvRepositoryHealthDialog extends LitElement {
   @state() private runningAction: string | null = null;
   @state() private stats: HealthStats | null = null;
 
+  /**
+   * Repo captured when the dialog opened. app-shell recreates this element on
+   * every open, so connectedCallback IS the open moment. `repositoryPath` is
+   * live-bound to the ACTIVE repository and rebinds the instant the user
+   * Ctrl+Tabs — a document-level shortcut this dialog's overlay does not
+   * block — while the stats on screen still describe the repo that was active
+   * at open. Reading the live prop ran `git gc`/`git prune` against a
+   * different repository than the one whose loose-object count justified it,
+   * destroying unreachable objects the user never chose to expire.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to, for the host's tab-close sweep. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.pinnedRepoPath || null;
+  }
+
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
+    this.pinnedRepoPath = this.repositoryPath;
     await this.loadHealthStats();
   }
 
   private async loadHealthStats(): Promise<void> {
-    if (!this.repositoryPath) return;
+    if (!this.pinnedRepoPath) return;
 
     this.loading = true;
 
     try {
       // Get repository statistics
       const [countResult, packsResult, branchesResult, tagsResult, stashesResult, repoStatsResult] = await Promise.all([
-        gitService.getRepositoryStats(this.repositoryPath),
-        gitService.getPackInfo(this.repositoryPath),
-        gitService.getBranches(this.repositoryPath),
-        gitService.getTags(this.repositoryPath),
-        gitService.getStashes(this.repositoryPath),
-        gitService.getRepoStats(this.repositoryPath, 10000),
+        gitService.getRepositoryStats(this.pinnedRepoPath),
+        gitService.getPackInfo(this.pinnedRepoPath),
+        gitService.getBranches(this.pinnedRepoPath),
+        gitService.getTags(this.pinnedRepoPath),
+        gitService.getStashes(this.pinnedRepoPath),
+        gitService.getRepoStats(this.pinnedRepoPath, 10000),
       ]);
 
       // Calculate recommendations
@@ -329,11 +347,11 @@ export class LvRepositoryHealthDialog extends LitElement {
   }
 
   private async runGc(aggressive: boolean): Promise<void> {
-    if (!this.repositoryPath || this.runningAction) return;
+    if (!this.pinnedRepoPath || this.runningAction) return;
 
     // Pinned before the confirm await: this dialog is bound to the active
     // repository and rebinds live on a tab switch.
-    const repoPath = this.repositoryPath;
+    const repoPath = this.pinnedRepoPath;
 
     // Same gate as the command palette (shared helper) — this dialog reaches
     // the identical irreversible command and must not be the unguarded route.
@@ -361,13 +379,13 @@ export class LvRepositoryHealthDialog extends LitElement {
   }
 
   private async runFsck(): Promise<void> {
-    if (!this.repositoryPath || this.runningAction) return;
+    if (!this.pinnedRepoPath || this.runningAction) return;
 
     this.runningAction = 'fsck';
 
     try {
       const result = await gitService.runFsck({
-        path: this.repositoryPath,
+        path: this.pinnedRepoPath,
         full: true,
         // silent: the service toasts by default; this dialog owns the message.
         silent: true,
@@ -387,9 +405,9 @@ export class LvRepositoryHealthDialog extends LitElement {
   }
 
   private async runPrune(): Promise<void> {
-    if (!this.repositoryPath || this.runningAction) return;
+    if (!this.pinnedRepoPath || this.runningAction) return;
 
-    const repoPath = this.repositoryPath;
+    const repoPath = this.pinnedRepoPath;
 
     if (!(await confirmPrune())) return;
 

--- a/src/components/dialogs/lv-settings-dialog.ts
+++ b/src/components/dialogs/lv-settings-dialog.ts
@@ -1199,7 +1199,7 @@ export class LvSettingsDialog extends LitElement {
           <div class="setting-row">
             <div class="setting-label">
               <span class="setting-name">Confirm Before Discard</span>
-              <span class="setting-description">Ask for confirmation when discarding changes</span>
+              <span class="setting-description">Ask for confirmation when discarding changes. Deleting untracked files always asks.</span>
             </div>
             ${this.renderToggle(this.confirmBeforeDiscard, 'confirmBeforeDiscard')}
           </div>

--- a/src/components/dialogs/lv-submodule-dialog.ts
+++ b/src/components/dialogs/lv-submodule-dialog.ts
@@ -357,11 +357,29 @@ export class LvSubmoduleDialog extends LitElement {
   @state() private addPath = '';
   @state() private addBranch = '';
 
+  /**
+   * This dialog paints its own overlay instead of using lv-modal, so it had no
+   * Escape handling at all — and app-shell's Escape chain now stops at the
+   * dialog layer (so a keypress cannot also close the diff behind it), which
+   * made Escape a completely dead key here. Dismiss like every sibling.
+   */
+  private handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this.open) {
+      this.handleClose();
+    }
+  };
+
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
+    document.addEventListener('keydown', this.handleKeyDown);
     if (this.open) {
       await this.loadSubmodules();
     }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener('keydown', this.handleKeyDown);
   }
 
   /**

--- a/src/components/dialogs/lv-submodule-dialog.ts
+++ b/src/components/dialogs/lv-submodule-dialog.ts
@@ -10,6 +10,7 @@ import * as gitService from '../../services/git.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
 import type { Submodule } from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 type DialogMode = 'list' | 'add';
 
@@ -364,7 +365,10 @@ export class LvSubmoduleDialog extends LitElement {
    * made Escape a completely dead key here. Dismiss like every sibling.
    */
   private handleKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape' && this.open) {
+    // Only the topmost overlay owns Escape: every dialog listens on
+    // `document`, so without this one keypress ran all of them.
+    if (!this.open || !isTopOverlay(this)) return;
+    if (e.key === 'Escape') {
       this.handleClose();
     }
   };
@@ -379,6 +383,7 @@ export class LvSubmoduleDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 
@@ -398,6 +403,10 @@ export class LvSubmoduleDialog extends LitElement {
   }
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProperties.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProperties.has('open') && this.open) {
       this.pinnedRepoPath = this.repositoryPath;
       this.mode = 'list';

--- a/src/components/dialogs/lv-submodule-dialog.ts
+++ b/src/components/dialogs/lv-submodule-dialog.ts
@@ -364,8 +364,24 @@ export class LvSubmoduleDialog extends LitElement {
     }
   }
 
+  /**
+   * Repo captured when the dialog opened. `repositoryPath` is live-bound to
+   * the ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this dialog's overlay does not block — while the
+   * data on screen still belongs to the repo that was active at open. Every
+   * read and every mutation must use THIS value, or the dialog acts on a
+   * repository the user is not looking at.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     if (changedProperties.has('open') && this.open) {
+      this.pinnedRepoPath = this.repositoryPath;
       this.mode = 'list';
       this.addUrl = '';
       this.addPath = '';
@@ -378,7 +394,7 @@ export class LvSubmoduleDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.getSubmodules(this.repositoryPath);
+    const result = await gitService.getSubmodules(this.pinnedRepoPath);
 
     if (result.success && result.data) {
       this.submodules = result.data;
@@ -399,7 +415,7 @@ export class LvSubmoduleDialog extends LitElement {
     this.error = '';
 
     const result = await gitService.addSubmodule(
-      this.repositoryPath,
+      this.pinnedRepoPath,
       this.addUrl,
       this.addPath,
       this.addBranch || undefined
@@ -426,11 +442,11 @@ export class LvSubmoduleDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.initSubmodules(this.repositoryPath, [submodule.path]);
+    const result = await gitService.initSubmodules(this.pinnedRepoPath, [submodule.path]);
 
     if (result.success) {
       // Also update after init
-      const updateResult = await gitService.updateSubmodules(this.repositoryPath, {
+      const updateResult = await gitService.updateSubmodules(this.pinnedRepoPath, {
         submodulePaths: [submodule.path],
       });
       if (!updateResult.success) {
@@ -454,7 +470,7 @@ export class LvSubmoduleDialog extends LitElement {
     // superproject has recorded for this submodule, leaving the superproject
     // clean. (Passing remote:true would run `--remote`, checking out the
     // upstream branch tip instead and dirtying the working tree.)
-    const result = await gitService.updateSubmodules(this.repositoryPath, {
+    const result = await gitService.updateSubmodules(this.pinnedRepoPath, {
       submodulePaths: [submodule.path],
     });
 
@@ -475,7 +491,7 @@ export class LvSubmoduleDialog extends LitElement {
     // uncommitted work inside it). This dialog is bound to the active
     // repository and rebinds live, so a mid-confirm tab switch would otherwise
     // aim that at the repo the user switched TO.
-    const repoPath = this.repositoryPath;
+    const repoPath = this.pinnedRepoPath;
 
     const confirmed = await showConfirm(
       'Remove Submodule',
@@ -507,7 +523,7 @@ export class LvSubmoduleDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.updateSubmodules(this.repositoryPath, {
+    const result = await gitService.updateSubmodules(this.pinnedRepoPath, {
       init: true,
       recursive: true,
     });

--- a/src/components/dialogs/lv-submodule-dialog.ts
+++ b/src/components/dialogs/lv-submodule-dialog.ts
@@ -470,9 +470,16 @@ export class LvSubmoduleDialog extends LitElement {
   }
 
   private async handleRemove(submodule: Submodule): Promise<void> {
+    // Captured BEFORE the confirm await: removal runs `git submodule deinit -f`
+    // + `git rm -f`, deleting the submodule's working tree (including any
+    // uncommitted work inside it). This dialog is bound to the active
+    // repository and rebinds live, so a mid-confirm tab switch would otherwise
+    // aim that at the repo the user switched TO.
+    const repoPath = this.repositoryPath;
+
     const confirmed = await showConfirm(
       'Remove Submodule',
-      `Are you sure you want to remove the submodule "${submodule.name}"?\n\nThis will remove the submodule from your repository.`,
+      `Are you sure you want to remove the submodule "${submodule.name}"?\n\nThis deletes its working directory, including any uncommitted changes inside it. This cannot be undone.`,
       'warning'
     );
 
@@ -481,7 +488,7 @@ export class LvSubmoduleDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.removeSubmodule(this.repositoryPath, submodule.path);
+    const result = await gitService.removeSubmodule(repoPath, submodule.path);
 
     if (result.success) {
       this.success = 'Submodule removed successfully';

--- a/src/components/dialogs/lv-workspace-manager-dialog.ts
+++ b/src/components/dialogs/lv-workspace-manager-dialog.ts
@@ -14,6 +14,7 @@ import { repositoryStore } from '../../stores/index.ts';
 import { workspaceStore } from '../../stores/workspace.store.ts';
 import { readTextFile, writeTextFile } from '@tauri-apps/plugin-fs';
 import type { Workspace, WorkspaceRepoStatus, WorkspaceSearchResult } from '../../types/git.types.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 const WORKSPACE_COLORS = [
   '#4fc3f7', '#81c784', '#ef5350', '#ffb74d',
@@ -693,6 +694,12 @@ export class LvWorkspaceManagerDialog extends LitElement {
   @state() private editColor = WORKSPACE_COLORS[0];
 
   async updated(changedProps: Map<string, unknown>): Promise<void> {
+    // Announce/withdraw overlay ownership of Escape. Missing this made a
+    // dialog opened over another one dismiss BOTH on a single keypress:
+    // the one underneath was still stack-top, so its own guard passed.
+    if (changedProps.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProps.has('open') && this.open) {
       await this.loadWorkspaces();
     }
@@ -1039,6 +1046,9 @@ export class LvWorkspaceManagerDialog extends LitElement {
   }
 
   private handleKeyDown = (e: KeyboardEvent): void => {
+    // Only the topmost overlay owns Escape.
+    if (!this.open || !isTopOverlay(this)) return;
+
     if (e.key === 'Escape') {
       this.close();
     }
@@ -1051,6 +1061,7 @@ export class LvWorkspaceManagerDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 

--- a/src/components/dialogs/lv-worktree-dialog.ts
+++ b/src/components/dialogs/lv-worktree-dialog.ts
@@ -442,6 +442,11 @@ export class LvWorktreeDialog extends LitElement {
       return;
     }
 
+    // Captured BEFORE the confirm await: this dialog is bound to the active
+    // repository and rebinds live, so a mid-confirm tab switch would otherwise
+    // run the removal against the repo the user switched TO.
+    const repoPath = this.repositoryPath;
+
     const confirmed = await showConfirm(
       'Remove Worktree',
       `Are you sure you want to remove the worktree at "${worktree.path}"?`,
@@ -453,7 +458,7 @@ export class LvWorktreeDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.removeWorktree(this.repositoryPath, worktree.path);
+    const result = await gitService.removeWorktree(repoPath, worktree.path);
 
     if (result.success) {
       this.success = 'Worktree removed';

--- a/src/components/dialogs/lv-worktree-dialog.ts
+++ b/src/components/dialogs/lv-worktree-dialog.ts
@@ -362,8 +362,24 @@ export class LvWorktreeDialog extends LitElement {
     }
   }
 
+  /**
+   * Repo captured when the dialog opened. `repositoryPath` is live-bound to
+   * the ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this dialog's overlay does not block — while the
+   * data on screen still belongs to the repo that was active at open. Every
+   * read and every mutation must use THIS value, or the dialog acts on a
+   * repository the user is not looking at.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     if (changedProperties.has('open') && this.open) {
+      this.pinnedRepoPath = this.repositoryPath;
       this.mode = 'list';
       await this.loadWorktrees();
       await this.loadBranches();
@@ -374,7 +390,7 @@ export class LvWorktreeDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.getWorktrees(this.repositoryPath);
+    const result = await gitService.getWorktrees(this.pinnedRepoPath);
 
     if (result.success && result.data) {
       this.worktrees = result.data;
@@ -386,7 +402,7 @@ export class LvWorktreeDialog extends LitElement {
   }
 
   private async loadBranches(): Promise<void> {
-    const result = await gitService.getBranches(this.repositoryPath);
+    const result = await gitService.getBranches(this.pinnedRepoPath);
     if (result.success && result.data) {
       // Filter out branches already checked out in other worktrees
       const usedBranches = new Set(this.worktrees.map((wt) => wt.branch).filter(Boolean));
@@ -415,7 +431,7 @@ export class LvWorktreeDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.addWorktree(this.repositoryPath, this.addPath, {
+    const result = await gitService.addWorktree(this.pinnedRepoPath, this.addPath, {
       branch: this.createNewBranch ? undefined : this.addBranch,
       newBranch: this.createNewBranch ? this.newBranchName : undefined,
     });
@@ -445,7 +461,7 @@ export class LvWorktreeDialog extends LitElement {
     // Captured BEFORE the confirm await: this dialog is bound to the active
     // repository and rebinds live, so a mid-confirm tab switch would otherwise
     // run the removal against the repo the user switched TO.
-    const repoPath = this.repositoryPath;
+    const repoPath = this.pinnedRepoPath;
 
     const confirmed = await showConfirm(
       'Remove Worktree',
@@ -475,7 +491,7 @@ export class LvWorktreeDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.lockWorktree(this.repositoryPath, worktree.path);
+    const result = await gitService.lockWorktree(this.pinnedRepoPath, worktree.path);
 
     if (result.success) {
       this.success = 'Worktree locked successfully';
@@ -492,7 +508,7 @@ export class LvWorktreeDialog extends LitElement {
     this.loading = true;
     this.error = '';
 
-    const result = await gitService.unlockWorktree(this.repositoryPath, worktree.path);
+    const result = await gitService.unlockWorktree(this.pinnedRepoPath, worktree.path);
 
     if (result.success) {
       this.success = 'Worktree unlocked successfully';

--- a/src/components/dialogs/lv-worktree-dialog.ts
+++ b/src/components/dialogs/lv-worktree-dialog.ts
@@ -355,11 +355,29 @@ export class LvWorktreeDialog extends LitElement {
   @state() private createNewBranch = false;
   @state() private newBranchName = '';
 
+  /**
+   * This dialog paints its own overlay instead of using lv-modal, so it had no
+   * Escape handling at all — and app-shell's Escape chain now stops at the
+   * dialog layer (so a keypress cannot also close the diff behind it), which
+   * made Escape a completely dead key here. Dismiss like every sibling.
+   */
+  private handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === 'Escape' && this.open) {
+      this.handleClose();
+    }
+  };
+
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
+    document.addEventListener('keydown', this.handleKeyDown);
     if (this.open) {
       await this.loadWorktrees();
     }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    document.removeEventListener('keydown', this.handleKeyDown);
   }
 
   /**

--- a/src/components/dialogs/lv-worktree-dialog.ts
+++ b/src/components/dialogs/lv-worktree-dialog.ts
@@ -11,6 +11,7 @@ import { showConfirm } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import type { Worktree } from '../../services/git.service.ts';
 import type { Branch } from '../../types/git.types.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
 
 type DialogMode = 'list' | 'add';
 
@@ -362,7 +363,10 @@ export class LvWorktreeDialog extends LitElement {
    * made Escape a completely dead key here. Dismiss like every sibling.
    */
   private handleKeyDown = (e: KeyboardEvent): void => {
-    if (e.key === 'Escape' && this.open) {
+    // Only the topmost overlay owns Escape: every dialog listens on
+    // `document`, so without this one keypress ran all of them.
+    if (!this.open || !isTopOverlay(this)) return;
+    if (e.key === 'Escape') {
       this.handleClose();
     }
   };
@@ -377,6 +381,7 @@ export class LvWorktreeDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    removeOverlay(this);
     document.removeEventListener('keydown', this.handleKeyDown);
   }
 
@@ -396,6 +401,10 @@ export class LvWorktreeDialog extends LitElement {
   }
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
+    // Announce/withdraw overlay ownership of Escape.
+    if (changedProperties.has('open')) {
+      if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
+    }
     if (changedProperties.has('open') && this.open) {
       this.pinnedRepoPath = this.repositoryPath;
       this.mode = 'list';

--- a/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-guards.test.ts
@@ -486,46 +486,6 @@ describe('lv-branch-list operationInProgress guards', () => {
     expect((renameCall!.args as { newName: string }).newName).to.equal('feature/new');
   });
 
-  it('handleDeleteMergedBranches deletes from the origin repo after a mid-confirm switch', async () => {
-    // Irreversible bulk delete. repoPath must be captured before the confirm —
-    // a mid-confirm tab switch must not redirect the deletes to another repo.
-    const el = await createComponent();
-
-    const merged = makeBranch({ name: 'feature/merged', shorthand: 'feature/merged', isHead: false });
-    (el as unknown as { localBranchGroups: Array<{ branches: unknown[] }> }).localBranchGroups = [
-      { branches: [merged] },
-    ];
-    (el as unknown as { mergedBranchNames: Set<string> }).mergedBranchNames = new Set([
-      'feature/merged',
-    ]);
-
-    let resolveConfirm!: (v: unknown) => void;
-    mockInvoke = (command: string) => {
-      if (command === 'plugin:dialog|message') {
-        return new Promise((resolve) => {
-          resolveConfirm = resolve;
-        });
-      }
-      if (command === 'delete_branch') return Promise.resolve(null);
-      return defaultMockInvoke(command);
-    };
-
-    invokeCalls.length = 0;
-    const promise = (
-      el as unknown as { handleDeleteMergedBranches: () => Promise<void> }
-    ).handleDeleteMergedBranches();
-
-    await new Promise((r) => setTimeout(r, 10));
-    (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
-
-    resolveConfirm('Ok');
-    await promise;
-
-    const deleteCall = invokeCalls.find((c) => c.command === 'delete_branch');
-    expect(deleteCall, 'delete_branch called').to.not.be.undefined;
-    expect((deleteCall!.args as { path: string }).path).to.equal(REPO_PATH);
-  });
-
   it('handleBranchCreated refreshes the origin repo, not the tab switched to during the reload', async () => {
     const el = await createComponent();
 

--- a/src/components/sidebar/__tests__/lv-branch-list-merged-remote.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-merged-remote.test.ts
@@ -60,13 +60,18 @@ function makeBranch(b: MockBranch) {
 async function createComponent(
   branches: ReturnType<typeof makeBranch>[],
   cleanupCandidates: Array<{ name: string; shorthand: string; category: string }> = [],
+  failCleanup = false,
 ): Promise<LvBranchList> {
   mockInvoke = (command: string) => {
     if (command === 'get_branches') return Promise.resolve(branches);
     if (command === 'get_remotes') return Promise.resolve([]);
     if (command === 'get_hidden_branches') return Promise.resolve([]);
     if (command === 'get_branch_sort_mode') return Promise.resolve('name');
-    if (command === 'get_cleanup_candidates') return Promise.resolve(cleanupCandidates);
+    if (command === 'get_cleanup_candidates') {
+      return failCleanup
+        ? Promise.reject(new Error('candidate scan failed'))
+        : Promise.resolve(cleanupCandidates);
+    }
     if (command === 'plugin:dialog|message') return Promise.resolve('Ok');
     return Promise.resolve(null);
   };
@@ -121,6 +126,35 @@ describe('lv-branch-list merged detection (Finding 13)', () => {
     const badge = el.shadowRoot!.querySelector('.cleanup-btn .badge');
     expect(badge, 'Clean up button rendered').to.not.be.null;
     expect(badge!.textContent!.trim()).to.equal('1');
+  });
+
+  // A failed candidate scan is NOT the same as "no candidates". Collapsing
+  // both to an empty set made the Clean up button vanish from the sidebar with
+  // no error, telling the user there is nothing to clean up when we simply
+  // could not find out.
+  it('keeps the Clean up button reachable when the candidate scan fails', async () => {
+    const el = await createComponent(
+      [
+        makeBranch({ name: 'main', shorthand: 'main', isHead: true }),
+        makeBranch({ name: 'feature', shorthand: 'feature' }),
+      ],
+      [],
+      true,
+    );
+
+    const btn = el.shadowRoot!.querySelector('.cleanup-btn');
+    expect(btn, 'Clean up button still rendered after a failed scan').to.not.be.null;
+    expect(btn!.getAttribute('title')).to.contain('Could not check');
+    // No count is known, so no badge may claim one.
+    expect(el.shadowRoot!.querySelector('.cleanup-btn .badge')).to.be.null;
+  });
+
+  it('hides the Clean up button when the scan succeeds with no candidates', async () => {
+    const el = await createComponent([
+      makeBranch({ name: 'main', shorthand: 'main', isHead: true }),
+    ]);
+
+    expect(el.shadowRoot!.querySelector('.cleanup-btn')).to.be.null;
   });
 });
 

--- a/src/components/sidebar/__tests__/lv-branch-list-merged-remote.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-merged-remote.test.ts
@@ -110,9 +110,17 @@ describe('lv-branch-list merged detection (Finding 13)', () => {
       [{ name: 'merged-no-upstream', shorthand: 'merged-no-upstream', category: 'merged' }],
     );
 
-    const merged = (el as unknown as { getMergedBranches: () => Array<{ name: string }> }).getMergedBranches();
-    const names = merged.map((b) => b.name).sort();
-    expect(names).to.deep.equal(['merged-no-upstream']);
+    // Assert the user-visible surface rather than a private helper: the
+    // Clean up badge is driven by the backend's candidate list, so a branch
+    // that is merely fully pushed must not be counted, and one that is merged
+    // without an upstream must be.
+    const candidates = (el as unknown as { cleanupCandidateNames: Set<string> })
+      .cleanupCandidateNames;
+    expect([...candidates].sort()).to.deep.equal(['merged-no-upstream']);
+
+    const badge = el.shadowRoot!.querySelector('.cleanup-btn .badge');
+    expect(badge, 'Clean up button rendered').to.not.be.null;
+    expect(badge!.textContent!.trim()).to.equal('1');
   });
 });
 

--- a/src/components/sidebar/__tests__/lv-file-status-discard-copy.test.ts
+++ b/src/components/sidebar/__tests__/lv-file-status-discard-copy.test.ts
@@ -35,6 +35,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 import '../lv-file-status.ts';
 import type { LvFileStatus } from '../lv-file-status.ts';
 import type { StatusEntry } from '../../../types/git.types.ts';
+import { settingsStore } from '../../../stores/settings.store.ts';
 
 const REPO_PATH = '/test/repo';
 
@@ -80,6 +81,42 @@ describe('lv-file-status discard confirm copy', () => {
   beforeEach(() => {
     invokeHistory.length = 0;
     lastConfirm = null;
+    settingsStore.setState({ confirmBeforeDiscard: true });
+  });
+
+  afterEach(() => {
+    settingsStore.setState({ confirmBeforeDiscard: true });
+  });
+
+  it('skips the confirm for a tracked file when the setting is off', async () => {
+    settingsStore.setState({ confirmBeforeDiscard: false });
+    const tracked = makeEntry({ path: 'src/main.ts', status: 'modified' });
+    const el = await render([tracked]);
+    invokeHistory.length = 0;
+    lastConfirm = null;
+
+    await internalOf(el).handleDiscardFile(tracked, new Event('click'));
+
+    expect(lastConfirm, 'setting should suppress the prompt').to.be.null;
+    expect(
+      invokeHistory.filter((h) => h.command === 'discard_changes'),
+      'the discard should still run',
+    ).to.have.length(1);
+  });
+
+  it('still confirms an untracked file even when the setting is off', async () => {
+    // Untracked files are DELETED with no git object and no trash. A "fewer
+    // dialogs" preference must never silently become unrecoverable deletion.
+    settingsStore.setState({ confirmBeforeDiscard: false });
+    const untracked = makeEntry({ path: 'notes.md', status: 'untracked' });
+    const el = await render([untracked]);
+    invokeHistory.length = 0;
+    lastConfirm = null;
+
+    await internalOf(el).handleDiscardFile(untracked, new Event('click'));
+
+    expect(lastConfirm, 'permanent deletion must always prompt').to.not.be.null;
+    expect(lastConfirm!.message!.toLowerCase()).to.include('permanently delete');
   });
 
   it('says "permanently delete" for a single untracked file', async () => {

--- a/src/components/sidebar/__tests__/lv-file-status-discard-copy.test.ts
+++ b/src/components/sidebar/__tests__/lv-file-status-discard-copy.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests that lv-file-status tells the truth about what a discard destroys.
+ *
+ * Discarding an UNTRACKED file deletes it from disk — staging.rs classifies
+ * anything absent from both the index and HEAD as untracked and removes it.
+ * There is no git object and no trash, so the file is unrecoverable. A confirm
+ * that says "discard changes to X" reads as "restore X", which materially
+ * understates that, and in bulk can mean N permanent deletions.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeHistory: Array<{ command: string; args?: unknown }> = [];
+/** Args of the last showConfirm(): plugin-dialog routes confirm() through it. */
+let lastConfirm: { title?: string; message?: string } | null = null;
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    if (command === 'plugin:dialog|message') {
+      const a = args as { title?: string; message?: string };
+      lastConfirm = { title: a?.title, message: a?.message };
+      return Promise.resolve('Ok');
+    }
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-file-status.ts';
+import type { LvFileStatus } from '../lv-file-status.ts';
+import type { StatusEntry } from '../../../types/git.types.ts';
+
+const REPO_PATH = '/test/repo';
+
+function makeEntry(overrides: Partial<StatusEntry> = {}): StatusEntry {
+  return {
+    path: 'src/main.ts',
+    status: 'modified',
+    isStaged: false,
+    isConflicted: false,
+    ...overrides,
+  };
+}
+
+interface Internal {
+  unstagedFiles: StatusEntry[];
+  stagedFiles: StatusEntry[];
+  selectedFiles: Set<string>;
+  handleDiscardFile: (file: StatusEntry, e: Event) => Promise<void>;
+  handleDiscardSelected: () => Promise<void>;
+}
+
+function internalOf(el: LvFileStatus): Internal {
+  return el as unknown as Internal;
+}
+
+async function render(entries: StatusEntry[]): Promise<LvFileStatus> {
+  mockInvoke = async (command: string) => (command === 'get_status' ? entries : null);
+
+  const el = await fixture<LvFileStatus>(html`
+    <lv-file-status .repositoryPath=${REPO_PATH}></lv-file-status>
+  `);
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+  const internal = internalOf(el);
+  internal.unstagedFiles = entries.filter((f) => !f.isStaged);
+  internal.stagedFiles = entries.filter((f) => f.isStaged);
+  await el.updateComplete;
+  return el;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+describe('lv-file-status discard confirm copy', () => {
+  beforeEach(() => {
+    invokeHistory.length = 0;
+    lastConfirm = null;
+  });
+
+  it('says "permanently delete" for a single untracked file', async () => {
+    const untracked = makeEntry({ path: 'notes.md', status: 'untracked' });
+    const el = await render([untracked]);
+
+    await internalOf(el).handleDiscardFile(untracked, new Event('click'));
+
+    expect(lastConfirm, 'confirm shown').to.not.be.null;
+    expect(lastConfirm!.message!.toLowerCase()).to.include('permanently delete');
+    expect(lastConfirm!.message).to.include('notes.md');
+    expect(lastConfirm!.message!.toLowerCase()).to.include('cannot be recovered');
+  });
+
+  it('keeps "discard changes" wording for a tracked file', async () => {
+    const tracked = makeEntry({ path: 'src/main.ts', status: 'modified' });
+    const el = await render([tracked]);
+
+    await internalOf(el).handleDiscardFile(tracked, new Event('click'));
+
+    expect(lastConfirm, 'confirm shown').to.not.be.null;
+    expect(lastConfirm!.message!.toLowerCase()).to.include('discard changes');
+    expect(lastConfirm!.message!.toLowerCase()).to.not.include('permanently delete');
+  });
+
+  it('names both counts when a bulk discard mixes tracked and untracked', async () => {
+    const tracked = makeEntry({ path: 'a.ts', status: 'modified' });
+    const untrackedA = makeEntry({ path: 'b.txt', status: 'untracked' });
+    const untrackedB = makeEntry({ path: 'c.txt', status: 'untracked' });
+    const el = await render([tracked, untrackedA, untrackedB]);
+
+    const internal = internalOf(el);
+    internal.selectedFiles = new Set(['a.ts', 'b.txt', 'c.txt']);
+    await el.updateComplete;
+
+    await internal.handleDiscardSelected();
+
+    expect(lastConfirm, 'confirm shown').to.not.be.null;
+    expect(lastConfirm!.message).to.include('1 file');
+    expect(lastConfirm!.message).to.include('2 untracked file');
+    expect(lastConfirm!.message!.toLowerCase()).to.include('permanently delete');
+  });
+
+  it('says delete-only when every selected file is untracked', async () => {
+    const a = makeEntry({ path: 'a.txt', status: 'untracked' });
+    const b = makeEntry({ path: 'b.txt', status: 'untracked' });
+    const el = await render([a, b]);
+
+    const internal = internalOf(el);
+    internal.selectedFiles = new Set(['a.txt', 'b.txt']);
+    await el.updateComplete;
+
+    await internal.handleDiscardSelected();
+
+    expect(lastConfirm, 'confirm shown').to.not.be.null;
+    expect(lastConfirm!.message!.toLowerCase()).to.include('permanently delete 2 untracked file');
+    expect(lastConfirm!.message!.toLowerCase()).to.not.include('discard changes');
+  });
+});

--- a/src/components/sidebar/__tests__/lv-gitflow-panel-squash.test.ts
+++ b/src/components/sidebar/__tests__/lv-gitflow-panel-squash.test.ts
@@ -100,6 +100,67 @@ describe('lv-gitflow-panel squash finish conflict (Fix 6)', () => {
     invokeCalls.length = 0;
   });
 
+  it('runs only one squash finish when clicked twice before the confirm resolves', async () => {
+    // There is an IPC round trip between the click and the native confirm
+    // opening, so a double-click lands a second call in that window. Testing
+    // the guard only at function entry let both calls through: two concurrent
+    // squash finishes on one repo can double-merge or mint a duplicate squash
+    // commit, and the Rust command takes no repo-level lock.
+    const el = await createComponent();
+
+    let releaseConfirm!: (v: unknown) => void;
+    mockInvoke = (command: string) => {
+      if (command === 'plugin:dialog|message') {
+        return new Promise((resolve) => {
+          releaseConfirm = resolve;
+        });
+      }
+      return defaultMockInvoke(command);
+    };
+
+    const internal = el as unknown as {
+      handleFinishFeature: (item: { name: string; branch: string }, squash?: boolean) => Promise<void>;
+    };
+
+    invokeCalls.length = 0;
+    const first = internal.handleFinishFeature({ name: 'x', branch: 'feature/x' }, true);
+    // Second click lands while the first confirm is still pending.
+    const second = internal.handleFinishFeature({ name: 'x', branch: 'feature/x' }, true);
+
+    releaseConfirm('Ok');
+    await Promise.all([first, second]);
+
+    expect(
+      invokeCalls.filter((c) => c.command === 'plugin:dialog|message'),
+      'the second click must not raise a second confirm',
+    ).to.have.length(1);
+    expect(
+      invokeCalls.filter((c) => c.command === 'gitflow_finish_feature'),
+      'only one squash finish may run',
+    ).to.have.length(1);
+  });
+
+  it('releases the re-entrancy guard when the squash confirm is declined', async () => {
+    const el = await createComponent();
+
+    mockInvoke = (command: string) => {
+      if (command === 'plugin:dialog|message') return Promise.resolve('Cancel');
+      return defaultMockInvoke(command);
+    };
+
+    const internal = el as unknown as {
+      handleFinishFeature: (item: { name: string; branch: string }, squash?: boolean) => Promise<void>;
+      operationInProgress: boolean;
+    };
+
+    await internal.handleFinishFeature({ name: 'x', branch: 'feature/x' }, true);
+
+    expect(
+      internal.operationInProgress,
+      'declining must not leave the panel wedged',
+    ).to.equal(false);
+  });
+
   it('does not squash-finish when the confirm is declined', async () => {
     // A squash finish collapses the branch to one commit and deletes it, so
     // every original commit becomes unreachable. gitflow deletes via git2

--- a/src/components/sidebar/__tests__/lv-gitflow-panel-squash.test.ts
+++ b/src/components/sidebar/__tests__/lv-gitflow-panel-squash.test.ts
@@ -47,6 +47,12 @@ function cleanupMockPrompt(): void {
 }
 
 function defaultMockInvoke(command: string): Promise<unknown> {
+  // A squash finish discards the branch's individual commits, so it is gated
+  // by a confirm. plugin-dialog routes confirm() through `message` and treats
+  // the OK button label as confirmed.
+  if (command === 'plugin:dialog|message') {
+    return Promise.resolve('Ok');
+  }
   if (command === 'get_gitflow_config') {
     return Promise.resolve({
       initialized: true,
@@ -92,6 +98,43 @@ interface ConflictDetail {
 describe('lv-gitflow-panel squash finish conflict (Fix 6)', () => {
   beforeEach(() => {
     invokeCalls.length = 0;
+  });
+
+  it('does not squash-finish when the confirm is declined', async () => {
+    // A squash finish collapses the branch to one commit and deletes it, so
+    // every original commit becomes unreachable. gitflow deletes via git2
+    // directly, bypassing delete_branch's merged-check, so this confirm is the
+    // only gate on the whole path.
+    const el = await createComponent();
+
+    mockInvoke = (command: string) => {
+      if (command === 'plugin:dialog|message') return Promise.resolve('Cancel');
+      return defaultMockInvoke(command);
+    };
+
+    invokeCalls.length = 0;
+    await (el as unknown as {
+      handleFinishFeature: (item: { name: string; branch: string }, squash?: boolean) => Promise<void>;
+    }).handleFinishFeature({ name: 'x', branch: 'feature/x' }, true);
+
+    expect(
+      invokeCalls.filter((c) => c.command === 'gitflow_finish_feature'),
+      'declining must not run the squash finish',
+    ).to.have.length(0);
+  });
+
+  it('does not confirm for an ordinary (non-squash) finish', async () => {
+    // The plain finish keeps the branch's commits reachable via the merge, so
+    // it must not acquire a gate the squash path needs.
+    const el = await createComponent();
+    invokeCalls.length = 0;
+
+    await (el as unknown as {
+      handleFinishFeature: (item: { name: string; branch: string }, squash?: boolean) => Promise<void>;
+    }).handleFinishFeature({ name: 'x', branch: 'feature/x' }, false);
+
+    expect(invokeCalls.filter((c) => c.command === 'plugin:dialog|message')).to.have.length(0);
+    expect(invokeCalls.filter((c) => c.command === 'gitflow_finish_feature')).to.have.length(1);
   });
 
   it('dispatches squash=true when a squash finish hits a merge conflict', async () => {

--- a/src/components/sidebar/__tests__/lv-stash-list-conflict.test.ts
+++ b/src/components/sidebar/__tests__/lv-stash-list-conflict.test.ts
@@ -36,8 +36,11 @@ function makeStash(index: number) {
   return { index, message: `WIP on main ${index}`, oid: `oid${index}` };
 }
 
+/** Live stash list the handlers re-resolve against; seeded by setContextMenu. */
+let mockStashes: unknown[] = [];
+
 function defaultMockInvoke(command: string): Promise<unknown> {
-  if (command === 'get_stashes') return Promise.resolve([]);
+  if (command === 'get_stashes') return Promise.resolve(mockStashes);
   // Tauri confirm() dialogs resolve via plugin:dialog|message; a truthy value =
   // confirmed.
   if (command === 'plugin:dialog|message') return Promise.resolve('Ok');
@@ -68,6 +71,11 @@ function listenForConflict(el: LvStashList): { detail: ConflictDetail | null } {
 }
 
 function setContextMenu(el: LvStashList, stash: ReturnType<typeof makeStash>): void {
+  // The handlers re-resolve the right-clicked stash by oid against the live
+  // list before acting, so the mocked list must actually hold it at its index.
+  mockStashes = Array.from({ length: stash.index + 1 }, (_, i) =>
+    i === stash.index ? stash : makeStash(i)
+  );
   (el as unknown as { contextMenu: unknown }).contextMenu = {
     visible: true, x: 0, y: 0, stash,
   };

--- a/src/components/sidebar/__tests__/lv-stash-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-stash-list-guards.test.ts
@@ -43,14 +43,22 @@ function makeStash(overrides: Partial<{
   };
 }
 
+/**
+ * Stash list returned by `get_stashes`. The handlers re-resolve the
+ * right-clicked stash by oid against this list before acting, so a test that
+ * expects an operation to RUN must seed it with that stash.
+ */
+let mockStashes: unknown[] = [];
+
 function defaultMockInvoke(command: string): Promise<unknown> {
   if (command === 'get_stashes') {
-    return Promise.resolve([]);
+    return Promise.resolve(mockStashes);
   }
   return Promise.resolve(null);
 }
 
 async function createComponent(): Promise<LvStashList> {
+  mockStashes = [];
   mockInvoke = defaultMockInvoke;
   const el = await fixture<LvStashList>(
     html`<lv-stash-list .repositoryPath=${REPO_PATH}></lv-stash-list>`
@@ -133,6 +141,7 @@ describe('lv-stash-list operationInProgress guards', () => {
     };
 
     const stash = makeStash({ index: 0 });
+    mockStashes = [stash];
     (el as unknown as { contextMenu: { visible: boolean; x: number; y: number; stash: typeof stash | null } }).contextMenu = {
       visible: true, x: 0, y: 0, stash,
     };
@@ -142,6 +151,10 @@ describe('lv-stash-list operationInProgress guards', () => {
 
     // Should be in progress now
     expect((el as unknown as { operationInProgress: boolean }).operationInProgress).to.equal(true);
+
+    // The handler re-resolves the stash by oid (an extra awaited round trip)
+    // before calling apply_stash, so let that settle before resolving it.
+    await new Promise((r) => setTimeout(r, 0));
 
     // Resolve
     resolveApply({ success: true });
@@ -162,6 +175,7 @@ describe('lv-stash-list operationInProgress guards', () => {
     };
 
     const stash = makeStash({ index: 0 });
+    mockStashes = [stash];
     (el as unknown as { contextMenu: { visible: boolean; x: number; y: number; stash: typeof stash | null } }).contextMenu = {
       visible: true, x: 0, y: 0, stash,
     };
@@ -197,6 +211,7 @@ describe('lv-stash-list operationInProgress guards', () => {
     });
 
     const stash = makeStash({ index: 0 });
+    mockStashes = [stash];
     (
       el as unknown as {
         contextMenu: { visible: boolean; x: number; y: number; stash: typeof stash | null };
@@ -206,6 +221,9 @@ describe('lv-stash-list operationInProgress guards', () => {
     const promise = (
       el as unknown as { handleApplyStash: () => Promise<void> }
     ).handleApplyStash();
+
+    // Let the oid re-resolution settle so apply_stash is actually in flight.
+    await new Promise((r) => setTimeout(r, 0));
 
     // User switches tabs mid-apply: the prop rebinds to another repo.
     (el as unknown as { repositoryPath: string }).repositoryPath = '/other/repo';
@@ -236,6 +254,7 @@ describe('lv-stash-list operationInProgress guards', () => {
     };
 
     const stash = makeStash({ index: 0 });
+    mockStashes = [stash];
     (
       el as unknown as {
         contextMenu: { visible: boolean; x: number; y: number; stash: typeof stash | null };
@@ -254,6 +273,73 @@ describe('lv-stash-list operationInProgress guards', () => {
     const dropCall = invokeCalls.find((c) => c.command === 'drop_stash');
     expect(dropCall, 'drop_stash called').to.not.be.undefined;
     expect((dropCall!.args as { path: string }).path).to.equal(REPO_PATH);
+  });
+
+  it('handleDropStash drops the stash the user right-clicked after the list shifts', async () => {
+    // Stash.index is a POSITION. Creating a stash while the context menu is
+    // open (Ctrl+Shift+S does not close it) pushes every entry down one, so the
+    // cached index names a different stash by the time Drop is clicked.
+    const el = await createComponent();
+
+    const target = makeStash({ index: 1, message: 'refactor WIP', oid: 'target-oid' });
+    (
+      el as unknown as {
+        contextMenu: { visible: boolean; x: number; y: number; stash: typeof target | null };
+      }
+    ).contextMenu = { visible: true, x: 0, y: 0, stash: target };
+
+    // A new stash landed at 0, so the target now sits at index 2.
+    mockStashes = [
+      makeStash({ index: 0, message: 'brand new', oid: 'new-oid' }),
+      makeStash({ index: 1, message: 'other', oid: 'other-oid' }),
+      target,
+    ];
+
+    // Confirm the drop: plugin-dialog's confirm() resolves via
+    // `plugin:dialog|message`, where the OK button label means confirmed.
+    mockInvoke = (command: string) =>
+      command === 'plugin:dialog|message'
+        ? Promise.resolve('Ok')
+        : defaultMockInvoke(command);
+
+    invokeCalls.length = 0;
+    await (el as unknown as { handleDropStash: () => Promise<void> }).handleDropStash();
+
+    const dropCall = invokeCalls.find((c) => c.command === 'drop_stash');
+    expect(dropCall, 'drop_stash called').to.not.be.undefined;
+    expect(
+      (dropCall!.args as { index: number }).index,
+      'must drop the right-clicked stash at its CURRENT position, not the stale one'
+    ).to.equal(2);
+  });
+
+  it('handleDropStash aborts when the right-clicked stash is gone', async () => {
+    const el = await createComponent();
+
+    const target = makeStash({ index: 0, message: 'gone', oid: 'gone-oid' });
+    (
+      el as unknown as {
+        contextMenu: { visible: boolean; x: number; y: number; stash: typeof target | null };
+      }
+    ).contextMenu = { visible: true, x: 0, y: 0, stash: target };
+
+    // Someone dropped it from a terminal — it is no longer in the list.
+    mockStashes = [makeStash({ index: 0, message: 'unrelated', oid: 'other-oid' })];
+
+    // Confirm the drop: plugin-dialog's confirm() resolves via
+    // `plugin:dialog|message`, where the OK button label means confirmed.
+    mockInvoke = (command: string) =>
+      command === 'plugin:dialog|message'
+        ? Promise.resolve('Ok')
+        : defaultMockInvoke(command);
+
+    invokeCalls.length = 0;
+    await (el as unknown as { handleDropStash: () => Promise<void> }).handleDropStash();
+
+    expect(
+      invokeCalls.filter((c) => c.command === 'drop_stash'),
+      'must not drop a substitute stash'
+    ).to.have.length(0);
   });
 
   it('isStashing guard prevents double createStash', async () => {

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -573,6 +573,14 @@ export class LvBranchList extends LitElement {
   // graph_descendant_of detection, including tip==HEAD). Refreshed by
   // loadBranches; used for the "Delete Merged Branches" flow and its badge.
   @state() private mergedBranchNames = new Set<string>();
+  /**
+   * Every branch the cleanup dialog would list, by name and across ALL
+   * categories. The button used merged+stale computed locally, which
+   * double-counted a branch that is both and hid the button entirely for a
+   * repo whose only candidates are gone-upstream — while the command-palette
+   * entry still opened the dialog, so the two surfaces disagreed.
+   */
+  @state() private cleanupCandidateNames = new Set<string>();
 
   @query('lv-create-branch-dialog') private createBranchDialog!: LvCreateBranchDialog;
   @query('lv-interactive-rebase-dialog') private interactiveRebaseDialog!: LvInteractiveRebaseDialog;
@@ -887,6 +895,10 @@ export class LvBranchList extends LitElement {
         ? new Set(cleanupResult.data.filter(c => c.category === 'merged').map(c => c.name))
         : new Set();
 
+      this.cleanupCandidateNames = cleanupResult.success && cleanupResult.data
+        ? new Set(cleanupResult.data.map(c => c.name))
+        : new Set();
+
     } catch (err) {
       if (this.repositoryPath === loadedPath) {
         this.error = err instanceof Error ? err.message : 'Unknown error';
@@ -999,18 +1011,16 @@ export class LvBranchList extends LitElement {
    * unmerged branches (ahead-of-upstream 0 right after a push) as merged, and it
    * missed merged branches that have no upstream at all (aheadBehind undefined).
    */
-  private getMergedBranches(): Branch[] {
-    const allLocal = this.localBranchGroups.flatMap(g => g.branches);
-    return allLocal.filter(b => !b.isHead && this.mergedBranchNames.has(b.name));
+  /**
+   * Distinct local branches the cleanup dialog would list.
+   *
+   * Counted by NAME: merged and stale are independent filters over the same
+   * list, so a branch that is both was counted twice by the badge.
+   */
+  private getCleanupCandidateCount(): number {
+    return this.cleanupCandidateNames.size;
   }
 
-  /**
-   * Find all local branches that are stale (older than staleBranchDays setting)
-   */
-  private getStaleBranches(): Branch[] {
-    const allLocal = this.localBranchGroups.flatMap(g => g.branches);
-    return allLocal.filter(b => !b.isHead && this.isBranchStale(b));
-  }
 
   /**
    * Open the branch cleanup dialog
@@ -2183,18 +2193,18 @@ export class LvBranchList extends LitElement {
       ${this.localBranchGroups.length > 0 ? html`
         <div class="local-header">
           <span class="local-header-title">Local Branches</span>
-          ${this.getMergedBranches().length + this.getStaleBranches().length > 0 ? html`
+          ${this.getCleanupCandidateCount() > 0 ? html`
             <button
               class="cleanup-btn"
               @click=${this.handleOpenCleanupDialog}
-              title="${this.getMergedBranches().length} merged + ${this.getStaleBranches().length} stale branches can be safely deleted"
+              title="${this.getCleanupCandidateCount()} branch${this.getCleanupCandidateCount() === 1 ? '' : 'es'} can be reviewed for cleanup"
             >
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="3 6 5 6 21 6"></polyline>
                 <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"></path>
               </svg>
               Clean up
-              <span class="badge">${this.getMergedBranches().length + this.getStaleBranches().length}</span>
+              <span class="badge">${this.getCleanupCandidateCount()}</span>
             </button>
           ` : nothing}
         </div>

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1065,6 +1065,7 @@ export class LvBranchList extends LitElement {
     // Delete branches one by one
     let deleted = 0;
     let failed = 0;
+    const failures: string[] = [];
 
     for (const branch of mergedBranches) {
       const result = await gitService.deleteBranch(
@@ -1076,6 +1077,10 @@ export class LvBranchList extends LitElement {
         deleted++;
       } else {
         failed++;
+        // Keep the reason. A bare count cannot distinguish a protection rule
+        // from an unmerged tip or a branch checked out in a worktree, and
+        // branch rules made "refused on purpose" a routine outcome here.
+        failures.push(`${branch.name}: ${result.error?.message ?? 'unknown error'}`);
         console.error(`Failed to delete ${branch.name}:`, result.error);
       }
     }
@@ -1088,7 +1093,7 @@ export class LvBranchList extends LitElement {
     if (failed > 0) {
       await showConfirm(
         'Partial Success',
-        `Deleted ${deleted} branch${deleted !== 1 ? 'es' : ''}, but ${failed} failed to delete.`,
+        `Deleted ${deleted} branch${deleted !== 1 ? 'es' : ''}, but ${failed} failed to delete.\n\n${failures.join('\n')}`,
         'warning'
       );
     }

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -751,7 +751,15 @@ export class LvBranchList extends LitElement {
       const [branchesResult, , cleanupResult] = await Promise.all([
         gitService.getBranches(loadedPath),
         gitService.getRemotes(loadedPath),
-        gitService.getCleanupCandidates(loadedPath),
+        // The staleDays argument is what makes the badge and the cleanup
+        // dialog agree. Omitting it fell back to the backend's 90-day default,
+        // so the badge counted stale branches the dialog's Stale tab did not
+        // list (and kept counting them when the user set the window to 0 to
+        // disable staleness entirely).
+        gitService.getCleanupCandidates(
+          loadedPath,
+          settingsStore.getState().staleBranchDays,
+        ),
       ]);
 
       // A newer load for the SAME path supersedes this one entirely (its

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -596,11 +596,16 @@ export class LvBranchList extends LitElement {
   async connectedCallback(): Promise<void> {
     super.connectedCallback();
     this.loadHiddenBranches();
-    await this.loadBranches();
+    // Registered BEFORE the load, not after. loadBranches() awaits three IPC
+    // round-trips, and every event dispatched in that window was dropped on
+    // the floor: the command palette's "Clean up branches" silently did
+    // nothing, and a repository-refresh raised during initial load was lost.
+    // None of these handlers depend on branch data being present.
     document.addEventListener('click', this.handleDocumentClick);
     document.addEventListener('keydown', this.handleKeydown);
     window.addEventListener('open-branch-cleanup', this.handleExternalCleanupOpen);
     window.addEventListener('repository-refresh', this.handleRepositoryRefresh);
+    await this.loadBranches();
     // Close our OWN embedded interactive-rebase dialog when its pinned repo's
     // tab is closed — mirrors app-shell's guard for the app-level dialogs.
     // Without it, the dialog (kept alive across refreshes by the single

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -15,6 +15,7 @@ import type { LvInteractiveRebaseDialog } from '../dialogs/lv-interactive-rebase
 import '../dialogs/lv-branch-cleanup-dialog.ts';
 import type { LvBranchCleanupDialog } from '../dialogs/lv-branch-cleanup-dialog.ts';
 import type { Branch } from '../../types/git.types.ts';
+import { isTopOverlay } from '../../utils/overlay-stack.ts';
 
 type BranchSortMode = 'name' | 'date' | 'date-asc';
 
@@ -661,6 +662,9 @@ export class LvBranchList extends LitElement {
   };
 
   private handleKeydown = (e: KeyboardEvent): void => {
+    // A context menu must not eat an Escape aimed at a dialog opened over
+    // it: every global keydown listener fires on the same keypress.
+    if (!isTopOverlay(this)) return;
     if (e.key === 'Escape' && this.contextMenu.visible) {
       this.contextMenu = { ...this.contextMenu, visible: false };
     }

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -569,10 +569,6 @@ export class LvBranchList extends LitElement {
   @state() private hiddenBranches = new Set<string>();
   @state() private showSortMenu = false;
   @state() private operationInProgress = false;
-  // Names of local branches the backend reports as merged into HEAD (real
-  // graph_descendant_of detection, including tip==HEAD). Refreshed by
-  // loadBranches; used for the "Delete Merged Branches" flow and its badge.
-  @state() private mergedBranchNames = new Set<string>();
   /**
    * Every branch the cleanup dialog would list, by name and across ALL
    * categories. The button used merged+stale computed locally, which
@@ -581,6 +577,13 @@ export class LvBranchList extends LitElement {
    * entry still opened the dialog, so the two surfaces disagreed.
    */
   @state() private cleanupCandidateNames = new Set<string>();
+  /**
+   * The candidate fetch failed for the current repo. Distinct from "no
+   * candidates": an empty set renders as "nothing to clean up", which is a
+   * lie when we simply could not find out. Keeps the button reachable and
+   * says so, instead of the feature silently vanishing from the sidebar.
+   */
+  @state() private cleanupCheckFailed = false;
 
   @query('lv-create-branch-dialog') private createBranchDialog!: LvCreateBranchDialog;
   @query('lv-interactive-rebase-dialog') private interactiveRebaseDialog!: LvInteractiveRebaseDialog;
@@ -886,15 +889,11 @@ export class LvBranchList extends LitElement {
         };
       });
 
-      // Track the set of branches the backend considers merged into HEAD, so
-      // the "Delete Merged Branches" flow and its badge reflect real
-      // `git branch --merged` semantics rather than an ahead-of-upstream guess.
-      // Fetched in the Promise.all above to keep loadBranches to a single await
-      // point (extra await points perturb render timing for callers).
-      this.mergedBranchNames = cleanupResult.success && cleanupResult.data
-        ? new Set(cleanupResult.data.filter(c => c.category === 'merged').map(c => c.name))
-        : new Set();
-
+      // The badge and the cleanup dialog share one source of truth: the
+      // backend's candidate list. Fetched in the Promise.all above to keep
+      // loadBranches to a single await point (extra await points perturb
+      // render timing for callers).
+      this.cleanupCheckFailed = !cleanupResult.success;
       this.cleanupCandidateNames = cleanupResult.success && cleanupResult.data
         ? new Set(cleanupResult.data.map(c => c.name))
         : new Set();
@@ -2193,18 +2192,22 @@ export class LvBranchList extends LitElement {
       ${this.localBranchGroups.length > 0 ? html`
         <div class="local-header">
           <span class="local-header-title">Local Branches</span>
-          ${this.getCleanupCandidateCount() > 0 ? html`
+          ${this.getCleanupCandidateCount() > 0 || this.cleanupCheckFailed ? html`
             <button
               class="cleanup-btn"
               @click=${this.handleOpenCleanupDialog}
-              title="${this.getCleanupCandidateCount()} branch${this.getCleanupCandidateCount() === 1 ? '' : 'es'} can be reviewed for cleanup"
+              title=${this.cleanupCheckFailed
+                ? 'Could not check for cleanup candidates — open to retry'
+                : `${this.getCleanupCandidateCount()} branch${this.getCleanupCandidateCount() === 1 ? '' : 'es'} can be reviewed for cleanup`}
             >
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <polyline points="3 6 5 6 21 6"></polyline>
                 <path d="M19 6v14a2 2 0 01-2 2H7a2 2 0 01-2-2V6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"></path>
               </svg>
               Clean up
-              <span class="badge">${this.getCleanupCandidateCount()}</span>
+              ${this.cleanupCheckFailed
+                ? nothing
+                : html`<span class="badge">${this.getCleanupCandidateCount()}</span>`}
             </button>
           ` : nothing}
         </div>

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1037,68 +1037,6 @@ export class LvBranchList extends LitElement {
   /**
    * Delete all branches that are merged into HEAD
    */
-  private async handleDeleteMergedBranches(): Promise<void> {
-    // Captured BEFORE the confirm await: these irreversible deletes (and the
-    // refresh) must target the repo they were invoked on, even if the user
-    // switches tabs while the confirm is up and this.repositoryPath rebinds.
-    const repoPath = this.repositoryPath;
-    const mergedBranches = this.getMergedBranches();
-
-    if (mergedBranches.length === 0) {
-      await showConfirm(
-        'No Merged Branches',
-        'There are no local branches that are fully merged into the current branch.',
-        'info'
-      );
-      return;
-    }
-
-    const branchNames = mergedBranches.map(b => `  • ${b.shorthand}`).join('\n');
-    const confirmed = await showConfirm(
-      'Delete Merged Branches',
-      `The following ${mergedBranches.length} branch${mergedBranches.length > 1 ? 'es are' : ' is'} merged and will be deleted:\n\n${branchNames}\n\nThis action cannot be undone.`,
-      'warning'
-    );
-
-    if (!confirmed) return;
-
-    // Delete branches one by one
-    let deleted = 0;
-    let failed = 0;
-    const failures: string[] = [];
-
-    for (const branch of mergedBranches) {
-      const result = await gitService.deleteBranch(
-        repoPath,
-        branch.name,
-        false
-      );
-      if (result.success) {
-        deleted++;
-      } else {
-        failed++;
-        // Keep the reason. A bare count cannot distinguish a protection rule
-        // from an unmerged tip or a branch checked out in a worktree, and
-        // branch rules made "refused on purpose" a routine outcome here.
-        failures.push(`${branch.name}: ${result.error?.message ?? 'unknown error'}`);
-        console.error(`Failed to delete ${branch.name}:`, result.error);
-      }
-    }
-
-    if (deleted > 0) {
-      await this.loadBranches();
-      this.dispatchBranchesChanged(repoPath);
-    }
-
-    if (failed > 0) {
-      await showConfirm(
-        'Partial Success',
-        `Deleted ${deleted} branch${deleted !== 1 ? 'es' : ''}, but ${failed} failed to delete.\n\n${failures.join('\n')}`,
-        'warning'
-      );
-    }
-  }
-
   private async handleBranchCreated(e?: CustomEvent<{ repositoryPath?: string }>): Promise<void> {
     // The dialog pins to the repo it was opened for and reports it here. The
     // user may have switched tabs while the dialog was open (rebinding our live

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -1034,9 +1034,6 @@ export class LvBranchList extends LitElement {
     this.dispatchBranchesChanged(repoPath);
   }
 
-  /**
-   * Delete all branches that are merged into HEAD
-   */
   private async handleBranchCreated(e?: CustomEvent<{ repositoryPath?: string }>): Promise<void> {
     // The dialog pins to the repo it was opened for and reports it here. The
     // user may have switched tabs while the dialog was open (rebinding our live

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -709,17 +709,15 @@ export class LvFileStatus extends LitElement {
     const filesToDiscard = this.getFilesUnderPath(this.unstagedFiles, dirPath);
     if (filesToDiscard.length === 0) return;
 
-    const paths = this.discardablePaths(filesToDiscard);
-    if (paths.length === 0) return;
+    const entries = this.discardableEntries(filesToDiscard);
+    if (entries.length === 0) return;
+    const paths = entries.map((f) => f.path);
     // Captured BEFORE the confirm await: discarding is irreversible and must
     // target the repo it was invoked on, even if the user switches tabs (which
     // rebinds this.repositoryPath) while the confirm is up.
     const repoPath = this.repositoryPath;
-    const confirmed = await showConfirm(
-      "Discard Changes",
-      `Discard changes to ${paths.length} file${paths.length > 1 ? "s" : ""} in "${dirPath}"? This cannot be undone.`,
-      "warning",
-    );
+    const { title, message } = this.discardConfirmCopy(entries, dirPath);
+    const confirmed = await showConfirm(title, message, "warning");
     if (!confirmed) return;
 
     const result = await gitService.discardChanges(repoPath, paths);
@@ -1193,7 +1191,7 @@ export class LvFileStatus extends LitElement {
    * the index stays conflicted — either way the conflict must be resolved
    * (or the operation aborted) in the merge editor instead.
    */
-  private discardablePaths(files: StatusEntry[]): string[] {
+  private discardableEntries(files: StatusEntry[]): StatusEntry[] {
     const conflicted = files.filter((f) => f.isConflicted);
     if (conflicted.length > 0) {
       showToast(
@@ -1201,7 +1199,58 @@ export class LvFileStatus extends LitElement {
         'warning',
       );
     }
-    return files.filter((f) => !f.isConflicted).map((f) => f.path);
+    return files.filter((f) => !f.isConflicted);
+  }
+
+  /**
+   * Confirm title/message for a discard.
+   *
+   * Discarding an UNTRACKED file deletes it from disk — staging.rs classifies
+   * anything absent from both the index and HEAD as untracked and removes it.
+   * There is no git object and no trash, so the file is unrecoverable. "Discard
+   * changes to X" reads as "restore X to its previous state", which materially
+   * understates that, and in bulk "discard changes to 12 files" can mean 12
+   * permanent deletions. Name the deletion whenever one is involved.
+   */
+  private discardConfirmCopy(
+    files: StatusEntry[],
+    scope?: string,
+  ): { title: string; message: string } {
+    const untracked = files.filter((f) => f.status === 'untracked').length;
+    const tracked = files.length - untracked;
+    const where = scope ? ` in "${scope}"` : '';
+    const plural = (n: number) => (n === 1 ? '' : 's');
+
+    if (files.length === 1) {
+      return untracked === 1
+        ? {
+            title: 'Delete Untracked File',
+            message: `Permanently delete the untracked file "${files[0].path}"? It is not in Git and cannot be recovered.`,
+          }
+        : {
+            title: 'Discard Changes',
+            message: `Discard changes to "${files[0].path}"? This cannot be undone.`,
+          };
+    }
+
+    if (untracked === 0) {
+      return {
+        title: 'Discard Changes',
+        message: `Discard changes to ${tracked} file${plural(tracked)}${where}? This cannot be undone.`,
+      };
+    }
+
+    if (tracked === 0) {
+      return {
+        title: 'Delete Untracked Files',
+        message: `Permanently delete ${untracked} untracked file${plural(untracked)}${where}? They are not in Git and cannot be recovered.`,
+      };
+    }
+
+    return {
+      title: 'Discard Changes',
+      message: `Discard changes to ${tracked} file${plural(tracked)} and permanently delete ${untracked} untracked file${plural(untracked)}${where}? This cannot be undone.`,
+    };
   }
 
   private async handleStageFile(file: StatusEntry, e: Event): Promise<void> {
@@ -1271,11 +1320,8 @@ export class LvFileStatus extends LitElement {
     // target the repo it was invoked on, even if the user switches tabs (which
     // rebinds this.repositoryPath) while the confirm is up.
     const repoPath = this.repositoryPath;
-    const confirmed = await showConfirm(
-      "Discard Changes",
-      `Are you sure you want to discard changes to "${file.path}"? This action cannot be undone.`,
-      "warning",
-    );
+    const { title, message } = this.discardConfirmCopy([file]);
+    const confirmed = await showConfirm(title, message, "warning");
 
     if (!confirmed) return;
 
@@ -1405,20 +1451,18 @@ export class LvFileStatus extends LitElement {
   }
 
   private async handleDiscardSelected(): Promise<void> {
-    const paths = this.discardablePaths(
+    const entries = this.discardableEntries(
       this.unstagedFiles.filter((f) => this.selectedFiles.has(f.path))
     );
-    if (paths.length === 0) return;
+    if (entries.length === 0) return;
+    const paths = entries.map((f) => f.path);
 
     // Captured BEFORE the confirm await: discarding is irreversible and must
     // target the repo it was invoked on, even if the user switches tabs (which
     // rebinds this.repositoryPath) while the confirm is up.
     const repoPath = this.repositoryPath;
-    const confirmed = await showConfirm(
-      "Discard Changes",
-      `Discard changes to ${paths.length} file${paths.length > 1 ? "s" : ""}? This cannot be undone.`,
-      "warning",
-    );
+    const { title, message } = this.discardConfirmCopy(entries);
+    const confirmed = await showConfirm(title, message, "warning");
     if (!confirmed) return;
 
     const result = await gitService.discardChanges(repoPath, paths);
@@ -1545,11 +1589,8 @@ export class LvFileStatus extends LitElement {
     // target the repo it was invoked on, even if the user switches tabs (which
     // rebinds this.repositoryPath) while the confirm is up.
     const repoPath = this.repositoryPath;
-    const confirmed = await showConfirm(
-      "Discard Changes",
-      `Discard changes to "${file.path}"? This cannot be undone.`,
-      "warning",
-    );
+    const { title, message } = this.discardConfirmCopy([file]);
+    const confirmed = await showConfirm(title, message, "warning");
     if (!confirmed) return;
     const result = await gitService.discardChanges(repoPath, [
       file.path,

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -10,6 +10,7 @@ import { join } from "@tauri-apps/api/path";
 import type { StatusEntry, FileStatus } from "../../types/git.types.ts";
 import { repositoryStore } from "../../stores/repository.store.ts";
 import { settingsStore } from "../../stores/settings.store.ts";
+import { isTopOverlay } from "../../utils/overlay-stack.ts";
 
 interface FileContextMenuState {
   visible: boolean;
@@ -536,6 +537,9 @@ export class LvFileStatus extends LitElement {
   };
 
   private handleKeydownForContextMenu = (e: KeyboardEvent): void => {
+    // A context menu must not eat an Escape aimed at a dialog opened over it:
+    // every global keydown listener fires on the same keypress.
+    if (!isTopOverlay(this)) return;
     if (e.key === "Escape" && this.contextMenu.visible) {
       this.contextMenu = { ...this.contextMenu, visible: false };
     }

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -9,6 +9,7 @@ import { open as shellOpen } from "@tauri-apps/plugin-shell";
 import { join } from "@tauri-apps/api/path";
 import type { StatusEntry, FileStatus } from "../../types/git.types.ts";
 import { repositoryStore } from "../../stores/repository.store.ts";
+import { settingsStore } from "../../stores/settings.store.ts";
 
 interface FileContextMenuState {
   visible: boolean;
@@ -716,9 +717,7 @@ export class LvFileStatus extends LitElement {
     // target the repo it was invoked on, even if the user switches tabs (which
     // rebinds this.repositoryPath) while the confirm is up.
     const repoPath = this.repositoryPath;
-    const { title, message } = this.discardConfirmCopy(entries, dirPath);
-    const confirmed = await showConfirm(title, message, "warning");
-    if (!confirmed) return;
+    if (!(await this.confirmDiscard(entries, dirPath))) return;
 
     const result = await gitService.discardChanges(repoPath, paths);
     if (result.success) {
@@ -1212,6 +1211,27 @@ export class LvFileStatus extends LitElement {
    * understates that, and in bulk "discard changes to 12 files" can mean 12
    * permanent deletions. Name the deletion whenever one is involved.
    */
+  /**
+   * Prompt for a discard, honouring the "Confirm Before Discard" setting.
+   *
+   * Returns true when the caller should proceed.
+   *
+   * The setting only suppresses the prompt for TRACKED files, whose content is
+   * restored from the index and is therefore recoverable. Any selection that
+   * includes an untracked file always prompts: those are deleted from disk with
+   * no git object and no trash, and a preference for fewer dialogs must not
+   * silently become unrecoverable deletion.
+   */
+  private async confirmDiscard(files: StatusEntry[], scope?: string): Promise<boolean> {
+    const hasUntracked = files.some((f) => f.status === 'untracked');
+    if (!hasUntracked && !settingsStore.getState().confirmBeforeDiscard) {
+      return true;
+    }
+
+    const { title, message } = this.discardConfirmCopy(files, scope);
+    return showConfirm(title, message, 'warning');
+  }
+
   private discardConfirmCopy(
     files: StatusEntry[],
     scope?: string,
@@ -1320,10 +1340,7 @@ export class LvFileStatus extends LitElement {
     // target the repo it was invoked on, even if the user switches tabs (which
     // rebinds this.repositoryPath) while the confirm is up.
     const repoPath = this.repositoryPath;
-    const { title, message } = this.discardConfirmCopy([file]);
-    const confirmed = await showConfirm(title, message, "warning");
-
-    if (!confirmed) return;
+    if (!(await this.confirmDiscard([file]))) return;
 
     const result = await gitService.discardChanges(repoPath, [
       file.path,
@@ -1461,9 +1478,7 @@ export class LvFileStatus extends LitElement {
     // target the repo it was invoked on, even if the user switches tabs (which
     // rebinds this.repositoryPath) while the confirm is up.
     const repoPath = this.repositoryPath;
-    const { title, message } = this.discardConfirmCopy(entries);
-    const confirmed = await showConfirm(title, message, "warning");
-    if (!confirmed) return;
+    if (!(await this.confirmDiscard(entries))) return;
 
     const result = await gitService.discardChanges(repoPath, paths);
     if (result.success) {
@@ -1589,9 +1604,7 @@ export class LvFileStatus extends LitElement {
     // target the repo it was invoked on, even if the user switches tabs (which
     // rebinds this.repositoryPath) while the confirm is up.
     const repoPath = this.repositoryPath;
-    const { title, message } = this.discardConfirmCopy([file]);
-    const confirmed = await showConfirm(title, message, "warning");
-    if (!confirmed) return;
+    if (!(await this.confirmDiscard([file]))) return;
     const result = await gitService.discardChanges(repoPath, [
       file.path,
     ]);

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -453,6 +453,11 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleFinishFeature(item: ActiveItem, squash = false): Promise<void> {
+    // Re-entrancy guard, matching handleInitialize. The confirm below is
+    // awaited before operationInProgress is set, so without this a second
+    // finish started during that window would run concurrently.
+    if (this.operationInProgress) return;
+
     // Captured BEFORE the awaits: the conflict dialog must pin to the repo
     // the finish actually ran on, even if the prop is rebound mid-flight.
     const repoPath = this.repositoryPath;

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -586,7 +586,17 @@ export class LvGitflowPanel extends LitElement {
     // capture it with the path.
     const repoPath = this.repositoryPath;
     const developBranch = this.config?.developBranch ?? 'develop';
-    const tagMessage = await showPrompt('Finish Release', `Enter tag message for release ${item.name}:`, `Release ${item.name}`);
+    // showPrompt dynamically imports the prompt component; a chunk-load
+    // failure rejects here, and the flag is already claimed while the try that
+    // releases it starts below — leaving every button in this panel disabled
+    // for the session. Same wrapping as handleFinishFeature's confirm.
+    let tagMessage: string | null = null;
+    try {
+      tagMessage = await showPrompt('Finish Release', `Enter tag message for release ${item.name}:`, `Release ${item.name}`);
+    } catch {
+      this.operationInProgress = false;
+      return;
+    }
     if (tagMessage === null) {
       this.operationInProgress = false;
       return;
@@ -680,7 +690,17 @@ export class LvGitflowPanel extends LitElement {
 
     const repoPath = this.repositoryPath;
     const developBranch = this.config?.developBranch ?? 'develop';
-    const tagMessage = await showPrompt('Finish Hotfix', `Enter tag message for hotfix ${item.name}:`, `Hotfix ${item.name}`);
+    // showPrompt dynamically imports the prompt component; a chunk-load
+    // failure rejects here, and the flag is already claimed while the try that
+    // releases it starts below — leaving every button in this panel disabled
+    // for the session. Same wrapping as handleFinishFeature's confirm.
+    let tagMessage: string | null = null;
+    try {
+      tagMessage = await showPrompt('Finish Hotfix', `Enter tag message for hotfix ${item.name}:`, `Hotfix ${item.name}`);
+    } catch {
+      this.operationInProgress = false;
+      return;
+    }
     if (tagMessage === null) {
       this.operationInProgress = false;
       return;

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -477,13 +477,22 @@ export class LvGitflowPanel extends LitElement {
     // ordinary finish with only a tooltip between them, so it needs its own
     // gate; the plain finish is non-destructive by comparison.
     if (squash) {
-      const confirmed = await showConfirm(
+      // The guard flag is claimed above but the try/finally that releases it
+      // starts below, so a rejecting confirm would leave operationInProgress
+      // stuck true — which disables every button in this panel. Treat a failed
+      // prompt as declined.
+      let confirmed = false;
+      try {
+        confirmed = await showConfirm(
         'Squash and Finish',
         `"${item.name}" will be squashed into a single commit on develop and then ` +
           `deleted. Its individual commits will no longer be reachable from any ` +
           `branch.\n\nThis cannot be undone.`,
         'warning',
-      );
+        );
+      } catch {
+        confirmed = false;
+      }
       if (!confirmed) {
         this.operationInProgress = false;
         return;
@@ -562,10 +571,13 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleFinishRelease(item: ActiveItem): Promise<void> {
-    // Same re-entrancy guard as handleFinishFeature: these await a prompt
-    // before setting operationInProgress, and they are strictly MORE
-    // destructive (merge to master, tag, merge develop, delete branch).
+    // Claimed BEFORE the prompt, like handleFinishFeature. showPrompt is a
+    // singleton whose open() overwrites its resolver, so a second click during
+    // the prompt strands the first call on a promise that never settles rather
+    // than racing it — claiming up front prevents that hang and keeps the three
+    // finish handlers consistent.
     if (this.operationInProgress) return;
+    this.operationInProgress = true;
 
     // Captured BEFORE the prompt (an in-app overlay — Ctrl+Tab can rebind
     // this prop while it is open): the finish must run on the repo whose
@@ -575,10 +587,12 @@ export class LvGitflowPanel extends LitElement {
     const repoPath = this.repositoryPath;
     const developBranch = this.config?.developBranch ?? 'develop';
     const tagMessage = await showPrompt('Finish Release', `Enter tag message for release ${item.name}:`, `Release ${item.name}`);
-    if (tagMessage === null) return;
+    if (tagMessage === null) {
+      this.operationInProgress = false;
+      return;
+    }
 
     this.error = null;
-    this.operationInProgress = true;
 
     try {
       const result = await gitService.gitFlowFinishRelease(
@@ -656,18 +670,23 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleFinishHotfix(item: ActiveItem): Promise<void> {
-    // Same re-entrancy guard as handleFinishFeature: these await a prompt
-    // before setting operationInProgress, and they are strictly MORE
-    // destructive (merge to master, tag, merge develop, delete branch).
+    // Claimed BEFORE the prompt, like handleFinishFeature. showPrompt is a
+    // singleton whose open() overwrites its resolver, so a second click during
+    // the prompt strands the first call on a promise that never settles rather
+    // than racing it — claiming up front prevents that hang and keeps the three
+    // finish handlers consistent.
     if (this.operationInProgress) return;
+    this.operationInProgress = true;
 
     const repoPath = this.repositoryPath;
     const developBranch = this.config?.developBranch ?? 'develop';
     const tagMessage = await showPrompt('Finish Hotfix', `Enter tag message for hotfix ${item.name}:`, `Hotfix ${item.name}`);
-    if (tagMessage === null) return;
+    if (tagMessage === null) {
+      this.operationInProgress = false;
+      return;
+    }
 
     this.error = null;
-    this.operationInProgress = true;
 
     try {
       const result = await gitService.gitFlowFinishHotfix(

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -8,6 +8,7 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles, buttonStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showPrompt } from '../../services/dialog.service.ts';
+import { showToast } from '../../services/notification.service.ts';
 import type { GitFlowConfig } from '../../services/git.service.ts';
 import type { Branch } from '../../types/git.types.ts';
 import type { GitflowFinishContext } from '../dialogs/lv-conflict-resolution-dialog.ts';
@@ -461,6 +462,12 @@ export class LvGitflowPanel extends LitElement {
     try {
       const result = await gitService.gitFlowFinishFeature(repoPath, item.name, true, squash);
       if (result.success) {
+        // A branch rule can block the finish's branch deletion. The merge and
+        // tag still landed, so this is a warning about what was KEPT, not a
+        // failure — but it must be said, or the branch silently survives.
+        if (result.data?.branchKeptReason) {
+          showToast(result.data.branchKeptReason, 'warning');
+        }
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
           detail: { type: 'finish-feature', name: item.name, repositoryPath: repoPath },
@@ -544,6 +551,12 @@ export class LvGitflowPanel extends LitElement {
         true,
       );
       if (result.success) {
+        // A branch rule can block the finish's branch deletion. The merge and
+        // tag still landed, so this is a warning about what was KEPT, not a
+        // failure — but it must be said, or the branch silently survives.
+        if (result.data?.branchKeptReason) {
+          showToast(result.data.branchKeptReason, 'warning');
+        }
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
           detail: { type: 'finish-release', name: item.name, repositoryPath: repoPath },
@@ -622,6 +635,12 @@ export class LvGitflowPanel extends LitElement {
         true,
       );
       if (result.success) {
+        // A branch rule can block the finish's branch deletion. The merge and
+        // tag still landed, so this is a warning about what was KEPT, not a
+        // failure — but it must be said, or the branch silently survives.
+        if (result.data?.branchKeptReason) {
+          showToast(result.data.branchKeptReason, 'warning');
+        }
         await this.loadActiveItems();
         this.dispatchEvent(new CustomEvent('gitflow-operation', {
           detail: { type: 'finish-hotfix', name: item.name, repositoryPath: repoPath },

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -453,10 +453,17 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleFinishFeature(item: ActiveItem, squash = false): Promise<void> {
-    // Re-entrancy guard, matching handleInitialize. The confirm below is
-    // awaited before operationInProgress is set, so without this a second
-    // finish started during that window would run concurrently.
     if (this.operationInProgress) return;
+
+    // Claim the guard SYNCHRONOUSLY, before the confirm's await.
+    //
+    // Testing it at function entry alone does not close the race: there is an
+    // IPC round trip between the click and the native dialog actually opening
+    // and taking focus, so a double-click lands a second call while the flag is
+    // still false and both pass the check. Two concurrent squash finishes on
+    // one repo can double-merge or mint a duplicate squash commit — the Rust
+    // command takes no repo-level lock. Claim first, release on decline.
+    this.operationInProgress = true;
 
     // Captured BEFORE the awaits: the conflict dialog must pin to the repo
     // the finish actually ran on, even if the prop is rebound mid-flight.
@@ -477,11 +484,13 @@ export class LvGitflowPanel extends LitElement {
           `branch.\n\nThis cannot be undone.`,
         'warning',
       );
-      if (!confirmed) return;
+      if (!confirmed) {
+        this.operationInProgress = false;
+        return;
+      }
     }
 
     this.error = null;
-    this.operationInProgress = true;
     try {
       const result = await gitService.gitFlowFinishFeature(repoPath, item.name, true, squash);
       if (result.success) {
@@ -553,6 +562,11 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleFinishRelease(item: ActiveItem): Promise<void> {
+    // Same re-entrancy guard as handleFinishFeature: these await a prompt
+    // before setting operationInProgress, and they are strictly MORE
+    // destructive (merge to master, tag, merge develop, delete branch).
+    if (this.operationInProgress) return;
+
     // Captured BEFORE the prompt (an in-app overlay — Ctrl+Tab can rebind
     // this prop while it is open): the finish must run on the repo whose
     // release the user clicked, and the conflict dialog must pin to it.
@@ -642,6 +656,11 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleFinishHotfix(item: ActiveItem): Promise<void> {
+    // Same re-entrancy guard as handleFinishFeature: these await a prompt
+    // before setting operationInProgress, and they are strictly MORE
+    // destructive (merge to master, tag, merge develop, delete branch).
+    if (this.operationInProgress) return;
+
     const repoPath = this.repositoryPath;
     const developBranch = this.config?.developBranch ?? 'develop';
     const tagMessage = await showPrompt('Finish Hotfix', `Enter tag message for hotfix ${item.name}:`, `Hotfix ${item.name}`);

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -7,7 +7,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles, buttonStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
-import { showPrompt } from '../../services/dialog.service.ts';
+import { showPrompt, showConfirm } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import type { GitFlowConfig } from '../../services/git.service.ts';
 import type { Branch } from '../../types/git.types.ts';
@@ -453,12 +453,30 @@ export class LvGitflowPanel extends LitElement {
   }
 
   private async handleFinishFeature(item: ActiveItem, squash = false): Promise<void> {
-    this.error = null;
-    this.operationInProgress = true;
-
     // Captured BEFORE the awaits: the conflict dialog must pin to the repo
     // the finish actually ran on, even if the prop is rebound mid-flight.
     const repoPath = this.repositoryPath;
+
+    // A squash finish collapses the branch into ONE commit on develop and then
+    // deletes it. Because a squash commit never makes the feature tip an
+    // ancestor of develop, every original commit becomes unreachable
+    // immediately — and gitflow deletes the branch with git2 directly, so
+    // delete_branch's merged-check never runs. This button sits next to the
+    // ordinary finish with only a tooltip between them, so it needs its own
+    // gate; the plain finish is non-destructive by comparison.
+    if (squash) {
+      const confirmed = await showConfirm(
+        'Squash and Finish',
+        `"${item.name}" will be squashed into a single commit on develop and then ` +
+          `deleted. Its individual commits will no longer be reachable from any ` +
+          `branch.\n\nThis cannot be undone.`,
+        'warning',
+      );
+      if (!confirmed) return;
+    }
+
+    this.error = null;
+    this.operationInProgress = true;
     try {
       const result = await gitService.gitFlowFinishFeature(repoPath, item.name, true, squash);
       if (result.success) {

--- a/src/components/sidebar/lv-stash-list.ts
+++ b/src/components/sidebar/lv-stash-list.ts
@@ -306,6 +306,54 @@ export class LvStashList extends LitElement {
     };
   }
 
+  /**
+   * Re-resolve a stash captured at context-menu time to its CURRENT index in
+   * `repoPath`'s stash list.
+   *
+   * `Stash.index` is a POSITION, not an identity: creating or dropping any
+   * stash shifts every entry below it. The context menu caches the Stash object
+   * from when it opened and survives list reloads — `repository-refresh`
+   * reloads the list without closing the menu (handleRepositoryRefresh), and
+   * only Escape or a click dismisses it — so the cached index can name a
+   * different stash by the time the user clicks an action, or by the time a
+   * confirm is dismissed. Match on `oid`, which is stable.
+   *
+   * Reads the list from `repoPath` rather than `this.stashes`: the caller pins
+   * repoPath before its confirm, and on a mid-confirm tab switch `this.stashes`
+   * holds the OTHER repo's entries — resolving against it would produce an
+   * index into the wrong list.
+   *
+   * Returns the live index, or null if the caller must abort (already toasted).
+   */
+  private async resolveStashIndex(
+    repoPath: string,
+    stash: Stash,
+    action: 'applied' | 'popped' | 'dropped'
+  ): Promise<number | null> {
+    const result = await gitService.getStashes(repoPath);
+
+    if (!result.success || !result.data) {
+      showToast(
+        result.error?.message ?? `Could not read the stash list — nothing was ${action}`,
+        'error'
+      );
+      return null;
+    }
+
+    const index = result.data.findIndex(s => s.oid === stash.oid);
+
+    if (index < 0) {
+      showToast(
+        `"${stash.message}" is no longer in the stash list — nothing was ${action}`,
+        'warning'
+      );
+      await this.loadStashes();
+      return null;
+    }
+
+    return index;
+  }
+
   private async handleApplyStash(): Promise<void> {
     const stash = this.contextMenu.stash;
     if (!stash || this.operationInProgress) return;
@@ -317,9 +365,12 @@ export class LvStashList extends LitElement {
     // apply actually ran on, even if the prop is rebound mid-flight.
     const repoPath = this.repositoryPath;
     try {
+      const index = await this.resolveStashIndex(repoPath, stash, 'applied');
+      if (index === null) return;
+
       const result = await gitService.applyStash({
         path: repoPath,
-        index: stash.index,
+        index,
         dropAfter: false,
       });
 
@@ -342,7 +393,7 @@ export class LvStashList extends LitElement {
             composed: true,
             detail: {
               operationType: 'stash',
-              stashIndex: stash.index,
+              stashIndex: index,
               dropStashOnComplete: false,
               repositoryPath: repoPath,
             },
@@ -383,9 +434,12 @@ export class LvStashList extends LitElement {
     this.operationInProgress = true;
 
     try {
+      const index = await this.resolveStashIndex(repoPath, stash, 'popped');
+      if (index === null) return;
+
       const result = await gitService.popStash({
         path: repoPath,
-        index: stash.index,
+        index,
       });
 
       if (result.success) {
@@ -407,7 +461,7 @@ export class LvStashList extends LitElement {
             composed: true,
             detail: {
               operationType: 'stash',
-              stashIndex: stash.index,
+              stashIndex: index,
               dropStashOnComplete: true,
               repositoryPath: repoPath,
             },
@@ -441,9 +495,12 @@ export class LvStashList extends LitElement {
     this.operationInProgress = true;
 
     try {
+      const index = await this.resolveStashIndex(repoPath, stash, 'dropped');
+      if (index === null) return;
+
       const result = await gitService.dropStash({
         path: repoPath,
-        index: stash.index,
+        index,
       });
 
       if (result.success) {

--- a/src/components/sidebar/lv-stash-list.ts
+++ b/src/components/sidebar/lv-stash-list.ts
@@ -10,6 +10,7 @@ import * as gitService from '../../services/git.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import type { Stash } from '../../types/git.types.ts';
+import { isTopOverlay } from '../../utils/overlay-stack.ts';
 
 interface ContextMenuState {
   visible: boolean;
@@ -179,6 +180,9 @@ export class LvStashList extends LitElement {
   };
 
   private handleKeydown = (e: KeyboardEvent): void => {
+    // A context menu must not eat an Escape aimed at a dialog opened over
+    // it: every global keydown listener fires on the same keypress.
+    if (!isTopOverlay(this)) return;
     if (e.key === 'Escape' && this.contextMenu.visible) {
       this.contextMenu = { ...this.contextMenu, visible: false };
     }

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -13,6 +13,7 @@ import { repositoryStore } from '../../stores/repository.store.ts';
 import type { Tag } from '../../types/git.types.ts';
 import '../dialogs/lv-create-tag-dialog.ts';
 import type { LvCreateTagDialog } from '../dialogs/lv-create-tag-dialog.ts';
+import { isTopOverlay } from '../../utils/overlay-stack.ts';
 
 type TagSortMode = 'name' | 'date' | 'date-asc';
 
@@ -369,6 +370,9 @@ export class LvTagList extends LitElement {
   };
 
   private handleKeydown = (e: KeyboardEvent): void => {
+    // A context menu must not eat an Escape aimed at a dialog opened over
+    // it: every global keydown listener fires on the same keypress.
+    if (!isTopOverlay(this)) return;
     if (e.key === 'Escape' && this.contextMenu.visible) {
       this.contextMenu = { ...this.contextMenu, visible: false };
     }

--- a/src/components/toolbar/lv-toolbar.ts
+++ b/src/components/toolbar/lv-toolbar.ts
@@ -22,6 +22,7 @@ import './lv-search-bar.ts';
 import type { LvCloneDialog } from '../dialogs/lv-clone-dialog.ts';
 import type { LvInitDialog } from '../dialogs/lv-init-dialog.ts';
 import type { LvSearchBar, SearchFilter } from './lv-search-bar.ts';
+import { isTopOverlay } from '../../utils/overlay-stack.ts';
 
 @customElement('lv-toolbar')
 export class LvToolbar extends LitElement {
@@ -703,6 +704,11 @@ export class LvToolbar extends LitElement {
   // Close the tab menus on Escape, matching the other context menus in the
   // app (e.g. lv-file-status). Registered only while a menu is open.
   private handleMenuEscape = (e: KeyboardEvent): void => {
+    // Capture phase on `document` runs before every dialog's listener, and
+    // this handler calls stopPropagation() — so without this check, closing
+    // the tab menu swallowed an Escape aimed at whatever dialog was open on
+    // top, and that dialog simply stopped responding to the key.
+    if (!isTopOverlay(this)) return;
     if (e.key === 'Escape') {
       e.stopPropagation();
       this.tabListAnchor = null;

--- a/src/services/__tests__/keyboard.service.test.ts
+++ b/src/services/__tests__/keyboard.service.test.ts
@@ -325,6 +325,50 @@ describe('registerDefaultShortcuts', () => {
       }
     });
 
+    // Space reports ' ' shifted or not, so shift is NOT redundant there — the
+    // first version of this rule collapsed them and made Shift+Space unbindable.
+    it('keeps shift significant for Space', () => {
+      let plain = 0;
+      let shifted = 0;
+      keyboardService.register('test-space', {
+        key: ' ', action: () => { plain++; }, description: 'space', category: 'Test',
+      });
+      keyboardService.register('test-shift-space', {
+        key: ' ', shift: true, action: () => { shifted++; }, description: 'shift space', category: 'Test',
+      });
+
+      try {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', shiftKey: false }));
+        expect(plain, 'Space').to.equal(1);
+        expect(shifted, 'Shift+Space must not fire on plain Space').to.equal(0);
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: ' ', shiftKey: true }));
+        expect(shifted, 'Shift+Space').to.equal(1);
+        expect(plain, 'Space must not fire again').to.equal(1);
+      } finally {
+        keyboardService.unregister('test-space');
+        keyboardService.unregister('test-shift-space');
+      }
+    });
+
+    // Accented and non-Latin letters have case, so shift stays significant.
+    it('keeps shift significant for non-ASCII letters', () => {
+      let plain = 0;
+      keyboardService.register('test-umlaut', {
+        key: 'ü', action: () => { plain++; }, description: 'umlaut', category: 'Test',
+      });
+
+      try {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ü', shiftKey: true }));
+        expect(plain, 'Shift+ü must not fire the plain ü binding').to.equal(0);
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'ü', shiftKey: false }));
+        expect(plain, 'plain ü').to.equal(1);
+      } finally {
+        keyboardService.unregister('test-umlaut');
+      }
+    });
+
     // Letters must keep the distinction: shift+a and a are different bindings.
     it('keeps shift significant for letter shortcuts', () => {
       let plain = 0;

--- a/src/services/__tests__/keyboard.service.test.ts
+++ b/src/services/__tests__/keyboard.service.test.ts
@@ -1,5 +1,6 @@
 import { expect } from '@open-wc/testing';
 import type { Shortcut } from '../keyboard.service.ts';
+import { keyboardService } from '../keyboard.service.ts';
 
 // Clear localStorage before tests
 const STORAGE_KEY = 'leviathan-keyboard-settings';
@@ -163,10 +164,28 @@ describe('keyboard.service', () => {
   describe('setEnabled', () => {
     it('can disable keyboard shortcuts', async () => {
       const { keyboardService } = await import('../keyboard.service.ts');
-      keyboardService.setEnabled(false);
-      // When disabled, shortcuts shouldn't fire (tested via integration)
-      // Just verify the method exists and doesn't throw
-      expect(() => keyboardService.setEnabled(true)).to.not.throw;
+
+      let fired = 0;
+      keyboardService.register('test-disabled', {
+        key: 'y', action: () => { fired++; }, description: 'disabled probe', category: 'Test',
+      });
+
+      try {
+        keyboardService.setEnabled(false);
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
+        expect(fired, 'disabled shortcuts must not fire').to.equal(0);
+
+        // Re-enabled in the same test, and asserted. This used to be
+        // `expect(() => setEnabled(true)).to.not.throw` — a property access,
+        // never invoked — so the service was left DISABLED for every later
+        // test in this file, silently neutering any that dispatch a key.
+        keyboardService.setEnabled(true);
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
+        expect(fired, 'shortcuts fire again once re-enabled').to.equal(1);
+      } finally {
+        keyboardService.setEnabled(true);
+        keyboardService.unregister('test-disabled');
+      }
     });
   });
 
@@ -274,5 +293,61 @@ describe('registerDefaultShortcuts', () => {
     expect(descriptions).to.include('Push to remote');
     expect(descriptions).to.include('Create new branch');
     expect(descriptions).to.include('Create stash');
+  });
+
+  describe('shifted punctuation shortcuts', () => {
+    beforeEach(() => {
+      keyboardService.setEnabled(true);
+    });
+
+    // "?" cannot be typed without a modifier, and which modifier depends on the
+    // layout. Hashing the shift state into the binding made the shortcut match
+    // only when the event happened to carry shiftKey — so a keypress that
+    // produced the character still missed the binding.
+    it('fires a "?" shortcut whether or not the event carries shiftKey', () => {
+      let fired = 0;
+      keyboardService.register('test-question', {
+        key: '?',
+        shift: true,
+        action: () => { fired++; },
+        description: 'Test question mark',
+        category: 'Test',
+      });
+
+      try {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: '?', shiftKey: true }));
+        expect(fired, 'with shiftKey').to.equal(1);
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: '?', shiftKey: false }));
+        expect(fired, 'without shiftKey').to.equal(2);
+      } finally {
+        keyboardService.unregister('test-question');
+      }
+    });
+
+    // Letters must keep the distinction: shift+a and a are different bindings.
+    it('keeps shift significant for letter shortcuts', () => {
+      let plain = 0;
+      let shifted = 0;
+      keyboardService.register('test-plain', {
+        key: 'q', action: () => { plain++; }, description: 'plain', category: 'Test',
+      });
+      keyboardService.register('test-shifted', {
+        key: 'q', shift: true, action: () => { shifted++; }, description: 'shifted', category: 'Test',
+      });
+
+      try {
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'q', shiftKey: false }));
+        expect(plain, 'plain q').to.equal(1);
+        expect(shifted, 'shifted must not fire').to.equal(0);
+
+        document.dispatchEvent(new KeyboardEvent('keydown', { key: 'q', shiftKey: true }));
+        expect(shifted, 'shift+q').to.equal(1);
+        expect(plain, 'plain must not fire again').to.equal(1);
+      } finally {
+        keyboardService.unregister('test-plain');
+        keyboardService.unregister('test-shifted');
+      }
+    });
   });
 });

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -1698,15 +1698,25 @@ export async function getReflog(
   return invokeCommand<ReflogEntry[]>("get_reflog", { path: repoPath, limit });
 }
 
+/**
+ * Reset HEAD to a reflog entry.
+ *
+ * `expectedOid` guards against the reflog shifting between listing and reset
+ * (a commit or checkout from another window renumbers every entry). Pass the
+ * oid the user was shown; the backend refuses if the position no longer holds
+ * it. Omitting it skips the check.
+ */
 export async function resetToReflog(
   repoPath: string,
   reflogIndex: number,
   mode: "soft" | "mixed" | "hard" = "mixed",
+  expectedOid?: string,
 ): Promise<CommandResult<ReflogEntry>> {
   return invokeCommand<ReflogEntry>("reset_to_reflog", {
     path: repoPath,
     reflogIndex,
     mode,
+    expectedOid,
   });
 }
 

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -4749,13 +4749,19 @@ export async function gitFlowStartFeature(
   return invokeCommand<Branch>("gitflow_start_feature", { path: repoPath, name });
 }
 
+/** Outcome of a git-flow finish; branchKeptReason is set when a branch rule blocked the delete. */
+export interface GitFlowFinishResult {
+  branchDeleted: boolean;
+  branchKeptReason: string | null;
+}
+
 export async function gitFlowFinishFeature(
   repoPath: string,
   name: string,
   deleteBranch?: boolean,
   squash?: boolean,
-): Promise<CommandResult<void>> {
-  return invokeCommand<void>("gitflow_finish_feature", {
+): Promise<CommandResult<GitFlowFinishResult>> {
+  return invokeCommand<GitFlowFinishResult>("gitflow_finish_feature", {
     path: repoPath,
     name,
     deleteBranch,
@@ -4775,8 +4781,8 @@ export async function gitFlowFinishRelease(
   version: string,
   tagMessage?: string,
   deleteBranch?: boolean,
-): Promise<CommandResult<void>> {
-  return invokeCommand<void>("gitflow_finish_release", {
+): Promise<CommandResult<GitFlowFinishResult>> {
+  return invokeCommand<GitFlowFinishResult>("gitflow_finish_release", {
     path: repoPath,
     version,
     tagMessage,
@@ -4796,8 +4802,8 @@ export async function gitFlowFinishHotfix(
   version: string,
   tagMessage?: string,
   deleteBranch?: boolean,
-): Promise<CommandResult<void>> {
-  return invokeCommand<void>("gitflow_finish_hotfix", {
+): Promise<CommandResult<GitFlowFinishResult>> {
+  return invokeCommand<GitFlowFinishResult>("gitflow_finish_hotfix", {
     path: repoPath,
     version,
     tagMessage,

--- a/src/services/keyboard.service.ts
+++ b/src/services/keyboard.service.ts
@@ -120,7 +120,14 @@ class KeyboardService {
     // depending on the layout — and made the "?" shortcut match only when the
     // event happened to carry shiftKey. Letters and digits still need it,
     // since "shift+a" and "a" are genuinely different bindings.
-    const shiftIsRedundant = key.length === 1 && !/[a-z0-9]/.test(key);
+    // Caselessness, not "non-alphanumeric". The ASCII test this replaced was
+    // true for ' ' — collapsing Shift+Space onto Space and making Shift+Space
+    // unbindable — and for every accented or non-Latin letter, so Shift+ü and
+    // ü collided too. A character with no case distinction is one whose shift
+    // state is already baked into the character; Space is the exception, since
+    // shifted and unshifted both report ' '.
+    const shiftIsRedundant =
+      key.length === 1 && key !== ' ' && key.toUpperCase() === key.toLowerCase();
 
     const parts: string[] = [];
     if (ctrl || meta) parts.push('mod');

--- a/src/services/keyboard.service.ts
+++ b/src/services/keyboard.service.ts
@@ -113,9 +113,18 @@ class KeyboardService {
     const meta = 'metaKey' in e ? e.metaKey : e.meta;
     const key = e.key.toLowerCase();
 
+    // For a single non-alphanumeric character the shift state is already
+    // encoded in the character itself: you cannot type "?" without whatever
+    // modifier your layout requires, and on some layouts that is not Shift at
+    // all. Including it would make the same keypress hash differently
+    // depending on the layout — and made the "?" shortcut match only when the
+    // event happened to carry shiftKey. Letters and digits still need it,
+    // since "shift+a" and "a" are genuinely different bindings.
+    const shiftIsRedundant = key.length === 1 && !/[a-z0-9]/.test(key);
+
     const parts: string[] = [];
     if (ctrl || meta) parts.push('mod');
-    if (shift) parts.push('shift');
+    if (shift && !shiftIsRedundant) parts.push('shift');
     if (alt) parts.push('alt');
     parts.push(key);
 

--- a/src/utils/__tests__/overlay-stack.test.ts
+++ b/src/utils/__tests__/overlay-stack.test.ts
@@ -1,0 +1,82 @@
+/**
+ * Every dialog registers its own document-level Escape listener, so a single
+ * keypress ran all of them: dismissing the command palette opened over the
+ * clean dialog also dismissed the clean dialog, discarding the file selection
+ * the user had built. The stack decides which overlay owns the key.
+ */
+
+import { expect } from '@open-wc/testing';
+import {
+  pushOverlay,
+  removeOverlay,
+  isTopOverlay,
+  resetOverlayStack,
+} from '../overlay-stack.ts';
+
+describe('overlay-stack', () => {
+  beforeEach(() => {
+    resetOverlayStack();
+  });
+
+  it('treats an unregistered overlay as owning the key', () => {
+    // A dialog that never announces itself must keep working, not go dead.
+    expect(isTopOverlay({})).to.be.true;
+  });
+
+  it('gives the key to the last overlay opened', () => {
+    const dialog = {};
+    const palette = {};
+
+    pushOverlay(dialog);
+    expect(isTopOverlay(dialog)).to.be.true;
+
+    pushOverlay(palette);
+    expect(isTopOverlay(palette), 'palette on top').to.be.true;
+    expect(isTopOverlay(dialog), 'dialog underneath must ignore Escape').to.be.false;
+  });
+
+  it('returns the key to the dialog underneath when the top one closes', () => {
+    const dialog = {};
+    const palette = {};
+    pushOverlay(dialog);
+    pushOverlay(palette);
+
+    removeOverlay(palette);
+
+    expect(isTopOverlay(dialog), 'dialog owns the key again').to.be.true;
+  });
+
+  it('does not register the same overlay twice', () => {
+    const dialog = {};
+    const other = {};
+    pushOverlay(dialog);
+    pushOverlay(other);
+    // Re-opening without closing must not leave a stale duplicate behind.
+    pushOverlay(other);
+
+    removeOverlay(other);
+
+    expect(isTopOverlay(dialog)).to.be.true;
+  });
+
+  it('ignores removal of an overlay that never registered', () => {
+    const dialog = {};
+    pushOverlay(dialog);
+
+    removeOverlay({});
+
+    expect(isTopOverlay(dialog)).to.be.true;
+  });
+
+  it('re-pushing an open overlay moves it to the top', () => {
+    const a = {};
+    const b = {};
+    pushOverlay(a);
+    pushOverlay(b);
+
+    pushOverlay(a);
+
+    expect(isTopOverlay(a)).to.be.true;
+    expect(isTopOverlay(b)).to.be.false;
+  });
+});

--- a/src/utils/maintenance-confirms.ts
+++ b/src/utils/maintenance-confirms.ts
@@ -66,3 +66,40 @@ export function summariseFsck(message: string | undefined): string {
 
   return `Repository integrity check completed — ${lines.length} notes reported (${lines[0].trim()}, …)`;
 }
+
+/**
+ * Which repositories currently have a maintenance command running.
+ *
+ * `gc`, `prune` and `fsck` each have TWO implementations — the command palette
+ * (app-shell) and the Repository Health dialog — and only the dialog tracked
+ * whether one was already running. So a palette "Run Garbage Collection"
+ * launched a second concurrent gc over the dialog's, defeating the
+ * runningAction machinery entirely. For gc-vs-gc git's own pid lock rejects
+ * the second with a raw, unhelpful error; for gc-vs-prune there is no such
+ * serialization at all and the two race on the objects directory.
+ *
+ * Keyed by repository path: maintenance on different repos is independent.
+ */
+const maintenanceInFlight = new Set<string>();
+
+/** Claim the maintenance slot for a repo. False when one is already running. */
+export function tryAcquireMaintenance(repoPath: string): boolean {
+  if (maintenanceInFlight.has(repoPath)) return false;
+  maintenanceInFlight.add(repoPath);
+  return true;
+}
+
+/** Release the slot. Safe to call for a repo that never held one. */
+export function releaseMaintenance(repoPath: string): void {
+  maintenanceInFlight.delete(repoPath);
+}
+
+/** True while a maintenance command is running against `repoPath`. */
+export function isMaintenanceRunning(repoPath: string): boolean {
+  return maintenanceInFlight.has(repoPath);
+}
+
+/** Test seam: drop all claims. */
+export function resetMaintenanceLocks(): void {
+  maintenanceInFlight.clear();
+}

--- a/src/utils/maintenance-confirms.ts
+++ b/src/utils/maintenance-confirms.ts
@@ -45,3 +45,24 @@ export function confirmPrune(): Promise<boolean> {
     'warning'
   );
 }
+
+/**
+ * Condense `git fsck` output for a toast.
+ *
+ * `git fsck --full` prints one line per dangling/unreachable object, which on a
+ * repo with rebased or amended history is dozens of lines. A toast is ~400px
+ * wide with no max-height and auto-dismisses, so dumping that raw makes it both
+ * unreadable and large enough to cover the view. Lead with the count instead.
+ *
+ * Shared by the command palette and the Repository Health dialog: they reach
+ * the same command, so summarising only one of them left the problem reachable.
+ */
+export function summariseFsck(message: string | undefined): string {
+  const text = (message ?? '').trim();
+  if (!text) return 'Repository integrity check completed';
+
+  const lines = text.split('\n').filter((l) => l.trim().length > 0);
+  if (lines.length <= 2 && text.length <= 200) return text;
+
+  return `Repository integrity check completed — ${lines.length} notes reported (${lines[0].trim()}, …)`;
+}

--- a/src/utils/maintenance-confirms.ts
+++ b/src/utils/maintenance-confirms.ts
@@ -1,0 +1,47 @@
+/**
+ * Shared confirmations for repository maintenance operations.
+ *
+ * `git gc` and `git prune` are reachable from BOTH the command palette
+ * (app-shell) and the Repository Health dialog. They were previously gated in
+ * only one of those places, so the same irreversible operation was guarded on
+ * one surface and one click away on the other. Keeping the gate and its copy
+ * here means both surfaces cannot drift apart again.
+ */
+
+import { showConfirm } from '../services/dialog.service.ts';
+
+/**
+ * Confirm a `git gc` run.
+ *
+ * Deliberately narrower than the prune wording: run_gc passes no `--prune`, so
+ * git applies its own grace periods (`gc.pruneExpire`, 2 weeks by default, and
+ * `gc.reflogExpireUnreachable`, 30 days). A stash dropped minutes ago survives
+ * this, and claiming otherwise would train users to dismiss the warning.
+ */
+export function confirmGarbageCollection(aggressive: boolean): Promise<boolean> {
+  return showConfirm(
+    aggressive ? 'Run Garbage Collection (Aggressive)' : 'Run Garbage Collection',
+    'This repacks the repository and removes unreachable objects that are past ' +
+      "git's grace period (2 weeks by default), along with expired reflog " +
+      'entries. Recently dropped stashes and deleted branches are not affected. ' +
+      'Continue?',
+    'warning'
+  );
+}
+
+/**
+ * Confirm a `git prune` run.
+ *
+ * Unlike gc, bare `git prune` has no expiry — it removes every unreachable
+ * object immediately, including work dropped seconds ago, so the stronger
+ * wording here is accurate.
+ */
+export function confirmPrune(): Promise<boolean> {
+  return showConfirm(
+    'Prune Unreachable Objects',
+    'This permanently deletes unreachable objects with no grace period. Work ' +
+      'recoverable only through the reflog — dropped stashes, deleted ' +
+      'branches, amended commits — will become unrecoverable. Continue?',
+    'warning'
+  );
+}

--- a/src/utils/overlay-stack.ts
+++ b/src/utils/overlay-stack.ts
@@ -1,0 +1,44 @@
+/**
+ * Which overlay owns the Escape key.
+ *
+ * Fourteen dialogs register their own `document`-level keydown listener, and
+ * every one of them asked only "am I open?" — never "am I the one on top?".
+ * Because those listeners all sit on `document`, a single Escape ran ALL of
+ * them: dismissing the command palette opened over the clean dialog also
+ * dismissed the clean dialog underneath, discarding the file selection the
+ * user had built. `stopPropagation()` cannot fix this — listeners on the same
+ * node still fire — and `e.defaultPrevented` cannot either, because listener
+ * order is mount order, not stacking order.
+ *
+ * So overlays announce themselves as they open. The last one to open owns the
+ * key; everyone else ignores it. Registration is by identity, so a component
+ * that opens twice without closing does not appear twice.
+ */
+
+const stack: object[] = [];
+
+/** Mark `owner` as the topmost overlay. */
+export function pushOverlay(owner: object): void {
+  removeOverlay(owner);
+  stack.push(owner);
+}
+
+/** Remove `owner` from the stack; the previous overlay regains the key. */
+export function removeOverlay(owner: object): void {
+  const i = stack.indexOf(owner);
+  if (i !== -1) stack.splice(i, 1);
+}
+
+/**
+ * True when `owner` is the topmost overlay — or when nothing has registered,
+ * so a dialog that never announces itself keeps its old behaviour instead of
+ * going silently dead.
+ */
+export function isTopOverlay(owner: object): boolean {
+  return stack.length === 0 || stack[stack.length - 1] === owner;
+}
+
+/** Test seam: drop all registrations. */
+export function resetOverlayStack(): void {
+  stack.length = 0;
+}


### PR DESCRIPTION
## Summary

This PR fixes critical bugs in dialog Escape key handling and overlay stacking that caused dialogs to dismiss each other unintentionally. It also adds missing re-entrancy guards, fixes repository path capture for live-bound properties, and improves confirmation gating for destructive operations.

## Key Changes

### Overlay Stack Management
- **New `src/utils/overlay-stack.ts`**: Implements a document-level overlay stack to ensure only the topmost dialog owns the Escape key. Prevents cascading dismissals when multiple dialogs are open.
- **ESLint rule `eslint-rules/overlay-stack-membership.mjs`**: Enforces that all dialogs registering Escape listeners join the overlay stack, preventing regressions.
- Updated 15+ dialogs to call `pushOverlay(this)` on open and `removeOverlay(this)` on close.

### Repository Path Capture
Multiple dialogs (`lv-bisect-dialog`, `lv-repository-health-dialog`, `lv-reflog-dialog`, `lv-clean-dialog`, `lv-changelog-dialog`, `lv-config-dialog`, `lv-credentials-dialog`) now capture `repositoryPath` at open time instead of reading the live-bound property during operations. This prevents operations from running against the wrong repository when the user switches repos via Ctrl+Tab while a dialog is open.

### Abort Operation Gating
- **New `src/utils/maintenance-confirms.ts`**: Centralized confirmation dialogs for `git gc` and `git prune` to ensure both the command palette and Repository Health dialog use identical gates.
- **`src/app-shell.ts`**: Added `ABORTABLE_STATES` constant defining which repository states support abort, with `abortInProgress` flag to prevent double-click races.

### Branch Cleanup Dialog Improvements
- **`lv-branch-cleanup-dialog.ts`**: 
  - Added `loadFailed` state to distinguish "scan failed" from "no candidates found"
  - Fixed risk assessment by grouping candidates by branch name first (branches can appear in multiple categories)
  - Added re-entrancy guard in `open()` to prevent reset during active delete loop
  - Improved `loadCleanupData()` to preserve selection across refreshes

### Bisect Dialog Fixes
- **`lv-bisect-dialog.ts`**: Added Escape key handling with overlay stack integration; events now include `repositoryPath` to ensure operations target the correct repo.
- **New test file `lv-bisect-dialog.test.ts`**: Regression tests for repo switching and event dispatch consistency.

### Reflog and Clean Dialog Fixes
- **`lv-reflog-dialog.ts`** and **`lv-clean-dialog.ts`**: Added `expectedOid` parameter to `reset_to_reflog` to guard against reflog index shifts from concurrent writes.
- Both dialogs now capture repo path at open and validate operations against it.

### Git Flow Finish Improvements
- **`src-tauri/src/commands/gitflow.rs`**: New `GitFlowFinishResult` struct with `branch_deleted` and `branch_kept_reason` fields to report why branch deletion was skipped.
- **`lv-gitflow-panel.ts`**: Added confirmation gate for squash finishes (which discard individual commits).

### Branch Protection Rules
- **`src-tauri/src/commands/branch.rs`**: Enforce `preventDeletion` rules in `delete_branch` command, not just in cleanup dialog candidate listing. Prevents sidebar and graph ref menu from bypassing protection.
- **`src-tauri/src/commands/branch_rules.rs`**: Extracted `match_rule()` function for consistent pattern matching.

### File Discard Clarity
- **`src-tauri/src/commands/staging.rs`**: Improved `discard_changes` to validate paths before processing and clarify untracked file deletion.
- **New test file `lv-file-status-discard-copy.test.ts`**: Tests that discard confirmations accurately describe permanent deletion of untracked files.

### Keyboard Service Improvements
- **`src/services/keyboard.service.ts`**:

https://claude.ai/code/session_01G7sct7xmRYxLME2bgU1scF