### PR TITLE
Truncate AI diffs on a char boundary instead of panicking

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -8,7 +8,7 @@ use crate::services::ai::{
     ConflictExplanation, ConflictResolutionSuggestion, FindingCategory, GeneratedChangelog,
     GeneratedCommitMessage, GeneratedPrDescription, ReflogMatch, RiskLevel, Severity,
     StagedAnalysis, CHANGELOG_PROMPT, COMMIT_SPLIT_PROMPT, CONFLICT_EXPLAIN_PROMPT,
-    CONFLICT_RESOLUTION_PROMPT, MAX_CHANGELOG_CHARS, MAX_CONFLICT_CONTEXT_CHARS, MAX_DIFF_CHARS,
+    CONFLICT_RESOLUTION_PROMPT, MAX_CHANGELOG_BYTES, MAX_CONFLICT_CONTEXT_BYTES, MAX_DIFF_BYTES,
     PR_DESCRIPTION_PROMPT, REFLOG_MATCH_PROMPT, VIBE_CHECK_PROMPT,
 };
 use tauri::{command, State};
@@ -138,7 +138,7 @@ pub async fn suggest_conflict_resolution(
 
     // Add surrounding context if available
     if let Some(ref before) = context_before {
-        let truncated = truncate_content(before, MAX_CONFLICT_CONTEXT_CHARS / 4);
+        let truncated = truncate_content(before, MAX_CONFLICT_CONTEXT_BYTES / 4);
         if !truncated.is_empty() {
             user_prompt.push_str(&format!(
                 "Context before the conflict:\n```\n{}\n```\n\n",
@@ -149,7 +149,7 @@ pub async fn suggest_conflict_resolution(
 
     // Add base content if available
     if let Some(ref base) = base_content {
-        let truncated = truncate_content(base, MAX_CONFLICT_CONTEXT_CHARS / 4);
+        let truncated = truncate_content(base, MAX_CONFLICT_CONTEXT_BYTES / 4);
         if !truncated.is_empty() {
             user_prompt.push_str(&format!(
                 "Base (common ancestor):\n```\n{}\n```\n\n",
@@ -159,8 +159,8 @@ pub async fn suggest_conflict_resolution(
     }
 
     // Add ours and theirs
-    let ours_truncated = truncate_content(&ours_content, MAX_CONFLICT_CONTEXT_CHARS / 3);
-    let theirs_truncated = truncate_content(&theirs_content, MAX_CONFLICT_CONTEXT_CHARS / 3);
+    let ours_truncated = truncate_content(&ours_content, MAX_CONFLICT_CONTEXT_BYTES / 3);
+    let theirs_truncated = truncate_content(&theirs_content, MAX_CONFLICT_CONTEXT_BYTES / 3);
 
     user_prompt.push_str(&format!(
         "Ours (current branch):\n```\n{}\n```\n\n",
@@ -172,7 +172,7 @@ pub async fn suggest_conflict_resolution(
     ));
 
     if let Some(ref after) = context_after {
-        let truncated = truncate_content(after, MAX_CONFLICT_CONTEXT_CHARS / 4);
+        let truncated = truncate_content(after, MAX_CONFLICT_CONTEXT_BYTES / 4);
         if !truncated.is_empty() {
             user_prompt.push_str(&format!(
                 "\nContext after the conflict:\n```\n{}\n```\n",
@@ -211,7 +211,7 @@ pub async fn generate_changelog(
     }
 
     // Truncate if too long
-    let truncated = truncate_content(&commits_text, MAX_CHANGELOG_CHARS);
+    let truncated = truncate_content(&commits_text, MAX_CHANGELOG_BYTES);
 
     let service = state.read().await;
     let response = service
@@ -249,7 +249,7 @@ pub async fn explain_conflict(
     }
 
     if let Some(ref base) = base_content {
-        let truncated = truncate_content(base, MAX_CONFLICT_CONTEXT_CHARS / 4);
+        let truncated = truncate_content(base, MAX_CONFLICT_CONTEXT_BYTES / 4);
         if !truncated.is_empty() {
             user_prompt.push_str(&format!(
                 "Base (common ancestor):\n```\n{}\n```\n\n",
@@ -258,8 +258,8 @@ pub async fn explain_conflict(
         }
     }
 
-    let ours_truncated = truncate_content(&ours_content, MAX_CONFLICT_CONTEXT_CHARS / 3);
-    let theirs_truncated = truncate_content(&theirs_content, MAX_CONFLICT_CONTEXT_CHARS / 3);
+    let ours_truncated = truncate_content(&ours_content, MAX_CONFLICT_CONTEXT_BYTES / 3);
+    let theirs_truncated = truncate_content(&theirs_content, MAX_CONFLICT_CONTEXT_BYTES / 3);
 
     user_prompt.push_str(&format!(
         "Ours (current branch):\n```\n{}\n```\n\n",
@@ -404,7 +404,7 @@ pub async fn analyze_staged_changes(
     let mut findings = detect_secrets(&diff);
 
     // AI analysis for complexity and quality
-    let truncated = truncate_content(&diff, MAX_DIFF_CHARS);
+    let truncated = truncate_content(&diff, MAX_DIFF_BYTES);
     let service = state.read().await;
 
     if let Ok(response) = service
@@ -469,7 +469,7 @@ pub async fn generate_pr_description(
     let stats = get_diff_stats(&repo_path, &base_ref, &head_ref)?;
 
     let user_prompt = format!("{}\n\nDiff statistics:\n{}", commits_text, stats);
-    let truncated = truncate_content(&user_prompt, MAX_CHANGELOG_CHARS);
+    let truncated = truncate_content(&user_prompt, MAX_CHANGELOG_BYTES);
 
     // Replace {title} placeholder in prompt
     let system_prompt = PR_DESCRIPTION_PROMPT.replace("{title}", &title);
@@ -511,7 +511,7 @@ pub async fn suggest_commit_splits(
         });
     }
 
-    let truncated = truncate_content(&diff, MAX_DIFF_CHARS);
+    let truncated = truncate_content(&diff, MAX_DIFF_BYTES);
 
     let service = state.read().await;
     let response = service
@@ -633,16 +633,16 @@ fn strip_code_fences(s: &str) -> &str {
     }
 }
 
-/// Truncate content to a maximum character length at a line boundary
-fn truncate_content(content: &str, max_chars: usize) -> &str {
-    if content.len() <= max_chars {
+/// Truncate content to at most `max_bytes`, preferring a line boundary.
+///
+/// The limit is a BYTE count, and slicing a `&str` mid-character panics. Both
+/// this slice and the rfind slice below used the raw index, so a large diff
+/// containing any non-ASCII text could kill the command task.
+fn truncate_content(content: &str, max_bytes: usize) -> &str {
+    if content.len() <= max_bytes {
         return content;
     }
-    // Cut on a char boundary first: max_chars is a BYTE count, and slicing a
-    // &str mid-character panics. Both this slice and the rfind slice below used
-    // the raw index, so a large diff containing any non-ASCII text could kill
-    // the command task.
-    let head = crate::services::ai::truncate_at_char_boundary(content, max_chars);
+    let head = crate::services::ai::truncate_at_char_boundary(content, max_bytes);
     // Prefer a line boundary within that.
     match head.rfind('\n') {
         Some(pos) => &head[..pos],

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -638,10 +638,15 @@ fn truncate_content(content: &str, max_chars: usize) -> &str {
     if content.len() <= max_chars {
         return content;
     }
-    // Find a newline before the max_chars boundary
-    match content[..max_chars].rfind('\n') {
-        Some(pos) => &content[..pos],
-        None => &content[..max_chars],
+    // Cut on a char boundary first: max_chars is a BYTE count, and slicing a
+    // &str mid-character panics. Both this slice and the rfind slice below used
+    // the raw index, so a large diff containing any non-ASCII text could kill
+    // the command task.
+    let head = crate::services::ai::truncate_at_char_boundary(content, max_chars);
+    // Prefer a line boundary within that.
+    match head.rfind('\n') {
+        Some(pos) => &head[..pos],
+        None => head,
     }
 }
 
@@ -720,6 +725,35 @@ fn get_staged_diff(repo_path: &str) -> Result<String> {
 mod tests {
     use super::*;
     use crate::test_utils::TestRepo;
+
+    /// truncate_content takes a BYTE limit and used it as a slice index twice.
+    /// A staged diff over the limit containing non-ASCII text would panic the
+    /// command task, so "Generate commit message" / "Vibe Check" died outright
+    /// for that user whenever their diff was large.
+    #[test]
+    fn test_truncate_content_does_not_panic_on_multibyte_input() {
+        // No newlines, so the line-boundary path cannot rescue the cut.
+        let content = "é".repeat(500);
+        assert_eq!(content.len(), 1000);
+
+        for max in [1, 7, 99, 501, 999] {
+            let out = truncate_content(&content, max);
+            assert!(out.len() <= max);
+            assert!(content.starts_with(out));
+        }
+    }
+
+    /// Emoji land on 4-byte boundaries — the same hazard, one step wider.
+    #[test]
+    fn test_truncate_content_handles_emoji_and_keeps_line_boundaries() {
+        let content = format!("first line\n{}\nlast", "🎉".repeat(100));
+
+        let out = truncate_content(&content, 50);
+        assert!(out.len() <= 50);
+        assert!(content.starts_with(out));
+        // Still prefers a line boundary when one is available within the limit.
+        assert_eq!(out, "first line");
+    }
 
     // ========================================================================
     // get_staged_diff Tests

--- a/src-tauri/src/services/ai/mod.rs
+++ b/src-tauri/src/services/ai/mod.rs
@@ -176,14 +176,14 @@ Rules:
 Diff:
 "#;
 
-/// Maximum diff length to send to the AI provider
-pub const MAX_DIFF_CHARS: usize = 12000;
+/// Maximum diff size, in BYTES, to send to the AI provider.
+pub const MAX_DIFF_BYTES: usize = 12000;
 
-/// Maximum conflict context length to send to the AI provider
-pub const MAX_CONFLICT_CONTEXT_CHARS: usize = 16000;
+/// Maximum conflict context size, in BYTES, to send to the AI provider.
+pub const MAX_CONFLICT_CONTEXT_BYTES: usize = 16000;
 
-/// Maximum commit text length to send for changelog generation
-pub const MAX_CHANGELOG_CHARS: usize = 24000;
+/// Maximum commit text size, in BYTES, to send for changelog generation.
+pub const MAX_CHANGELOG_BYTES: usize = 24000;
 
 /// Generated changelog result
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -784,10 +784,10 @@ impl AiService {
         // per-file truncation internally and needs all files for good summaries)
         let truncated_diff = if provider_type == AiProviderType::LocalInference {
             diff
-        } else if diff.len() > MAX_DIFF_CHARS {
+        } else if diff.len() > MAX_DIFF_BYTES {
             format!(
                 "{}...\n[Diff truncated for length]",
-                truncate_at_char_boundary(&diff, MAX_DIFF_CHARS)
+                truncate_at_char_boundary(&diff, MAX_DIFF_BYTES)
             )
         } else {
             diff

--- a/src-tauri/src/services/ai/mod.rs
+++ b/src-tauri/src/services/ai/mod.rs
@@ -787,7 +787,7 @@ impl AiService {
         } else if diff.len() > MAX_DIFF_CHARS {
             format!(
                 "{}...\n[Diff truncated for length]",
-                &diff[..MAX_DIFF_CHARS]
+                truncate_at_char_boundary(&diff, MAX_DIFF_CHARS)
             )
         } else {
             diff
@@ -901,6 +901,26 @@ impl AiService {
 /// Global AI service state
 pub type AiState = Arc<RwLock<AiService>>;
 
+/// Truncate at or before `max_bytes` without splitting a UTF-8 character.
+///
+/// Slicing a `&str` at a byte index that is not a char boundary panics. The
+/// truncation limits here are byte counts, so any diff or commit log over the
+/// limit that contains non-ASCII text — comments, names, emoji, all routine in
+/// real repositories — could land the cut mid-character and kill the command
+/// task outright, leaving "Generate commit message" and "Vibe Check" dead for
+/// that user whenever their diff was large.
+pub(crate) fn truncate_at_char_boundary(s: &str, max_bytes: usize) -> &str {
+    if s.len() <= max_bytes {
+        return s;
+    }
+
+    let mut end = max_bytes;
+    while end > 0 && !s.is_char_boundary(end) {
+        end -= 1;
+    }
+    &s[..end]
+}
+
 /// Create the AI service state
 pub fn create_ai_state(config_dir: PathBuf) -> AiState {
     Arc::new(RwLock::new(AiService::new(config_dir)))
@@ -908,6 +928,41 @@ pub fn create_ai_state(config_dir: PathBuf) -> AiState {
 
 #[cfg(test)]
 mod tests {
+
+    /// Truncation limits are BYTE counts, but slicing a &str at a byte index
+    /// that is not a char boundary panics. A diff over the limit containing any
+    /// non-ASCII text — comments, names, emoji, all routine — could land the cut
+    /// mid-character and kill the command task.
+    #[test]
+    fn test_truncate_at_char_boundary_never_splits_a_character() {
+        // é is two bytes, so every odd cut inside the string is mid-character.
+        let s = "ééééééééé";
+        assert_eq!(s.len(), 18);
+
+        for max in 0..=s.len() {
+            let out = truncate_at_char_boundary(s, max);
+            assert!(out.len() <= max, "must not exceed the limit");
+            assert!(s.starts_with(out), "must be a prefix");
+            // Round-tripping through chars proves it is valid UTF-8 at the cut.
+            assert_eq!(out.chars().count() * 2, out.len());
+        }
+    }
+
+    #[test]
+    fn test_truncate_at_char_boundary_handles_wide_characters() {
+        // A 4-byte emoji: a cut anywhere inside it must fall back to before it.
+        let s = "ab🎉cd";
+        assert_eq!(truncate_at_char_boundary(s, 3), "ab");
+        assert_eq!(truncate_at_char_boundary(s, 4), "ab");
+        assert_eq!(truncate_at_char_boundary(s, 5), "ab");
+        assert_eq!(truncate_at_char_boundary(s, 6), "ab🎉");
+    }
+
+    #[test]
+    fn test_truncate_at_char_boundary_returns_short_input_unchanged() {
+        assert_eq!(truncate_at_char_boundary("abc", 10), "abc");
+        assert_eq!(truncate_at_char_boundary("abc", 3), "abc");
+    }
     use super::*;
 
     #[test]

--- a/src-tauri/src/services/ai/providers/local_inference.rs
+++ b/src-tauri/src/services/ai/providers/local_inference.rs
@@ -432,10 +432,15 @@ fn extract_file_diffs(diff: &str) -> Vec<FileDiff> {
     // Truncate each file's content to keep batches within model context.
     // Each batch has ~3 files, and the model has ~8192 tokens (~32K chars).
     // Budget ~2000 chars per file to leave room for the prompt template.
-    let max_chars_per_file = if files.len() > 10 { 1500 } else { 2500 };
+    let max_bytes_per_file = if files.len() > 10 { 1500 } else { 2500 };
     for file in &mut files {
-        if file.content.len() > max_chars_per_file {
-            file.content = file.content[..max_chars_per_file].to_string();
+        if file.content.len() > max_bytes_per_file {
+            // On a char boundary: the budget is a BYTE count, and slicing a
+            // &str mid-character panics — which killed the whole local-model
+            // summary for any diff carrying non-ASCII text.
+            file.content =
+                crate::services::ai::truncate_at_char_boundary(&file.content, max_bytes_per_file)
+                    .to_string();
             file.content.push_str("\n[truncated]");
         }
     }
@@ -1246,6 +1251,33 @@ diff --git a/src/b.rs b/src/b.rs
     fn test_extract_file_diffs_empty() {
         let files = extract_file_diffs("");
         assert!(files.is_empty());
+    }
+
+    /// The per-file budget is a BYTE count, so a multi-byte character sitting
+    /// across it panicked — killing the local-model commit summary for any diff
+    /// with an accent, a CJK identifier or an emoji in it, which is routine.
+    #[test]
+    fn test_extract_file_diffs_truncates_multibyte_content_without_panicking() {
+        // 'é' is two bytes, so the 2500-byte cut lands mid-character for one of
+        // these lengths whatever the header adds.
+        for pad in 0..4 {
+            let body = format!("{}{}", "a".repeat(pad), "é".repeat(4000));
+            let diff = format!(
+                "diff --git a/notes.txt b/notes.txt\n--- a/notes.txt\n+++ b/notes.txt\n@@ -0,0 +1 @@\n+{}",
+                body
+            );
+
+            let files = extract_file_diffs(&diff);
+            assert_eq!(files.len(), 1);
+            assert!(
+                files[0].content.ends_with("\n[truncated]"),
+                "oversized content must be truncated"
+            );
+            assert!(
+                files[0].content.len() <= 2500 + "\n[truncated]".len(),
+                "truncation must respect the budget"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## The problem

The truncation limits are **byte** counts, but both sites used them directly as slice indices — and slicing a `&str` at an index that isn't a char boundary panics.

- `services/ai/mod.rs`: `&diff[..MAX_DIFF_CHARS]` in `generate_commit_message`
- `commands/ai.rs`: `truncate_content`, used by `analyze_staged_changes`, `suggest_commit_splits`, `generate_changelog` and the conflict commands — which sliced **twice**, once for the `rfind` and once for the fallback

So any staged diff or commit log over the 12KB/16KB/24KB limits containing non-ASCII text — comments, names, emoji, all routine in real repositories — could land the cut mid-character and kill the command task. "Generate commit message" and "Vibe Check" then died with no result whenever that user's diff was large.

## The fix

Both go through a shared `truncate_at_char_boundary`, which walks back to the nearest boundary at or before the limit. `truncate_content` still prefers a line boundary within that, so its existing behaviour is otherwise unchanged.

## Tests

- every cut position across a two-byte-character string (`é` × 500, no newlines, so the line-boundary path can't mask the bug)
- four-byte emoji, where a cut can land at three different bad offsets
- short input returned unchanged
- `truncate_content` itself, since that's the entry point the commands actually call

Restoring the byte slicing reproduces the original panic exactly:

```
end byte index 1 is not a char boundary; it is inside 'é' (bytes 0..2 of string)
```

## Verification

`cargo test --lib` (2082 tests), `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` all pass on this branch.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_