### PR TITLE
Switch to the branch on reflog checkout entries instead of resetting

### DIFF
--- a/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
@@ -35,6 +35,33 @@ const mockEntry: ReflogEntry = {
   index: 0,
 } as unknown as ReflogEntry;
 
+
+/** A "checkout: moving from X to Y" reflog entry. */
+function checkoutEntry(from: string, to: string): ReflogEntry {
+  return {
+    oid: 'feed0000beef',
+    shortId: 'feed000',
+    index: 1,
+    action: 'checkout',
+    message: `checkout: moving from ${from} to ${to}`,
+    timestamp: Math.floor(Date.now() / 1000),
+    author: 'T',
+  } as unknown as ReflogEntry;
+}
+
+/** An ordinary commit entry, which SHOULD still offer a reset. */
+function commitEntry(): ReflogEntry {
+  return {
+    oid: 'cafe0000babe',
+    shortId: 'cafe000',
+    index: 2,
+    action: 'commit',
+    message: 'commit: work',
+    timestamp: Math.floor(Date.now() / 1000),
+    author: 'T',
+  } as unknown as ReflogEntry;
+}
+
 describe('lv-reflog-dialog', () => {
   beforeEach(() => {
     uiStore.setState({ toasts: [] });
@@ -162,5 +189,81 @@ describe('lv-reflog-dialog', () => {
     ).to.be.true;
 
     resetRefOpLocks();
+  });
+
+  // ── Checkout entries must switch, not reset ──────────────────────────────
+  describe('checkout entries', () => {
+    async function dialogWith(entries: ReflogEntry[]): Promise<LvReflogDialog> {
+      const el = await fixture<LvReflogDialog>(
+        html`<lv-reflog-dialog .repositoryPath=${'/test/repo'}></lv-reflog-dialog>`
+      );
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).entries = entries;
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).loading = false;
+      await el.updateComplete;
+      return el;
+    }
+
+    it('offers Switch instead of a reset on a checkout entry', async () => {
+      // A "checkout: moving from main to feature" entry records ANOTHER
+      // branch's tip. Resetting onto it repoints the current branch there and
+      // orphans its commits — the opposite of "go back to that state".
+      const el = await dialogWith([checkoutEntry('main', 'feature')]);
+
+      const labels = Array.from(el.shadowRoot!.querySelectorAll('.entry-actions button')).map(
+        (b) => b.textContent!.trim()
+      );
+
+      expect(labels.join(' | ')).to.contain('Switch to feature');
+      expect(labels, 'a checkout entry must not offer a hard reset').to.not.include('Hard');
+      expect(labels, 'a checkout entry must not offer an "Undo" reset').to.not.include('Undo');
+    });
+
+    it('still offers Undo and Hard on an ordinary commit entry', async () => {
+      const el = await dialogWith([commitEntry()]);
+
+      const labels = Array.from(el.shadowRoot!.querySelectorAll('.entry-actions button')).map(
+        (b) => b.textContent!.trim()
+      );
+
+      expect(labels).to.include('Undo');
+      expect(labels).to.include('Hard');
+    });
+
+    it('checks out the target branch rather than resetting', async () => {
+      const calls: string[] = [];
+      mockInvoke = async (command: string) => {
+        calls.push(command);
+        if (command === 'checkout_with_autostash') {
+          return {
+            success: true,
+            stashed: false,
+            stashApplied: false,
+            stashConflict: false,
+            stashOid: null,
+            message: 'Switched',
+          };
+        }
+        return null;
+      };
+
+      const el = await dialogWith([checkoutEntry('main', 'feature')]);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleSwitchTo(checkoutEntry('main', 'feature'));
+
+      expect(calls).to.include('checkout_with_autostash');
+      expect(calls, 'a switch must never reset the branch').to.not.include('reset_to_reflog');
+    });
+
+    it('parses the target only from checkout entries', async () => {
+      const el = await dialogWith([]);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const target = (e: ReflogEntry) => (el as any).checkoutTarget(e);
+
+      expect(target(checkoutEntry('main', 'feature'))).to.equal('feature');
+      expect(target(checkoutEntry('feature', 'release/2.0'))).to.equal('release/2.0');
+      expect(target(commitEntry()), 'a commit entry is not a checkout').to.be.null;
+    });
   });
 });

--- a/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
@@ -193,16 +193,41 @@ describe('lv-reflog-dialog', () => {
 
   // ── Checkout entries must switch, not reset ──────────────────────────────
   describe('checkout entries', () => {
-    async function dialogWith(entries: ReflogEntry[]): Promise<LvReflogDialog> {
+    /**
+     * Opens the dialog for real, so the repo it pins is the one under test.
+     * Poking `entries` on a closed dialog left `pinnedRepoPath` empty, which no
+     * longer resembles anything a user can produce.
+     */
+    async function dialogWith(
+      entries: ReflogEntry[],
+      repositoryPath = '/test/repo'
+    ): Promise<LvReflogDialog> {
+      const inner = mockInvoke;
+      mockInvoke = async (command, args) => {
+        if (command === 'get_reflog') return entries;
+        return inner(command, args);
+      };
+
       const el = await fixture<LvReflogDialog>(
-        html`<lv-reflog-dialog .repositoryPath=${'/test/repo'}></lv-reflog-dialog>`
+        html`<lv-reflog-dialog ?open=${true} .repositoryPath=${repositoryPath}></lv-reflog-dialog>`
       );
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (el as any).entries = entries;
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (el as any).loading = false;
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 0));
       await el.updateComplete;
       return el;
+    }
+
+    /** A successful `checkout_with_autostash` payload, with overrides. */
+    function stashResult(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+      return {
+        success: true,
+        stashed: false,
+        stashApplied: false,
+        stashConflict: false,
+        stashOid: null,
+        message: 'Switched',
+        ...overrides,
+      };
     }
 
     it('offers Switch instead of a reset on a checkout entry', async () => {
@@ -235,16 +260,7 @@ describe('lv-reflog-dialog', () => {
       const calls: string[] = [];
       mockInvoke = async (command: string) => {
         calls.push(command);
-        if (command === 'checkout_with_autostash') {
-          return {
-            success: true,
-            stashed: false,
-            stashApplied: false,
-            stashConflict: false,
-            stashOid: null,
-            message: 'Switched',
-          };
-        }
+        if (command === 'checkout_with_autostash') return stashResult();
         return null;
       };
 
@@ -254,6 +270,93 @@ describe('lv-reflog-dialog', () => {
 
       expect(calls).to.include('checkout_with_autostash');
       expect(calls, 'a switch must never reset the branch').to.not.include('reset_to_reflog');
+    });
+
+    // The same live-prop trap the reset path already guards against: the
+    // overlay does not block Ctrl+Tab, so reading `repositoryPath` at call time
+    // ran the checkout against whichever repo the user had switched to — where
+    // the branch name means something else, or nothing at all.
+    it('switches the repository the entries were read from, not the newly active one', async () => {
+      const calls: Array<{ command: string; args?: unknown }> = [];
+      mockInvoke = async (command, args) => {
+        calls.push({ command, args });
+        if (command === 'checkout_with_autostash') return stashResult();
+        return null;
+      };
+
+      const el = await dialogWith([checkoutEntry('main', 'feature')], '/repo/a');
+      el.repositoryPath = '/repo/b';
+      await el.updateComplete;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleSwitchTo(checkoutEntry('main', 'feature'));
+
+      const checkout = calls.find((c) => c.command === 'checkout_with_autostash');
+      expect(checkout, 'checkout_with_autostash issued').to.not.be.undefined;
+      expect((checkout!.args as { path: string }).path).to.equal('/repo/a');
+    });
+
+    // The switch auto-stashes, so it can land with the user's changes still
+    // shelved or conflicted. A bare "Switched to feature" hid that entirely.
+    it('reports a conflicting auto-stash instead of a bare success', async () => {
+      mockInvoke = async (command: string) => {
+        if (command === 'checkout_with_autostash') {
+          return stashResult({
+            stashed: true,
+            stashApplied: false,
+            stashConflict: true,
+            stashOid: 'stash0id',
+            message: 'Stash conflicts',
+          });
+        }
+        return null;
+      };
+
+      const el = await dialogWith([checkoutEntry('main', 'feature')]);
+      let conflictDetail: Record<string, unknown> | null = null;
+      el.addEventListener('open-conflict-dialog', (e) => {
+        conflictDetail = (e as CustomEvent).detail;
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleSwitchTo(checkoutEntry('main', 'feature'));
+
+      const toasts = uiStore.getState().toasts;
+      expect(
+        toasts.some((t) => t.type === 'warning' && /stash conflicts/i.test(t.message)),
+        'the user must be told the stash needs resolving'
+      ).to.be.true;
+      expect(conflictDetail, 'the conflict dialog must be opened').to.not.be.null;
+      expect(conflictDetail!).to.include({
+        operationType: 'stash',
+        stashOid: 'stash0id',
+        dropStashOnComplete: true,
+        repositoryPath: '/test/repo',
+      });
+    });
+
+    it('warns when the auto-stash could not be re-applied', async () => {
+      mockInvoke = async (command: string) => {
+        if (command === 'checkout_with_autostash') {
+          return stashResult({
+            stashed: true,
+            stashApplied: false,
+            stashConflict: false,
+            message: 'Changes are kept in the stash',
+          });
+        }
+        return null;
+      };
+
+      const el = await dialogWith([checkoutEntry('main', 'feature')]);
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleSwitchTo(checkoutEntry('main', 'feature'));
+
+      const toasts = uiStore.getState().toasts;
+      expect(
+        toasts.some((t) => t.type === 'warning' && /kept in the stash/i.test(t.message)),
+        'work left in the stash must not be reported as a clean switch'
+      ).to.be.true;
     });
 
     it('parses the target only from checkout entries', async () => {

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -499,6 +499,73 @@ export class LvReflogDialog extends LitElement {
     this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
   }
 
+  /**
+   * The ref a "checkout: moving from X to Y" entry landed on, if this entry is
+   * a checkout.
+   *
+   * Reflog entries record HEAD movements, so a checkout entry's oid is the tip
+   * of the branch that was switched TO. Resetting onto it is not "going back
+   * there" — it repoints the CURRENT branch at another branch's commit.
+   */
+  private checkoutTarget(entry: ReflogEntry): string | null {
+    if (entry.action !== 'checkout') return null;
+    const match = /moving from\s+(\S+)\s+to\s+(\S+)/.exec(entry.message);
+    return match ? match[2] : null;
+  }
+
+  /**
+   * Switch to the branch a checkout entry moved to — what "go back to that
+   * state" means for a checkout, and what `git switch -` does.
+   *
+   * Routing these through a reset instead moved the current branch's ref to the
+   * other branch's commit, orphaning every commit past the merge base (and,
+   * with Hard, overwriting the working tree with the other branch's content).
+   */
+  private async handleSwitchTo(entry: ReflogEntry): Promise<void> {
+    const target = this.checkoutTarget(entry);
+    if (!target || this.resetting) return;
+
+    const repoPath = this.repositoryPath;
+    if (!repoPath) return;
+
+    this.resetting = true;
+    if (!tryAcquireRefOp(repoPath)) {
+      this.resetting = false;
+      showToast('Another operation is already running in this repository.', 'warning');
+      return;
+    }
+
+    try {
+      const result = await gitService.checkoutWithAutoStash(repoPath, target);
+      if (result.success && result.data?.success) {
+        showToast(`Switched to ${target}`, 'success');
+        // Same event the reset path emits, so the host refreshes the repo the
+        // switch ran on even if the user changed tabs during the IPC await.
+        this.dispatchEvent(
+          new CustomEvent('undo-complete', {
+            detail: { entry: null, mode: 'checkout', repositoryPath: repoPath },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        this.close();
+      } else {
+        showToast(
+          result.error?.message ?? result.data?.message ?? `Failed to switch to ${target}`,
+          'error',
+        );
+      }
+    } catch (err) {
+      showToast(
+        `Failed to switch to ${target}: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        'error',
+      );
+    } finally {
+      this.resetting = false;
+      releaseRefOp(repoPath);
+    }
+  }
+
   private async handleReset(entry: ReflogEntry, mode: 'soft' | 'mixed' | 'hard'): Promise<void> {
     if (this.resetting) return;
     // Claimed BEFORE the confirm, not after. Unlike the context-menu surfaces —
@@ -532,6 +599,16 @@ export class LvReflogDialog extends LitElement {
       `This branch will point at ${entry.shortId}. Any commit no longer reachable ` +
       `from it is recoverable only through the reflog.`;
 
+    // A checkout entry belongs to a DIFFERENT branch, so resetting onto it
+    // moves the current branch to that branch's commit. "This branch will
+    // point at <oid>" is true but does not say whose commit that is.
+    const checkoutTarget = this.checkoutTarget(entry);
+    const crossBranchNote = checkoutTarget
+      ? `\n\nThis entry is a checkout of "${checkoutTarget}", not a state of the ` +
+        `current branch. Resetting moves the current branch onto that commit. To ` +
+        `go back to "${checkoutTarget}", close this and use Switch instead.`
+      : '';
+
     const modeNote =
       mode === 'hard'
         ? 'All uncommitted changes are also discarded permanently — those are not in the reflog and cannot be recovered.'
@@ -543,7 +620,7 @@ export class LvReflogDialog extends LitElement {
 
     const confirmed = await showConfirm(
       titles[mode],
-      `Reset to ${entry.shortId}?\n\n${droppedNote}\n\n${modeNote}`,
+      `Reset to ${entry.shortId}?\n\n${droppedNote}${crossBranchNote}\n\n${modeNote}`,
       'warning'
     );
     if (!confirmed) {
@@ -620,6 +697,14 @@ export class LvReflogDialog extends LitElement {
     const entry = this.contextMenu.entry;
     if (!entry) return;
     this.contextMenu = { ...this.contextMenu, visible: false };
+
+    // For a checkout entry, "go back there" is a switch — a reset would move
+    // the current branch onto another branch's commit.
+    if (this.checkoutTarget(entry)) {
+      void this.handleSwitchTo(entry);
+      return;
+    }
+
     this.handleReset(entry, 'mixed');
   }
 
@@ -670,7 +755,20 @@ export class LvReflogDialog extends LitElement {
           </div>
         </div>
 
-        ${!isCurrent ? html`
+        ${!isCurrent && this.checkoutTarget(entry) ? html`
+          <div class="entry-actions">
+            <button
+              class="reset-btn"
+              @click=${(e: Event) => { e.stopPropagation(); this.handleSwitchTo(entry); }}
+              ?disabled=${this.resetting || this.repositoryBusy}
+              title="Switch back to ${this.checkoutTarget(entry)}"
+            >
+              Switch to ${this.checkoutTarget(entry)}
+            </button>
+          </div>
+        ` : nothing}
+
+        ${!isCurrent && !this.checkoutTarget(entry) ? html`
           <div class="entry-actions">
             <button
               class="reset-btn"

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -525,7 +525,11 @@ export class LvReflogDialog extends LitElement {
     const target = this.checkoutTarget(entry);
     if (!target || this.resetting) return;
 
-    const repoPath = this.repositoryPath;
+    // The repo the dialog was OPENED on, like the reset path uses.
+    // `repositoryPath` is live-bound to the active tab, so reading it here ran
+    // the checkout against whatever repo the user switched to while the dialog
+    // was up — a switch to a branch name that means something different there.
+    const repoPath = this.pinnedRepoPath;
     if (!repoPath) return;
 
     this.resetting = true;
@@ -538,7 +542,39 @@ export class LvReflogDialog extends LitElement {
     try {
       const result = await gitService.checkoutWithAutoStash(repoPath, target);
       if (result.success && result.data?.success) {
-        showToast(`Switched to ${target}`, 'success');
+        const data = result.data;
+        // The switch auto-stashes, so it can land with the user's changes still
+        // shelved or in conflict. Reporting a bare "Switched to X" hid that:
+        // the work looked lost, with the only clue in a stash entry nobody was
+        // told about. Same reporting the branch and tag lists give.
+        if (data.stashed && data.stashConflict) {
+          showToast(`Switched to ${target} — stash conflicts need resolution`, 'warning');
+          this.dispatchEvent(
+            new CustomEvent('open-conflict-dialog', {
+              bubbles: true,
+              composed: true,
+              // Auto-stash is pop semantics: drop it once resolved. Identified
+              // by oid, not position — another surface can push a stash in
+              // between and renumber the list.
+              detail: {
+                operationType: 'stash',
+                stashOid: data.stashOid ?? null,
+                stashIndex: 0,
+                dropStashOnComplete: true,
+                repositoryPath: repoPath,
+              },
+            }),
+          );
+        } else if (data.stashed && !data.stashApplied) {
+          showToast(data.message, 'warning');
+        } else if (data.stashed) {
+          showToast(
+            data.message,
+            data.message.includes('staged status was not preserved') ? 'warning' : 'info',
+          );
+        } else {
+          showToast(`Switched to ${target}`, 'success');
+        }
         // Same event the reset path emits, so the host refreshes the repo the
         // switch ran on even if the user changed tabs during the IPC await.
         this.dispatchEvent(


### PR DESCRIPTION
## The problem

The dialog put **Undo** (mixed reset) and **Hard** on every non-current reflog entry — including `checkout: moving from X to Y` — and routed them all through `reset_to_reflog`, which repoints the **current** branch at the entry's oid.

A checkout entry's oid is the tip of the branch that was switched **to**. So a user on `main` who sees `checkout: moving from main to feature` and clicks **Undo**, expecting to be back on `feature`, instead moves `main`'s ref onto `feature`'s commit and **orphans every commit past the merge base**. **Hard** additionally overwrites the working tree with the other branch's content.

The confirm said "This branch will point at `<oid>`" — true, but it never said that commit belonged to a *different branch*.

## This is a known hazard, already handled elsewhere

The backend special-cases exactly this in `undo_last_action`, restoring HEAD symbolically like `git switch -`:

> a mixed reset here would rewrite the current branch to the pre-checkout commit and orphan its commits (data loss)

But that safe path is **unreachable from the UI** — `undo.rs` notes Ctrl+Z opens this dialog instead — while the dialog had no checkout handling at all.

## The fix

Checkout entries offer **Switch to `<branch>`**, which performs a checkout. The context menu's own checkout item routes there too, rather than to a mixed reset. Ordinary entries keep Undo and Hard unchanged.

The reset confirm also gains a checkout-specific warning, so any checkout entry that still reaches a reset by another route states whose commit it is.

## Tests

- a checkout entry offers **Switch** and neither Undo nor Hard
- an ordinary commit entry still offers **both** (control — guards against over-applying the change)
- switching invokes `checkout_with_autostash` and **never** `reset_to_reflog`
- the target is parsed only from checkout entries, including branch names containing `/`

Three of the four fail when the checkout detection is disabled; the control passes either way by design.

## Verification

`npm run typecheck` and the full suite (4,375 tests) pass on this branch.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass that traced the unreachable safe path.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_