### PR TITLE
Report merge commits excluded from an interactive rebase plan

### DIFF
--- a/e2e/tests/interactive-rebase.spec.ts
+++ b/e2e/tests/interactive-rebase.spec.ts
@@ -18,11 +18,14 @@ test.describe('Interactive Rebase Dialog', () => {
     await setupOpenRepository(page);
 
     await injectCommandMock(page, {
-      get_rebase_commits: [
+      get_rebase_commits: {
+        commits: [
         { oid: 'abc123', shortId: 'abc123', summary: 'First commit', author: 'Test', timestamp: Date.now() / 1000 },
         { oid: 'def456', shortId: 'def456', summary: 'Second commit', author: 'Test', timestamp: Date.now() / 1000 - 3600 },
         { oid: 'ghi789', shortId: 'ghi789', summary: 'Third commit', author: 'Test', timestamp: Date.now() / 1000 - 7200 },
-      ],
+        ],
+        mergeCount: 0,
+      },
       execute_interactive_rebase: null,
     });
   });
@@ -246,11 +249,14 @@ test.describe('Interactive Rebase Autosquash', () => {
     await setupOpenRepository(page);
 
     await injectCommandMock(page, {
-      get_rebase_commits: [
+      get_rebase_commits: {
+        commits: [
         { oid: 'abc123', shortId: 'abc123', summary: 'Add feature', author: 'Test', timestamp: Date.now() / 1000 },
         { oid: 'def456', shortId: 'def456', summary: 'fixup! Add feature', author: 'Test', timestamp: Date.now() / 1000 - 3600 },
         { oid: 'ghi789', shortId: 'ghi789', summary: 'Another commit', author: 'Test', timestamp: Date.now() / 1000 - 7200 },
-      ],
+        ],
+        mergeCount: 0,
+      },
       execute_interactive_rebase: null,
     });
   });
@@ -299,10 +305,13 @@ test.describe('Interactive Rebase - Event Propagation', () => {
     await setupOpenRepository(page);
 
     await injectCommandMock(page, {
-      get_rebase_commits: [
+      get_rebase_commits: {
+        commits: [
         { oid: 'abc123', shortId: 'abc123', summary: 'First commit', author: 'Test', timestamp: Date.now() / 1000 },
         { oid: 'def456', shortId: 'def456', summary: 'Second commit', author: 'Test', timestamp: Date.now() / 1000 - 3600 },
-      ],
+        ],
+        mergeCount: 0,
+      },
       execute_interactive_rebase: null,
     });
   });
@@ -345,10 +354,13 @@ test.describe('Interactive Rebase - Error Handling', () => {
     await setupOpenRepository(page);
 
     await injectCommandMock(page, {
-      get_rebase_commits: [
+      get_rebase_commits: {
+        commits: [
         { oid: 'abc123', shortId: 'abc123', summary: 'First commit', author: 'Test', timestamp: Date.now() / 1000 },
         { oid: 'def456', shortId: 'def456', summary: 'Second commit', author: 'Test', timestamp: Date.now() / 1000 - 3600 },
-      ],
+        ],
+        mergeCount: 0,
+      },
       execute_interactive_rebase: { __error__: 'Rebase failed: conflicts detected' },
     });
   });
@@ -423,10 +435,13 @@ test.describe('Interactive Rebase - Command Verification', () => {
     await setupOpenRepository(page);
 
     await injectCommandMock(page, {
-      get_rebase_commits: [
+      get_rebase_commits: {
+        commits: [
         { oid: 'abc123', shortId: 'abc123', summary: 'First commit', author: 'Test', timestamp: Date.now() / 1000 },
         { oid: 'def456', shortId: 'def456', summary: 'Second commit', author: 'Test', timestamp: Date.now() / 1000 - 3600 },
-      ],
+        ],
+        mergeCount: 0,
+      },
       execute_interactive_rebase: null,
     });
   });
@@ -468,10 +483,13 @@ test.describe('Interactive Rebase - Injected Error on Execute', () => {
     await setupOpenRepository(page);
 
     await injectCommandMock(page, {
-      get_rebase_commits: [
+      get_rebase_commits: {
+        commits: [
         { oid: 'abc123', shortId: 'abc123', summary: 'First commit', author: 'Test', timestamp: Date.now() / 1000 },
         { oid: 'def456', shortId: 'def456', summary: 'Second commit', author: 'Test', timestamp: Date.now() / 1000 - 3600 },
-      ],
+        ],
+        mergeCount: 0,
+      },
       execute_interactive_rebase: null,
     });
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -6176,9 +6176,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "dev": true,
       "funding": [
         {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6176,9 +6176,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.18",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
-      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
+      "version": "3.3.17",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
+      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
       "dev": true,
       "funding": [
         {

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -24,6 +24,21 @@ pub struct InteractiveRebaseOutcome {
     pub paused: bool,
 }
 
+/// The commits `git rebase -i` would list for a range, plus how many merge
+/// commits the range contained.
+///
+/// Merges are omitted from the todo (canonical `git rebase -i` does the same,
+/// and a `pick` of one fails mid-run), but omitting them SILENTLY hid that
+/// replaying the plan would flatten the topology and rewrite the merged-in side
+/// commits — from a gesture that promised only to change one commit message.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RebasePlan {
+    pub commits: Vec<RebaseCommit>,
+    /// Merge commits in the range, excluded from `commits`.
+    pub merge_count: usize,
+}
+
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct RebaseCommit {
@@ -1003,7 +1018,7 @@ pub async fn is_ancestor_of_head(path: String, oid: String) -> Result<bool> {
 
 /// Get commits between HEAD and a target ref for interactive rebase
 #[command]
-pub async fn get_rebase_commits(path: String, onto: String) -> Result<Vec<RebaseCommit>> {
+pub async fn get_rebase_commits(path: String, onto: String) -> Result<RebasePlan> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
     // Find the onto commit.
@@ -1036,6 +1051,7 @@ pub async fn get_rebase_commits(path: String, onto: String) -> Result<Vec<Rebase
     revwalk.hide(onto_oid)?;
 
     let mut commits = Vec::new();
+    let mut merge_count: usize = 0;
 
     for oid in revwalk {
         let oid = oid?;
@@ -1048,6 +1064,11 @@ pub async fn get_rebase_commits(path: String, onto: String) -> Result<Vec<Rebase
         // abort. The plain revwalk also emitted commits from the merged-in
         // side, which the user never touched and did not expect to see.
         if commit.parent_count() > 1 {
+            // Counted, not just skipped. Dropping them silently produced a plan
+            // that LOOKS linear while the range is not: replaying it flattens
+            // the merge topology and rewrites the merged-in side commits. The
+            // caller needs to know so it can warn — or refuse.
+            merge_count += 1;
             continue;
         }
 
@@ -1063,7 +1084,10 @@ pub async fn get_rebase_commits(path: String, onto: String) -> Result<Vec<Rebase
     // Reverse to get oldest first (git rebase order)
     commits.reverse();
 
-    Ok(commits)
+    Ok(RebasePlan {
+        commits,
+        merge_count,
+    })
 }
 
 /// Execute an interactive rebase using git CLI
@@ -2681,7 +2705,7 @@ mod tests {
         let result = get_rebase_commits(repo.path_str(), initial_branch).await;
         assert!(result.is_ok());
 
-        let commits = result.unwrap();
+        let commits = result.unwrap().commits;
         assert_eq!(commits.len(), 3);
 
         // Commits should be in oldest-first order (git rebase order)
@@ -2718,7 +2742,8 @@ mod tests {
 
         let commits = get_rebase_commits(repo.path_str(), base.clone())
             .await
-            .unwrap();
+            .unwrap()
+            .commits;
         assert_eq!(commits.len(), 2);
 
         // Oldest-first from get_rebase_commits, which is git's todo order.
@@ -2730,7 +2755,10 @@ mod tests {
         assert!(!outcome.paused, "and must not leave the rebase paused");
 
         // One commit above the base instead of two.
-        let after = get_rebase_commits(repo.path_str(), base).await.unwrap();
+        let after = get_rebase_commits(repo.path_str(), base)
+            .await
+            .unwrap()
+            .commits;
         assert_eq!(after.len(), 1, "the two commits became one");
         assert_eq!(
             repo.repo().state(),
@@ -2780,7 +2808,8 @@ mod tests {
 
         let commits = get_rebase_commits(repo.path_str(), base.clone())
             .await
-            .unwrap();
+            .unwrap()
+            .commits;
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].summary, "Add retry to the uploader");
         assert!(
@@ -2807,7 +2836,8 @@ mod tests {
 
         let commits = get_rebase_commits(repo.path_str(), base.clone())
             .await
-            .unwrap();
+            .unwrap()
+            .commits;
         // An `edit` line pauses the rebase, which is the state Abort exists for.
         let todo = format!("edit {}\npick {}\n", commits[0].oid, commits[1].oid);
 
@@ -2892,7 +2922,10 @@ mod tests {
             .expect("a clean merge");
         repo.create_commit("after", &[("a.txt", "a")]);
 
-        let plan = get_rebase_commits(repo.path_str(), base).await.unwrap();
+        let plan = get_rebase_commits(repo.path_str(), base)
+            .await
+            .unwrap()
+            .commits;
         let git_repo = repo.repo();
         for c in &plan {
             let commit = git_repo.find_commit(c.oid.parse().unwrap()).unwrap();
@@ -3148,7 +3181,8 @@ mod tests {
 
         let commits = get_rebase_commits(repo.path_str(), base.clone())
             .await
-            .unwrap();
+            .unwrap()
+            .commits;
         let todo = commits
             .iter()
             .map(|c| format!("pick {}", c.oid))
@@ -3160,7 +3194,10 @@ mod tests {
             .expect("an all-pick interactive rebase must run");
         assert!(!outcome.paused);
 
-        let after = get_rebase_commits(repo.path_str(), base).await.unwrap();
+        let after = get_rebase_commits(repo.path_str(), base)
+            .await
+            .unwrap()
+            .commits;
         assert_eq!(after.len(), 2, "both commits survive an all-pick plan");
     }
 
@@ -3174,14 +3211,18 @@ mod tests {
 
         let commits = get_rebase_commits(repo.path_str(), base.clone())
             .await
-            .unwrap();
+            .unwrap()
+            .commits;
         let todo = format!("pick {}\ndrop {}\n", commits[0].oid, commits[1].oid);
 
         execute_interactive_rebase(repo.path_str(), base.clone(), todo)
             .await
             .expect("a drop plan must run");
 
-        let after = get_rebase_commits(repo.path_str(), base).await.unwrap();
+        let after = get_rebase_commits(repo.path_str(), base)
+            .await
+            .unwrap()
+            .commits;
         assert_eq!(after.len(), 1);
         assert!(after[0].summary.contains("keep"));
     }
@@ -3200,7 +3241,8 @@ mod tests {
 
         let commits = get_rebase_commits(repo.path_str(), format!("{}^", head_oid))
             .await
-            .expect("a revspec must resolve, not error");
+            .expect("a revspec must resolve, not error")
+            .commits;
 
         assert_eq!(commits.len(), 1, "just the tip, whose parent we asked for");
         assert_eq!(commits[0].oid, head_oid);
@@ -3214,7 +3256,10 @@ mod tests {
         repo.checkout_branch("feature");
         repo.create_commit("on feature", &[("a.txt", "a")]);
 
-        let commits = get_rebase_commits(repo.path_str(), base).await.unwrap();
+        let commits = get_rebase_commits(repo.path_str(), base)
+            .await
+            .unwrap()
+            .commits;
         assert_eq!(commits.len(), 1);
     }
 
@@ -3229,7 +3274,7 @@ mod tests {
         assert!(result.is_ok());
 
         // No commits to rebase
-        let commits = result.unwrap();
+        let commits = result.unwrap().commits;
         assert!(commits.is_empty());
     }
 
@@ -3519,6 +3564,64 @@ mod tests {
 
     /// Set up a merge conflict on shared.txt between the initial branch and
     /// "feature", ending checked out on the initial branch (merge not run).
+    /// The plan must report merges it excluded.
+    ///
+    /// Omitting them silently produced a todo that reads as a clean linear list
+    /// while the range is not linear: replaying it flattens the topology and
+    /// rewrites the merged-in side commits.
+    #[tokio::test]
+    async fn test_get_rebase_commits_reports_excluded_merges() {
+        let repo = TestRepo::with_initial_commit();
+        let base = repo.head_oid();
+        let default_branch = repo.current_branch();
+
+        // A side branch merged back in, so the range contains a merge commit.
+        repo.create_branch("side");
+        repo.checkout_branch("side");
+        repo.create_commit("Side work", &[("side.txt", "side")]);
+        repo.checkout_branch(&default_branch);
+        repo.create_commit("Main work", &[("main.txt", "main")]);
+
+        merge(repo.path_str(), "side".to_string(), Some(true), None, None)
+            .await
+            .expect("merge should succeed");
+
+        let plan = get_rebase_commits(repo.path_str(), base.to_string())
+            .await
+            .expect("plan should load");
+
+        assert_eq!(
+            plan.merge_count, 1,
+            "the excluded merge commit must be reported"
+        );
+        assert!(
+            plan.commits
+                .iter()
+                .all(|c| c.summary != "Merge branch 'side'"),
+            "merge commits stay out of the todo"
+        );
+        assert!(
+            !plan.commits.is_empty(),
+            "the non-merge commits are still listed"
+        );
+    }
+
+    /// A linear range reports nothing, so the warning stays off.
+    #[tokio::test]
+    async fn test_get_rebase_commits_reports_zero_merges_for_linear_history() {
+        let repo = TestRepo::with_initial_commit();
+        let base = repo.head_oid();
+        repo.create_commit("One", &[("a.txt", "a")]);
+        repo.create_commit("Two", &[("b.txt", "b")]);
+
+        let plan = get_rebase_commits(repo.path_str(), base.to_string())
+            .await
+            .expect("plan should load");
+
+        assert_eq!(plan.merge_count, 0);
+        assert_eq!(plan.commits.len(), 2);
+    }
+
     fn setup_conflicting_branches(repo: &TestRepo) {
         let initial_branch = repo.current_branch();
         repo.create_commit("Add shared", &[("shared.txt", "base")]);

--- a/src/components/dialogs/__tests__/lv-interactive-rebase-conflict.test.ts
+++ b/src/components/dialogs/__tests__/lv-interactive-rebase-conflict.test.ts
@@ -11,10 +11,13 @@ let executeRebaseBehavior: 'success' | 'conflict' | 'error' = 'success';
 const mockInvoke = (command: string): Promise<unknown> => {
   switch (command) {
     case 'get_rebase_commits':
-      return Promise.resolve([
-        { oid: 'abc1234567890', shortId: 'abc1234', summary: 'Commit A', action: 'pick' },
-        { oid: 'def1234567890', shortId: 'def1234', summary: 'Commit B', action: 'pick' },
-      ]);
+      return Promise.resolve({
+        commits: [
+          { oid: 'abc1234567890', shortId: 'abc1234', summary: 'Commit A', action: 'pick' },
+          { oid: 'def1234567890', shortId: 'def1234', summary: 'Commit B', action: 'pick' },
+        ],
+        mergeCount: 0,
+      });
     case 'execute_interactive_rebase':
       if (executeRebaseBehavior === 'conflict') {
         return Promise.reject({ code: 'REBASE_CONFLICT', message: 'Conflicts detected' });

--- a/src/components/dialogs/__tests__/lv-interactive-rebase-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-interactive-rebase-dialog.test.ts
@@ -57,11 +57,11 @@ function findCommands(name: string): Array<{ command: string; args?: unknown }> 
   return invokeHistory.filter((h) => h.command === name);
 }
 
-function setupDefaultMocks(commits = mockCommits): void {
+function setupDefaultMocks(commits = mockCommits, mergeCount = 0): void {
   mockInvoke = async (command: string) => {
     switch (command) {
       case 'get_rebase_commits':
-        return commits;
+        return { commits, mergeCount };
       case 'execute_interactive_rebase':
         return undefined;
       default:
@@ -514,7 +514,7 @@ describe('lv-interactive-rebase-dialog (fixture)', () => {
       mockInvoke = async (command: string) => {
         switch (command) {
           case 'get_rebase_commits':
-            return mockCommits;
+            return { commits: mockCommits, mergeCount: 0 };
           case 'execute_interactive_rebase':
             return new Promise((resolve) => { resolveExec = resolve; });
           default:
@@ -551,7 +551,7 @@ describe('lv-interactive-rebase-dialog (fixture)', () => {
       mockInvoke = async (command: string) => {
         switch (command) {
           case 'get_rebase_commits':
-            return mockCommits;
+            return { commits: mockCommits, mergeCount: 0 };
           case 'execute_interactive_rebase':
             return new Promise((resolve) => { resolveExec = resolve; });
           default:
@@ -681,7 +681,7 @@ describe('lv-interactive-rebase-dialog (fixture)', () => {
       mockInvoke = async (command: string) => {
         switch (command) {
           case 'get_rebase_commits':
-            return mockCommits;
+            return { commits: mockCommits, mergeCount: 0 };
           case 'execute_interactive_rebase':
             throw new Error('Rebase failed: conflicts detected');
           default:
@@ -709,7 +709,7 @@ describe('lv-interactive-rebase-dialog (fixture)', () => {
       mockInvoke = async (command: string) => {
         switch (command) {
           case 'get_rebase_commits':
-            return mockCommits;
+            return { commits: mockCommits, mergeCount: 0 };
           case 'execute_interactive_rebase':
             // Tauri serializes Rust errors as objects, caught by invokeCommand
             throw { code: 'REBASE_CONFLICT', message: 'Conflict during rebase' };
@@ -739,7 +739,7 @@ describe('lv-interactive-rebase-dialog (fixture)', () => {
       mockInvoke = async (command: string) => {
         switch (command) {
           case 'get_rebase_commits':
-            return mockCommits;
+            return { commits: mockCommits, mergeCount: 0 };
           case 'execute_interactive_rebase':
             throw { code: 'REBASE_CONFLICT', message: 'Conflict during rebase' };
           default:
@@ -962,6 +962,60 @@ describe('lv-interactive-rebase-dialog (fixture)', () => {
       const warning = el.shadowRoot!.querySelector('.warning-message');
       expect(warning, 'the user is told why').to.not.be.null;
       expect(warning!.textContent).to.contain('cannot be reworded by rebase');
+    });
+
+    it('refuses a reword when the range contains merge commits', async () => {
+      // The unguarded case: merges ABOVE the target. They are omitted from the
+      // plan, so it reads as a clean linear list — but replaying it flattens the
+      // merge topology and rewrites the merged-in side commits, from a gesture
+      // that promised only to change one commit message.
+      setupDefaultMocks(mockCommits, 2);
+      const el = await createDialog();
+      await el.open('main', { rewordCommitOid: 'aaa1111111111' });
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      const start = Array.from(el.shadowRoot!.querySelectorAll('button')).find((b) =>
+        /start rebase/i.test(b.textContent ?? '')
+      ) as HTMLButtonElement;
+      expect(start.disabled, 'a reword must not arm a topology-flattening rebase').to.equal(true);
+
+      const warning = el.shadowRoot!.querySelector('.warning-message');
+      expect(warning, 'the user is told why').to.not.be.null;
+      expect(warning!.textContent).to.contain('2 merge');
+      expect(warning!.textContent).to.contain('flatten');
+    });
+
+    it('warns but still allows a deliberately started rebase over merges', async () => {
+      // Opened WITHOUT a reword target: the user chose an interactive rebase, so
+      // it proceeds — but the excluded merges must be visible, not silent.
+      setupDefaultMocks(mockCommits, 1);
+      const el = await createDialog();
+      await el.open('main');
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      const warning = el.shadowRoot!.querySelector('.warning-message');
+      expect(warning, 'excluded merges must be surfaced').to.not.be.null;
+      expect(warning!.textContent).to.contain('1 merge');
+
+      const start = Array.from(el.shadowRoot!.querySelectorAll('button')).find((b) =>
+        /start rebase/i.test(b.textContent ?? '')
+      ) as HTMLButtonElement;
+      expect(start.disabled, 'a deliberate rebase is still allowed').to.equal(false);
+    });
+
+    it('shows no merge warning when the range has none', async () => {
+      setupDefaultMocks(mockCommits, 0);
+      const el = await createDialog();
+      await el.open('main');
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.querySelector('.warning-message')).to.be.null;
     });
 
     it('arms the rebase normally when the reword target IS in the plan', async () => {

--- a/src/components/dialogs/lv-interactive-rebase-dialog.ts
+++ b/src/components/dialogs/lv-interactive-rebase-dialog.ts
@@ -497,6 +497,8 @@ export class LvInteractiveRebaseDialog extends LitElement {
   @state() private warning = '';
   /** Set when open() was given a reword target the loaded plan does not contain. */
   @state() private rewordTargetMissing = false;
+  /** Merge commits in the rebase range; they are excluded from the plan. */
+  @state() private mergeCountInRange = 0;
   @state() private draggedIndex: number | null = null;
   @state() private dropTargetIndex: number | null = null;
   @state() private showPreview = true;
@@ -574,6 +576,23 @@ export class LvInteractiveRebaseDialog extends LitElement {
           'rewritten here. Merge commits cannot be reworded by rebase.';
         return;
       }
+
+      // Merges ABOVE the target are the unguarded case. The plan omits them, so
+      // it reads as a clean linear list, but replaying it flattens the merge
+      // topology and rewrites the merged-in side commits — a destructive
+      // history rewrite from a gesture that promised to change one commit
+      // message. Refuse, the same way an unrebaseable target is refused.
+      if (this.mergeCountInRange > 0) {
+        this.rewordTargetMissing = true;
+        this.warning =
+          `This commit cannot be reworded here: the range contains ` +
+          `${this.mergeCountInRange} merge ` +
+          `${this.mergeCountInRange === 1 ? 'commit' : 'commits'}, and rebasing ` +
+          `would flatten ${this.mergeCountInRange === 1 ? 'it' : 'them'} and ` +
+          `rewrite the merged-in commits. Reword it from an interactive rebase ` +
+          `you start deliberately instead.`;
+        return;
+      }
       this.commits = this.commits.map((c) =>
         c.oid === options.rewordCommitOid
           ? { ...c, action: 'reword' as RebaseAction, newMessage: this.fullMessage(c) }
@@ -609,6 +628,7 @@ export class LvInteractiveRebaseDialog extends LitElement {
     this.error = '';
     this.warning = '';
     this.rewordTargetMissing = false;
+    this.mergeCountInRange = 0;
     this.draggedIndex = null;
     this.dropTargetIndex = null;
     this.showPreview = true;
@@ -624,10 +644,14 @@ export class LvInteractiveRebaseDialog extends LitElement {
       const result = await gitService.getRebaseCommits(this.pinnedRepoPath, this.onto);
 
       if (result.success) {
-        this.commits = (result.data || []).map(c => ({
+        this.commits = (result.data?.commits ?? []).map(c => ({
           ...c,
           action: 'pick' as RebaseAction,
         }));
+        // Merges are excluded from the todo, so a range containing them yields
+        // a plan that LOOKS linear while the history is not. Replaying it
+        // flattens the topology and rewrites the merged-in side commits.
+        this.mergeCountInRange = result.data?.mergeCount ?? 0;
       } else {
         this.error = result.error?.message ?? 'Failed to load commits';
       }
@@ -1222,6 +1246,15 @@ export class LvInteractiveRebaseDialog extends LitElement {
             </div>
           </div>
 
+          ${this.mergeCountInRange > 0 && !this.rewordTargetMissing
+            ? html`<div class="warning-message">
+                This range contains ${this.mergeCountInRange} merge
+                ${this.mergeCountInRange === 1 ? 'commit' : 'commits'}, which are not
+                listed below. Rebasing will flatten
+                ${this.mergeCountInRange === 1 ? 'it' : 'them'} and rewrite the
+                commits that were merged in.
+              </div>`
+            : nothing}
           ${this.warning
             ? html`<div class="warning-message">${this.warning}</div>`
             : nothing}

--- a/src/components/dialogs/lv-interactive-rebase-dialog.ts
+++ b/src/components/dialogs/lv-interactive-rebase-dialog.ts
@@ -495,8 +495,13 @@ export class LvInteractiveRebaseDialog extends LitElement {
   @state() private executing = false;
   @state() private error = '';
   @state() private warning = '';
-  /** Set when open() was given a reword target the loaded plan does not contain. */
-  @state() private rewordTargetMissing = false;
+  /**
+   * Set when open()'s reword request was refused, so the dialog shows the
+   * reason and keeps Start Rebase disabled. Two causes: the target is not in
+   * the loaded plan, or the range contains merge commits a rebase would
+   * flatten.
+   */
+  @state() private rewordRefused = false;
   /** Merge commits in the rebase range; they are excluded from the plan. */
   @state() private mergeCountInRange = 0;
   @state() private draggedIndex: number | null = null;
@@ -570,7 +575,7 @@ export class LvInteractiveRebaseDialog extends LitElement {
       // that would destroy the very commit the user asked to reword. Refuse
       // instead: say so, and keep Start Rebase disabled.
       if (!this.commits.some((c) => c.oid === options.rewordCommitOid)) {
-        this.rewordTargetMissing = true;
+        this.rewordRefused = true;
         this.warning =
           'This commit is not part of the rebase plan, so its message cannot be ' +
           'rewritten here. Merge commits cannot be reworded by rebase.';
@@ -583,7 +588,7 @@ export class LvInteractiveRebaseDialog extends LitElement {
       // history rewrite from a gesture that promised to change one commit
       // message. Refuse, the same way an unrebaseable target is refused.
       if (this.mergeCountInRange > 0) {
-        this.rewordTargetMissing = true;
+        this.rewordRefused = true;
         this.warning =
           `This commit cannot be reworded here: the range contains ` +
           `${this.mergeCountInRange} merge ` +
@@ -627,7 +632,7 @@ export class LvInteractiveRebaseDialog extends LitElement {
     this.executing = false;
     this.error = '';
     this.warning = '';
-    this.rewordTargetMissing = false;
+    this.rewordRefused = false;
     this.mergeCountInRange = 0;
     this.draggedIndex = null;
     this.dropTargetIndex = null;
@@ -1034,7 +1039,7 @@ export class LvInteractiveRebaseDialog extends LitElement {
   private get canExecute(): boolean {
     return (
       this.commits.length > 0 &&
-      !this.rewordTargetMissing &&
+      !this.rewordRefused &&
       !this.executing &&
       !this.hasValidationErrors()
     );
@@ -1246,7 +1251,7 @@ export class LvInteractiveRebaseDialog extends LitElement {
             </div>
           </div>
 
-          ${this.mergeCountInRange > 0 && !this.rewordTargetMissing
+          ${this.mergeCountInRange > 0 && !this.rewordRefused
             ? html`<div class="warning-message">
                 This range contains ${this.mergeCountInRange} merge
                 ${this.mergeCountInRange === 1 ? 'commit' : 'commits'}, which are not

--- a/src/services/__tests__/merge-rebase.service.test.ts
+++ b/src/services/__tests__/merge-rebase.service.test.ts
@@ -136,18 +136,26 @@ describe('git.service - Rebase operations', () => {
   });
 
   describe('getRebaseCommits', () => {
-    it('invokes get_rebase_commits with path and onto', async () => {
-      const mockCommits = [
-        { oid: 'abc', summary: 'commit 1', action: 'pick' },
-        { oid: 'def', summary: 'commit 2', action: 'pick' },
-      ];
-      mockInvoke = () => Promise.resolve(mockCommits);
+    // The command returns a PLAN — the todo commits plus the count of merge
+    // commits the todo excludes — not a bare commit array. Mocking the old
+    // shape here meant the service test agreed with nothing the backend sends.
+    it('invokes get_rebase_commits with path and onto, and returns the plan', async () => {
+      const mockPlan = {
+        commits: [
+          { oid: 'abc', summary: 'commit 1', action: 'pick' },
+          { oid: 'def', summary: 'commit 2', action: 'pick' },
+        ],
+        mergeCount: 1,
+      };
+      mockInvoke = () => Promise.resolve(mockPlan);
 
       const result = await getRebaseCommits('/test/repo', 'main');
       expect(lastInvokedCommand).to.equal('get_rebase_commits');
       expect(lastInvokedArgs).to.deep.equal({ path: '/test/repo', onto: 'main' });
       expect(result.success).to.be.true;
-      expect(result.data).to.deep.equal(mockCommits);
+      expect(result.data).to.deep.equal(mockPlan);
+      expect(result.data?.commits).to.have.length(2);
+      expect(result.data?.mergeCount).to.equal(1);
     });
   });
 

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -231,6 +231,7 @@ import type {
   Stash,
   StashShowResult,
   RebaseCommit,
+  RebasePlan,
   RebaseState,
   RebaseTodo,
   RebaseTodoEntry,
@@ -1284,8 +1285,8 @@ export async function abortRebase(
 export async function getRebaseCommits(
   path: string,
   onto: string,
-): Promise<CommandResult<RebaseCommit[]>> {
-  return invokeCommand<RebaseCommit[]>("get_rebase_commits", { path, onto });
+): Promise<CommandResult<RebasePlan>> {
+  return invokeCommand<RebasePlan>("get_rebase_commits", { path, onto });
 }
 
 /** Is `oid` reachable from HEAD? Gates the reword/amend rebase route. */

--- a/src/types/git.types.ts
+++ b/src/types/git.types.ts
@@ -160,6 +160,20 @@ export interface RebaseCommit {
   action: string;
 }
 
+/**
+ * The commits `git rebase -i` would list for a range, plus how many merge
+ * commits the range contained.
+ *
+ * Merges are omitted from the todo, but the count must reach the UI: replaying
+ * a plan over a range containing merges flattens the topology and rewrites the
+ * merged-in side commits.
+ */
+export interface RebasePlan {
+  commits: RebaseCommit[];
+  /** Merge commits in the range, excluded from `commits`. */
+  mergeCount: number;
+}
+
 export type RebaseAction = 'pick' | 'reword' | 'edit' | 'squash' | 'fixup' | 'drop';
 
 /**


### PR DESCRIPTION
## The problem

`get_rebase_commits` omits merge commits from the todo — canonical `git rebase -i` does the same, and a `pick` of one fails mid-run — but it omitted them **silently**, while its revwalk still emitted the merged-in *side* commits.

So a range containing merges produced a plan that reads as a clean linear list, with side-branch commits interleaved and no sign anything was left out. Replaying it **flattens the merge topology and rewrites those side commits**.

The graph's **Reword** and **Amend** route any non-HEAD commit here as `<oid>^..HEAD`, guarded only against the *target* being a merge. Merges **above** the target — PR merges on main, "merge main into feature" — are common and passed every guard. A gesture that promised to change one commit message armed a destructive history rewrite.

`app-shell.ts` documents this exact failure mode for the merge-*target* case; the merges-in-range case was unhandled and unwarned.

## The fix

`get_rebase_commits` returns a plan carrying the count of merges it excluded.

- **Reword** refuses when that count is non-zero, the same way it already refuses an unrebaseable target — a reword should never flatten topology as a side effect.
- **A deliberately started rebase** gets a warning banner and still proceeds. The user chose an interactive rebase there; they just need to see what's excluded.

## Note for reviewers

The return shape changed from `Vec<RebaseCommit>` to `RebasePlan { commits, mergeCount }`. That ripples into the service type, the dialog's load path, and the existing test mocks, which now read `.commits`. The alternative — a second command just to count merges — leaves the two answers able to disagree, so I took the shape change.

## Tests

**Backend:** a range with a real merge reports `mergeCount: 1` and keeps the merge out of the todo while still listing the non-merge commits; a linear range reports `0`.

**Dialog:** a reword over a range with merges disables Start Rebase and explains why; a deliberate rebase warns but stays enabled; a clean range shows no banner at all.

## Verification

`cargo test --lib` (2079), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `npm run typecheck` and the full frontend suite (4,375) all pass on this branch.

Found by a 40-reviewer parallel review; confirmed by an adversarial verification pass that traced the guard gap.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_