### PR TITLE
Leave native editing shortcuts to text fields

### DIFF
--- a/src/services/__tests__/keyboard.service.native-editing.test.ts
+++ b/src/services/__tests__/keyboard.service.native-editing.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Global shortcuts must not steal the browser's text-editing combos.
+ *
+ * handleKeyDown deliberately lets ctrl/meta shortcuts through while the caret is
+ * in an input, so that Ctrl+P and friends still work from a search box. But the
+ * Undo History dialog is registered on Ctrl/Cmd+Z, and matching it there
+ * preventDefault()s the field's own undo: pressing Ctrl+Z to take back a word of
+ * a commit message threw a modal over the user's work instead — on every text
+ * field in the app.
+ */
+
+import { expect } from '@open-wc/testing';
+import { keyboardService } from '../keyboard.service.ts';
+
+const STORAGE_KEY = 'leviathan-keyboard-settings';
+
+/** Dispatch a keydown as though it originated inside `target`. */
+function typeIn(target: HTMLElement, init: KeyboardEventInit): KeyboardEvent {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init });
+  target.dispatchEvent(event);
+  return event;
+}
+
+describe('keyboard.service native editing keys', () => {
+  let input: HTMLInputElement;
+  let textarea: HTMLTextAreaElement;
+  const registered: string[] = [];
+
+  beforeEach(() => {
+    localStorage.removeItem(STORAGE_KEY);
+    registered.length = 0;
+
+    input = document.createElement('input');
+    textarea = document.createElement('textarea');
+    document.body.append(input, textarea);
+  });
+
+  afterEach(() => {
+    input.remove();
+    textarea.remove();
+    for (const id of registered) {
+      keyboardService.unregister(id);
+    }
+  });
+
+  function register(id: string, fired: string[], shortcut: Partial<Parameters<typeof keyboardService.register>[1]>): void {
+    keyboardService.register(id, {
+      key: 'z',
+      ctrl: true,
+      description: 'Test',
+      category: 'Test',
+      action: () => fired.push(id),
+      ...shortcut,
+    } as Parameters<typeof keyboardService.register>[1]);
+    registered.push(id);
+  }
+
+  it('leaves Ctrl+Z to the input instead of opening Undo History', () => {
+    const fired: string[] = [];
+    register('test-reflog', fired, { key: 'z', ctrl: true });
+
+    const event = typeIn(input, { key: 'z', ctrlKey: true });
+
+    expect(fired, 'the global shortcut must not run while typing').to.be.empty;
+    expect(event.defaultPrevented, 'native undo must not be preventDefault()ed').to.be.false;
+  });
+
+  it('leaves Cmd+Z alone too (ctrl and meta collapse to the same binding)', () => {
+    const fired: string[] = [];
+    register('test-reflog-meta', fired, { key: 'z', ctrl: true });
+
+    const event = typeIn(textarea, { key: 'z', metaKey: true });
+
+    expect(fired).to.be.empty;
+    expect(event.defaultPrevented).to.be.false;
+  });
+
+  it('leaves select-all and clipboard combos to the field', () => {
+    const fired: string[] = [];
+    register('test-select-all', fired, { key: 'a', ctrl: true });
+    register('test-cut', fired, { key: 'x', ctrl: true });
+
+    const selectAll = typeIn(input, { key: 'a', ctrlKey: true });
+    const cut = typeIn(input, { key: 'x', ctrlKey: true });
+
+    expect(fired).to.be.empty;
+    expect(selectAll.defaultPrevented).to.be.false;
+    expect(cut.defaultPrevented).to.be.false;
+  });
+
+  it('still runs non-editing ctrl shortcuts from inside an input', () => {
+    const fired: string[] = [];
+    register('test-palette', fired, { key: 'p', ctrl: true });
+
+    typeIn(input, { key: 'p', ctrlKey: true });
+
+    expect(fired, 'Ctrl+P must keep working from a text field').to.deep.equal(['test-palette']);
+  });
+
+  it('still runs Ctrl+Z when focus is not in a text field', () => {
+    const fired: string[] = [];
+    register('test-reflog-global', fired, { key: 'z', ctrl: true });
+
+    const button = document.createElement('button');
+    document.body.append(button);
+    try {
+      typeIn(button, { key: 'z', ctrlKey: true });
+      expect(fired, 'Undo History must still open from outside an input').to.deep.equal([
+        'test-reflog-global',
+      ]);
+    } finally {
+      button.remove();
+    }
+  });
+});

--- a/src/services/keyboard.service.ts
+++ b/src/services/keyboard.service.ts
@@ -37,6 +37,22 @@ export interface KeyboardSettings {
 const STORAGE_KEY = 'leviathan-keyboard-settings';
 
 class KeyboardService {
+  /**
+   * Key combos the browser reserves for editing text. While the caret is in an
+   * input, textarea, or contenteditable these belong to the field, so a global
+   * shortcut must never claim them — undo/redo, select-all, and clipboard are
+   * reflexes users expect to work in every text box.
+   */
+  private static readonly NATIVE_EDITING_KEYS: ReadonlySet<string> = new Set([
+    'mod+z',
+    'mod+shift+z',
+    'mod+y',
+    'mod+a',
+    'mod+x',
+    'mod+c',
+    'mod+v',
+  ]);
+
   private shortcuts: Map<string, Shortcut> = new Map();
   /** Map of shortcut ID to default binding */
   private defaultBindings: Map<string, ShortcutBinding> = new Map();
@@ -521,6 +537,16 @@ class KeyboardService {
     }
 
     const key = this.getShortcutKey(e);
+
+    // Never take over the native editing combos while the caret is in a text
+    // field. `mod+z` is registered globally (Undo History), and matching it here
+    // preventDefault()s the browser's own undo — so pressing Ctrl/Cmd+Z to take
+    // back a word of a commit message threw a modal over the user's work
+    // instead, on every input in the app.
+    if (isInInput && KeyboardService.NATIVE_EDITING_KEYS.has(key)) {
+      return;
+    }
+
     const shortcut = this.shortcuts.get(key);
 
     if (shortcut) {


### PR DESCRIPTION
## The problem

`handleKeyDown` deliberately lets ctrl/meta shortcuts through while the caret is in an input, so that things like Ctrl+P still work from a search box:

```ts
if (isInInput) {
  // Allow some shortcuts even in inputs (ones with ctrl/meta)
  if (!e.ctrlKey && !e.metaKey) return;
}
```

But the Undo History dialog is registered on **Ctrl+Z**, and `getShortcutKey` collapses ctrl and meta into a single `mod` binding — so both Ctrl+Z and Cmd+Z matched.

Result: typing a commit message and pressing Ctrl/Cmd+Z to take back a word called `preventDefault()` on the field's native undo and threw the Undo History modal over the user's work. With a repository open this happened in **every text field in the app**.

## The fix

Combos the browser reserves for editing are now skipped while focus is in an `input`, `textarea` or contenteditable:

`mod+z`, `mod+shift+z`, `mod+y`, `mod+a`, `mod+x`, `mod+c`, `mod+v`

Everything else is unchanged: other ctrl/meta shortcuts still fire from text fields, and Ctrl+Z still opens Undo History anywhere outside one.

## Tests

`keyboard.service.native-editing.test.ts`:

- Ctrl+Z in an input doesn't run the global shortcut and doesn't `preventDefault()` native undo
- Cmd+Z is covered too, since ctrl and meta share a binding
- select-all and cut are left to the field
- **control:** Ctrl+P still works from inside an input
- **control:** Ctrl+Z still opens Undo History outside a text field

The two controls pass with and without the fix by design — they exist to prove the fix doesn't over-reach. The other three fail without it.

## Verification

`npm run typecheck` and the new tests pass on this branch; the full suite (4385 tests) passed with all seven critical fixes applied together.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_