### PR TITLE
Stop listing origin/HEAD as a checkoutable remote branch

### DIFF
--- a/src-tauri/src/commands/branch.rs
+++ b/src-tauri/src/commands/branch.rs
@@ -31,6 +31,20 @@ pub async fn get_branches(path: String) -> Result<Vec<Branch>> {
         let reference = branch.get();
 
         let is_remote = branch_type == git2::BranchType::Remote;
+
+        // Skip the remote's symbolic HEAD pointer (refs/remotes/origin/HEAD),
+        // which every clone has.
+        //
+        // It is a pointer at the remote's default branch, not a branch of its
+        // own: `git branch -r` renders it as "origin/HEAD -> origin/main" and
+        // never offers it for checkout. Listing it produced a row named
+        // "origin/HEAD" with an empty target oid and no timestamp — a symbolic
+        // ref has no direct target — and checking that row out derived the
+        // local branch name "HEAD", which libgit2 rejects as invalid.
+        if is_remote && reference.kind() == Some(git2::ReferenceType::Symbolic) {
+            continue;
+        }
+
         let is_head = head
             .as_ref()
             .map(|h| h.name() == reference.name())
@@ -1272,6 +1286,64 @@ pub async fn checkout_with_autostash(
 mod tests {
     use super::*;
     use crate::test_utils::TestRepo;
+
+    /// refs/remotes/origin/HEAD is a pointer at the remote's default branch,
+    /// not a branch of its own.
+    ///
+    /// Every clone has it. Listing it gave the UI a row named "origin/HEAD"
+    /// with an empty target oid and no timestamp (a symbolic ref has no direct
+    /// target), and checking that row out derived the local branch name "HEAD",
+    /// which libgit2 rejects as an invalid branch name. `git branch -r` renders
+    /// it as "origin/HEAD -> origin/main" and never offers it for checkout.
+    #[tokio::test]
+    async fn test_get_branches_omits_the_remote_symbolic_head() {
+        let test_repo = TestRepo::with_initial_commit();
+        let default_branch = test_repo.current_branch();
+
+        {
+            let repo = test_repo.repo();
+            let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+
+            // A real remote-tracking branch, plus the symbolic HEAD pointer a
+            // clone would create alongside it.
+            repo.reference(
+                &format!("refs/remotes/origin/{}", default_branch),
+                head_commit.id(),
+                true,
+                "test remote branch",
+            )
+            .unwrap();
+            repo.reference_symbolic(
+                "refs/remotes/origin/HEAD",
+                &format!("refs/remotes/origin/{}", default_branch),
+                true,
+                "test remote head",
+            )
+            .unwrap();
+        }
+
+        let branches = get_branches(test_repo.path_str()).await.unwrap();
+
+        assert!(
+            !branches.iter().any(|b| b.name == "origin/HEAD"),
+            "origin/HEAD must not be offered as a checkoutable branch: {:?}",
+            branches.iter().map(|b| &b.name).collect::<Vec<_>>()
+        );
+
+        // The branch it points at is still listed.
+        assert!(
+            branches
+                .iter()
+                .any(|b| b.name == format!("origin/{}", default_branch)),
+            "the real remote branch must still be listed"
+        );
+
+        // Nothing else lost a target oid along the way.
+        assert!(
+            branches.iter().all(|b| !b.target_oid.is_empty()),
+            "every listed branch should resolve to a commit"
+        );
+    }
 
     #[tokio::test]
     async fn test_get_branches_empty_repo() {


### PR DESCRIPTION
## The problem

`refs/remotes/origin/HEAD` is a **symbolic pointer** at the remote's default branch, not a branch of its own — and every clone has one. `git branch -r` renders it as `origin/HEAD -> origin/main` and never offers it for checkout.

The `get_branches` loop didn't skip symbolic refs, so the UI received a remote-branch row:

- named `origin/HEAD`
- with an **empty target oid** — a symbolic ref has no direct target
- with **no timestamp**, so it also sorted oddly

Checking that row out funnels into the remote-branch arm, which derives the local branch name `HEAD`. libgit2 rejects that as an invalid branch name — and on the plain checkout path the working tree is rewritten *before* it finds out. That's the crash path traced in #319; this removes the way a user reaches it at all.

## The fix

Symbolic remote refs are skipped. The branch they point at is still listed, so nothing disappears from the list.

## Note on the discriminator

The obvious check — `reference.symbolic_target().is_some()` — doesn't work here. In this git2 version `symbolic_target()` returns a `Result` that is `Ok` for **direct** references too, so testing it filtered out every remote branch. A probe confirmed the actual behaviour:

```
PROBE name=Some("main")        type=Local  sym_ok=true target_is_none=false kind=Some(Direct)
PROBE name=Some("origin/HEAD") type=Remote sym_ok=true target_is_none=true  kind=Some(Symbolic)
PROBE name=Some("origin/main") type=Remote sym_ok=true target_is_none=false kind=Some(Direct)
```

So the filter discriminates on `kind() == Some(ReferenceType::Symbolic)`, which reports `Symbolic` only for the pointer.

## Test

`test_get_branches_omits_the_remote_symbolic_head` builds both refs a clone would have and asserts `origin/HEAD` is gone, the real remote branch is still listed, and every listed branch still resolves to a commit — that last assertion is what caught the over-broad first attempt. Verified to fail without the filter.

## Verification

`cargo test --lib` (2078 tests), `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` all pass on this branch.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_