### PR TITLE
Build unstage patches with the reverse-apply transformation

### DIFF
--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -1040,6 +1040,114 @@ describe('lv-diff-view', () => {
       expect(patchLines).to.include('+new\r');
     });
 
+    // A hunk with BOTH a selected and an unselected change of each kind — the
+    // shape that made partial unstaging fail on every mixed hunk.
+    function mixedHunk() {
+      return makeDiffHunk({
+        header: '@@ -1,4 +1,4 @@',
+        oldStart: 1,
+        oldLines: 4,
+        newStart: 1,
+        newLines: 4,
+        lines: [
+          makeDiffLine({ content: 'ctx\n', origin: 'context', oldLineNo: 1, newLineNo: 1 }),
+          makeDiffLine({ content: 'del-sel\n', origin: 'deletion', oldLineNo: 2, newLineNo: null }),
+          makeDiffLine({ content: 'del-unsel\n', origin: 'deletion', oldLineNo: 3, newLineNo: null }),
+          makeDiffLine({ content: 'add-sel\n', origin: 'addition', oldLineNo: null, newLineNo: 2 }),
+          makeDiffLine({ content: 'add-unsel\n', origin: 'addition', oldLineNo: null, newLineNo: 3 }),
+        ],
+      });
+    }
+
+    async function viewWithMixedHunk(): Promise<LvDiffView> {
+      const el = await bareView();
+      (el as unknown as { file: unknown }).file = makeStatusEntry({ path: 'f.txt' });
+      (el as unknown as { diff: unknown }).diff = makeDiffFile({
+        path: 'f.txt',
+        hunks: [mixedHunk()],
+      });
+      // Select the deletion at index 1 and the addition at index 3.
+      (el as unknown as { selectedLines: Set<string> }).selectedLines = new Set(['0-1', '0-3']);
+      return el;
+    }
+
+    type PatchBuilder = { buildSelectedLinesPatch: (d?: 'stage' | 'unstage') => string };
+
+    it('staging keeps an unselected deletion as context and omits an unselected addition', async () => {
+      const el = await viewWithMixedHunk();
+      const patch = (el as unknown as PatchBuilder).buildSelectedLinesPatch('stage');
+      const lines = patch.split('\n');
+
+      expect(lines).to.include('-del-sel');
+      expect(lines).to.include('+add-sel');
+      // Still in the index, so it is context on both sides.
+      expect(lines).to.include(' del-unsel');
+      // Not in the index yet, so it must not appear at all.
+      expect(lines.some((l) => l.includes('add-unsel'))).to.be.false;
+    });
+
+    it('unstaging omits an unselected deletion and keeps an unselected addition as context', async () => {
+      const el = await viewWithMixedHunk();
+      const patch = (el as unknown as PatchBuilder).buildSelectedLinesPatch('unstage');
+      const lines = patch.split('\n');
+
+      expect(lines).to.include('-del-sel');
+      expect(lines).to.include('+add-sel');
+      // The deletion is already in the index, so this line is NOT there —
+      // emitting it as context makes the reverse apply reject the patch.
+      expect(
+        lines.some((l) => l.includes('del-unsel')),
+        'an unselected deletion must not appear in an unstage patch',
+      ).to.be.false;
+      // The addition IS in the index and is staying, so it is context.
+      expect(lines).to.include(' add-unsel');
+    });
+
+    it('unstageSelectedLines sends an unstage-shaped patch to the backend', async () => {
+      // The direction must be wired at the CALL SITE, not just supported by the
+      // builder: unstage_hunk reverse-applies the patch, so a patch built with
+      // the staging transformation is rejected for every mixed hunk.
+      const el = await viewWithMixedHunk();
+      (el as unknown as { repositoryPath: string }).repositoryPath = '/test/repo';
+
+      clearHistory();
+      mockInvoke = () => Promise.resolve(null);
+      await (el as unknown as { unstageSelectedLines: () => Promise<void> }).unstageSelectedLines();
+
+      const calls = findCommands('unstage_hunk');
+      expect(calls.length, 'unstage_hunk should have been invoked').to.equal(1);
+
+      const args = calls[0].args as Record<string, unknown>;
+      const payload = (args?.args ?? args) as Record<string, unknown>;
+      const patch = String(payload.patch ?? payload.patchText ?? '');
+      const lines = patch.split('\n');
+
+      expect(
+        lines.some((l) => l.includes('del-unsel')),
+        'the patch sent to unstage_hunk still used the staging transformation',
+      ).to.be.false;
+      expect(lines).to.include(' add-unsel');
+    });
+
+    it('hunk header counts match the emitted lines in both directions', async () => {
+      const countFor = (patch: string) => {
+        const lines = patch.split('\n');
+        const header = lines.find((l) => l.startsWith('@@'))!;
+        const m = /@@ -\d+,(\d+) \+\d+,(\d+) @@/.exec(header)!;
+        const body = lines.slice(lines.indexOf(header) + 1).filter((l) => l.length > 0);
+        const oldSide = body.filter((l) => l.startsWith(' ') || l.startsWith('-')).length;
+        const newSide = body.filter((l) => l.startsWith(' ') || l.startsWith('+')).length;
+        return { declaredOld: Number(m[1]), declaredNew: Number(m[2]), oldSide, newSide };
+      };
+
+      for (const direction of ['stage', 'unstage'] as const) {
+        const el = await viewWithMixedHunk();
+        const c = countFor((el as unknown as PatchBuilder).buildSelectedLinesPatch(direction));
+        expect(c.declaredOld, `${direction}: old count`).to.equal(c.oldSide);
+        expect(c.declaredNew, `${direction}: new count`).to.equal(c.newSide);
+      }
+    });
+
     it('buildSelectedLinesPatch emits "\\ No newline at end of file" markers', async () => {
       const el = await bareView();
       // Mirrors libgit2 output for a file whose last line lacks a trailing

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -1517,7 +1517,28 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    * 2. Include context lines around selected lines
    * 3. Adjust line numbers in hunk headers
    */
-  private buildSelectedLinesPatch(): string {
+  /**
+   * Build a patch containing only the selected lines.
+   *
+   * The transformations for the unselected lines differ by direction, because
+   * staging applies the patch FORWARD to the index while unstaging
+   * reverse-applies it (see unstage_hunk -> apply_patch_to_index(.., true)).
+   * A patch reverse-applies cleanly only when its NEW side matches the index.
+   *
+   * Staging (unstaged diff, index -> worktree):
+   *   unselected deletion -> context  (the line still exists in the index)
+   *   unselected addition -> omitted  (it is not in the index yet)
+   *
+   * Unstaging (staged diff, HEAD -> index) is the mirror image:
+   *   unselected deletion -> omitted  (the line is NOT in the index)
+   *   unselected addition -> context  (the line IS in the index and stays)
+   *
+   * Using the staging transformation for both is why unstaging a subset of
+   * lines failed on every hunk that had other changes: an unselected deletion
+   * emitted as context claimed a line the index does not have, and a dropped
+   * unselected addition broke contiguity against the index.
+   */
+  private buildSelectedLinesPatch(direction: 'stage' | 'unstage' = 'stage'): string {
     if (!this.diff || !this.file || this.selectedLines.size === 0) return '';
 
     const filePath = this.file.path;
@@ -1603,25 +1624,37 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
             // Include this deletion in the patch
             hunkPatchLines.push('-' + content);
             oldLineCount++;
-          } else {
-            // Unselected deletions become context lines in the patch.
-            // This is correct for partial staging: the line remains in the index
-            // (not staged for deletion) while the working tree still shows it as deleted.
-            // The next diff will continue to show it as a deletion that can be staged.
+            lastContentEmitted = true;
+          } else if (direction === 'stage') {
+            // The line still exists in the index (its deletion is not being
+            // staged), so it is context on both sides.
             hunkPatchLines.push(' ' + content);
             oldLineCount++;
             newLineCount++;
+            lastContentEmitted = true;
+          } else {
+            // Unstaging: the deletion is already in the index, so this line is
+            // absent from the index. Emitting it as context would claim a line
+            // the index does not have and the reverse apply would reject the
+            // whole patch.
+            lastContentEmitted = false;
           }
-          lastContentEmitted = true;
         } else if (line.origin === 'addition') {
           if (isSelected) {
             // Include this addition
             hunkPatchLines.push('+' + content);
             newLineCount++;
             lastContentEmitted = true;
-          } else {
-            // Unselected additions are simply not included
+          } else if (direction === 'stage') {
+            // Not in the index yet, so it must not appear in the patch at all.
             lastContentEmitted = false;
+          } else {
+            // Unstaging: the addition IS in the index and is staying there, so
+            // it is context — present on both sides of the reverse apply.
+            hunkPatchLines.push(' ' + content);
+            oldLineCount++;
+            newLineCount++;
+            lastContentEmitted = true;
           }
         }
       }
@@ -1675,7 +1708,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   private async unstageSelectedLines(): Promise<void> {
     if (!this.repositoryPath || !this.file || this.selectedLines.size === 0) return;
 
-    const patch = this.buildSelectedLinesPatch();
+    const patch = this.buildSelectedLinesPatch('unstage');
     if (!patch) return;
 
     try {


### PR DESCRIPTION
## The problem

`buildSelectedLinesPatch` is used for both staging and unstaging, but its handling of the **unselected** lines is only correct for a forward apply.

`unstage_hunk` **reverse-applies** the patch to the index (`apply_patch_to_index(.., true)`), and a patch reverse-applies cleanly only when its **new side matches the index**. In the staged diff (HEAD → index) the two directions are mirror images:

| unselected line | staging | unstaging |
|---|---|---|
| deletion | → context (still in the index) | → **omitted** (already gone from the index) |
| addition | → omitted (not in the index yet) | → **context** (in the index, and staying) |

Using the staging transformation for both meant an unselected deletion was emitted as context — claiming a line the index does not have — and an unselected addition was dropped, breaking contiguity against the index. Either one makes git reject the patch.

So unstaging a subset of lines **failed on every hunk that had other changes**: a "Failed to unstage lines" toast, every time. Per-line unstage was a dead end on exactly the hunks it's most useful for.

## The fix

The builder takes the direction and applies the matching transformation; `unstageSelectedLines` passes `'unstage'`. Staging behaviour is unchanged.

## Tests

- both transformations, asserted on the emitted patch lines
- hunk header counts match the lines actually emitted, in **both** directions
- `unstageSelectedLines` really sends an unstage-shaped patch to the backend

That last test earns its place: when I reverted **only** the call site, every builder test still passed, because they call the builder directly. It fails now, as does the transformation change on its own.

## Verification

`npm run typecheck` and the full suite (4,375 tests) pass on this branch.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_