### PR TITLE
Show real commit ages in blame instead of "just now"

### DIFF
--- a/src/components/panels/__tests__/lv-blame-view.test.ts
+++ b/src/components/panels/__tests__/lv-blame-view.test.ts
@@ -46,6 +46,27 @@ async function renderBlame(): Promise<LvBlameView> {
   return el;
 }
 
+/** A blame result whose single group is `secondsAgo` old. */
+function blameResultAged(secondsAgo: number) {
+  const timestamp = Math.floor(Date.now() / 1000) - secondsAgo;
+  return {
+    path: 'src/main.ts',
+    lines: [
+      {
+        lineNumber: 1,
+        content: 'const a = 1;',
+        commitOid: 'deadbeefdeadbeefdeadbeefdeadbeefdeadbeef',
+        commitShortId: 'deadbee',
+        authorName: 'Alice',
+        authorEmail: 'alice@example.com',
+        timestamp,
+        summary: 'Add a',
+        isBoundary: false,
+      },
+    ],
+  };
+}
+
 describe('lv-blame-view', () => {
   beforeEach(() => {
     uiStore.setState({ toasts: [] });
@@ -87,6 +108,58 @@ describe('lv-blame-view', () => {
 
       const toasts = uiStore.getState().toasts;
       expect(toasts.some((t) => t.type === 'error' && /copy hash/i.test(t.message))).to.be.true;
+    });
+  });
+
+  // ── Relative dates ───────────────────────────────────────────────────────
+  describe('commit age', () => {
+    it('shows a real age for an old commit, not "just now"', async () => {
+      // BlameLine.timestamp is Unix SECONDS, and formatRelativeTime multiplies
+      // by 1000 itself. Passing milliseconds made every diff hugely negative, so
+      // "seconds < 60" always won and every group read "just now" — defeating
+      // the whole point of blame.
+      const threeYears = 3 * 365 * 24 * 60 * 60;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_file_blame') return blameResultAged(threeYears);
+        return null;
+      };
+
+      const el = await renderBlame();
+      const date = el.shadowRoot!.querySelector('.commit-date');
+      expect(date, 'a blame group should render').to.not.be.null;
+
+      const text = date!.textContent!.trim();
+      expect(text, `a three-year-old commit rendered as "${text}"`).to.not.equal('just now');
+      expect(text, 'should read as years old').to.match(/\b3\s*y(ears?)?\b/);
+    });
+
+    it('still says "just now" for a commit made seconds ago', async () => {
+      mockInvoke = async (command: string) => {
+        if (command === 'get_file_blame') return blameResultAged(5);
+        return null;
+      };
+
+      const el = await renderBlame();
+      const date = el.shadowRoot!.querySelector('.commit-date');
+      expect(date!.textContent!.trim()).to.equal('just now');
+    });
+
+    it('agrees with the tooltip on the same group', async () => {
+      const oneYear = 365 * 24 * 60 * 60;
+      mockInvoke = async (command: string) => {
+        if (command === 'get_file_blame') return blameResultAged(oneYear);
+        return null;
+      };
+
+      const el = await renderBlame();
+      const info = el.shadowRoot!.querySelector('.group-info')!;
+      const tooltipYear = new Date(Date.now() - oneYear * 1000).getFullYear();
+
+      // The tooltip always formatted the timestamp correctly; the header did not.
+      expect(info.getAttribute('title')).to.contain(String(tooltipYear));
+      expect(el.shadowRoot!.querySelector('.commit-date')!.textContent!.trim()).to.not.equal(
+        'just now',
+      );
     });
   });
 });

--- a/src/components/panels/__tests__/lv-blame-view.test.ts
+++ b/src/components/panels/__tests__/lv-blame-view.test.ts
@@ -23,6 +23,7 @@ let mockInvoke: MockInvoke = () => Promise.resolve(null);
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
 import { expect, fixture, html } from '@open-wc/testing';
 import { uiStore } from '../../../stores/ui.store.ts';
+import type { BlameResult } from '../../../types/git.types.ts';
 import type { LvBlameView } from '../lv-blame-view.ts';
 import '../lv-blame-view.ts';
 
@@ -47,7 +48,7 @@ async function renderBlame(): Promise<LvBlameView> {
 }
 
 /** A blame result whose single group is `secondsAgo` old. */
-function blameResultAged(secondsAgo: number) {
+function blameResultAged(secondsAgo: number): BlameResult {
   const timestamp = Math.floor(Date.now() / 1000) - secondsAgo;
   return {
     path: 'src/main.ts',
@@ -64,6 +65,7 @@ function blameResultAged(secondsAgo: number) {
         isBoundary: false,
       },
     ],
+    totalLines: 1,
   };
 }
 
@@ -153,10 +155,17 @@ describe('lv-blame-view', () => {
 
       const el = await renderBlame();
       const info = el.shadowRoot!.querySelector('.group-info')!;
-      const tooltipYear = new Date(Date.now() - oneYear * 1000).getFullYear();
+
+      // Compared against the component's OWN formatting rather than a bare year
+      // string: toLocaleString() can render digits in a non-Latin numbering
+      // system depending on the environment's locale, which would make a
+      // String(year) check flaky.
+      const shownTimestamp = (el as unknown as { groups: Array<{ timestamp: number }> })
+        .groups[0].timestamp;
+      const expectedTooltipDate = new Date(shownTimestamp * 1000).toLocaleString();
 
       // The tooltip always formatted the timestamp correctly; the header did not.
-      expect(info.getAttribute('title')).to.contain(String(tooltipYear));
+      expect(info.getAttribute('title')).to.contain(expectedTooltipDate);
       expect(el.shadowRoot!.querySelector('.commit-date')!.textContent!.trim()).to.not.equal(
         'just now',
       );

--- a/src/components/panels/lv-blame-view.ts
+++ b/src/components/panels/lv-blame-view.ts
@@ -652,7 +652,12 @@ export class LvBlameView extends CodeRenderMixin(LitElement) {
                     <div class="commit-bottom-row">
                       <span class="author-name" style="color: ${authorColor}">${group.authorName}</span>
                       <span>•</span>
-                      <span class="commit-date">${formatRelativeTime(group.timestamp * 1000)}</span>
+                      <!-- Seconds, not milliseconds: formatRelativeTime does the
+                           *1000 itself. Converting here too made every diff
+                           hugely negative, so "seconds < 60" always won and
+                           every blame group read "just now" — contradicting the
+                           tooltip above, which formats the same value correctly. -->
+                      <span class="commit-date">${formatRelativeTime(group.timestamp)}</span>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## The problem

`BlameLine.timestamp` is Unix **seconds** (`author.when().seconds()`), and `formatRelativeTime` multiplies by 1000 itself:

```ts
const diff = now - timestamp * 1000;
```

The blame header passed **milliseconds** into it, so `diff` went hugely negative, `seconds < 60` always won, and **every blame group rendered "just now"** — whether the line last changed today or five years ago.

That defeats the whole point of blame. It also contradicted the tooltip on the very same group, which formats the identical value correctly via `new Date(group.timestamp * 1000)`.

## The fix

Pass seconds, as the formatter expects. One-line change plus a comment explaining the double conversion, since the `* 1000` looks correct in isolation.

## Tests

- a three-year-old commit renders as years old, not "just now"
- a commit made seconds ago **still** reads "just now" (so the fix isn't just inverting the bug)
- the header agrees with the tooltip on the same group

The first and third fail with the `* 1000` restored; the middle one passes either way by design, as the control.

## Verification

`npm run typecheck` and the full suite (4,375 tests) pass on this branch.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_