### PR TITLE
Make an in-flight clone cancellable

### DIFF
--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -414,6 +414,12 @@ pub async fn clone_repository(
             })
         } else {
             // Full clone: use git2 RepoBuilder with progress callbacks
+            //
+            // Declared out here, not inside the blocking closure: the error arm
+            // below needs it, and libgit2 reports a deadline abort as the same
+            // generic error a user cancellation produces.
+            let timed_out = Arc::new(AtomicBool::new(false));
+            let timed_out_cb = Arc::clone(&timed_out);
             let result = tokio::task::spawn_blocking(move || {
                 let mut builder = git2::build::RepoBuilder::new();
 
@@ -452,6 +458,7 @@ pub async fn clone_repository(
                     // tokio::time::timeout only drops the future, so without this
                     // the transfer keeps running after the caller gave up.
                     if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+                        timed_out_cb.store(true, Ordering::Relaxed);
                         return false;
                     }
 
@@ -511,6 +518,17 @@ pub async fn clone_repository(
                     if CLONE_CANCELLED.load(Ordering::Relaxed) {
                         let _ = std::fs::remove_dir_all(Path::new(&path));
                         return Err(LeviathanError::Custom("Clone cancelled".to_string()));
+                    }
+                    // A deadline abort leaves exactly the same partial checkout
+                    // a cancellation does, and reported it as a bare libgit2
+                    // error with the directory still on disk — so the retry the
+                    // message invites failed at "destination already exists",
+                    // with nothing saying the first attempt had timed out.
+                    if timed_out.load(Ordering::Relaxed) {
+                        let _ = std::fs::remove_dir_all(Path::new(&path));
+                        return Err(LeviathanError::OperationTimeout(
+                            "Clone operation timed out".to_string(),
+                        ));
                     }
                     return Err(e.into());
                 }

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -285,33 +285,72 @@ pub async fn clone_repository(
                 let stderr_pipe = child.stderr.take();
                 let stderr_reader = std::thread::spawn(move || {
                     use std::io::Read;
-                    let mut buf = String::new();
+                    // Bytes, not read_to_string: git may emit a non-UTF-8 path or
+                    // remote message, and read_to_string aborts on the first
+                    // invalid sequence — leaving the pipe undrained (the very
+                    // deadlock this thread exists to prevent) and the error lost.
+                    let mut buf = Vec::new();
                     if let Some(mut pipe) = stderr_pipe {
-                        let _ = pipe.read_to_string(&mut buf);
+                        let _ = pipe.read_to_end(&mut buf);
                     }
-                    buf
+                    String::from_utf8_lossy(&buf).into_owned()
                 });
 
-                let status = loop {
+                enum CloneOutcome {
+                    Finished(std::process::ExitStatus),
+                    Cancelled,
+                    TimedOut,
+                    WaitFailed(String),
+                }
+
+                // The timeout is enforced HERE as well as by the outer
+                // tokio::time::timeout. That one only drops the future — this
+                // blocking task, and the git process it spawned, would keep
+                // running unattended after the caller gave up.
+                let deadline = timeout_secs
+                    .filter(|secs| *secs > 0)
+                    .map(|secs| std::time::Instant::now() + std::time::Duration::from_secs(secs));
+
+                let outcome = loop {
                     if CLONE_CANCELLED.load(Ordering::Relaxed) {
-                        let _ = child.kill();
-                        let _ = child.wait();
-                        let _ = stderr_reader.join();
-                        // Nothing here is usable; leaving it behind would also
-                        // make the destination look occupied on a retry.
-                        let _ = std::fs::remove_dir_all(&dest_path);
-                        return Err(LeviathanError::Custom("Clone cancelled".to_string()));
+                        break CloneOutcome::Cancelled;
+                    }
+
+                    if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
+                        break CloneOutcome::TimedOut;
                     }
 
                     match child.try_wait() {
-                        Ok(Some(status)) => break status,
+                        Ok(Some(status)) => break CloneOutcome::Finished(status),
                         Ok(None) => std::thread::sleep(std::time::Duration::from_millis(100)),
-                        Err(e) => {
-                            return Err(LeviathanError::Custom(format!(
-                                "Failed to wait for git: {}",
-                                e
-                            )))
-                        }
+                        Err(e) => break CloneOutcome::WaitFailed(e.to_string()),
+                    }
+                };
+
+                // Single exit path for every abnormal outcome: kill the child,
+                // join the drain thread, and clear the partial destination.
+                // Returning early from any of these without killing would leave
+                // an orphaned git process still writing into that directory.
+                let status = match outcome {
+                    CloneOutcome::Finished(status) => status,
+                    abnormal => {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        let _ = stderr_reader.join();
+                        let _ = std::fs::remove_dir_all(&dest_path);
+
+                        return Err(match abnormal {
+                            CloneOutcome::Cancelled => {
+                                LeviathanError::Custom("Clone cancelled".to_string())
+                            }
+                            CloneOutcome::TimedOut => LeviathanError::OperationTimeout(
+                                "Clone operation timed out".to_string(),
+                            ),
+                            CloneOutcome::WaitFailed(e) => {
+                                LeviathanError::Custom(format!("Failed to wait for git: {}", e))
+                            }
+                            CloneOutcome::Finished(_) => unreachable!("handled above"),
+                        });
                     }
                 };
 
@@ -398,10 +437,21 @@ pub async fn clone_repository(
                 let last_percent_clone = Arc::clone(&last_percent);
                 let app_clone = app_for_progress;
 
+                let deadline = timeout_secs
+                    .filter(|secs| *secs > 0)
+                    .map(|secs| std::time::Instant::now() + std::time::Duration::from_secs(secs));
+
                 callbacks.transfer_progress(move |stats| {
                     // Returning false aborts the transfer — the only cancellation
                     // point libgit2 offers.
                     if CLONE_CANCELLED.load(Ordering::Relaxed) {
+                        return false;
+                    }
+
+                    // Same reason the CLI path polls its own deadline: the outer
+                    // tokio::time::timeout only drops the future, so without this
+                    // the transfer keeps running after the caller gave up.
+                    if deadline.is_some_and(|d| std::time::Instant::now() >= d) {
                         return false;
                     }
 

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -1,7 +1,7 @@
 //! Repository command handlers
 
 use std::path::Path;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 use std::sync::Arc;
 use tauri::{command, AppHandle, Emitter};
 
@@ -157,6 +157,25 @@ fn detect_partial_clone_status(repo: &git2::Repository) -> (bool, Option<String>
     }
 }
 
+/// Set when the user cancels an in-flight clone.
+///
+/// A single flag is sufficient: the clone dialog runs one clone at a time and
+/// blocks further input while it is in flight. Cleared at the start of every
+/// clone so a stale cancellation cannot kill the next one.
+static CLONE_CANCELLED: AtomicBool = AtomicBool::new(false);
+
+/// Request cancellation of the in-flight clone.
+///
+/// Without this a clone against an unreachable host, a hung connection, or an
+/// SSH remote waiting on interactive auth left the modal permanently locked —
+/// Cancel was disabled and Escape/overlay dismissal was refused, so restarting
+/// the app was the only way out.
+#[command]
+pub async fn cancel_clone() -> Result<()> {
+    CLONE_CANCELLED.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
 /// Clone a repository with progress reporting
 #[allow(clippy::too_many_arguments)]
 #[command]
@@ -172,6 +191,9 @@ pub async fn clone_repository(
     single_branch: Option<bool>,
     timeout_secs: Option<u64>,
 ) -> Result<Repository> {
+    // A cancellation requested against a previous clone must not kill this one.
+    CLONE_CANCELLED.store(false, Ordering::SeqCst);
+
     validate_clone_url(&url)?;
     // `--branch` and `--filter` consume the next argv as their value, so a
     // value starting with `-` is not a flag injection today. We reject them
@@ -249,12 +271,53 @@ pub async fn clone_repository(
                 cmd.arg(&effective_url);
                 cmd.arg(&dest_path);
 
-                let output = cmd.output().map_err(|e| {
+                // Spawned rather than run to completion so a cancel can kill it.
+                // stderr is drained on its own thread: git clone writes progress
+                // there, and leaving a piped stream unread deadlocks the child
+                // once the pipe buffer fills on a large clone.
+                cmd.stdout(std::process::Stdio::null());
+                cmd.stderr(std::process::Stdio::piped());
+
+                let mut child = cmd.spawn().map_err(|e| {
                     LeviathanError::Custom(format!("Failed to execute git command: {}", e))
                 })?;
 
-                if !output.status.success() {
-                    let stderr = String::from_utf8_lossy(&output.stderr);
+                let stderr_pipe = child.stderr.take();
+                let stderr_reader = std::thread::spawn(move || {
+                    use std::io::Read;
+                    let mut buf = String::new();
+                    if let Some(mut pipe) = stderr_pipe {
+                        let _ = pipe.read_to_string(&mut buf);
+                    }
+                    buf
+                });
+
+                let status = loop {
+                    if CLONE_CANCELLED.load(Ordering::Relaxed) {
+                        let _ = child.kill();
+                        let _ = child.wait();
+                        let _ = stderr_reader.join();
+                        // Nothing here is usable; leaving it behind would also
+                        // make the destination look occupied on a retry.
+                        let _ = std::fs::remove_dir_all(&dest_path);
+                        return Err(LeviathanError::Custom("Clone cancelled".to_string()));
+                    }
+
+                    match child.try_wait() {
+                        Ok(Some(status)) => break status,
+                        Ok(None) => std::thread::sleep(std::time::Duration::from_millis(100)),
+                        Err(e) => {
+                            return Err(LeviathanError::Custom(format!(
+                                "Failed to wait for git: {}",
+                                e
+                            )))
+                        }
+                    }
+                };
+
+                let stderr = stderr_reader.join().unwrap_or_default();
+
+                if !status.success() {
                     return Err(LeviathanError::Custom(format!(
                         "git clone failed: {}",
                         stderr.trim()
@@ -336,6 +399,12 @@ pub async fn clone_repository(
                 let app_clone = app_for_progress;
 
                 callbacks.transfer_progress(move |stats| {
+                    // Returning false aborts the transfer — the only cancellation
+                    // point libgit2 offers.
+                    if CLONE_CANCELLED.load(Ordering::Relaxed) {
+                        return false;
+                    }
+
                     let total = stats.total_objects();
                     let received = stats.received_objects();
                     let indexed = stats.indexed_objects();
@@ -383,7 +452,19 @@ pub async fn clone_repository(
             .await
             .map_err(|e| LeviathanError::Custom(format!("Clone task failed: {}", e)))?;
 
-            let repo = result?;
+            let repo = match result {
+                Ok(repo) => repo,
+                Err(e) => {
+                    // libgit2 surfaces a cancelled transfer as a generic error;
+                    // report it as the cancellation it was and clear the partial
+                    // checkout so a retry does not hit an occupied destination.
+                    if CLONE_CANCELLED.load(Ordering::Relaxed) {
+                        let _ = std::fs::remove_dir_all(Path::new(&path));
+                        return Err(LeviathanError::Custom("Clone cancelled".to_string()));
+                    }
+                    return Err(e.into());
+                }
+            };
 
             // git runs post-checkout after a clone checks out the initial
             // working tree (old-ref = all-zeros, flag = 1). The shallow/CLI

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -272,6 +272,7 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             commands::repository::open_repository,
             commands::repository::clone_repository,
+            commands::repository::cancel_clone,
             commands::repository::init_repository,
             commands::repository::get_repository_info,
             commands::repository::get_clone_filter_info,

--- a/src/components/dialogs/__tests__/lv-clone-dialog-cancel.test.ts
+++ b/src/components/dialogs/__tests__/lv-clone-dialog-cancel.test.ts
@@ -154,6 +154,55 @@ describe('lv-clone-dialog cancellation', () => {
       .not.be.undefined;
   });
 
+  // The success path leaves isCloning set across a 500ms close delay so a
+  // second clone cannot start into the same destination. The footer button and
+  // the modal-close handler both routed to cancellation while it was set, so a
+  // FINISHED clone still offered "Cancel Clone" — and Escape or the x fired a
+  // cancel request for an operation that had already succeeded.
+  it('stops offering to cancel once the clone has succeeded', async () => {
+    await startClone(el);
+
+    finishClone?.(
+      Promise.resolve({ path: '/tmp/clone-target', name: 'repo', currentBranch: null }),
+    );
+    await flush();
+    await el.updateComplete;
+
+    expect(cancelButton(el).textContent!.trim(), 'a finished clone is not cancellable').to.equal(
+      'Cancel',
+    );
+
+    invoked.length = 0;
+    cancelButton(el).click();
+    await flush();
+    await el.updateComplete;
+    expect(
+      invoked.some((c) => c.command === 'cancel_clone'),
+      'clicking Cancel after success must not cancel the finished clone',
+    ).to.be.false;
+  });
+
+  it('does not cancel a succeeded clone when the modal is dismissed', async () => {
+    await startClone(el);
+
+    finishClone?.(
+      Promise.resolve({ path: '/tmp/clone-target', name: 'repo', currentBranch: null }),
+    );
+    await flush();
+    await el.updateComplete;
+
+    invoked.length = 0;
+    const modal = el.shadowRoot!.querySelector('lv-modal')!;
+    modal.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+    await flush();
+    await el.updateComplete;
+
+    expect(
+      invoked.some((c) => c.command === 'cancel_clone'),
+      'dismissing after success must not cancel the finished clone',
+    ).to.be.false;
+  });
+
   it('releases the dialog once the cancelled clone returns', async () => {
     await startClone(el);
     cancelButton(el).click();

--- a/src/components/dialogs/__tests__/lv-clone-dialog-cancel.test.ts
+++ b/src/components/dialogs/__tests__/lv-clone-dialog-cancel.test.ts
@@ -1,0 +1,171 @@
+/**
+ * A clone in flight must be cancellable.
+ *
+ * The Cancel button was disabled while cloning and handleModalClose re-asserted
+ * modal.open, so Escape, the overlay and the × could not dismiss the dialog
+ * either. With no cancellation on the backend and no timeout passed from the
+ * frontend, a clone against an unreachable host or an SSH remote waiting on
+ * interactive auth locked the modal for the life of the application — the only
+ * recovery was restarting it.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invoked: { command: string; args?: unknown }[] = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invoked.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+(globalThis as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+  convertCallback: (callback: unknown, once: boolean) => {
+    void once;
+    void callback;
+    return 0;
+  },
+  unregisterListener: (_event: string, _eventId: number) => {},
+};
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-clone-dialog.ts';
+import type { LvCloneDialog } from '../lv-clone-dialog.ts';
+import { settingsStore } from '../../../stores/settings.store.ts';
+
+/** Resolver for the pending clone, so the test controls when it finishes. */
+let finishClone: ((value: unknown) => void) | null = null;
+
+function footerButtons(el: LvCloneDialog): HTMLButtonElement[] {
+  return Array.from(el.shadowRoot!.querySelectorAll('[slot="footer"] button'));
+}
+
+function cancelButton(el: LvCloneDialog): HTMLButtonElement {
+  return footerButtons(el)[0];
+}
+
+function cloneButton(el: LvCloneDialog): HTMLButtonElement {
+  return footerButtons(el)[1];
+}
+
+async function startClone(el: LvCloneDialog): Promise<void> {
+  el.open();
+  await el.updateComplete;
+
+  const urlInput = el.shadowRoot!.querySelector('input') as HTMLInputElement;
+  urlInput.value = 'https://example.com/hung/repo.git';
+  urlInput.dispatchEvent(new Event('input'));
+  await el.updateComplete;
+
+  const destInput = el.shadowRoot!.querySelectorAll('input')[1] as HTMLInputElement;
+  destInput.value = '/tmp/clone-target';
+  destInput.dispatchEvent(new Event('input'));
+  await el.updateComplete;
+
+  cloneButton(el).click();
+  // handleClone awaits the progress listener before invoking the clone, so a
+  // single update tick is not enough for the command to have been sent.
+  await flush();
+  await el.updateComplete;
+}
+
+/** Let pending microtasks and timers settle. */
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+describe('lv-clone-dialog cancellation', () => {
+  let el: LvCloneDialog;
+
+  beforeEach(async () => {
+    invoked.length = 0;
+    finishClone = null;
+    settingsStore.getState().setDefaultClonePath('');
+
+    mockInvoke = (command) => {
+      if (command === 'clone_repository') {
+        // Never resolves on its own — this is the hung clone.
+        return new Promise((resolve) => {
+          finishClone = resolve;
+        });
+      }
+      return Promise.resolve(null);
+    };
+
+    el = await fixture<LvCloneDialog>(html`<lv-clone-dialog></lv-clone-dialog>`);
+  });
+
+  afterEach(() => {
+    finishClone?.(null);
+  });
+
+  it('offers a usable Cancel button while the clone is in flight', async () => {
+    await startClone(el);
+
+    const cancel = cancelButton(el);
+    expect(cancel.disabled, 'Cancel must be pressable during a clone').to.be.false;
+    expect(cancel.textContent?.trim()).to.contain('Cancel');
+  });
+
+  it('asks the backend to cancel when Cancel is pressed', async () => {
+    await startClone(el);
+
+    cancelButton(el).click();
+    await flush();
+    await el.updateComplete;
+
+    expect(
+      invoked.some((c) => c.command === 'cancel_clone'),
+      'pressing Cancel must invoke cancel_clone',
+    ).to.be.true;
+  });
+
+  it('cancels rather than silently ignoring an Escape/overlay dismissal', async () => {
+    await startClone(el);
+
+    const modal = el.shadowRoot!.querySelector('lv-modal')!;
+    modal.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+    await flush();
+    await el.updateComplete;
+
+    expect(
+      invoked.some((c) => c.command === 'cancel_clone'),
+      'dismissing the modal during a clone must cancel it',
+    ).to.be.true;
+  });
+
+  it('sends a network timeout so a hung clone cannot run forever', async () => {
+    settingsStore.getState().setNetworkOperationTimeout?.(30);
+    await startClone(el);
+
+    const cloneCall = invoked.find((c) => c.command === 'clone_repository');
+    expect(cloneCall, 'clone should have been invoked').to.exist;
+
+    const args = cloneCall!.args as Record<string, unknown> | undefined;
+    // Tauri nests command args under the parameter name.
+    const payload = (args?.args ?? args) as Record<string, unknown> | undefined;
+    expect(payload?.timeoutSecs, 'clone must carry the network timeout like fetch/pull/push').to
+      .not.be.undefined;
+  });
+
+  it('releases the dialog once the cancelled clone returns', async () => {
+    await startClone(el);
+    cancelButton(el).click();
+    await flush();
+    await el.updateComplete;
+
+    // Backend reports the cancellation as a failed clone.
+    finishClone?.(Promise.reject(new Error('Clone cancelled')));
+    await flush();
+    await el.updateComplete;
+
+    // The dialog must now be closable: Cancel goes back to plain dismissal.
+    expect(cancelButton(el).disabled).to.be.false;
+  });
+});

--- a/src/components/dialogs/lv-clone-dialog.ts
+++ b/src/components/dialogs/lv-clone-dialog.ts
@@ -6,7 +6,7 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state, query } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
-import { isNetworkGateRefusal, cloneRepository } from '../../services/git.service.ts';
+import { isNetworkGateRefusal, cloneRepository, cancelClone } from '../../services/git.service.ts';
 import { openCloneDestinationDialog } from '../../services/dialog.service.ts';
 import { repositoryStore } from '../../stores/index.ts';
 import { settingsStore } from '../../stores/settings.store.ts';
@@ -184,6 +184,8 @@ export class LvCloneDialog extends LitElement {
   @state() private filter: string | null = null;
   @state() private singleBranch = false;
   @state() private isCloning = false;
+  /** Set while a cancellation request is in flight, so Cancel cannot be spammed. */
+  @state() private isCancelling = false;
   @state() private progress = 0;
   @state() private progressText = '';
   @state() private error = '';
@@ -210,6 +212,7 @@ export class LvCloneDialog extends LitElement {
     // reset() can clear it, which made "Clone Repository" silently dead for
     // the rest of the session after the first successful clone.
     this.isCloning = false;
+    this.isCancelling = false;
     this.cleanupListener();
   }
 
@@ -226,6 +229,7 @@ export class LvCloneDialog extends LitElement {
     this.repoName = '';
     this.depth = null;
     this.isCloning = false;
+    this.isCancelling = false;
     this.progress = 0;
     this.progressText = '';
     this.error = '';
@@ -354,27 +358,57 @@ export class LvCloneDialog extends LitElement {
           this.error = result.error?.message ?? 'Failed to clone repository';
         }
         this.isCloning = false;
+        // Cleared alongside isCloning: leaving it set keeps Cancel disabled, so
+        // the dialog the cancellation was meant to release stays stuck.
+        this.isCancelling = false;
         this.cleanupListener();
       }
     } catch (err) {
       this.error = err instanceof Error ? err.message : 'Unknown error occurred';
       this.isCloning = false;
+      this.isCancelling = false;
       this.cleanupListener();
     }
   }
 
   private handleModalClose(): void {
-    // Cancel is disabled while isCloning is in flight; Escape, the overlay and the
-    // × must honour the same rule. lv-modal.close() sets open=false BEFORE
-    // dispatching, so without re-asserting it here the clone kept running with no
-    // visible surface — and reported any failure into `error` on a hidden
-    // dialog. Mirrors lv-branch-cleanup-dialog.handleModalClose.
+    // A clone in flight must not be abandoned behind a hidden dialog: lv-modal
+    // sets open=false BEFORE dispatching, so re-assert it and route Escape, the
+    // overlay and the × into the same cancellation the Cancel button performs.
+    // Previously this simply refused to close, and since the clone had no
+    // cancellation and no timeout, a hung clone locked the modal for the life of
+    // the app.
     if (this.isCloning) {
       this.modal.open = true;
+      void this.handleCancelClone();
       return;
     }
 
     this.reset();
+  }
+
+  /**
+   * Stop the clone in flight.
+   *
+   * The backend kills the `git clone` child process (CLI path) or aborts the
+   * transfer (git2 path) and removes the partial destination, then
+   * `handleClone` returns an error and clears `isCloning`, which releases the
+   * dialog.
+   */
+  private async handleCancelClone(): Promise<void> {
+    if (this.isCancelling) return;
+
+    this.isCancelling = true;
+    this.progressText = 'Cancelling…';
+
+    const result = await cancelClone();
+    if (!result.success) {
+      // The dialog stays open, so the failure belongs inline rather than in a
+      // toast — and Cancel must become pressable again.
+      this.isCancelling = false;
+      this.progressText = '';
+      this.error = result.error?.message ?? 'Failed to cancel the clone';
+    }
   }
 
   private get fullPath(): string {
@@ -492,10 +526,10 @@ export class LvCloneDialog extends LitElement {
         <div slot="footer">
           <button
             class="btn btn-secondary"
-            @click=${this.close}
-            ?disabled=${this.isCloning}
+            @click=${this.isCloning ? this.handleCancelClone : this.close}
+            ?disabled=${this.isCancelling}
           >
-            Cancel
+            ${this.isCloning ? (this.isCancelling ? 'Cancelling…' : 'Cancel Clone') : 'Cancel'}
           </button>
           <button
             class="btn btn-primary"

--- a/src/components/dialogs/lv-clone-dialog.ts
+++ b/src/components/dialogs/lv-clone-dialog.ts
@@ -184,6 +184,17 @@ export class LvCloneDialog extends LitElement {
   @state() private filter: string | null = null;
   @state() private singleBranch = false;
   @state() private isCloning = false;
+  /**
+   * The clone SUCCEEDED and the dialog is in its brief close delay.
+   *
+   * `isCloning` stays true across that delay (clearing it would re-enable the
+   * Clone button and let a second clone start into the same destination), but
+   * the footer button and the modal-close handler both route to cancellation
+   * while it is set — so for those 500ms a finished clone still offered
+   * "Cancel Clone", and Escape or the × fired a cancel request for an
+   * operation that had already succeeded and been added to the store.
+   */
+  @state() private isComplete = false;
   /** Set while a cancellation request is in flight, so Cancel cannot be spammed. */
   @state() private isCancelling = false;
   @state() private progress = 0;
@@ -213,6 +224,7 @@ export class LvCloneDialog extends LitElement {
     // the rest of the session after the first successful clone.
     this.isCloning = false;
     this.isCancelling = false;
+    this.isComplete = false;
     this.cleanupListener();
   }
 
@@ -230,6 +242,7 @@ export class LvCloneDialog extends LitElement {
     this.depth = null;
     this.isCloning = false;
     this.isCancelling = false;
+    this.isComplete = false;
     this.progress = 0;
     this.progressText = '';
     this.error = '';
@@ -341,6 +354,7 @@ export class LvCloneDialog extends LitElement {
       if (result.success && result.data) {
         this.progress = 100;
         this.progressText = 'Clone complete!';
+        this.isComplete = true;
 
         // Add the repository to the store
         const store = repositoryStore.getState();
@@ -378,7 +392,7 @@ export class LvCloneDialog extends LitElement {
     // Previously this simply refused to close, and since the clone had no
     // cancellation and no timeout, a hung clone locked the modal for the life of
     // the app.
-    if (this.isCloning) {
+    if (this.isCloning && !this.isComplete) {
       this.modal.open = true;
       void this.handleCancelClone();
       return;
@@ -526,10 +540,12 @@ export class LvCloneDialog extends LitElement {
         <div slot="footer">
           <button
             class="btn btn-secondary"
-            @click=${this.isCloning ? this.handleCancelClone : this.close}
+            @click=${this.isCloning && !this.isComplete ? this.handleCancelClone : this.close}
             ?disabled=${this.isCancelling}
           >
-            ${this.isCloning ? (this.isCancelling ? 'Cancelling…' : 'Cancel Clone') : 'Cancel'}
+            ${this.isCloning && !this.isComplete
+              ? (this.isCancelling ? 'Cancelling…' : 'Cancel Clone')
+              : 'Cancel'}
           </button>
           <button
             class="btn btn-primary"

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -365,7 +365,25 @@ export async function cloneRepository(
       // Since getAdoToken isn't exported globally/generically in this file (it's inside getRepoToken logic), we will stick to GitHub for now.
     }
   }
+  // Apply the same network timeout fetch/pull/push use. Without it a clone
+  // against an unreachable host hangs forever, and the dialog cannot be closed
+  // while one is in flight.
+  const timeoutSecs = settingsStore.getState().networkOperationTimeout;
+  if (args && timeoutSecs > 0) {
+    args.timeoutSecs = timeoutSecs;
+  }
+
   return invokeCommand<Repository>("clone_repository", args);
+}
+
+/**
+ * Cancel the clone currently in flight.
+ *
+ * Kills the `git clone` child process on the CLI path and aborts the transfer
+ * on the git2 path, then clears the partial destination directory.
+ */
+export async function cancelClone(): Promise<CommandResult<void>> {
+  return invokeCommand<void>("cancel_clone", {});
 }
 
 export async function initRepository(

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -33,6 +33,7 @@ export interface CloneRepositoryCommand {
   depth?: number;
   filter?: string;
   singleBranch?: boolean;
+  timeoutSecs?: number;
 }
 
 export interface InitRepositoryCommand {


### PR DESCRIPTION
## The problem

A clone could not be stopped, and the dialog could not be closed while one was running:

- the Cancel button was `?disabled=${this.isCloning}`
- `handleModalClose` re-asserted `modal.open = true`, so Escape, the overlay and the × were all refused
- the backend had no cancellation mechanism at all
- `cloneRepository` — unlike its `fetch` / `pull` / `push` siblings — never passed `timeoutSecs`, so the backend's timeout branch was unreachable

A clone against an unreachable host, a hung TCP connection, or an SSH remote waiting on interactive auth therefore locked the modal **for the life of the application**. The only recovery was restarting it.

## The fix

**`cancel_clone` command.** Sets a flag that both clone paths observe:
- *CLI path* (`--depth` / `--filter` / `--single-branch`): kills the `git clone` child process.
- *git2 path*: returns `false` from the `transfer_progress` callback, which is the only cancellation point libgit2 offers.

Either way the partial destination directory is removed, so a retry doesn't hit an occupied path.

**CLI path is now spawned rather than run to completion.** `cmd.output()` blocks until exit, so there was nothing to kill. It now spawns and polls `try_wait`, with **stderr drained on its own thread** — `git clone` writes progress to stderr, and leaving a piped stream unread would deadlock the child once the pipe buffer filled on a large clone.

**Timeout is passed.** `cloneRepository` now sends the configured `networkOperationTimeout` like fetch/pull/push, so even a clone nobody cancels cannot run forever.

**Cancel is usable.** The button stays enabled during a clone and reads "Cancel Clone" (then "Cancelling…"), and Escape / overlay dismissal route into the same cancellation instead of being silently swallowed. `isCancelling` is cleared wherever `isCloning` is, so the dialog is released once the cancelled clone returns.

## Tests

`lv-clone-dialog-cancel.test.ts`, driving a clone that never resolves:

- Cancel is enabled while cloning
- pressing Cancel invokes `cancel_clone`
- dismissing the modal cancels rather than being ignored
- the clone carries a network timeout
- the dialog is released once the cancelled clone returns

That last test caught a real gap in the first version of this fix: `isCancelling` was never reset, which left Cancel disabled after cancelling.

## Verification

`npm run typecheck`, the new tests, and `cargo clippy --lib -- -D warnings` pass on this branch; the full gate passed with all seven critical fixes applied together.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_