### PR TITLE
Resolve a usable token for GitHub App connections

### DIFF
--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -256,8 +256,13 @@ pub async fn check_github_connection(token: Option<String>) -> Result<GitHubConn
     // "disconnected" the next time the dialog opens.
     let token = match token {
         Some(t) if !t.is_empty() => t,
-        _ => match github_app_installation_token().await {
-            Ok(Some(app_token)) => {
+        // An error here is NOT the same as "no App configured". A corrupt
+        // config or a failed mint is actionable, and folding it into
+        // connected:false would hide the reason — something the user-token path
+        // never does. Propagate it and report disconnected only when there is
+        // genuinely no App to fall back to.
+        _ => match github_app_installation_token().await? {
+            Some(app_token) => {
                 // /user is a user-scoped endpoint an installation token cannot
                 // reach, so report the installation itself as the connection.
                 return Ok(GitHubConnectionStatus {
@@ -266,7 +271,7 @@ pub async fn check_github_connection(token: Option<String>) -> Result<GitHubConn
                     scopes: vec!["app-installation".to_string()],
                 });
             }
-            _ => {
+            None => {
                 return Ok(GitHubConnectionStatus {
                     connected: false,
                     user: None,

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -197,30 +197,83 @@ pub struct DetectedGitHubRepo {
 // Authentication Commands
 // ============================================================================
 
-/// Helper to resolve token from parameter
-/// Returns an error if no token is provided
-fn resolve_github_token(token: Option<String>) -> Result<String> {
-    match token {
-        Some(t) if !t.is_empty() => Ok(t),
-        _ => Err(LeviathanError::OperationFailed(
-            "GitHub token not configured".to_string(),
-        )),
+/// Helper to resolve the token for a request.
+///
+/// Falls back to a GitHub App installation token when the caller has no
+/// per-account token but an App is configured. Without this, connecting via
+/// GitHub App was a dead end: `configure_github_app` persists only the app
+/// config, so every subsequent request arrived with `None` and failed with
+/// "GitHub token not configured" despite the UI reporting a live connection.
+///
+/// Minted per call rather than stored at connect time — installation tokens
+/// expire after an hour, so a stored one would leave the integration dead again
+/// shortly after it started working.
+async fn resolve_github_token(token: Option<String>) -> Result<String> {
+    if let Some(t) = token {
+        if !t.is_empty() {
+            return Ok(t);
+        }
     }
+
+    if let Some(app_token) = github_app_installation_token().await? {
+        return Ok(app_token);
+    }
+
+    Err(LeviathanError::OperationFailed(
+        "GitHub token not configured".to_string(),
+    ))
+}
+
+/// Mint a fresh installation token from the stored GitHub App config.
+///
+/// Returns `Ok(None)` when no App is configured, so callers can fall through to
+/// their own "not configured" handling.
+async fn github_app_installation_token() -> Result<Option<String>> {
+    use crate::commands::credentials::get_keyring_token;
+    use crate::services::github_app;
+
+    let raw = match get_keyring_token(GITHUB_APP_KEYRING_KEY.to_string()).await? {
+        Some(s) => s,
+        None => return Ok(None),
+    };
+
+    let cfg = deserialize_app_config(&raw)?;
+
+    let jwt = github_app::generate_jwt(cfg.app_id, &cfg.private_key_pem)
+        .map_err(LeviathanError::OperationFailed)?;
+    let token = github_app::get_installation_token(&jwt, cfg.installation_id)
+        .await
+        .map_err(LeviathanError::OperationFailed)?;
+
+    Ok(Some(token.token))
 }
 
 /// Check GitHub connection and get user info
 #[command]
 pub async fn check_github_connection(token: Option<String>) -> Result<GitHubConnectionStatus> {
-    // Use provided token - no fallback to file storage
+    // No per-account token: fall back to a GitHub App installation token so an
+    // App-connected account reports connected instead of flipping back to
+    // "disconnected" the next time the dialog opens.
     let token = match token {
         Some(t) if !t.is_empty() => t,
-        _ => {
-            return Ok(GitHubConnectionStatus {
-                connected: false,
-                user: None,
-                scopes: vec![],
-            })
-        }
+        _ => match github_app_installation_token().await {
+            Ok(Some(app_token)) => {
+                // /user is a user-scoped endpoint an installation token cannot
+                // reach, so report the installation itself as the connection.
+                return Ok(GitHubConnectionStatus {
+                    connected: !app_token.is_empty(),
+                    user: None,
+                    scopes: vec!["app-installation".to_string()],
+                });
+            }
+            _ => {
+                return Ok(GitHubConnectionStatus {
+                    connected: false,
+                    user: None,
+                    scopes: vec![],
+                })
+            }
+        },
     };
 
     let client = reqwest::Client::new();
@@ -334,7 +387,7 @@ pub async fn list_pull_requests(
     per_page: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<PullRequestSummary>> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let state = state.unwrap_or_else(|| "open".to_string());
     let per_page = per_page.unwrap_or(30);
@@ -440,7 +493,7 @@ pub async fn get_pull_request(
     number: u32,
     token: Option<String>,
 ) -> Result<PullRequestDetails> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let client = reqwest::Client::new();
     let response = client
@@ -595,7 +648,7 @@ pub async fn create_pull_request(
     input: CreatePullRequestInput,
     token: Option<String>,
 ) -> Result<PullRequestSummary> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     #[derive(Serialize)]
     struct CreatePRBody {
@@ -709,7 +762,7 @@ pub async fn get_pull_request_reviews(
     number: u32,
     token: Option<String>,
 ) -> Result<Vec<PullRequestReview>> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let client = reqwest::Client::new();
     let response = client
@@ -790,7 +843,7 @@ pub async fn get_workflow_runs(
     per_page: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<WorkflowRun>> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let per_page = per_page.unwrap_or(20);
 
@@ -876,7 +929,7 @@ pub async fn get_check_runs(
     commit_sha: String,
     token: Option<String>,
 ) -> Result<Vec<CheckRun>> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let client = reqwest::Client::new();
     let response = client
@@ -946,7 +999,7 @@ pub async fn get_commit_status(
     commit_sha: String,
     token: Option<String>,
 ) -> Result<String> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let client = reqwest::Client::new();
     let response = client
@@ -1044,7 +1097,7 @@ pub async fn list_issues(
     per_page: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<IssueSummary>> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let state = state.unwrap_or_else(|| "open".to_string());
     let per_page = per_page.unwrap_or(30);
@@ -1172,7 +1225,7 @@ pub async fn get_issue(
     number: u32,
     token: Option<String>,
 ) -> Result<IssueSummary> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let client = reqwest::Client::new();
     let response = client
@@ -1284,7 +1337,7 @@ pub async fn create_issue(
     input: CreateIssueInput,
     token: Option<String>,
 ) -> Result<IssueSummary> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     #[derive(Serialize)]
     struct CreateIssueBody {
@@ -1416,7 +1469,7 @@ pub async fn update_issue_state(
     state: String,
     token: Option<String>,
 ) -> Result<IssueSummary> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     #[derive(Serialize)]
     struct UpdateBody {
@@ -1535,7 +1588,7 @@ pub async fn get_issue_comments(
     per_page: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<IssueComment>> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let per_page = per_page.unwrap_or(30);
 
@@ -1615,7 +1668,7 @@ pub async fn add_issue_comment(
     body: String,
     token: Option<String>,
 ) -> Result<IssueComment> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     #[derive(Serialize)]
     struct CommentBody {
@@ -1694,7 +1747,7 @@ pub async fn get_repo_labels(
     per_page: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<Label>> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let per_page = per_page.unwrap_or(100);
 
@@ -1807,7 +1860,7 @@ pub async fn list_releases(
     per_page: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<ReleaseSummary>> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let per_page = per_page.unwrap_or(30);
 
@@ -1896,7 +1949,7 @@ pub async fn get_release_by_tag(
     tag: String,
     token: Option<String>,
 ) -> Result<ReleaseSummary> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let client = reqwest::Client::new();
     let response = client
@@ -1978,7 +2031,7 @@ pub async fn get_latest_release(
     repo: String,
     token: Option<String>,
 ) -> Result<ReleaseSummary> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let client = reqwest::Client::new();
     let response = client
@@ -2062,7 +2115,7 @@ pub async fn create_release(
     input: CreateReleaseInput,
     token: Option<String>,
 ) -> Result<ReleaseSummary> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     #[derive(Serialize)]
     struct CreateReleaseBody {
@@ -2173,7 +2226,7 @@ pub async fn delete_release(
     release_id: u64,
     token: Option<String>,
 ) -> Result<()> {
-    let token = resolve_github_token(token)?;
+    let token = resolve_github_token(token).await?;
 
     let client = reqwest::Client::new();
     let response = client

--- a/src/components/dialogs/__tests__/lv-github-dialog-app-cleanup.test.ts
+++ b/src/components/dialogs/__tests__/lv-github-dialog-app-cleanup.test.ts
@@ -1,0 +1,129 @@
+/**
+ * Disconnecting a GitHub App must remove its stored config.
+ *
+ * An App keeps its credentials in their own keyring entry, separate from the
+ * per-account token. Deleting only the account token therefore left the App
+ * able to keep authenticating requests after the user pressed Disconnect — a
+ * zombie config the UI gave no way to clear.
+ *
+ * The cleanup must also stay off PAT and OAuth accounts, which have no App
+ * config to remove, and must report its own failure rather than pretending the
+ * disconnect was clean.
+ */
+
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeHistory: Array<{ command: string; args: unknown }> = [];
+
+(globalThis as unknown as { __TAURI_INTERNALS__: { invoke: MockInvoke } }).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    return mockInvoke(command, args);
+  },
+};
+
+import { expect, fixture, html } from '@open-wc/testing';
+import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
+import { createEmptyIntegrationAccount } from '../../../types/unified-profile.types.ts';
+import type { IntegrationAccount } from '../../../types/unified-profile.types.ts';
+import '../lv-github-dialog.ts';
+import type { LvGitHubDialog } from '../lv-github-dialog.ts';
+
+interface DialogInternals {
+  selectedAccountId: string | null;
+  connectionStatus: { connected: boolean; user: unknown; scopes: string[] } | null;
+  handleDisconnect: () => Promise<void>;
+}
+
+function account(id: string, name: string): IntegrationAccount {
+  return {
+    ...createEmptyIntegrationAccount('github'),
+    id,
+    name,
+  } as IntegrationAccount;
+}
+
+const APP_ACCOUNT = account('github-app-4242', 'GitHub App 4242');
+const PAT_ACCOUNT = account('gh-acc-1', 'octocat');
+
+async function openDialog(): Promise<LvGitHubDialog> {
+  const el = await fixture<LvGitHubDialog>(html`<lv-github-dialog .open=${true}></lv-github-dialog>`);
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+  return el;
+}
+
+function removeAppConfigCalls(): number {
+  return invokeHistory.filter((h) => h.command === 'remove_github_app_config').length;
+}
+
+describe('lv-github-dialog GitHub App cleanup on disconnect', () => {
+  beforeEach(() => {
+    invokeHistory.length = 0;
+    mockInvoke = () => Promise.resolve(null);
+    uiStore.setState({ toasts: [] });
+  });
+
+  it('removes the stored App config when disconnecting an App account', async () => {
+    unifiedProfileStore.getState().setAccounts([APP_ACCOUNT]);
+    const el = await openDialog();
+    const internals = el as unknown as DialogInternals;
+
+    internals.selectedAccountId = APP_ACCOUNT.id;
+    internals.connectionStatus = { connected: true, user: null, scopes: ['app-installation'] };
+    await el.updateComplete;
+
+    invokeHistory.length = 0;
+    await internals.handleDisconnect();
+
+    expect(removeAppConfigCalls(), 'App config must be cleared on disconnect').to.equal(1);
+  });
+
+  it('leaves the App config alone when disconnecting a token-backed account', async () => {
+    unifiedProfileStore.getState().setAccounts([PAT_ACCOUNT]);
+    const el = await openDialog();
+    const internals = el as unknown as DialogInternals;
+
+    internals.selectedAccountId = PAT_ACCOUNT.id;
+    internals.connectionStatus = { connected: true, user: null, scopes: ['repo', 'read:user'] };
+    await el.updateComplete;
+
+    invokeHistory.length = 0;
+    await internals.handleDisconnect();
+
+    expect(
+      removeAppConfigCalls(),
+      'a PAT/OAuth disconnect must not touch App config',
+    ).to.equal(0);
+  });
+
+  it('warns the user when the App config cannot be removed', async () => {
+    unifiedProfileStore.getState().setAccounts([APP_ACCOUNT]);
+    const el = await openDialog();
+    const internals = el as unknown as DialogInternals;
+
+    internals.selectedAccountId = APP_ACCOUNT.id;
+    internals.connectionStatus = { connected: true, user: null, scopes: ['app-installation'] };
+    await el.updateComplete;
+
+    // The token deletion succeeds, the App cleanup does not.
+    mockInvoke = (command) => {
+      if (command === 'remove_github_app_config') {
+        return Promise.reject(new Error('keyring locked'));
+      }
+      return Promise.resolve(null);
+    };
+
+    invokeHistory.length = 0;
+    await internals.handleDisconnect();
+
+    const toasts = uiStore.getState().toasts;
+    expect(toasts.length, 'a failed cleanup must not be silent').to.be.greaterThan(0);
+    expect(
+      toasts.some((t) => /GitHub App configuration could not be removed/i.test(t.message)),
+      `expected a cleanup warning, got: ${toasts.map((t) => t.message).join(' | ')}`,
+    ).to.be.true;
+  });
+});

--- a/src/components/dialogs/lv-github-dialog.ts
+++ b/src/components/dialogs/lv-github-dialog.ts
@@ -1420,9 +1420,23 @@ export class LvGitHubDialog extends LitElement {
     }
   }
 
+  /**
+   * True when this connection is backed by a GitHub App installation rather
+   * than a token. App connections keep their credentials in a separate keyring
+   * entry, so removing the account's token alone leaves them working.
+   */
+  private isAppConnection(accountId: string | null): boolean {
+    return (
+      (accountId?.startsWith('github-app-') ?? false) ||
+      (this.connectionStatus?.scopes?.includes('app-installation') ?? false)
+    );
+  }
+
   private async handleDisconnect(): Promise<void> {
     this.isLoading = true;
     this.error = null;
+
+    const wasAppConnection = this.isAppConnection(this.selectedAccountId);
 
     try {
       // Delete token for selected account or legacy token
@@ -1430,6 +1444,22 @@ export class LvGitHubDialog extends LitElement {
         await credentialService.deleteAccountToken('github', this.selectedAccountId);
       } else {
         await gitService.deleteGitHubToken();
+      }
+
+      // The App config lives in its own keyring entry, so deleting the account
+      // token does not disconnect an App. Leaving it behind kept the App
+      // authenticating requests after the user pressed Disconnect.
+      if (wasAppConnection) {
+        try {
+          await credentialService.removeGitHubAppConfig();
+        } catch (appErr) {
+          showToast(
+            appErr instanceof Error
+              ? `Disconnected, but the GitHub App configuration could not be removed: ${appErr.message}`
+              : 'Disconnected, but the GitHub App configuration could not be removed',
+            'warning',
+          );
+        }
       }
 
       this.syncSharedConnectionStatus(false);
@@ -1467,8 +1497,25 @@ export class LvGitHubDialog extends LitElement {
     // deletion is best-effort last; if it fails we surface a warning rather than
     // leaving a half-deleted state.
     const accountId = this.selectedAccountId;
+    const wasAppConnection = this.isAppConnection(accountId);
     try {
       await unifiedProfileService.deleteGlobalAccount(accountId);
+
+      // Same as Disconnect: the App keeps its credentials in a separate keyring
+      // entry, so deleting the account record alone leaves it able to
+      // authenticate.
+      if (wasAppConnection) {
+        try {
+          await credentialService.removeGitHubAppConfig();
+        } catch (appErr) {
+          showToast(
+            appErr instanceof Error
+              ? `Account deleted, but the GitHub App configuration could not be removed: ${appErr.message}`
+              : 'Account deleted, but the GitHub App configuration could not be removed',
+            'warning',
+          );
+        }
+      }
 
       await unifiedProfileService.loadUnifiedProfiles();
       this.accounts = getAccountsByType('github');


### PR DESCRIPTION
## The problem

Connecting via GitHub App was a dead end.

`handleConnectGitHubApp` called `configureGitHubApp` (which persists the app config under its own keyring key) and `saveGlobalAccount`, but never stored a token for that account. Every subsequent data load went through `getSelectedAccountToken`, which reads the per-account token and returned `null` for the app account. `resolve_github_token` had no fallback to the stored app config, so it errored with `GitHub token not configured`.

Net effect: the user "connected", saw a success toast and a connected status, then **every** PR / issue / workflow / release request failed — and reopening the dialog reported disconnected.

Disconnect and Delete also never removed the app config, leaving a zombie entry in the keyring that kept authenticating.

## The fix

**Mint installation tokens on demand.** `resolve_github_token` now falls back to generating one from the stored app config when the caller has no per-account token.

Minted per call rather than stored at connect time deliberately: installation tokens expire after an hour, so storing one would leave the integration dead again shortly after it started working.

**Report the connection honestly.** `check_github_connection` performs the same fallback and reports the installation as the connection. `/user` is a user-scoped endpoint an installation token cannot reach, so it returns the `app-installation` scope rather than a user.

**Clean up on disconnect.** Both `handleDisconnect` and `handleDeleteIntegration` now clear the stored app config for App-backed connections, with a warning toast if that cleanup fails. App connections are identified by the `github-app-` account id prefix or the `app-installation` scope.

## Note for reviewers

`resolve_github_token` became `async`, so its 19 call sites in `github.rs` gained `.await`. That's the bulk of the diff and is purely mechanical.

## Verification

`npm run typecheck` and `cargo clippy --lib -- -D warnings` pass on this branch; the full gate (lint, typecheck, 4385 frontend tests, 2080 Rust tests, fmt, clippy) passed with all seven critical fixes applied together.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass that traced the token path end to end.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_