### PR TITLE
Create the local branch before rewriting the working tree on checkout

### DIFF
--- a/src-tauri/src/commands/branch.rs
+++ b/src-tauri/src/commands/branch.rs
@@ -858,6 +858,18 @@ pub struct CheckoutWithStashResult {
     pub message: String,
 }
 
+/// Delete a local branch created by an in-progress checkout that then failed.
+///
+/// Best effort: the caller is already returning an error the user needs to see,
+/// and a failure to clean up must not replace it.
+fn rollback_created_branch(repo: &git2::Repository, name: Option<&str>) {
+    if let Some(name) = name {
+        if let Ok(mut branch) = repo.find_branch(name, git2::BranchType::Local) {
+            let _ = branch.delete();
+        }
+    }
+}
+
 /// Checkout a branch with automatic stash handling
 /// 1. If there are uncommitted changes, stash them
 /// 2. Perform the checkout
@@ -1037,6 +1049,11 @@ pub async fn checkout_with_autostash(
     // the tree already at the target commit — popping the auto-stash over the
     // wrong tree while HEAD still named the old branch. Failing here leaves the
     // working tree untouched, so the restore lands on the tree it came from.
+    // Records a branch created by THIS call, so a later failure can roll it back
+    // the way checkout() does. Without it a failing checkout_tree left the new
+    // tracking branch behind, making a failed checkout non-transactional.
+    let mut created_branch: Option<String> = None;
+
     if is_remote_branch {
         let local_name = if let Some(pos) = ref_name.find('/') {
             &ref_name[pos + 1..]
@@ -1053,6 +1070,7 @@ pub async fn checkout_with_autostash(
                     Ok(mut new_branch) => {
                         // Best effort: tracking config must not abort the checkout.
                         let _ = new_branch.set_upstream(Some(&ref_name));
+                        created_branch = Some(local_name.to_string());
                         None
                     }
                     Err(e) => Some(format!(
@@ -1083,6 +1101,11 @@ pub async fn checkout_with_autostash(
     }; // obj dropped here
 
     if let Some(msg) = checkout_error {
+        // Roll back a branch this call created. The checkout failed, so the ref
+        // must not outlive it — otherwise a retry sees a branch that already
+        // exists and silently takes the "local branch exists" path instead.
+        rollback_created_branch(&repo, created_branch.as_deref());
+
         // Restore the auto-stash now the checkout has failed.
         //
         // Resolved by oid rather than verified at index 0: `git stash push`
@@ -1146,6 +1169,7 @@ pub async fn checkout_with_autostash(
     // the tree is at the target commit, HEAD is not, and the raw set_head
     // error says nothing about where the user's changes went.
     if let Err(err) = set_head_result {
+        rollback_created_branch(&repo, created_branch.as_deref());
         return Err(autostash_failure(
             &mut repo,
             stashed,
@@ -1993,10 +2017,16 @@ mod tests {
 
         // Index untouched: nothing staged against HEAD.
         let statuses = repo.statuses(None).unwrap();
+        // Every staged bit, not just new/modified/deleted: a rewritten tree can
+        // also stage renames and typechanges, which would slip past a narrower
+        // check and let this assertion pass over a dirty index.
+        let staged = git2::Status::INDEX_NEW
+            | git2::Status::INDEX_MODIFIED
+            | git2::Status::INDEX_DELETED
+            | git2::Status::INDEX_RENAMED
+            | git2::Status::INDEX_TYPECHANGE;
         assert!(
-            statuses.iter().all(|s| !s.status().is_index_new()
-                && !s.status().is_index_modified()
-                && !s.status().is_index_deleted()),
+            statuses.iter().all(|s| !s.status().intersects(staged)),
             "failed checkout left staged changes in the index"
         );
 
@@ -2005,6 +2035,64 @@ mod tests {
             repo.find_branch("feature", git2::BranchType::Local)
                 .is_err(),
             "a failed checkout must not leave the local branch behind"
+        );
+    }
+
+    /// A branch created by checkout_with_autostash must not survive a failed
+    /// checkout.
+    ///
+    /// Creating the ref before checkout_tree is what keeps a failure from
+    /// corrupting the tree, but it also means a later checkout_tree failure
+    /// would leave the branch behind — non-transactional, and inconsistent with
+    /// checkout(), which rolls its ref back. A retry would then see the branch
+    /// already exists and silently take the "local branch exists" path.
+    #[tokio::test]
+    async fn test_failed_autostash_checkout_rolls_back_the_created_branch() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_commit("Adds shared.txt", &[("shared.txt", "base")]);
+        let original_branch = test_repo.current_branch();
+
+        // The "remote" changes shared.txt, so switching to it must rewrite that
+        // file in the working tree.
+        test_repo.create_branch("staging-for-remote");
+        test_repo.checkout_branch("staging-for-remote");
+        let remote_tip = test_repo.create_commit("Remote edit", &[("shared.txt", "remote")]);
+        test_repo.checkout_branch(&original_branch);
+
+        {
+            let repo = test_repo.repo();
+            repo.reference(
+                "refs/remotes/origin/feature",
+                remote_tip,
+                true,
+                "test remote branch",
+            )
+            .unwrap();
+        }
+
+        // Uncommitted local edit to that same file, with auto-stash OFF: nothing
+        // moves it out of the way, so the safe checkout_tree refuses rather than
+        // discarding the user's work — a failure that lands AFTER the branch has
+        // been created.
+        test_repo.create_file("shared.txt", "local edit");
+
+        let result = checkout_with_autostash(
+            test_repo.path_str(),
+            "origin/feature".to_string(),
+            Some(false),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "checkout must fail rather than discard an uncommitted local edit"
+        );
+
+        let repo = test_repo.repo();
+        assert_eq!(test_repo.current_branch(), original_branch);
+        assert!(
+            repo.find_branch("feature", git2::BranchType::Local)
+                .is_err(),
+            "a failed checkout must not leave the branch it created behind"
         );
     }
 

--- a/src-tauri/src/commands/branch.rs
+++ b/src-tauri/src/commands/branch.rs
@@ -563,18 +563,41 @@ pub async fn checkout(path: String, ref_name: String, force: Option<bool>) -> Re
                     LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
                 })?)?;
             } else {
-                // Create new local branch from the remote branch
+                // Create new local branch from the remote branch.
+                //
+                // The ref must exist BEFORE the working tree is rewritten. A
+                // failure here (invalid derived name such as "HEAD" from
+                // refs/remotes/origin/HEAD, or a D/F conflict against an
+                // existing refs/heads/<name>/*) would otherwise return with the
+                // tree already holding the remote tip while HEAD still names the
+                // old branch — the whole inter-branch diff appears staged and
+                // committing writes the other branch's tree onto this one.
                 let commit = remote_branch.get().peel_to_commit()?;
-                repo.checkout_tree(commit.as_object(), Some(&mut checkout_opts))?;
                 let mut new_branch = repo.branch(local_name, &commit, false)?;
 
-                // Set upstream tracking
-                new_branch.set_upstream(Some(&remote_name))?;
+                // Upstream tracking is best-effort: the branch already exists, so
+                // a tracking-config failure must not abort the checkout (matches
+                // checkout_with_autostash).
+                let _ = new_branch.set_upstream(Some(&remote_name));
 
-                // Set HEAD to the new branch
-                repo.set_head(new_branch.get().name().map_err(|_| {
-                    LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
-                })?)?;
+                let branch_ref = new_branch
+                    .get()
+                    .name()
+                    .map_err(|_| {
+                        LeviathanError::OperationFailed(
+                            "Invalid reference name encoding".to_string(),
+                        )
+                    })?
+                    .to_string();
+
+                // Roll the new ref back if the tree cannot be written, so a
+                // failed checkout leaves no half-created branch behind.
+                if let Err(e) = repo.checkout_tree(commit.as_object(), Some(&mut checkout_opts)) {
+                    let _ = new_branch.delete();
+                    return Err(e.into());
+                }
+
+                repo.set_head(&branch_ref)?;
             }
         } else {
             // Couldn't parse remote name, detach HEAD
@@ -1004,6 +1027,47 @@ pub async fn checkout_with_autostash(
     };
     if let Some(msg) = find_error {
         return Err(autostash_failure(&mut repo, stashed, stash_oid, &msg));
+    }
+
+    // Create the local tracking branch BEFORE the working tree is rewritten.
+    //
+    // Creating it inside the set_head closure below put it AFTER checkout_tree,
+    // so a failure (invalid derived name such as "HEAD", or a D/F conflict
+    // against an existing refs/heads/<name>/*) reached autostash_failure with
+    // the tree already at the target commit — popping the auto-stash over the
+    // wrong tree while HEAD still named the old branch. Failing here leaves the
+    // working tree untouched, so the restore lands on the tree it came from.
+    if is_remote_branch {
+        let local_name = if let Some(pos) = ref_name.find('/') {
+            &ref_name[pos + 1..]
+        } else {
+            ref_name.as_str()
+        };
+
+        if repo
+            .find_branch(local_name, git2::BranchType::Local)
+            .is_err()
+        {
+            let create_error: Option<String> = match repo.find_commit(target_oid) {
+                Ok(commit) => match repo.branch(local_name, &commit, false) {
+                    Ok(mut new_branch) => {
+                        // Best effort: tracking config must not abort the checkout.
+                        let _ = new_branch.set_upstream(Some(&ref_name));
+                        None
+                    }
+                    Err(e) => Some(format!(
+                        "Could not create local branch '{}': {}",
+                        local_name,
+                        e.message()
+                    )),
+                },
+                Err(e) => Some(format!("Could not find object: {}", e.message())),
+            };
+
+            if let Some(msg) = create_error {
+                return Err(autostash_failure(&mut repo, stashed, stash_oid, &msg));
+            }
+        }
     }
 
     // Perform checkout using the OID
@@ -1859,6 +1923,89 @@ mod tests {
             // Should be back on the original branch
             assert_eq!(repo.current_branch(), original_branch);
         }
+    }
+
+    /// Creating the local branch must happen BEFORE the working tree is
+    /// rewritten.
+    ///
+    /// With the old ordering, checkout_tree ran first and a failing
+    /// `repo.branch(..)` returned an error having already written the remote
+    /// tip into the tree and index while HEAD still named the old branch: the
+    /// entire inter-branch diff showed up staged, and committing recorded the
+    /// other branch's tree onto the current one. A D/F conflict reaches that
+    /// failure — refs/heads/feature cannot be created while refs/heads/feature/sub
+    /// exists — as does the "HEAD" name derived from refs/remotes/origin/HEAD.
+    #[tokio::test]
+    async fn test_failed_remote_checkout_leaves_tree_and_head_untouched() {
+        let test_repo = TestRepo::with_initial_commit();
+        let original_branch = test_repo.current_branch();
+
+        // A commit that only exists on the "remote" branch, so a rewritten
+        // working tree is detectable by remote-only.txt appearing on disk.
+        test_repo.create_branch("staging-for-remote");
+        test_repo.checkout_branch("staging-for-remote");
+        let remote_tip =
+            test_repo.create_commit("Remote only", &[("remote-only.txt", "remote content")]);
+        test_repo.checkout_branch(&original_branch);
+
+        {
+            let repo = test_repo.repo();
+            repo.reference(
+                "refs/remotes/origin/feature",
+                remote_tip,
+                true,
+                "test remote branch",
+            )
+            .unwrap();
+
+            // Forces the D/F conflict: refs/heads/feature/ now exists as a
+            // directory, so refs/heads/feature cannot be created.
+            let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+            repo.branch("feature/sub", &head_commit, false).unwrap();
+        }
+
+        let head_before = {
+            let repo = test_repo.repo();
+            let oid = repo.head().unwrap().peel_to_commit().unwrap().id();
+            oid
+        };
+
+        let result = checkout(test_repo.path_str(), "origin/feature".to_string(), None).await;
+        assert!(
+            result.is_err(),
+            "checking out origin/feature must fail while refs/heads/feature/sub exists"
+        );
+
+        let repo = test_repo.repo();
+
+        // HEAD untouched: same branch, same commit.
+        assert_eq!(test_repo.current_branch(), original_branch);
+        assert_eq!(
+            repo.head().unwrap().peel_to_commit().unwrap().id(),
+            head_before
+        );
+
+        // Working tree untouched: the remote-only file was never written.
+        assert!(
+            !test_repo.path.join("remote-only.txt").exists(),
+            "working tree was rewritten to the remote tip before the branch was created"
+        );
+
+        // Index untouched: nothing staged against HEAD.
+        let statuses = repo.statuses(None).unwrap();
+        assert!(
+            statuses.iter().all(|s| !s.status().is_index_new()
+                && !s.status().is_index_modified()
+                && !s.status().is_index_deleted()),
+            "failed checkout left staged changes in the index"
+        );
+
+        // No half-created branch left behind.
+        assert!(
+            repo.find_branch("feature", git2::BranchType::Local)
+                .is_err(),
+            "a failed checkout must not leave the local branch behind"
+        );
     }
 
     // ── checkout_with_autostash tests ──────────────────────────────────

--- a/src-tauri/src/commands/branch.rs
+++ b/src-tauri/src/commands/branch.rs
@@ -597,7 +597,47 @@ pub async fn checkout(path: String, ref_name: String, force: Option<bool>) -> Re
                     return Err(e.into());
                 }
 
-                repo.set_head(&branch_ref)?;
+                // Moving HEAD is the LAST thing that can fail, and by then the
+                // working tree already holds the remote tip. Returning there
+                // left HEAD naming the old branch over the other branch's
+                // content: the whole inter-branch diff reads as uncommitted
+                // work, and committing it writes the other branch's tree onto
+                // this one — the exact corruption creating the ref early is
+                // meant to prevent, just one step later. Reachable through a
+                // HEAD.lock left by a crashed process or a concurrent git.
+                //
+                // So put the tree back, then drop the ref, and report the
+                // original failure.
+                //
+                // The restore is `force()`, and has to be: the files to undo
+                // now differ from HEAD, so a `safe()` checkout reads them as
+                // local modifications and refuses to touch the very files it
+                // needs to revert. That is safe here only because the checkout
+                // above ran `safe()` and SUCCEEDED — which means no tracked
+                // file carried a conflicting local edit, so everything this
+                // reverts is content we just wrote ourselves. Untracked files
+                // are not touched either way.
+                if let Err(e) = repo.set_head(&branch_ref) {
+                    let restored = repo
+                        .head()
+                        .and_then(|h| h.peel_to_commit())
+                        .and_then(|prev| {
+                            let mut restore = git2::build::CheckoutBuilder::new();
+                            restore.force();
+                            repo.checkout_tree(prev.as_object(), Some(&mut restore))
+                        })
+                        .is_ok();
+                    let _ = new_branch.delete();
+
+                    if !restored {
+                        return Err(LeviathanError::OperationFailed(format!(
+                            "Could not switch to {}: {}. The working tree still holds \
+                             {}'s content — check it out again to recover.",
+                            local_name, e, remote_name
+                        )));
+                    }
+                    return Err(e.into());
+                }
             }
         } else {
             // Couldn't parse remote name, detach HEAD
@@ -2031,6 +2071,63 @@ mod tests {
         );
 
         // No half-created branch left behind.
+        assert!(
+            repo.find_branch("feature", git2::BranchType::Local)
+                .is_err(),
+            "a failed checkout must not leave the local branch behind"
+        );
+    }
+
+    /// A set_head failure must not leave the tree on one branch and HEAD on
+    /// another.
+    ///
+    /// Moving HEAD is the last step that can fail, and by then checkout_tree
+    /// has already written the remote tip into the working tree. Returning
+    /// there left the whole inter-branch diff reading as uncommitted work, and
+    /// committing it would write the other branch's tree onto the current one.
+    /// A HEAD.lock — left by a crashed process or a concurrent git — is the way
+    /// in, and is exactly what this test uses.
+    #[tokio::test]
+    async fn test_failed_set_head_restores_the_tree_and_drops_the_branch() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_commit("Adds shared.txt", &[("shared.txt", "base")]);
+        let original_branch = test_repo.current_branch();
+
+        // A "remote" branch whose tip changes shared.txt.
+        test_repo.create_branch("staging-for-remote");
+        test_repo.checkout_branch("staging-for-remote");
+        let remote_tip = test_repo.create_commit("Remote edit", &[("shared.txt", "remote")]);
+        test_repo.checkout_branch(&original_branch);
+        test_repo.create_remote_branch("feature", remote_tip);
+
+        // Block the HEAD update, leaving checkout_tree as the only step that
+        // gets to run.
+        let head_lock = test_repo.path.join(".git").join("HEAD.lock");
+        std::fs::write(&head_lock, b"").expect("create HEAD.lock");
+
+        let result = checkout(test_repo.path_str(), "origin/feature".to_string(), None).await;
+        assert!(
+            result.is_err(),
+            "a blocked HEAD update must fail the checkout"
+        );
+
+        std::fs::remove_file(&head_lock).ok();
+
+        let repo = test_repo.repo();
+
+        // HEAD never moved...
+        assert_eq!(repo.head().unwrap().shorthand().unwrap(), original_branch);
+
+        // ...so the working tree must not be holding the other branch's content.
+        assert_eq!(
+            std::fs::read_to_string(test_repo.path.join("shared.txt")).unwrap(),
+            "base",
+            "the working tree was left on the remote branch's content while HEAD \
+             stayed put — the whole diff would read as uncommitted work"
+        );
+
+        // And no half-created branch is left to make a retry take the
+        // "local branch exists" path.
         assert!(
             repo.find_branch("feature", git2::BranchType::Local)
                 .is_err(),


### PR DESCRIPTION
## The problem

In `checkout`'s create-new-local-branch arm, `checkout_tree` ran **before** `repo.branch()`, `set_upstream()` and `set_head()`. If branch creation failed, the command returned an error with the working tree and index already rewritten to the remote tip while HEAD still named the old branch — the entire inter-branch diff appeared staged, and a user who committed recorded the other branch's tree onto their own.

This is the corruption class the file's own `branch_checked_out_elsewhere` comments already describe.

## How it's reachable

Both failure modes were reproduced directly against libgit2:

1. **`origin/HEAD`.** Every cloned repo has `refs/remotes/origin/HEAD`, which `get_branches` lists as a checkoutable remote branch named `HEAD`. Checking it out derives the local name `HEAD`, and `git_branch_create` rejects it with `'HEAD' is not a valid branch name` — after the tree was rewritten.
2. **Ref D/F conflict.** With a local `feature/sub`, checking out `origin/feature` fails with `cannot lock ref 'refs/heads/feature', there are refs beneath that folder` — again after the tree was rewritten.

`checkout_with_autostash` had the same ordering inside its `set_head` closure. It at least routed through `autostash_failure`, but that popped the auto-stash over the target tree while HEAD still named the old branch.

## The fix

Both remote-branch arms now create the ref first and write the tree second. A failing `checkout_tree` rolls the new ref back, so a failed checkout leaves no half-created branch behind.

Upstream tracking is now best-effort in both paths. Plain checkout propagated that error with `?` while the autostash path treated it as best-effort — the branch already exists at that point, so a tracking-config failure should not abort the checkout.

## Test

`test_failed_remote_checkout_leaves_tree_and_head_untouched` triggers the D/F conflict and asserts HEAD, the working tree and the index are all untouched, and that no partial branch survives. Verified to fail with the original ordering restored.

## Verification

`cargo test --lib`, `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` all pass on this branch.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass that re-read the code and reproduced both failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_