### PR TITLE
Make the SSH connection test check the host the user typed

### DIFF
--- a/src-tauri/src/commands/ssh.rs
+++ b/src-tauri/src/commands/ssh.rs
@@ -280,25 +280,60 @@ pub async fn generate_ssh_key(
     })
 }
 
+/// Which host to connect to, and the success banner to expect from it.
+///
+/// The canonical SaaS hosts are matched EXACTLY. Matching on `contains` and then
+/// rewriting the target sent `github.mycompany.com` or `gitlab.internal.io` to
+/// the public servers instead: the test passed against a machine the user never
+/// named (their personal key works on github.com), while the result panel still
+/// displayed the host they typed. Anything else is contacted as entered.
+fn resolve_ssh_target(host: &str) -> (String, &'static str) {
+    let trimmed = host.trim().trim_end_matches('/');
+    // Compare on the host part so "git@github.com" resolves like "github.com".
+    let bare = trimmed.rsplit('@').next().unwrap_or(trimmed);
+
+    let expected_pattern = match bare.to_ascii_lowercase().as_str() {
+        "github.com" | "ssh.github.com" => "successfully authenticated",
+        "gitlab.com" => "welcome to gitlab",
+        "bitbucket.org" => "logged in as",
+        _ => "",
+    };
+
+    let ssh_host = if trimmed.contains('@') {
+        trimmed.to_string()
+    } else {
+        format!("git@{}", trimmed)
+    };
+
+    (ssh_host, expected_pattern)
+}
+
+/// Whether an `ssh -T` result means authentication succeeded.
+///
+/// `expected_pattern` is empty for hosts with no known banner, and
+/// `contains("")` is ALWAYS true — so every custom host reported success no
+/// matter what ssh said, including "Permission denied (publickey)" and
+/// "Connection refused". Those hosts now rest on ssh's exit status, which is
+/// non-zero for both.
+fn ssh_test_succeeded(message: &str, expected_pattern: &str, status_success: bool) -> bool {
+    let lower = message.to_lowercase();
+
+    if !expected_pattern.is_empty() && lower.contains(expected_pattern) {
+        return true;
+    }
+
+    // The known banners are still accepted from any host: a GitHub Enterprise or
+    // self-hosted GitLab answers with the same wording as the SaaS original.
+    lower.contains("successfully authenticated")
+        || lower.contains("welcome to gitlab")
+        || lower.contains("logged in as")
+        || status_success
+}
+
 /// Test SSH connection to a host
 #[command]
 pub async fn test_ssh_connection(host: String) -> Result<SshTestResult> {
-    // Common git hosts and their SSH test commands
-    let (ssh_host, expected_pattern): (String, &str) = if host.contains("github") {
-        ("git@github.com".to_string(), "successfully authenticated")
-    } else if host.contains("gitlab") {
-        ("git@gitlab.com".to_string(), "Welcome to GitLab")
-    } else if host.contains("bitbucket") {
-        ("git@bitbucket.org".to_string(), "logged in as")
-    } else {
-        // For custom hosts, just try to connect
-        let ssh_host = if host.contains('@') {
-            host.clone()
-        } else {
-            format!("git@{}", host)
-        };
-        (ssh_host, "")
-    };
+    let (ssh_host, expected_pattern) = resolve_ssh_target(&host);
 
     // Run ssh -T to test connection
     let output = create_command("ssh")
@@ -324,11 +359,7 @@ pub async fn test_ssh_connection(host: String) -> Result<SshTestResult> {
     };
 
     // GitHub returns exit code 1 even on success, so check the message
-    let success = message.to_lowercase().contains(expected_pattern)
-        || message.contains("successfully authenticated")
-        || message.contains("Welcome")
-        || message.contains("logged in as")
-        || output.status.success();
+    let success = ssh_test_succeeded(&message, expected_pattern, output.status.success());
 
     // Try to extract username from the message
     let username = if message.contains("Hi ") {
@@ -457,6 +488,106 @@ pub async fn delete_ssh_key(key_name: String) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── SSH connection test targeting and verdict ────────────────────────────
+
+    /// A self-hosted host must be contacted as entered.
+    ///
+    /// `host.contains("github")` matched github.mycompany.com and then replaced
+    /// the target with git@github.com, so the test ran against the PUBLIC server
+    /// while the result panel showed the enterprise host. A pass there proves
+    /// only that the user's key works on github.com.
+    #[test]
+    fn test_self_hosted_hosts_are_not_redirected_to_the_saas_servers() {
+        for host in [
+            "github.mycompany.com",
+            "gitlab.internal.io",
+            "bitbucket.corp.example",
+            "git.example.com",
+        ] {
+            let (target, _) = resolve_ssh_target(host);
+            assert_eq!(
+                target,
+                format!("git@{}", host),
+                "{} must be contacted as entered",
+                host
+            );
+        }
+    }
+
+    /// The canonical hosts still resolve to their known banner.
+    #[test]
+    fn test_canonical_hosts_keep_their_expected_banner() {
+        assert_eq!(
+            resolve_ssh_target("github.com"),
+            ("git@github.com".to_string(), "successfully authenticated")
+        );
+        assert_eq!(
+            resolve_ssh_target("gitlab.com"),
+            ("git@gitlab.com".to_string(), "welcome to gitlab")
+        );
+        assert_eq!(
+            resolve_ssh_target("bitbucket.org"),
+            ("git@bitbucket.org".to_string(), "logged in as")
+        );
+        // An explicit user resolves the same way and is preserved.
+        assert_eq!(
+            resolve_ssh_target("git@github.com"),
+            ("git@github.com".to_string(), "successfully authenticated")
+        );
+        // A self-hosted host gets no banner to match on.
+        assert_eq!(resolve_ssh_target("github.mycompany.com").1, "");
+    }
+
+    /// With no known banner, expected_pattern is "" — and contains("") is
+    /// ALWAYS true, so every custom host reported success no matter what ssh
+    /// said. A green "Connection Successful" over "Permission denied" defeats
+    /// the entire purpose of the test.
+    #[test]
+    fn test_custom_host_failures_are_reported_as_failures() {
+        for failure in [
+            "git@git.example.com: Permission denied (publickey).",
+            "ssh: connect to host git.example.com port 22: Connection refused",
+            "Host key verification failed.",
+            "ssh: Could not resolve hostname git.example.com",
+        ] {
+            assert!(
+                !ssh_test_succeeded(failure, "", false),
+                "should have failed: {}",
+                failure
+            );
+        }
+    }
+
+    /// A custom host that genuinely authenticates still passes.
+    #[test]
+    fn test_custom_host_success_is_reported_as_success() {
+        // ssh exiting 0 is the only signal a bannerless host gives.
+        assert!(ssh_test_succeeded("", "", true));
+        // A self-hosted GitHub Enterprise answers with the SaaS wording.
+        assert!(ssh_test_succeeded(
+            "Hi alice! You've successfully authenticated, but GitHub does not provide shell access.",
+            "",
+            false
+        ));
+        // ...as does a self-hosted GitLab.
+        assert!(ssh_test_succeeded("Welcome to GitLab, @alice!", "", false));
+    }
+
+    /// The canonical hosts keep working: GitHub exits 1 even on success.
+    #[test]
+    fn test_canonical_host_success_survives_a_nonzero_exit() {
+        assert!(ssh_test_succeeded(
+            "Hi alice! You've successfully authenticated, but GitHub does not provide shell access.",
+            "successfully authenticated",
+            false
+        ));
+        assert!(!ssh_test_succeeded(
+            "git@github.com: Permission denied (publickey).",
+            "successfully authenticated",
+            false
+        ));
+    }
 
     // ==========================================================================
     // SshKey Struct Tests

--- a/src-tauri/src/commands/ssh.rs
+++ b/src-tauri/src/commands/ssh.rs
@@ -280,6 +280,47 @@ pub async fn generate_ssh_key(
     })
 }
 
+/// Where to point `ssh -T`, and the success banner to expect from it.
+struct SshTarget {
+    /// The `[user@]host` argument for ssh.
+    ssh_host: String,
+    /// An explicit port from an `ssh://host:port/…` URL, if the user gave one.
+    port: Option<String>,
+    /// The banner this host is known to answer with, or "" if it is unknown.
+    expected_pattern: &'static str,
+}
+
+/// Split a `[user@]host[:port]` fragment into its host and port parts.
+///
+/// Bracketed IPv6 literals keep their brackets — `ssh` wants them that way —
+/// and only an all-digit suffix counts as a port, so an SCP path remnant like
+/// `github.com:owner` does not turn into one.
+fn split_host_port(host_port: &str) -> (&str, Option<String>) {
+    let split_at = if host_port.starts_with('[') {
+        // Only a colon AFTER the closing bracket can be a port separator.
+        match host_port.find(']') {
+            Some(end) => host_port[end..].find(':').map(|i| end + i),
+            None => None,
+        }
+    } else {
+        host_port.rfind(':')
+    };
+
+    match split_at {
+        Some(i) => {
+            let (bare, rest) = host_port.split_at(i);
+            let port = &rest[1..];
+            if !port.is_empty() && port.chars().all(|c| c.is_ascii_digit()) {
+                (bare, Some(port.to_string()))
+            } else {
+                // An SCP-style path (`git@github.com:owner/repo.git`) — not a port.
+                (bare, None)
+            }
+        }
+        None => (host_port, None),
+    }
+}
+
 /// Which host to connect to, and the success banner to expect from it.
 ///
 /// The canonical SaaS hosts are matched EXACTLY. Matching on `contains` and then
@@ -287,10 +328,32 @@ pub async fn generate_ssh_key(
 /// the public servers instead: the test passed against a machine the user never
 /// named (their personal key works on github.com), while the result panel still
 /// displayed the host they typed. Anything else is contacted as entered.
-fn resolve_ssh_target(host: &str) -> (String, &'static str) {
-    let trimmed = host.trim().trim_end_matches('/');
-    // Compare on the host part so "git@github.com" resolves like "github.com".
-    let bare = trimmed.rsplit('@').next().unwrap_or(trimmed);
+///
+/// The input is whatever the user pasted, so a remote URL is accepted as well as
+/// a bare host: `github.com`, `git@github.com`, `git@github.com:owner/repo.git`
+/// and `ssh://git@github.com:2222/owner/repo.git` all resolve to the same host.
+/// Handing those URL forms to `ssh -T` verbatim made every one of them miss the
+/// canonical-host match and then fail to connect at all.
+fn resolve_ssh_target(host: &str) -> SshTarget {
+    let mut rest = host.trim();
+    for scheme in ["ssh://", "git+ssh://"] {
+        if let Some(stripped) = rest.strip_prefix(scheme) {
+            rest = stripped;
+            break;
+        }
+    }
+    // Drop the repository path, from either URL form.
+    if let Some(slash) = rest.find('/') {
+        rest = &rest[..slash];
+    }
+
+    let (user, host_port) = match rest.rsplit_once('@') {
+        Some((user, host_port)) if !user.is_empty() => (Some(user), host_port),
+        Some((_, host_port)) => (None, host_port),
+        None => (None, rest),
+    };
+
+    let (bare, port) = split_host_port(host_port);
 
     let expected_pattern = match bare.to_ascii_lowercase().as_str() {
         "github.com" | "ssh.github.com" => "successfully authenticated",
@@ -299,13 +362,11 @@ fn resolve_ssh_target(host: &str) -> (String, &'static str) {
         _ => "",
     };
 
-    let ssh_host = if trimmed.contains('@') {
-        trimmed.to_string()
-    } else {
-        format!("git@{}", trimmed)
-    };
-
-    (ssh_host, expected_pattern)
+    SshTarget {
+        ssh_host: format!("{}@{}", user.unwrap_or("git"), bare),
+        port,
+        expected_pattern,
+    }
 }
 
 /// Whether an `ssh -T` result means authentication succeeded.
@@ -333,20 +394,28 @@ fn ssh_test_succeeded(message: &str, expected_pattern: &str, status_success: boo
 /// Test SSH connection to a host
 #[command]
 pub async fn test_ssh_connection(host: String) -> Result<SshTestResult> {
-    let (ssh_host, expected_pattern) = resolve_ssh_target(&host);
+    let SshTarget {
+        ssh_host,
+        port,
+        expected_pattern,
+    } = resolve_ssh_target(&host);
 
     // Run ssh -T to test connection
-    let output = create_command("ssh")
-        .args([
-            "-T",
-            "-o",
-            "StrictHostKeyChecking=accept-new",
-            "-o",
-            "BatchMode=yes",
-            "-o",
-            "ConnectTimeout=10",
-            &ssh_host,
-        ])
+    let mut command = create_command("ssh");
+    command.args([
+        "-T",
+        "-o",
+        "StrictHostKeyChecking=accept-new",
+        "-o",
+        "BatchMode=yes",
+        "-o",
+        "ConnectTimeout=10",
+    ]);
+    if let Some(port) = &port {
+        command.args(["-p", port]);
+    }
+    let output = command
+        .arg(&ssh_host)
         .output()
         .map_err(|e| LeviathanError::OperationFailed(format!("Failed to run ssh: {}", e)))?;
 
@@ -505,9 +574,9 @@ mod tests {
             "bitbucket.corp.example",
             "git.example.com",
         ] {
-            let (target, _) = resolve_ssh_target(host);
+            let target = resolve_ssh_target(host);
             assert_eq!(
-                target,
+                target.ssh_host,
                 format!("git@{}", host),
                 "{} must be contacted as entered",
                 host
@@ -518,25 +587,72 @@ mod tests {
     /// The canonical hosts still resolve to their known banner.
     #[test]
     fn test_canonical_hosts_keep_their_expected_banner() {
-        assert_eq!(
-            resolve_ssh_target("github.com"),
-            ("git@github.com".to_string(), "successfully authenticated")
-        );
-        assert_eq!(
-            resolve_ssh_target("gitlab.com"),
-            ("git@gitlab.com".to_string(), "welcome to gitlab")
-        );
-        assert_eq!(
-            resolve_ssh_target("bitbucket.org"),
-            ("git@bitbucket.org".to_string(), "logged in as")
-        );
-        // An explicit user resolves the same way and is preserved.
-        assert_eq!(
-            resolve_ssh_target("git@github.com"),
-            ("git@github.com".to_string(), "successfully authenticated")
-        );
+        for (input, ssh_host, pattern) in [
+            ("github.com", "git@github.com", "successfully authenticated"),
+            ("gitlab.com", "git@gitlab.com", "welcome to gitlab"),
+            ("bitbucket.org", "git@bitbucket.org", "logged in as"),
+            // An explicit user resolves the same way and is preserved.
+            (
+                "git@github.com",
+                "git@github.com",
+                "successfully authenticated",
+            ),
+        ] {
+            let target = resolve_ssh_target(input);
+            assert_eq!(target.ssh_host, ssh_host, "target for {}", input);
+            assert_eq!(target.expected_pattern, pattern, "banner for {}", input);
+            assert_eq!(target.port, None, "port for {}", input);
+        }
         // A self-hosted host gets no banner to match on.
-        assert_eq!(resolve_ssh_target("github.mycompany.com").1, "");
+        assert_eq!(
+            resolve_ssh_target("github.mycompany.com").expected_pattern,
+            ""
+        );
+    }
+
+    /// Pasting a remote URL is the natural thing to do, so every URL form has to
+    /// resolve to the same host as the bare name.
+    ///
+    /// Only the `user@` prefix used to be stripped, so `git@github.com:me/x.git`
+    /// missed the canonical-host match AND was handed to `ssh -T` complete with
+    /// its repository path — which cannot connect to anything.
+    #[test]
+    fn test_remote_urls_resolve_to_their_host() {
+        for input in [
+            "git@github.com:owner/repo.git",
+            "ssh://git@github.com/owner/repo.git",
+            "ssh://git@github.com:22/owner/repo.git",
+            "git+ssh://git@github.com/owner/repo.git",
+            "github.com/owner/repo",
+            "  git@github.com:owner/repo.git  ",
+        ] {
+            let target = resolve_ssh_target(input);
+            assert_eq!(target.ssh_host, "git@github.com", "target for {}", input);
+            assert_eq!(
+                target.expected_pattern, "successfully authenticated",
+                "banner for {}",
+                input
+            );
+        }
+    }
+
+    /// A non-default port from an SSH URL has to reach the ssh invocation, or
+    /// the test silently probes port 22 of a server that does not listen there.
+    #[test]
+    fn test_ssh_url_port_is_preserved() {
+        let target = resolve_ssh_target("ssh://git@git.example.com:2222/owner/repo.git");
+        assert_eq!(target.ssh_host, "git@git.example.com");
+        assert_eq!(target.port.as_deref(), Some("2222"));
+
+        // An SCP-style path is not a port.
+        let scp = resolve_ssh_target("git@git.example.com:owner/repo.git");
+        assert_eq!(scp.ssh_host, "git@git.example.com");
+        assert_eq!(scp.port, None);
+
+        // A bracketed IPv6 literal keeps its brackets and still yields its port.
+        let v6 = resolve_ssh_target("ssh://git@[2001:db8::1]:2222/owner/repo.git");
+        assert_eq!(v6.ssh_host, "git@[2001:db8::1]");
+        assert_eq!(v6.port.as_deref(), Some("2222"));
     }
 
     /// With no known banner, expected_pattern is "" — and contains("") is


### PR DESCRIPTION
Two defects in the same command, both of which made **Test Connection report success when it should not**.

## 1. Self-hosted hosts were redirected to the public servers

The target was chosen with `host.contains("github")` / `("gitlab")` / `("bitbucket")` and then **hard-replaced** with `git@github.com` / `git@gitlab.com` / `git@bitbucket.org`.

So testing `github.mycompany.com` or `gitlab.internal.io` actually contacted the SaaS server. The user's personal key works there, so the test passed and told them their **enterprise SSH setup was fine when nothing had verified it** — and the reverse, a genuinely working enterprise host failing because their public key isn't on github.com. The result panel still displayed the host they entered, next to a message that came from somewhere else entirely.

The canonical hosts are now matched **exactly**; anything else is contacted as entered.

## 2. Custom hosts always reported success

With no known banner, `expected_pattern` is `""` — and `contains("")` is **always true**:

```rust
let success = message.to_lowercase().contains(expected_pattern) || ...
```

So `success` was true regardless of what ssh returned, including `Permission denied (publickey)` and `Connection refused`. A green "Connection Successful" over a failed authentication defeats the entire purpose of the test.

Hosts without a banner now rest on ssh's exit status, which is non-zero for both of those. The known banners are still accepted from **any** host, since a GitHub Enterprise or self-hosted GitLab answers with the same wording as the original — so the fix doesn't punish self-hosted instances that do work.

## Structure

Targeting and the success verdict are split into two pure helpers (`resolve_ssh_target`, `ssh_test_succeeded`) so both are testable — the command itself shells out to `ssh` and needs a network.

## Tests

- self-hosted hosts are contacted as entered, not redirected
- canonical hosts keep their expected banner, including the `git@host` form
- custom-host failures (permission denied, connection refused, host key verification, DNS failure) all report failure
- a custom host that genuinely authenticates still passes, via exit status or a recognised banner
- GitHub's non-zero exit on success still counts as success

Restoring either bug fails its own test and leaves the other passing, so they're pinned independently.

## Verification

`cargo test --lib` (2082 tests), `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` all pass on this branch.

One unrelated test failed intermittently on a single suite run and passed on four consecutive re-runs; its name wasn't captured. It is not in this diff's blast radius — both helpers here are pure functions with no shared state — so I'm flagging it rather than attributing it to this change.

Found by a 40-reviewer parallel review; both findings confirmed by an adversarial verification pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_