### PR TITLE
Stop test_stash_show_basic failing on a same-size edit

### DIFF
--- a/src-tauri/src/commands/stash.rs
+++ b/src-tauri/src/commands/stash.rs
@@ -556,8 +556,15 @@ mod tests {
         // Create and commit a tracked file
         setup_tracked_file(&repo, "file.txt", "original content");
 
-        // Modify and stash
-        repo.create_file("file.txt", "modified content");
+        // Modify and stash.
+        //
+        // The edit must change the file's SIZE. "modified content" is the same
+        // 16 bytes as "original content", and the write lands in the same
+        // timestamp granularity bucket as the index git just wrote — the
+        // racily-clean case, where a same-size edit can be judged unchanged by
+        // stat alone. The stash then captured nothing and this test failed on
+        // `files.len()` with 0, on CI only and only sometimes.
+        repo.create_file("file.txt", "modified content, now a different length");
         create_stash(repo.path_str(), Some("Show test".to_string()), None)
             .await
             .unwrap();


### PR DESCRIPTION
## Symptom

`Test Backend` went red on **#323** with:

```
---- commands::stash::tests::test_stash_show_basic stdout ----
assertion `left == right` failed
  left: 0
 right: 1
```

That is `assert_eq!(show.files.len(), 1)` — the stash captured nothing. #323's diff is frontend-only (the command palette), so it cannot have caused this.

## Root cause

Not a mystery flake. The fixture is:

```rust
setup_tracked_file(&repo, "file.txt", "original content");  // commit → writes index
repo.create_file("file.txt", "modified content");           // modify
```

`"original content"` and `"modified content"` are **both exactly 16 bytes**, and the modification happens immediately after the commit that wrote the index. That is git's *racily clean* case: when a file's mtime falls in the same timestamp-granularity bucket as the index write and the size is unchanged, the entry can be judged unchanged by `stat` alone. `create_stash` then finds nothing to stash, `stash_show` reports zero files, and the assertion fails.

It reproduces only where timestamp granularity is coarse enough — which is why it passes locally (12/12 in isolation, 8/8 full-suite runs here) and fails intermittently on CI.

## Fix

Make the edit change the file's **size**. No stat comparison can miss that, regardless of mtime granularity:

```rust
repo.create_file("file.txt", "modified content, now a different length");
```

Test-only, one line plus a comment explaining the trap so it does not come back. This was the only same-size pair among the stash fixtures — the others already differ in length (`"content"` → `"modified"`, `"original"` → `"stashed content"`, etc.).

## Why its own PR

The failure can land on any PR's `Test Backend`, so it is worth merging independently rather than riding along with an unrelated change — the same reasoning as #342.

Full gate green: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, 2077 backend tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_