### PR TITLE
Pass the gc prune date in stuck form so git accepts it

### DIFF
--- a/src-tauri/src/commands/maintenance.rs
+++ b/src-tauri/src/commands/maintenance.rs
@@ -960,8 +960,19 @@ mod tests {
     async fn test_run_gc_with_prune_date_succeeds() {
         let repo = TestRepo::with_initial_commit();
 
+        // An unreachable loose object: nothing refers to it, so "--prune=now"
+        // must collect it. Asserting on the object rather than on git's wording
+        // proves the date REACHED git as the option's value — a stray positional
+        // is rejected outright, and any other misuse leaves the blob behind.
+        let dangling = repo
+            .repo()
+            .blob(b"unreachable content")
+            .expect("write a dangling blob");
+
         let result = run_gc(repo.path_str(), None, Some("now".to_string()), None).await;
 
+        // A usage error comes back as Err carrying git's message, so this is
+        // where a rejected argument surfaces.
         let gc_result = result.expect("gc with a prune date should not error");
         assert!(
             gc_result.success,
@@ -969,9 +980,8 @@ mod tests {
             gc_result.message
         );
         assert!(
-            !gc_result.message.contains("usage: git gc"),
-            "git rejected the prune argument: {:?}",
-            gc_result.message
+            repo.repo().find_blob(dangling).is_err(),
+            "--prune=now must collect an unreachable object"
         );
     }
 

--- a/src-tauri/src/commands/maintenance.rs
+++ b/src-tauri/src/commands/maintenance.rs
@@ -490,7 +490,12 @@ pub async fn run_gc(
     }
 
     if let Some(prune_date) = prune {
-        cmd.arg("--prune").arg(prune_date);
+        // Stuck form. `--prune` takes an OPTIONAL argument, so the two-token
+        // form leaves the date as a stray positional and git exits with a usage
+        // error — making every call that supplied RunGcCommand.prune fail with
+        // "Garbage collection failed: usage: git gc ...". The legacy
+        // run_garbage_collection command above already does it this way.
+        cmd.arg(format!("--prune={}", prune_date));
     }
 
     // Run the command
@@ -945,6 +950,40 @@ mod tests {
         assert!(result.is_ok());
         let gc_result = result.unwrap();
         assert!(gc_result.success);
+    }
+
+    /// `git gc --prune` takes an OPTIONAL argument, so the date must be in
+    /// stuck form. Passing it as a separate token leaves it as a stray
+    /// positional and git exits with a usage error, so every caller supplying
+    /// RunGcCommand.prune got "Garbage collection failed: usage: git gc ...".
+    #[tokio::test]
+    async fn test_run_gc_with_prune_date_succeeds() {
+        let repo = TestRepo::with_initial_commit();
+
+        let result = run_gc(repo.path_str(), None, Some("now".to_string()), None).await;
+
+        let gc_result = result.expect("gc with a prune date should not error");
+        assert!(
+            gc_result.success,
+            "gc with a prune date failed: {:?}",
+            gc_result.message
+        );
+        assert!(
+            !gc_result.message.contains("usage: git gc"),
+            "git rejected the prune argument: {:?}",
+            gc_result.message
+        );
+    }
+
+    /// A relative date, the other form the API documents.
+    #[tokio::test]
+    async fn test_run_gc_with_relative_prune_date_succeeds() {
+        let repo = TestRepo::with_initial_commit();
+
+        let result = run_gc(repo.path_str(), None, Some("2.weeks.ago".to_string()), None).await;
+
+        let gc_result = result.expect("gc with a relative prune date should not error");
+        assert!(gc_result.success, "gc failed: {:?}", gc_result.message);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## The problem

`git gc --prune` takes an **optional** argument, so the date must be attached: `--prune=<date>`. `run_gc` passed it as a separate token:

```rust
cmd.arg("--prune").arg(prune_date);
```

That leaves the date as a stray positional and git exits with a usage error. Every caller supplying the documented `RunGcCommand.prune` field (`"2.weeks.ago"`, `"now"`) got:

```
Garbage collection failed: usage: git gc [<options>]
```

Verified directly against git in this environment — `git gc --prune now` prints the usage block, `git gc --prune=now` succeeds. git's own usage text spells out the required shape:

```
--[no-]prune[=<date>] prune unreferenced objects
```

The legacy `run_garbage_collection` command in the same file already builds it correctly with `format!("--prune={}")`, so this was an inconsistency between two siblings rather than a misunderstanding of the flag.

## Tests

Both documented forms — an absolute date (`now`) and a relative one (`2.weeks.ago`). Splitting the argument again makes both fail with the exact usage error above, so they pin the real behaviour rather than just exercising the code path. No test covered the prune path before.

## Verification

`cargo test --lib` (2079 tests), `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` all pass on this branch.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_