### PR TITLE
Take the safe Dependabot bumps, and auto-merge future ones when CI is green

### DIFF
--- a/.github/scripts/dependabot-auto-merge.mjs
+++ b/.github/scripts/dependabot-auto-merge.mjs
@@ -159,7 +159,14 @@ async function checksAreGreen({ github, owner, repo, sha }) {
     per_page: 100,
   });
   const relevant = runs.filter(
-    (workflowRun) => workflowRun.name !== SELF_WORKFLOW_NAME && PR_EVENTS.has(workflowRun.event),
+    (workflowRun) =>
+      // Scope to this commit here rather than trusting the `head_sha` query
+      // parameter. This is the predicate the whole safety argument rests on,
+      // and it also drops the superseded runs an earlier push left behind,
+      // which are frequently cancelled or still in progress.
+      workflowRun.head_sha === sha &&
+      workflowRun.name !== SELF_WORKFLOW_NAME &&
+      PR_EVENTS.has(workflowRun.event),
   );
 
   if (relevant.length === 0) {

--- a/.github/scripts/dependabot-auto-merge.mjs
+++ b/.github/scripts/dependabot-auto-merge.mjs
@@ -7,118 +7,119 @@ import { decide } from './dependabot-policy.mjs';
  */
 const SELF_CHECK_NAME = 'Auto-merge';
 
+/** Must match the `name:` at the top of dependabot-auto-merge.yml. */
+const SELF_WORKFLOW_NAME = 'Dependabot auto-merge';
+
 /** Identifies the comment this job leaves, so it only ever leaves one. */
 const COMMENT_MARKER = '<!-- dependabot-auto-merge -->';
 
 const DEPENDABOT = 'dependabot[bot]';
 
-/** Check conclusions that do not stand in the way of a merge. */
+/** Conclusions that do not stand in the way of a merge. */
 const PASSING = new Set(['success', 'neutral', 'skipped']);
 
+/** Events whose workflow runs are the pull request's own checks. */
+const PR_EVENTS = new Set(['pull_request', 'pull_request_target']);
+
 /**
- * Merges the Dependabot pull request whose checks just finished, if the update
- * is one the policy trusts CI to have vetted on its own.
+ * Merges Dependabot pull requests whose checks have all passed.
  *
  * Called from .github/workflows/dependabot-auto-merge.yml via actions/github-script,
  * which supplies an authenticated Octokit as `github`, the event payload as
  * `context`, and @actions/core as `core`.
+ *
+ * A `workflow_run` event considers the one pull request whose checks just
+ * finished. Any other event (the hourly sweep, or a manual dispatch) considers
+ * every open Dependabot pull request, which is what makes a dropped or missing
+ * webhook self-correcting rather than a pull request stuck forever.
  */
 export async function run({ github, context, core }) {
   const { owner, repo } = context.repo;
-  const workflowRun = context.payload.workflow_run;
-  const defaultBranch = context.payload.repository.default_branch;
-  const branch = workflowRun.head_branch;
+  const defaultBranch =
+    context.payload.repository?.default_branch ??
+    (await github.rest.repos.get({ owner, repo })).data.default_branch;
 
-  const skip = async (message) => {
-    core.info(message);
-    await core.summary.addRaw(message, true).write();
-    return { merged: false, reason: message };
-  };
+  const numbers = await candidates({ github, context, owner, repo, defaultBranch });
+  if (numbers.length === 0) {
+    return finish(core, [{ merged: false, reason: 'No open Dependabot pull request to consider.' }]);
+  }
 
-  const open = await github.rest.pulls.list({
+  const results = [];
+  for (const number of numbers) {
+    results.push(await consider({ github, core, owner, repo, number, defaultBranch }));
+  }
+  return finish(core, results);
+}
+
+async function finish(core, results) {
+  for (const result of results) core.info(result.reason);
+  await core.summary.addRaw(results.map((result) => result.reason).join('\n\n'), true).write();
+  return results;
+}
+
+async function candidates({ github, context, owner, repo, defaultBranch }) {
+  if (context.eventName === 'workflow_run') {
+    const branch = context.payload.workflow_run.head_branch;
+    const open = await github.rest.pulls.list({
+      owner,
+      repo,
+      state: 'open',
+      head: `${owner}:${branch}`,
+    });
+    return open.data.map((pr) => pr.number);
+  }
+
+  const open = await github.paginate(github.rest.pulls.list, {
     owner,
     repo,
     state: 'open',
-    head: `${owner}:${branch}`,
-  });
-  if (open.data.length !== 1) {
-    return skip(`Expected exactly one open pull request for ${branch}, found ${open.data.length}.`);
-  }
-
-  // Re-read the pull request rather than trusting the list entry: the event may
-  // be minutes old by the time this job gets a runner.
-  const { data: pr } = await github.rest.pulls.get({
-    owner,
-    repo,
-    pull_number: open.data[0].number,
-  });
-
-  if (pr.user.login !== DEPENDABOT) {
-    return skip(`#${pr.number} was opened by ${pr.user.login}, not Dependabot.`);
-  }
-  if (pr.draft) {
-    return skip(`#${pr.number} is a draft.`);
-  }
-  if (pr.base.ref !== defaultBranch) {
-    return skip(`#${pr.number} targets ${pr.base.ref}, not ${defaultBranch}.`);
-  }
-  if (pr.head.sha !== workflowRun.head_sha) {
-    return skip(
-      `#${pr.number} moved to ${pr.head.sha.slice(0, 7)} since these checks ran on ${workflowRun.head_sha.slice(0, 7)}.`,
-    );
-  }
-
-  // The triggering workflow passed, but a pull request here runs more than one.
-  // Every check on the head commit has to be green, not just the one that woke
-  // this job.
-  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
-    owner,
-    repo,
-    ref: pr.head.sha,
+    base: defaultBranch,
     per_page: 100,
   });
-  const unfinished = checkRuns.filter(
-    (check) =>
-      check.name !== SELF_CHECK_NAME &&
-      !(check.status === 'completed' && PASSING.has(check.conclusion)),
-  );
-  if (unfinished.length > 0) {
-    const names = unfinished.map((check) => `${check.name} (${check.conclusion ?? check.status})`);
-    return skip(`#${pr.number} still has checks that have not passed: ${names.join(', ')}.`);
+  return open.filter((pr) => pr.user?.login === DEPENDABOT && !pr.draft).map((pr) => pr.number);
+}
+
+async function consider({ github, core, owner, repo, number, defaultBranch }) {
+  // Re-read the pull request rather than trusting the list entry: the event may
+  // be minutes old by the time this job gets a runner.
+  const { data: pr } = await github.rest.pulls.get({ owner, repo, pull_number: number });
+
+  if (pr.user.login !== DEPENDABOT) {
+    return { merged: false, reason: `#${number} was opened by ${pr.user.login}, not Dependabot.` };
+  }
+  if (pr.draft) {
+    return { merged: false, reason: `#${number} is a draft.` };
+  }
+  if (pr.state !== 'open') {
+    return { merged: false, reason: `#${number} is ${pr.state}.` };
+  }
+  if (pr.base.ref !== defaultBranch) {
+    return { merged: false, reason: `#${number} targets ${pr.base.ref}, not ${defaultBranch}.` };
   }
 
-  const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
-    owner,
-    repo,
-    ref: pr.head.sha,
-  });
-  // A repository with no commit statuses at all reports "pending", so only a
-  // non-success state with statuses actually present counts against us.
-  if (combined.statuses.length > 0 && combined.state !== 'success') {
-    return skip(`#${pr.number} has commit statuses in state "${combined.state}".`);
+  const readiness = await checksAreGreen({ github, owner, repo, sha: pr.head.sha });
+  if (!readiness.ready) {
+    return { merged: false, reason: `#${number} is not ready: ${readiness.reason}` };
   }
 
   const commits = await github.paginate(github.rest.pulls.listCommits, {
     owner,
     repo,
-    pull_number: pr.number,
+    pull_number: number,
     per_page: 100,
   });
   const decision = decide(commits.map((entry) => entry.commit.message));
 
   if (!decision.merge) {
-    core.info(`Holding #${pr.number}: ${decision.reason}`);
-    await explainOnce({ github, owner, repo, pr, reason: decision.reason });
-    await core.summary.addRaw(`Held #${pr.number}. ${decision.reason}`, true).write();
-    return { merged: false, reason: decision.reason };
+    await explainOnce({ github, owner, repo, number, reason: decision.reason });
+    return { merged: false, reason: `Held #${number}. ${decision.reason}` };
   }
 
-  core.info(`Merging #${pr.number}: ${decision.reason}`);
   try {
     await github.rest.pulls.merge({
       owner,
       repo,
-      pull_number: pr.number,
+      pull_number: number,
       merge_method: 'squash',
       // Refuse to merge anything other than the commit that was tested.
       sha: pr.head.sha,
@@ -126,19 +127,84 @@ export async function run({ github, context, core }) {
   } catch (error) {
     if (error.status === 401 || error.status === 403) {
       core.setFailed(
-        `Not permitted to merge #${pr.number}: ${error.message}. Check that Actions has ` +
+        `Not permitted to merge #${number}: ${error.message}. Check that Actions has ` +
           'write access under Settings > Actions > General > Workflow permissions, or supply ' +
           'a DEPENDABOT_AUTOMERGE_TOKEN secret.',
       );
-      return { merged: false, reason: error.message };
+      return { merged: false, reason: `Could not merge #${number}: ${error.message}` };
     }
     // 405 and 409 mean the branch went stale or conflicted between the check
     // and the merge. Dependabot rebases and CI runs again, which comes back here.
-    return skip(`Could not merge #${pr.number} right now: ${error.message}`);
+    return { merged: false, reason: `Could not merge #${number} right now: ${error.message}` };
   }
 
-  await core.summary.addRaw(`Merged #${pr.number}. ${decision.reason}`, true).write();
-  return { merged: true, reason: decision.reason };
+  return { merged: true, reason: `Merged #${number}. ${decision.reason}` };
+}
+
+/**
+ * Decides whether every check on a commit has passed.
+ *
+ * Workflow runs are the authority for GitHub Actions, because CodeQL is
+ * configured through default setup and so has no file in .github/workflows to
+ * enumerate. Check runs and commit statuses cover anything reported by another
+ * app. Requiring at least one workflow run closes the window just after a push
+ * where nothing has registered yet and "no failures" would otherwise be
+ * vacuously true.
+ */
+async function checksAreGreen({ github, owner, repo, sha }) {
+  const runs = await github.paginate(github.rest.actions.listWorkflowRunsForRepo, {
+    owner,
+    repo,
+    head_sha: sha,
+    per_page: 100,
+  });
+  const relevant = runs.filter(
+    (workflowRun) => workflowRun.name !== SELF_WORKFLOW_NAME && PR_EVENTS.has(workflowRun.event),
+  );
+
+  if (relevant.length === 0) {
+    return { ready: false, reason: `no workflow runs have registered for ${sha.slice(0, 7)} yet.` };
+  }
+
+  const unfinished = relevant.filter(
+    (workflowRun) =>
+      !(workflowRun.status === 'completed' && PASSING.has(workflowRun.conclusion)),
+  );
+  if (unfinished.length > 0) {
+    const names = unfinished.map(
+      (workflowRun) => `${workflowRun.name} (${workflowRun.conclusion ?? workflowRun.status})`,
+    );
+    return { ready: false, reason: `waiting on ${names.join(', ')}.` };
+  }
+
+  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+    owner,
+    repo,
+    ref: sha,
+    per_page: 100,
+  });
+  const failing = checkRuns.filter(
+    (check) =>
+      check.name !== SELF_CHECK_NAME &&
+      !(check.status === 'completed' && PASSING.has(check.conclusion)),
+  );
+  if (failing.length > 0) {
+    const names = failing.map((check) => `${check.name} (${check.conclusion ?? check.status})`);
+    return { ready: false, reason: `waiting on ${names.join(', ')}.` };
+  }
+
+  const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
+    owner,
+    repo,
+    ref: sha,
+  });
+  // A commit with no statuses at all reports "pending", so only a non-success
+  // state with statuses actually present counts against us.
+  if (combined.statuses.length > 0 && combined.state !== 'success') {
+    return { ready: false, reason: `commit statuses are in state "${combined.state}".` };
+  }
+
+  return { ready: true, reason: 'every check passed.' };
 }
 
 /**
@@ -146,11 +212,11 @@ export async function run({ github, context, core }) {
  * rebases often and every rebase re-runs CI, so this would otherwise repeat the
  * same note on every push.
  */
-async function explainOnce({ github, owner, repo, pr, reason }) {
+async function explainOnce({ github, owner, repo, number, reason }) {
   const comments = await github.paginate(github.rest.issues.listComments, {
     owner,
     repo,
-    issue_number: pr.number,
+    issue_number: number,
     per_page: 100,
   });
   if (comments.some((comment) => comment.body?.includes(COMMENT_MARKER))) return;
@@ -158,7 +224,7 @@ async function explainOnce({ github, owner, repo, pr, reason }) {
   await github.rest.issues.createComment({
     owner,
     repo,
-    issue_number: pr.number,
+    issue_number: number,
     body: [
       COMMENT_MARKER,
       '**Not auto-merging this one.** Every check passed, so the build is fine — but this update falls outside the auto-merge policy and wants a human decision.',

--- a/.github/scripts/dependabot-auto-merge.mjs
+++ b/.github/scripts/dependabot-auto-merge.mjs
@@ -1,0 +1,171 @@
+import { decide } from './dependabot-policy.mjs';
+
+/**
+ * This job's own check run, which is still in progress while it inspects the
+ * head commit. Excluded from the "everything is green" test so it cannot block
+ * itself. Must match the `name:` of the job in dependabot-auto-merge.yml.
+ */
+const SELF_CHECK_NAME = 'Auto-merge';
+
+/** Identifies the comment this job leaves, so it only ever leaves one. */
+const COMMENT_MARKER = '<!-- dependabot-auto-merge -->';
+
+const DEPENDABOT = 'dependabot[bot]';
+
+/** Check conclusions that do not stand in the way of a merge. */
+const PASSING = new Set(['success', 'neutral', 'skipped']);
+
+/**
+ * Merges the Dependabot pull request whose checks just finished, if the update
+ * is one the policy trusts CI to have vetted on its own.
+ *
+ * Called from .github/workflows/dependabot-auto-merge.yml via actions/github-script,
+ * which supplies an authenticated Octokit as `github`, the event payload as
+ * `context`, and @actions/core as `core`.
+ */
+export async function run({ github, context, core }) {
+  const { owner, repo } = context.repo;
+  const workflowRun = context.payload.workflow_run;
+  const defaultBranch = context.payload.repository.default_branch;
+  const branch = workflowRun.head_branch;
+
+  const skip = async (message) => {
+    core.info(message);
+    await core.summary.addRaw(message, true).write();
+    return { merged: false, reason: message };
+  };
+
+  const open = await github.rest.pulls.list({
+    owner,
+    repo,
+    state: 'open',
+    head: `${owner}:${branch}`,
+  });
+  if (open.data.length !== 1) {
+    return skip(`Expected exactly one open pull request for ${branch}, found ${open.data.length}.`);
+  }
+
+  // Re-read the pull request rather than trusting the list entry: the event may
+  // be minutes old by the time this job gets a runner.
+  const { data: pr } = await github.rest.pulls.get({
+    owner,
+    repo,
+    pull_number: open.data[0].number,
+  });
+
+  if (pr.user.login !== DEPENDABOT) {
+    return skip(`#${pr.number} was opened by ${pr.user.login}, not Dependabot.`);
+  }
+  if (pr.draft) {
+    return skip(`#${pr.number} is a draft.`);
+  }
+  if (pr.base.ref !== defaultBranch) {
+    return skip(`#${pr.number} targets ${pr.base.ref}, not ${defaultBranch}.`);
+  }
+  if (pr.head.sha !== workflowRun.head_sha) {
+    return skip(
+      `#${pr.number} moved to ${pr.head.sha.slice(0, 7)} since these checks ran on ${workflowRun.head_sha.slice(0, 7)}.`,
+    );
+  }
+
+  // The triggering workflow passed, but a pull request here runs more than one.
+  // Every check on the head commit has to be green, not just the one that woke
+  // this job.
+  const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+    owner,
+    repo,
+    ref: pr.head.sha,
+    per_page: 100,
+  });
+  const unfinished = checkRuns.filter(
+    (check) =>
+      check.name !== SELF_CHECK_NAME &&
+      !(check.status === 'completed' && PASSING.has(check.conclusion)),
+  );
+  if (unfinished.length > 0) {
+    const names = unfinished.map((check) => `${check.name} (${check.conclusion ?? check.status})`);
+    return skip(`#${pr.number} still has checks that have not passed: ${names.join(', ')}.`);
+  }
+
+  const { data: combined } = await github.rest.repos.getCombinedStatusForRef({
+    owner,
+    repo,
+    ref: pr.head.sha,
+  });
+  // A repository with no commit statuses at all reports "pending", so only a
+  // non-success state with statuses actually present counts against us.
+  if (combined.statuses.length > 0 && combined.state !== 'success') {
+    return skip(`#${pr.number} has commit statuses in state "${combined.state}".`);
+  }
+
+  const commits = await github.paginate(github.rest.pulls.listCommits, {
+    owner,
+    repo,
+    pull_number: pr.number,
+    per_page: 100,
+  });
+  const decision = decide(commits.map((entry) => entry.commit.message));
+
+  if (!decision.merge) {
+    core.info(`Holding #${pr.number}: ${decision.reason}`);
+    await explainOnce({ github, owner, repo, pr, reason: decision.reason });
+    await core.summary.addRaw(`Held #${pr.number}. ${decision.reason}`, true).write();
+    return { merged: false, reason: decision.reason };
+  }
+
+  core.info(`Merging #${pr.number}: ${decision.reason}`);
+  try {
+    await github.rest.pulls.merge({
+      owner,
+      repo,
+      pull_number: pr.number,
+      merge_method: 'squash',
+      // Refuse to merge anything other than the commit that was tested.
+      sha: pr.head.sha,
+    });
+  } catch (error) {
+    if (error.status === 401 || error.status === 403) {
+      core.setFailed(
+        `Not permitted to merge #${pr.number}: ${error.message}. Check that Actions has ` +
+          'write access under Settings > Actions > General > Workflow permissions, or supply ' +
+          'a DEPENDABOT_AUTOMERGE_TOKEN secret.',
+      );
+      return { merged: false, reason: error.message };
+    }
+    // 405 and 409 mean the branch went stale or conflicted between the check
+    // and the merge. Dependabot rebases and CI runs again, which comes back here.
+    return skip(`Could not merge #${pr.number} right now: ${error.message}`);
+  }
+
+  await core.summary.addRaw(`Merged #${pr.number}. ${decision.reason}`, true).write();
+  return { merged: true, reason: decision.reason };
+}
+
+/**
+ * Says why a pull request was held, at most once per pull request. Dependabot
+ * rebases often and every rebase re-runs CI, so this would otherwise repeat the
+ * same note on every push.
+ */
+async function explainOnce({ github, owner, repo, pr, reason }) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    owner,
+    repo,
+    issue_number: pr.number,
+    per_page: 100,
+  });
+  if (comments.some((comment) => comment.body?.includes(COMMENT_MARKER))) return;
+
+  await github.rest.issues.createComment({
+    owner,
+    repo,
+    issue_number: pr.number,
+    body: [
+      COMMENT_MARKER,
+      '**Not auto-merging this one.** Every check passed, so the build is fine — but this update falls outside the auto-merge policy and wants a human decision.',
+      '',
+      reason,
+      '',
+      'Merge it by hand once you have looked it over. The policy lives in `.github/scripts/dependabot-policy.mjs`.',
+    ].join('\n'),
+  });
+}

--- a/.github/scripts/dependabot-auto-merge.test.mjs
+++ b/.github/scripts/dependabot-auto-merge.test.mjs
@@ -11,6 +11,8 @@ const workflow = (file) =>
 const AUTO_MERGE_YML = workflow('dependabot-auto-merge.yml');
 
 const HEAD_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+/** An earlier push on the same branch. */
+const STALE_SHA = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
 
 function dependabotCommit({ name = 'glob', version = '0.3.4', updateType = 'patch' } = {}) {
   return [
@@ -28,7 +30,13 @@ function dependabotCommit({ name = 'glob', version = '0.3.4', updateType = 'patc
   ].join('\n');
 }
 
-const green = (name) => ({ name, event: 'pull_request', status: 'completed', conclusion: 'success' });
+const green = (name, head_sha = HEAD_SHA) => ({
+  name,
+  head_sha,
+  event: 'pull_request',
+  status: 'completed',
+  conclusion: 'success',
+});
 
 /**
  * Builds a world where everything is in order, so each test can break exactly
@@ -182,14 +190,29 @@ test('refuses a pull request aimed somewhere other than the default branch', asy
 });
 
 test('waits for a workflow that is still running', async () => {
-  h.state.workflowRuns.push({ name: 'CodeQL', event: 'pull_request', status: 'in_progress', conclusion: null });
+  h.state.workflowRuns.push({
+    name: 'CodeQL',
+    head_sha: HEAD_SHA,
+    event: 'pull_request',
+    status: 'in_progress',
+    conclusion: null,
+  });
 
   assert.match(only(await run(h)).reason, /waiting on CodeQL \(in_progress\)/);
   assert.equal(h.calls.merged.length, 0);
 });
 
 test('refuses when a workflow other than the trigger failed', async () => {
-  h.state.workflowRuns = [green('CI'), { name: 'Build & Release', event: 'pull_request', status: 'completed', conclusion: 'failure' }];
+  h.state.workflowRuns = [
+    green('CI'),
+    {
+      name: 'Build & Release',
+      head_sha: HEAD_SHA,
+      event: 'pull_request',
+      status: 'completed',
+      conclusion: 'failure',
+    },
+  ];
 
   assert.match(only(await run(h)).reason, /Build & Release \(failure\)/);
   assert.equal(h.calls.merged.length, 0);
@@ -203,9 +226,29 @@ test('refuses a commit that no workflow has registered a run for yet', async () 
   assert.equal(h.calls.merged.length, 0);
 });
 
+test('a green run on another commit does not stand in for this one', async () => {
+  // The dangerous direction: readiness satisfied by a commit nobody tested.
+  h.state.workflowRuns = [green('CI', STALE_SHA), green('Build & Release', STALE_SHA)];
+
+  assert.match(only(await run(h)).reason, /no workflow runs have registered/);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('runs superseded by a later push do not block forever', async () => {
+  // ci.yml cancels superseded runs, so an earlier commit routinely leaves a
+  // cancelled run and an in-progress one behind.
+  h.state.workflowRuns.push(
+    { name: 'CI', head_sha: STALE_SHA, event: 'pull_request', status: 'completed', conclusion: 'cancelled' },
+    { name: 'Build & Release', head_sha: STALE_SHA, event: 'pull_request', status: 'in_progress', conclusion: null },
+  );
+
+  assert.equal(only(await run(h)).merged, true);
+});
+
 test('ignores workflow runs that are not the pull request\'s own checks', async () => {
   h.state.workflowRuns.push({
     name: 'Dependabot Updates',
+    head_sha: HEAD_SHA,
     event: 'dynamic',
     status: 'completed',
     conclusion: 'failure',
@@ -218,6 +261,7 @@ test('ignores its own workflow run and its own check run', async () => {
   // Guards the deadlock where the job waits for a check that is itself.
   h.state.workflowRuns.push({
     name: 'Dependabot auto-merge',
+    head_sha: HEAD_SHA,
     event: 'pull_request',
     status: 'in_progress',
     conclusion: null,
@@ -228,7 +272,13 @@ test('ignores its own workflow run and its own check run', async () => {
 });
 
 test('treats neutral and skipped results as passing', async () => {
-  h.state.workflowRuns.push({ name: 'Optional', event: 'pull_request', status: 'completed', conclusion: 'skipped' });
+  h.state.workflowRuns.push({
+    name: 'Optional',
+    head_sha: HEAD_SHA,
+    event: 'pull_request',
+    status: 'completed',
+    conclusion: 'skipped',
+  });
   h.state.checkRuns.push({ name: 'E2E Tests', status: 'completed', conclusion: 'skipped' });
 
   assert.equal(only(await run(h)).merged, true);

--- a/.github/scripts/dependabot-auto-merge.test.mjs
+++ b/.github/scripts/dependabot-auto-merge.test.mjs
@@ -5,10 +5,10 @@ import { fileURLToPath } from 'node:url';
 
 import { run } from './dependabot-auto-merge.mjs';
 
-const WORKFLOW = readFileSync(
-  fileURLToPath(new URL('../workflows/dependabot-auto-merge.yml', import.meta.url)),
-  'utf8',
-);
+const workflow = (file) =>
+  readFileSync(fileURLToPath(new URL(`../workflows/${file}`, import.meta.url)), 'utf8');
+
+const AUTO_MERGE_YML = workflow('dependabot-auto-merge.yml');
 
 const HEAD_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
 
@@ -28,6 +28,8 @@ function dependabotCommit({ name = 'glob', version = '0.3.4', updateType = 'patc
   ].join('\n');
 }
 
+const green = (name) => ({ name, event: 'pull_request', status: 'completed', conclusion: 'success' });
+
 /**
  * Builds a world where everything is in order, so each test can break exactly
  * one thing and assert on the consequence.
@@ -36,16 +38,19 @@ function harness(overrides = {}) {
   const calls = { merged: [], comments: [], failures: [], info: [] };
 
   const state = {
+    eventName: 'workflow_run',
     pr: {
       number: 318,
+      state: 'open',
       draft: false,
       user: { login: 'dependabot[bot]' },
       base: { ref: 'main' },
       head: { sha: HEAD_SHA },
     },
+    openPullRequests: [{ number: 318, user: { login: 'dependabot[bot]' }, draft: false }],
+    workflowRuns: [green('CI'), green('Build & Release'), green('CodeQL')],
     checkRuns: [
       { name: 'Lint Frontend', status: 'completed', conclusion: 'success' },
-      { name: 'Test Backend', status: 'completed', conclusion: 'success' },
       { name: 'Auto-merge', status: 'in_progress', conclusion: null },
     ],
     combinedStatus: { state: 'pending', statuses: [] },
@@ -55,52 +60,54 @@ function harness(overrides = {}) {
     ...overrides,
   };
 
-  const listForRef = () => state.checkRuns;
-  const listCommits = () => state.commits.map((message) => ({ commit: { message } }));
-  const listComments = () => state.existingComments;
-
   const github = {
     rest: {
+      repos: {
+        get: async () => ({ data: { default_branch: 'main' } }),
+        getCombinedStatusForRef: async () => ({ data: state.combinedStatus }),
+      },
       pulls: {
-        list: async () => ({ data: [{ number: state.pr.number }] }),
+        list: async () => ({ data: state.openPullRequests }),
         get: async () => ({ data: state.pr }),
-        listCommits,
+        listCommits: () => state.commits.map((message) => ({ commit: { message } })),
         merge: async (params) => {
           if (state.mergeError) throw state.mergeError;
           calls.merged.push(params);
           return { data: { merged: true } };
         },
       },
-      checks: { listForRef },
-      repos: { getCombinedStatusForRef: async () => ({ data: state.combinedStatus }) },
+      actions: { listWorkflowRunsForRepo: () => state.workflowRuns },
+      checks: { listForRef: () => state.checkRuns },
       issues: {
-        listComments,
+        listComments: () => state.existingComments,
         createComment: async (params) => {
           calls.comments.push(params);
         },
       },
     },
-    // The real Octokit paginate flattens the endpoint's collection; these
-    // endpoints already return arrays.
-    paginate: async (endpoint, params) => endpoint(params),
-  };
-
-  const summary = {
-    written: [],
-    addRaw(text) {
-      this.written.push(text);
-      return this;
+    // The real Octokit paginate flattens the endpoint's collection; the stubs
+    // above already return arrays.
+    paginate: async (endpoint, params) => {
+      const result = endpoint(params);
+      return result instanceof Promise ? (await result).data : result;
     },
-    async write() {},
   };
 
   const core = {
     info: (message) => calls.info.push(message),
     setFailed: (message) => calls.failures.push(message),
-    summary,
+    summary: {
+      addRaw() {
+        return this;
+      },
+      async write() {},
+    },
   };
 
   const context = {
+    get eventName() {
+      return state.eventName;
+    },
     repo: { owner: 'hegsie', repo: 'Leviathan' },
     payload: {
       workflow_run: { head_branch: 'dependabot/cargo/src-tauri/glob-0.3.4', head_sha: HEAD_SHA },
@@ -108,8 +115,13 @@ function harness(overrides = {}) {
     },
   };
 
-  return { github, core, context, state, calls, summary };
+  return { github, core, context, state, calls };
 }
+
+const only = (results) => {
+  assert.equal(results.length, 1);
+  return results[0];
+};
 
 let h;
 beforeEach(() => {
@@ -117,29 +129,29 @@ beforeEach(() => {
 });
 
 test('merges a compatible update by squash, pinned to the tested commit', async () => {
-  const result = await run(h);
+  const result = only(await run(h));
 
   assert.equal(result.merged, true);
-  assert.equal(h.calls.merged.length, 1);
-  assert.deepEqual(h.calls.merged[0], {
-    owner: 'hegsie',
-    repo: 'Leviathan',
-    pull_number: 318,
-    merge_method: 'squash',
-    sha: HEAD_SHA,
-  });
+  assert.deepEqual(h.calls.merged, [
+    {
+      owner: 'hegsie',
+      repo: 'Leviathan',
+      pull_number: 318,
+      merge_method: 'squash',
+      sha: HEAD_SHA,
+    },
+  ]);
   assert.equal(h.calls.comments.length, 0);
 });
 
 test('holds a breaking update, and says why exactly once', async () => {
   h = harness({ commits: [dependabotCommit({ name: 'base64', version: '0.23.1', updateType: 'minor' })] });
 
-  const result = await run(h);
+  const result = only(await run(h));
   assert.equal(result.merged, false);
   assert.equal(h.calls.merged.length, 0);
   assert.equal(h.calls.comments.length, 1);
   assert.match(h.calls.comments[0].body, /base64 -> 0\.23\.1/);
-  assert.match(h.calls.comments[0].body, /<!-- dependabot-auto-merge -->/);
 
   // A rebase re-runs CI and lands here again; the note must not repeat.
   h.state.existingComments = [{ body: h.calls.comments[0].body }];
@@ -147,11 +159,10 @@ test('holds a breaking update, and says why exactly once', async () => {
   assert.equal(h.calls.comments.length, 1);
 });
 
-test('refuses a pull request that is not Dependabot\'s', async () => {
+test("refuses a pull request that is not Dependabot's", async () => {
   h.state.pr.user.login = 'hegsie';
 
-  const result = await run(h);
-  assert.equal(result.merged, false);
+  const result = only(await run(h));
   assert.match(result.reason, /opened by hegsie/);
   assert.equal(h.calls.merged.length, 0);
 });
@@ -159,75 +170,93 @@ test('refuses a pull request that is not Dependabot\'s', async () => {
 test('refuses a draft', async () => {
   h.state.pr.draft = true;
 
-  assert.equal((await run(h)).merged, false);
+  assert.equal(only(await run(h)).merged, false);
   assert.equal(h.calls.merged.length, 0);
 });
 
 test('refuses a pull request aimed somewhere other than the default branch', async () => {
   h.state.pr.base.ref = 'release/v0.6.0';
 
-  const result = await run(h);
-  assert.match(result.reason, /targets release\/v0\.6\.0/);
+  assert.match(only(await run(h)).reason, /targets release\/v0\.6\.0/);
   assert.equal(h.calls.merged.length, 0);
 });
 
-test('refuses to merge a commit the checks did not run on', async () => {
-  h.state.pr.head.sha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+test('waits for a workflow that is still running', async () => {
+  h.state.workflowRuns.push({ name: 'CodeQL', event: 'pull_request', status: 'in_progress', conclusion: null });
 
-  const result = await run(h);
-  assert.match(result.reason, /moved to bbbbbbb/);
+  assert.match(only(await run(h)).reason, /waiting on CodeQL \(in_progress\)/);
   assert.equal(h.calls.merged.length, 0);
 });
 
-test('waits on a check from another workflow that is still running', async () => {
-  h.state.checkRuns.push({ name: 'Build Linux-x64', status: 'in_progress', conclusion: null });
+test('refuses when a workflow other than the trigger failed', async () => {
+  h.state.workflowRuns = [green('CI'), { name: 'Build & Release', event: 'pull_request', status: 'completed', conclusion: 'failure' }];
 
-  const result = await run(h);
-  assert.match(result.reason, /Build Linux-x64 \(in_progress\)/);
+  assert.match(only(await run(h)).reason, /Build & Release \(failure\)/);
   assert.equal(h.calls.merged.length, 0);
 });
 
-test('refuses when any check failed, even though the trigger succeeded', async () => {
-  h.state.checkRuns.push({ name: 'Security Audit', status: 'completed', conclusion: 'failure' });
+test('refuses a commit that no workflow has registered a run for yet', async () => {
+  // The window just after a push, where "nothing has failed" is vacuously true.
+  h.state.workflowRuns = [];
 
-  const result = await run(h);
-  assert.match(result.reason, /Security Audit \(failure\)/);
+  assert.match(only(await run(h)).reason, /no workflow runs have registered/);
   assert.equal(h.calls.merged.length, 0);
 });
 
-test('treats neutral and skipped checks as passing', async () => {
-  h.state.checkRuns.push(
-    { name: 'Optional', status: 'completed', conclusion: 'neutral' },
-    { name: 'E2E Tests', status: 'completed', conclusion: 'skipped' },
-  );
+test('ignores workflow runs that are not the pull request\'s own checks', async () => {
+  h.state.workflowRuns.push({
+    name: 'Dependabot Updates',
+    event: 'dynamic',
+    status: 'completed',
+    conclusion: 'failure',
+  });
 
-  assert.equal((await run(h)).merged, true);
+  assert.equal(only(await run(h)).merged, true);
 });
 
-test('ignores its own in-progress check run', async () => {
+test('ignores its own workflow run and its own check run', async () => {
   // Guards the deadlock where the job waits for a check that is itself.
+  h.state.workflowRuns.push({
+    name: 'Dependabot auto-merge',
+    event: 'pull_request',
+    status: 'in_progress',
+    conclusion: null,
+  });
   assert.equal(h.state.checkRuns.some((check) => check.name === 'Auto-merge'), true);
-  assert.equal((await run(h)).merged, true);
+
+  assert.equal(only(await run(h)).merged, true);
 });
 
-test('a repository with no commit statuses does not read as pending', async () => {
+test('treats neutral and skipped results as passing', async () => {
+  h.state.workflowRuns.push({ name: 'Optional', event: 'pull_request', status: 'completed', conclusion: 'skipped' });
+  h.state.checkRuns.push({ name: 'E2E Tests', status: 'completed', conclusion: 'skipped' });
+
+  assert.equal(only(await run(h)).merged, true);
+});
+
+test('refuses when a check run from another app is failing', async () => {
+  h.state.checkRuns.push({ name: 'external/scan', status: 'completed', conclusion: 'failure' });
+
+  assert.match(only(await run(h)).reason, /external\/scan \(failure\)/);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('a commit with no statuses does not read as pending', async () => {
   assert.equal(h.state.combinedStatus.state, 'pending');
-  assert.equal((await run(h)).merged, true);
+  assert.equal(only(await run(h)).merged, true);
 });
 
 test('refuses when a real commit status is failing', async () => {
   h.state.combinedStatus = { state: 'failure', statuses: [{ context: 'legacy/check' }] };
 
-  const result = await run(h);
-  assert.match(result.reason, /state "failure"/);
+  assert.match(only(await run(h)).reason, /state "failure"/);
   assert.equal(h.calls.merged.length, 0);
 });
 
 test('fails the job loudly when the token cannot merge', async () => {
   h.state.mergeError = Object.assign(new Error('Resource not accessible by integration'), { status: 403 });
 
-  const result = await run(h);
-  assert.equal(result.merged, false);
+  assert.equal(only(await run(h)).merged, false);
   assert.equal(h.calls.failures.length, 1);
   assert.match(h.calls.failures[0], /DEPENDABOT_AUTOMERGE_TOKEN/);
 });
@@ -235,37 +264,83 @@ test('fails the job loudly when the token cannot merge', async () => {
 test('stays quiet when the branch went stale between the check and the merge', async () => {
   h.state.mergeError = Object.assign(new Error('Pull Request is not mergeable'), { status: 405 });
 
-  const result = await run(h);
+  const result = only(await run(h));
   assert.equal(result.merged, false);
   // Dependabot will rebase and CI will run again, so this is not a failure.
   assert.equal(h.calls.failures.length, 0);
   assert.match(result.reason, /Could not merge #318/);
 });
 
-test('refuses when the branch has no single open pull request', async () => {
-  h.github.rest.pulls.list = async () => ({ data: [] });
+test('does nothing when the triggering branch has no open pull request', async () => {
+  h.state.openPullRequests = [];
 
-  const result = await run(h);
-  assert.match(result.reason, /found 0/);
+  assert.match(only(await run(h)).reason, /No open Dependabot pull request/);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('the sweep considers every open Dependabot pull request', async () => {
+  // The safety net for a workflow that finished without a matching trigger.
+  h.state.eventName = 'schedule';
+  h.state.openPullRequests = [
+    { number: 318, user: { login: 'dependabot[bot]' }, draft: false },
+    { number: 313, user: { login: 'dependabot[bot]' }, draft: false },
+  ];
+  const seen = [];
+  h.github.rest.pulls.get = async ({ pull_number }) => {
+    seen.push(pull_number);
+    return { data: { ...h.state.pr, number: pull_number } };
+  };
+
+  const results = await run(h);
+  assert.deepEqual(seen, [318, 313]);
+  assert.equal(results.length, 2);
+  assert.deepEqual(
+    h.calls.merged.map((call) => call.pull_number),
+    [318, 313],
+  );
+});
+
+test('the sweep skips pull requests that are not Dependabot drafts of its own', async () => {
+  h.state.eventName = 'schedule';
+  h.state.openPullRequests = [
+    { number: 345, user: { login: 'hegsie' }, draft: false },
+    { number: 346, user: { login: 'dependabot[bot]' }, draft: true },
+  ];
+
+  assert.match(only(await run(h)).reason, /No open Dependabot pull request/);
   assert.equal(h.calls.merged.length, 0);
 });
 
 test('the workflow job is named what the self-check filter looks for', () => {
   // If these drift apart the job waits for its own check run and never merges.
-  assert.match(WORKFLOW, /^ {4}name: Auto-merge$/m);
+  assert.match(AUTO_MERGE_YML, /^ {4}name: Auto-merge$/m);
 });
 
-test('the workflow waits on every workflow that runs against a pull request', () => {
-  const runsOnPullRequests = ['ci.yml', 'build.yml'].map((file) => {
-    const source = readFileSync(fileURLToPath(new URL(`../workflows/${file}`, import.meta.url)), 'utf8');
-    assert.match(source, /^ {2}pull_request:$/m, `${file} should run on pull requests`);
-    return /^name:\s*(.+)$/m.exec(source)[1].trim();
-  });
+test('the workflow is named what the self-run filter looks for', () => {
+  assert.match(AUTO_MERGE_YML, /^name: Dependabot auto-merge$/m);
+});
 
-  for (const name of runsOnPullRequests) {
+test('the workflow waits on every workflow file that runs against a pull request', () => {
+  // CodeQL is not covered here: it comes from GitHub's default setup and has no
+  // file to read, so it is asserted separately below.
+  for (const file of ['ci.yml', 'build.yml']) {
+    const source = workflow(file);
+    assert.match(source, /^ {2}pull_request:$/m, `${file} should run on pull requests`);
+    const name = /^name:\s*(.+)$/m.exec(source)[1].trim();
     assert.ok(
-      WORKFLOW.includes(`\n      - ${name}\n`),
+      AUTO_MERGE_YML.includes(`\n      - ${name}\n`),
       `${name} runs on pull requests but auto-merge does not wait for it`,
     );
   }
+});
+
+test('the workflow waits on default-setup CodeQL', () => {
+  assert.ok(AUTO_MERGE_YML.includes('\n      - CodeQL\n'));
+});
+
+test('the workflow keeps a sweep scheduled as the safety net', () => {
+  // Without this, a workflow missing from the wait list can leave a green pull
+  // request unmerged indefinitely.
+  assert.match(AUTO_MERGE_YML, /^ {2}schedule:$/m);
+  assert.match(AUTO_MERGE_YML, /^ {4}- cron: '.+'$/m);
 });

--- a/.github/scripts/dependabot-auto-merge.test.mjs
+++ b/.github/scripts/dependabot-auto-merge.test.mjs
@@ -1,0 +1,271 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { beforeEach, test } from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+import { run } from './dependabot-auto-merge.mjs';
+
+const WORKFLOW = readFileSync(
+  fileURLToPath(new URL('../workflows/dependabot-auto-merge.yml', import.meta.url)),
+  'utf8',
+);
+
+const HEAD_SHA = 'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa';
+
+function dependabotCommit({ name = 'glob', version = '0.3.4', updateType = 'patch' } = {}) {
+  return [
+    `deps(cargo): bump ${name}`,
+    '',
+    '---',
+    'updated-dependencies:',
+    `- dependency-name: ${name}`,
+    `  dependency-version: ${version}`,
+    '  dependency-type: direct:production',
+    `  update-type: version-update:semver-${updateType}`,
+    '...',
+    '',
+    'Signed-off-by: dependabot[bot] <support@github.com>',
+  ].join('\n');
+}
+
+/**
+ * Builds a world where everything is in order, so each test can break exactly
+ * one thing and assert on the consequence.
+ */
+function harness(overrides = {}) {
+  const calls = { merged: [], comments: [], failures: [], info: [] };
+
+  const state = {
+    pr: {
+      number: 318,
+      draft: false,
+      user: { login: 'dependabot[bot]' },
+      base: { ref: 'main' },
+      head: { sha: HEAD_SHA },
+    },
+    checkRuns: [
+      { name: 'Lint Frontend', status: 'completed', conclusion: 'success' },
+      { name: 'Test Backend', status: 'completed', conclusion: 'success' },
+      { name: 'Auto-merge', status: 'in_progress', conclusion: null },
+    ],
+    combinedStatus: { state: 'pending', statuses: [] },
+    commits: [dependabotCommit()],
+    existingComments: [],
+    mergeError: null,
+    ...overrides,
+  };
+
+  const listForRef = () => state.checkRuns;
+  const listCommits = () => state.commits.map((message) => ({ commit: { message } }));
+  const listComments = () => state.existingComments;
+
+  const github = {
+    rest: {
+      pulls: {
+        list: async () => ({ data: [{ number: state.pr.number }] }),
+        get: async () => ({ data: state.pr }),
+        listCommits,
+        merge: async (params) => {
+          if (state.mergeError) throw state.mergeError;
+          calls.merged.push(params);
+          return { data: { merged: true } };
+        },
+      },
+      checks: { listForRef },
+      repos: { getCombinedStatusForRef: async () => ({ data: state.combinedStatus }) },
+      issues: {
+        listComments,
+        createComment: async (params) => {
+          calls.comments.push(params);
+        },
+      },
+    },
+    // The real Octokit paginate flattens the endpoint's collection; these
+    // endpoints already return arrays.
+    paginate: async (endpoint, params) => endpoint(params),
+  };
+
+  const summary = {
+    written: [],
+    addRaw(text) {
+      this.written.push(text);
+      return this;
+    },
+    async write() {},
+  };
+
+  const core = {
+    info: (message) => calls.info.push(message),
+    setFailed: (message) => calls.failures.push(message),
+    summary,
+  };
+
+  const context = {
+    repo: { owner: 'hegsie', repo: 'Leviathan' },
+    payload: {
+      workflow_run: { head_branch: 'dependabot/cargo/src-tauri/glob-0.3.4', head_sha: HEAD_SHA },
+      repository: { default_branch: 'main' },
+    },
+  };
+
+  return { github, core, context, state, calls, summary };
+}
+
+let h;
+beforeEach(() => {
+  h = harness();
+});
+
+test('merges a compatible update by squash, pinned to the tested commit', async () => {
+  const result = await run(h);
+
+  assert.equal(result.merged, true);
+  assert.equal(h.calls.merged.length, 1);
+  assert.deepEqual(h.calls.merged[0], {
+    owner: 'hegsie',
+    repo: 'Leviathan',
+    pull_number: 318,
+    merge_method: 'squash',
+    sha: HEAD_SHA,
+  });
+  assert.equal(h.calls.comments.length, 0);
+});
+
+test('holds a breaking update, and says why exactly once', async () => {
+  h = harness({ commits: [dependabotCommit({ name: 'base64', version: '0.23.1', updateType: 'minor' })] });
+
+  const result = await run(h);
+  assert.equal(result.merged, false);
+  assert.equal(h.calls.merged.length, 0);
+  assert.equal(h.calls.comments.length, 1);
+  assert.match(h.calls.comments[0].body, /base64 -> 0\.23\.1/);
+  assert.match(h.calls.comments[0].body, /<!-- dependabot-auto-merge -->/);
+
+  // A rebase re-runs CI and lands here again; the note must not repeat.
+  h.state.existingComments = [{ body: h.calls.comments[0].body }];
+  await run(h);
+  assert.equal(h.calls.comments.length, 1);
+});
+
+test('refuses a pull request that is not Dependabot\'s', async () => {
+  h.state.pr.user.login = 'hegsie';
+
+  const result = await run(h);
+  assert.equal(result.merged, false);
+  assert.match(result.reason, /opened by hegsie/);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('refuses a draft', async () => {
+  h.state.pr.draft = true;
+
+  assert.equal((await run(h)).merged, false);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('refuses a pull request aimed somewhere other than the default branch', async () => {
+  h.state.pr.base.ref = 'release/v0.6.0';
+
+  const result = await run(h);
+  assert.match(result.reason, /targets release\/v0\.6\.0/);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('refuses to merge a commit the checks did not run on', async () => {
+  h.state.pr.head.sha = 'bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb';
+
+  const result = await run(h);
+  assert.match(result.reason, /moved to bbbbbbb/);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('waits on a check from another workflow that is still running', async () => {
+  h.state.checkRuns.push({ name: 'Build Linux-x64', status: 'in_progress', conclusion: null });
+
+  const result = await run(h);
+  assert.match(result.reason, /Build Linux-x64 \(in_progress\)/);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('refuses when any check failed, even though the trigger succeeded', async () => {
+  h.state.checkRuns.push({ name: 'Security Audit', status: 'completed', conclusion: 'failure' });
+
+  const result = await run(h);
+  assert.match(result.reason, /Security Audit \(failure\)/);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('treats neutral and skipped checks as passing', async () => {
+  h.state.checkRuns.push(
+    { name: 'Optional', status: 'completed', conclusion: 'neutral' },
+    { name: 'E2E Tests', status: 'completed', conclusion: 'skipped' },
+  );
+
+  assert.equal((await run(h)).merged, true);
+});
+
+test('ignores its own in-progress check run', async () => {
+  // Guards the deadlock where the job waits for a check that is itself.
+  assert.equal(h.state.checkRuns.some((check) => check.name === 'Auto-merge'), true);
+  assert.equal((await run(h)).merged, true);
+});
+
+test('a repository with no commit statuses does not read as pending', async () => {
+  assert.equal(h.state.combinedStatus.state, 'pending');
+  assert.equal((await run(h)).merged, true);
+});
+
+test('refuses when a real commit status is failing', async () => {
+  h.state.combinedStatus = { state: 'failure', statuses: [{ context: 'legacy/check' }] };
+
+  const result = await run(h);
+  assert.match(result.reason, /state "failure"/);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('fails the job loudly when the token cannot merge', async () => {
+  h.state.mergeError = Object.assign(new Error('Resource not accessible by integration'), { status: 403 });
+
+  const result = await run(h);
+  assert.equal(result.merged, false);
+  assert.equal(h.calls.failures.length, 1);
+  assert.match(h.calls.failures[0], /DEPENDABOT_AUTOMERGE_TOKEN/);
+});
+
+test('stays quiet when the branch went stale between the check and the merge', async () => {
+  h.state.mergeError = Object.assign(new Error('Pull Request is not mergeable'), { status: 405 });
+
+  const result = await run(h);
+  assert.equal(result.merged, false);
+  // Dependabot will rebase and CI will run again, so this is not a failure.
+  assert.equal(h.calls.failures.length, 0);
+  assert.match(result.reason, /Could not merge #318/);
+});
+
+test('refuses when the branch has no single open pull request', async () => {
+  h.github.rest.pulls.list = async () => ({ data: [] });
+
+  const result = await run(h);
+  assert.match(result.reason, /found 0/);
+  assert.equal(h.calls.merged.length, 0);
+});
+
+test('the workflow job is named what the self-check filter looks for', () => {
+  // If these drift apart the job waits for its own check run and never merges.
+  assert.match(WORKFLOW, /^ {4}name: Auto-merge$/m);
+});
+
+test('the workflow waits on every workflow that runs against a pull request', () => {
+  const runsOnPullRequests = ['ci.yml', 'build.yml'].map((file) => {
+    const source = readFileSync(fileURLToPath(new URL(`../workflows/${file}`, import.meta.url)), 'utf8');
+    assert.match(source, /^ {2}pull_request:$/m, `${file} should run on pull requests`);
+    return /^name:\s*(.+)$/m.exec(source)[1].trim();
+  });
+
+  for (const name of runsOnPullRequests) {
+    assert.ok(
+      WORKFLOW.includes(`\n      - ${name}\n`),
+      `${name} runs on pull requests but auto-merge does not wait for it`,
+    );
+  }
+});

--- a/.github/scripts/dependabot-policy.mjs
+++ b/.github/scripts/dependabot-policy.mjs
@@ -1,0 +1,156 @@
+/**
+ * Decides which Dependabot pull requests may merge themselves once CI is green.
+ *
+ * Dependabot labels a bump by which semver field moved, which is not the same
+ * question as whether the bump can break us. Below 1.0.0 both Cargo and npm
+ * treat the *minor* field as the compatibility boundary, so 0.22 -> 0.23 is
+ * every bit as breaking as 1.x -> 2.x, and Dependabot still calls it
+ * "semver-minor". Most of this repo's Rust tree is 0.x — git2, candle,
+ * rusqlite, base64 — so that distinction decides the majority of PRs.
+ *
+ * Everything here is pure so it can be unit tested; the workflow supplies the
+ * commit messages and performs the merge.
+ */
+
+const TRAILER_KEY = 'updated-dependencies:';
+
+/** A bump CI can be trusted to vet on its own. */
+export const COMPATIBLE = 'compatible';
+/** A bump that can change behaviour without failing CI. Needs a human. */
+export const BREAKING = 'breaking';
+/** Metadata we could not read. Treated like `BREAKING`. */
+export const UNKNOWN = 'unknown';
+
+function toCamelCase(key) {
+  return key.replace(/-([a-z])/g, (_, letter) => letter.toUpperCase());
+}
+
+function unquote(value) {
+  return value.trim().replace(/^["']|["']$/g, '');
+}
+
+/**
+ * Reads the `updated-dependencies:` YAML block Dependabot appends to every
+ * commit message it writes. A grouped update contributes one entry per
+ * dependency.
+ */
+export function parseUpdatedDependencies(commitMessage) {
+  const lines = String(commitMessage ?? '').split(/\r?\n/);
+  const start = lines.findIndex((line) => line.trim() === TRAILER_KEY);
+  if (start === -1) return [];
+
+  const entries = [];
+  for (const line of lines.slice(start + 1)) {
+    const trimmed = line.trim();
+    // The block is a YAML document; `...` closes it, and Dependabot follows it
+    // with a blank line and the sign-off.
+    if (trimmed === '' || trimmed === '...' || trimmed === '---') break;
+
+    const listItem = line.match(/^\s*-\s+([\w-]+):\s*(.*)$/);
+    if (listItem) {
+      entries.push({ [toCamelCase(listItem[1])]: unquote(listItem[2]) });
+      continue;
+    }
+
+    const field = line.match(/^\s+([\w-]+):\s*(.*)$/);
+    if (field && entries.length > 0) {
+      entries[entries.length - 1][toCamelCase(field[1])] = unquote(field[2]);
+      continue;
+    }
+
+    break;
+  }
+
+  return entries;
+}
+
+function parseVersion(raw) {
+  const match = /^v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/.exec(String(raw ?? '').trim());
+  if (!match) return null;
+  return { major: Number(match[1]), minor: Number(match[2] ?? 0) };
+}
+
+/**
+ * Classifies one `updated-dependencies` entry. `dependencyVersion` is the
+ * version being moved *to*, which combined with Dependabot's `updateType` is
+ * enough to locate the bump relative to the nearest compatibility boundary.
+ */
+export function classifyUpdate(entry) {
+  const updateType = entry?.updateType;
+
+  if (updateType === 'version-update:semver-major') return BREAKING;
+
+  const version = parseVersion(entry?.dependencyVersion);
+  if (!version) return UNKNOWN;
+
+  if (updateType === 'version-update:semver-minor') {
+    // 0.22.1 -> 0.23.1: a new compatibility range, not a compatible bump.
+    return version.major === 0 ? BREAKING : COMPATIBLE;
+  }
+
+  if (updateType === 'version-update:semver-patch') {
+    // 0.0.x releases are mutually incompatible; every other patch is safe.
+    return version.major === 0 && version.minor === 0 ? BREAKING : COMPATIBLE;
+  }
+
+  return UNKNOWN;
+}
+
+function describe(update) {
+  const name = update.dependencyName ?? 'unknown dependency';
+  const version = update.dependencyVersion;
+  const target = version ? `${name} -> ${version}` : name;
+
+  if (update.classification === UNKNOWN) {
+    return `${target} (could not read Dependabot's update metadata)`;
+  }
+  if (update.updateType === 'version-update:semver-major') {
+    return `${target} (major release)`;
+  }
+  return `${target} (pre-1.0 release that crosses a compatibility boundary, so it is breaking despite Dependabot calling it ${update.updateType?.replace('version-update:', '') ?? 'compatible'})`;
+}
+
+/**
+ * Given every commit message on a Dependabot pull request, decides whether it
+ * may merge. A grouped update merges only if every dependency in it qualifies.
+ */
+export function decide(commitMessages) {
+  const seen = new Set();
+  const updates = [];
+  for (const message of commitMessages ?? []) {
+    for (const entry of parseUpdatedDependencies(message)) {
+      const key = `${entry.dependencyName}@${entry.dependencyVersion}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      updates.push({ ...entry, classification: classifyUpdate(entry) });
+    }
+  }
+
+  if (updates.length === 0) {
+    return {
+      merge: false,
+      updates,
+      reason:
+        'No Dependabot `updated-dependencies` metadata was found on this pull request, so the update could not be classified.',
+    };
+  }
+
+  const held = updates.filter((update) => update.classification !== COMPATIBLE);
+  if (held.length > 0) {
+    return {
+      merge: false,
+      updates,
+      reason: `This update needs a human look before it lands:\n${held
+        .map((update) => `- ${describe(update)}`)
+        .join('\n')}`,
+    };
+  }
+
+  return {
+    merge: true,
+    updates,
+    reason: `Every dependency in this update stays inside its current compatibility range:\n${updates
+      .map((update) => `- ${update.dependencyName} -> ${update.dependencyVersion}`)
+      .join('\n')}`,
+  };
+}

--- a/.github/scripts/dependabot-policy.test.mjs
+++ b/.github/scripts/dependabot-policy.test.mjs
@@ -1,0 +1,213 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  BREAKING,
+  COMPATIBLE,
+  UNKNOWN,
+  classifyUpdate,
+  decide,
+  parseUpdatedDependencies,
+} from './dependabot-policy.mjs';
+
+/** A verbatim commit message from PR #314, trailer and sign-off included. */
+const BASE64_COMMIT = `deps(cargo): bump base64 from 0.22.1 to 0.23.1 in /src-tauri
+
+Bumps [base64](https://github.com/marshallpierce/rust-base64) from 0.22.1 to 0.23.1.
+- [Changelog](https://github.com/marshallpierce/rust-base64/blob/master/RELEASE-NOTES.md)
+- [Commits](https://github.com/marshallpierce/rust-base64/compare/v0.22.1...v0.23.1)
+
+---
+updated-dependencies:
+- dependency-name: base64
+  dependency-version: 0.23.1
+  dependency-type: direct:production
+  update-type: version-update:semver-minor
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>`;
+
+const GROUPED_COMMIT = `deps(npm): bump the dev-dependencies group with 2 updates
+
+Bumps the dev-dependencies group with 2 updates.
+
+---
+updated-dependencies:
+- dependency-name: typescript-eslint
+  dependency-version: 8.67.0
+  dependency-type: direct:development
+  update-type: version-update:semver-minor
+  dependency-group: dev-dependencies
+- dependency-name: prettier
+  dependency-version: 3.9.7
+  dependency-type: direct:development
+  update-type: version-update:semver-patch
+  dependency-group: dev-dependencies
+...
+
+Signed-off-by: dependabot[bot] <support@github.com>`;
+
+function commit({ name, version, updateType }) {
+  return [
+    `deps: bump ${name}`,
+    '',
+    '---',
+    'updated-dependencies:',
+    `- dependency-name: ${name}`,
+    `  dependency-version: ${version}`,
+    '  dependency-type: direct:production',
+    `  update-type: version-update:semver-${updateType}`,
+    '...',
+    '',
+    'Signed-off-by: dependabot[bot] <support@github.com>',
+  ].join('\n');
+}
+
+test('parses a single-dependency trailer and stops at the closing marker', () => {
+  assert.deepEqual(parseUpdatedDependencies(BASE64_COMMIT), [
+    {
+      dependencyName: 'base64',
+      dependencyVersion: '0.23.1',
+      dependencyType: 'direct:production',
+      updateType: 'version-update:semver-minor',
+    },
+  ]);
+});
+
+test('parses every dependency out of a grouped update', () => {
+  const entries = parseUpdatedDependencies(GROUPED_COMMIT);
+  assert.equal(entries.length, 2);
+  assert.deepEqual(
+    entries.map((entry) => entry.dependencyName),
+    ['typescript-eslint', 'prettier'],
+  );
+  assert.equal(entries[1].dependencyGroup, 'dev-dependencies');
+});
+
+test('returns nothing for a commit that carries no trailer', () => {
+  assert.deepEqual(parseUpdatedDependencies('Fix a bug\n\nNo trailer here.'), []);
+  assert.deepEqual(parseUpdatedDependencies(''), []);
+  assert.deepEqual(parseUpdatedDependencies(undefined), []);
+});
+
+test('a bump within a stable major is compatible', () => {
+  assert.equal(
+    classifyUpdate({ dependencyVersion: '17.11.0', updateType: 'version-update:semver-minor' }),
+    COMPATIBLE,
+  );
+  assert.equal(
+    classifyUpdate({ dependencyVersion: '5.0.15', updateType: 'version-update:semver-patch' }),
+    COMPATIBLE,
+  );
+});
+
+test('a major bump is breaking', () => {
+  assert.equal(
+    classifyUpdate({ dependencyVersion: '7.0.2', updateType: 'version-update:semver-major' }),
+    BREAKING,
+  );
+  assert.equal(
+    classifyUpdate({ dependencyVersion: '4.0.0', updateType: 'version-update:semver-major' }),
+    BREAKING,
+  );
+});
+
+test('a pre-1.0 minor bump is breaking even though Dependabot calls it minor', () => {
+  // base64 0.22.1 -> 0.23.1 and candle 0.10.2 -> 0.11.0 both land here.
+  assert.equal(
+    classifyUpdate({ dependencyVersion: '0.23.1', updateType: 'version-update:semver-minor' }),
+    BREAKING,
+  );
+  assert.equal(
+    classifyUpdate({ dependencyVersion: '0.11.0', updateType: 'version-update:semver-minor' }),
+    BREAKING,
+  );
+});
+
+test('a pre-1.0 patch bump is compatible, except below 0.1.0', () => {
+  // rusqlite 0.40.1 -> 0.40.2 stays inside the 0.40 range.
+  assert.equal(
+    classifyUpdate({ dependencyVersion: '0.40.2', updateType: 'version-update:semver-patch' }),
+    COMPATIBLE,
+  );
+  // 0.0.x releases are mutually incompatible under Cargo's rules.
+  assert.equal(
+    classifyUpdate({ dependencyVersion: '0.0.9', updateType: 'version-update:semver-patch' }),
+    BREAKING,
+  );
+});
+
+test('an action pinned to a bare major still classifies', () => {
+  assert.equal(
+    classifyUpdate({ dependencyVersion: 'v8', updateType: 'version-update:semver-major' }),
+    BREAKING,
+  );
+  assert.equal(
+    classifyUpdate({ dependencyVersion: '4.2.0', updateType: 'version-update:semver-minor' }),
+    COMPATIBLE,
+  );
+});
+
+test('unreadable metadata is never treated as compatible', () => {
+  assert.equal(classifyUpdate({}), UNKNOWN);
+  assert.equal(classifyUpdate({ dependencyVersion: '1.2.3' }), UNKNOWN);
+  assert.equal(
+    classifyUpdate({ dependencyVersion: 'not-a-version', updateType: 'version-update:semver-patch' }),
+    UNKNOWN,
+  );
+});
+
+test('decide holds a pull request with no Dependabot metadata', () => {
+  const result = decide(['Hand-written commit, no trailer']);
+  assert.equal(result.merge, false);
+  assert.match(result.reason, /could not be classified/);
+});
+
+test('decide merges the compatible bumps from the August batch', () => {
+  for (const update of [
+    { name: 'glob', version: '0.3.4', updateType: 'patch' },
+    { name: 'rusqlite', version: '0.40.2', updateType: 'patch' },
+    { name: 'globals', version: '17.11.0', updateType: 'minor' },
+    { name: 'zustand', version: '5.0.15', updateType: 'patch' },
+    { name: 'typescript-eslint', version: '8.67.0', updateType: 'minor' },
+  ]) {
+    const result = decide([commit(update)]);
+    assert.equal(result.merge, true, `${update.name} should auto-merge`);
+  }
+});
+
+test('decide holds the bumps from the August batch that needed judgement', () => {
+  for (const update of [
+    { name: 'base64', version: '0.23.1', updateType: 'minor' },
+    { name: 'pem', version: '4.0.0', updateType: 'major' },
+    { name: 'candle-transformers', version: '0.11.0', updateType: 'minor' },
+    { name: 'typescript', version: '7.0.2', updateType: 'major' },
+  ]) {
+    const result = decide([commit(update)]);
+    assert.equal(result.merge, false, `${update.name} should be held`);
+    assert.match(result.reason, new RegExp(update.name));
+  }
+});
+
+test('decide holds a group when any single member is breaking', () => {
+  const result = decide([
+    commit({ name: 'globals', version: '17.11.0', updateType: 'minor' }),
+    commit({ name: 'base64', version: '0.23.1', updateType: 'minor' }),
+  ]);
+  assert.equal(result.merge, false);
+  assert.match(result.reason, /base64/);
+  assert.doesNotMatch(result.reason, /globals/);
+});
+
+test('decide merges a grouped update whose members all qualify', () => {
+  const result = decide([GROUPED_COMMIT]);
+  assert.equal(result.merge, true);
+  assert.equal(result.updates.length, 2);
+});
+
+test('decide reports each dependency once across a rebased pull request', () => {
+  const message = commit({ name: 'glob', version: '0.3.4', updateType: 'patch' });
+  const result = decide([message, message]);
+  assert.equal(result.merge, true);
+  assert.equal(result.updates.length, 1);
+});

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,10 @@ jobs:
       - name: Lint
         run: npm run lint
 
+      # Explicit path because Node's test runner skips dot-directories.
+      - name: Test workflow scripts
+        run: node --test .github/scripts/*.test.mjs
+
   lint-backend:
     name: Lint Backend
     runs-on: ubuntu-22.04

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,64 @@
+name: Dependabot auto-merge
+
+# Merges a Dependabot pull request once every check on it has passed.
+#
+# This runs on `workflow_run` rather than `pull_request` on purpose. GitHub's
+# native auto-merge (`gh pr merge --auto`) only waits for CI when the base
+# branch has required status checks configured; `main` has no protection rules,
+# so that route would merge Dependabot pull requests the moment they opened.
+# Reacting to a finished workflow run instead makes CI passing the trigger, and
+# the job re-checks the whole check list before merging.
+#
+# It also keeps the writable token away from Dependabot's branch contents:
+# nothing here checks out the pull request, only the policy from the base branch.
+#
+# The decision logic lives in .github/scripts/dependabot-auto-merge.mjs and
+# .github/scripts/dependabot-policy.mjs, which are unit tested in CI.
+
+on:
+  workflow_run:
+    workflows:
+      - CI
+      - Build & Release
+    types:
+      - completed
+
+permissions:
+  contents: write
+  pull-requests: write
+
+# One merge at a time, so two pull requests cannot race each other into a
+# lockfile conflict.
+concurrency:
+  group: dependabot-auto-merge
+  cancel-in-progress: false
+
+jobs:
+  auto-merge:
+    # Keep in step with SELF_CHECK_NAME in .github/scripts/dependabot-auto-merge.mjs.
+    name: Auto-merge
+    runs-on: ubuntu-latest
+    if: >-
+      github.event.workflow_run.conclusion == 'success' &&
+      github.event.workflow_run.event == 'pull_request' &&
+      startsWith(github.event.workflow_run.head_branch, 'dependabot/')
+
+    steps:
+      - name: Check out the merge policy from the base branch
+        uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          sparse-checkout: .github/scripts
+          persist-credentials: false
+
+      - name: Merge if the policy allows it
+        uses: actions/github-script@v7
+        with:
+          # A PAT or App token is only needed if the repository later gates
+          # merges behind rules the built-in token cannot satisfy.
+          github-token: ${{ secrets.DEPENDABOT_AUTOMERGE_TOKEN || secrets.GITHUB_TOKEN }}
+          script: |
+            const { run } = await import(
+              `${process.env.GITHUB_WORKSPACE}/.github/scripts/dependabot-auto-merge.mjs`
+            );
+            await run({ github, context, core });

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -9,6 +9,12 @@ name: Dependabot auto-merge
 # Reacting to a finished workflow run instead makes CI passing the trigger, and
 # the job re-checks the whole check list before merging.
 #
+# The hourly sweep is the safety net. A `workflow_run` trigger has to name the
+# workflows it waits for, so any workflow missing from that list could finish
+# last and leave a pull request green but unmerged forever. The sweep considers
+# every open Dependabot pull request, so a missing trigger or a dropped webhook
+# costs an hour rather than wedging the queue.
+#
 # It also keeps the writable token away from Dependabot's branch contents:
 # nothing here checks out the pull request, only the policy from the base branch.
 #
@@ -17,11 +23,18 @@ name: Dependabot auto-merge
 
 on:
   workflow_run:
+    # Every workflow that runs against a pull request. CodeQL is configured
+    # through GitHub's default setup, so it has no file in this directory.
     workflows:
       - CI
       - Build & Release
+      - CodeQL
     types:
       - completed
+  schedule:
+    # Off the hour, so this is not queued behind everything else that runs at :00.
+    - cron: '17 * * * *'
+  workflow_dispatch:
 
 permissions:
   contents: write
@@ -39,9 +52,11 @@ jobs:
     name: Auto-merge
     runs-on: ubuntu-latest
     if: >-
-      github.event.workflow_run.conclusion == 'success' &&
-      github.event.workflow_run.event == 'pull_request' &&
-      startsWith(github.event.workflow_run.head_branch, 'dependabot/')
+      github.event_name != 'workflow_run' || (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        startsWith(github.event.workflow_run.head_branch, 'dependabot/')
+      )
 
     steps:
       - name: Check out the merge policy from the base branch
@@ -51,7 +66,7 @@ jobs:
           sparse-checkout: .github/scripts
           persist-credentials: false
 
-      - name: Merge if the policy allows it
+      - name: Merge whatever the policy allows
         uses: actions/github-script@v7
         with:
           # A PAT or App token is only needed if the repository later gates

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@vaadin/router": "^2.0.1",
         "lit": "^3.3.3",
         "shiki": "^4.4.2",
-        "zustand": "^5.0.14"
+        "zustand": "^5.0.15"
       },
       "devDependencies": {
         "@open-wc/testing": "^5.0.0",
@@ -30,12 +30,12 @@
         "@web/test-runner": "^1.0.0",
         "@web/test-runner-playwright": "^1.0.0",
         "eslint": "^10.8.0",
-        "globals": "^17.7.0",
+        "globals": "^17.11.0",
         "playwright-core": "1.62.1",
         "prettier": "^3.9.6",
         "sharp": "^0.35.3",
         "typescript": "^6.0.0",
-        "typescript-eslint": "^8.66.0",
+        "typescript-eslint": "^8.67.0",
         "vite": "^8.2.1"
       }
     },
@@ -2854,17 +2854,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
-      "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+      "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/type-utils": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/type-utils": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -2877,7 +2877,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.66.0",
+        "@typescript-eslint/parser": "^8.67.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -2893,16 +2893,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
-      "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+      "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2918,14 +2918,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
-      "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+      "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.66.0",
-        "@typescript-eslint/types": "^8.66.0",
+        "@typescript-eslint/tsconfig-utils": "^8.67.0",
+        "@typescript-eslint/types": "^8.67.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -2940,14 +2940,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
-      "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+      "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0"
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -2958,9 +2958,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
-      "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+      "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -2975,15 +2975,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
-      "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+      "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -3000,9 +3000,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-      "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+      "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3014,16 +3014,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
-      "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+      "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.66.0",
-        "@typescript-eslint/tsconfig-utils": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/visitor-keys": "8.66.0",
+        "@typescript-eslint/project-service": "8.67.0",
+        "@typescript-eslint/tsconfig-utils": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/visitor-keys": "8.67.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -3042,16 +3042,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
-      "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+      "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.66.0",
-        "@typescript-eslint/types": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0"
+        "@typescript-eslint/scope-manager": "8.67.0",
+        "@typescript-eslint/types": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -3066,13 +3066,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
-      "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+      "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.66.0",
+        "@typescript-eslint/types": "8.67.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -4837,9 +4837,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.9.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.9.0.tgz",
-      "integrity": "sha512-m/MvAW61QVU5VDNF1Vj8axt016h8w7L5TU1e9zlab7XIttAT2YAlCwl75K1fOqvMM9apmD7lbCIRhpfkhmxhCg==",
+      "version": "17.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.11.0.tgz",
+      "integrity": "sha512-Z2I8hM+PbJDXQDq3Icgpzv+mPdwr68iZUU9d5WW4FuXfDUQfkZaZuvjMv42/5crNyw154+9+VWXbYrUgDXbxNw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7540,16 +7540,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.66.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.66.0.tgz",
-      "integrity": "sha512-QlEbBPz/RuJ1XUHj29nm3t0F/O/cSlEnntozqPOYHnnTGAXFamnMBu5i9Vn6vhUPHGAjR+Vl+5J8vPN/BMUrJw==",
+      "version": "8.67.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.67.0.tgz",
+      "integrity": "sha512-S2udFs8tCKEKffuJ4TB1idGUZiXdCPGi3IPBGWXarbLQ5UPXORV8QEVzJ4gCRduURMb5EkpNCdjbk0eDIuI8Yg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.66.0",
-        "@typescript-eslint/parser": "8.66.0",
-        "@typescript-eslint/typescript-estree": "8.66.0",
-        "@typescript-eslint/utils": "8.66.0"
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
+        "@typescript-eslint/typescript-estree": "8.67.0",
+        "@typescript-eslint/utils": "8.67.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -8066,9 +8066,9 @@
       }
     },
     "node_modules/zustand": {
-      "version": "5.0.14",
-      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
-      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "version": "5.0.15",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.15.tgz",
+      "integrity": "sha512-MpSEjRiBkA9crSYeOUH32rJC7SVqAbm0Fqcqge/bUi2PPoLcBWKOsG+C8mevmpr8TwXHBVkChbbJiyvkE+i/3A==",
       "license": "MIT",
       "engines": {
         "node": ">=12.20.0"

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "@vaadin/router": "^2.0.1",
     "lit": "^3.3.3",
     "shiki": "^4.4.2",
-    "zustand": "^5.0.14"
+    "zustand": "^5.0.15"
   },
   "devDependencies": {
     "@open-wc/testing": "^5.0.0",
@@ -44,12 +44,12 @@
     "@web/test-runner": "^1.0.0",
     "@web/test-runner-playwright": "^1.0.0",
     "eslint": "^10.8.0",
-    "globals": "^17.7.0",
+    "globals": "^17.11.0",
     "playwright-core": "1.62.1",
     "prettier": "^3.9.6",
     "sharp": "^0.35.3",
     "typescript": "^6.0.0",
-    "typescript-eslint": "^8.66.0",
+    "typescript-eslint": "^8.67.0",
     "vite": "^8.2.1"
   },
   "overrides": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -285,6 +285,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
+
+[[package]]
 name = "base64ct"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -487,14 +493,15 @@ dependencies = [
 
 [[package]]
 name = "candle-core"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bd9895436c1ba5dc1037a19935d084b838db066ff4e15ef7dded020b7c12a4a"
+checksum = "5ecb245093b0f791b89d3420c3df9c6d49c60ab63ba54db896bf8a3baf486706"
 dependencies = [
  "byteorder",
  "float8",
  "gemm",
  "half",
+ "libc",
  "libm",
  "memmap2",
  "num-traits",
@@ -506,14 +513,15 @@ dependencies = [
  "thiserror 2.0.20",
  "tokenizers 0.22.2",
  "yoke",
- "zip 7.2.0",
+ "zerocopy",
+ "zip 8.6.0",
 ]
 
 [[package]]
 name = "candle-nn"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9317a09d6530b758990ed7f625ac69ff43653bc9ee28b0464644ad1169ada87"
+checksum = "eaa10b6ccc365b33210ce404fbf45e60d3e0bdac1004463cf1052e6ee1c1739a"
 dependencies = [
  "candle-core",
  "half",
@@ -527,9 +535,9 @@ dependencies = [
 
 [[package]]
 name = "candle-transformers"
-version = "0.10.2"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f59d08c89e9f4af9c464e2f3a8e16199e7cc601e6f34538c2cfbb42b623b1783"
+checksum = "3bcbbf7ff00ff6fe2af22b93600195917fe90e90ff48424a140d1a926c44b1c1"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -1214,7 +1222,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1467,7 +1475,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1511,9 +1519,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.17.0"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -2169,9 +2177,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "e4eba85ea1d0a966a983acd07deee566e67395d2d96b6fb39e62b5a833f1eb0b"
 
 [[package]]
 name = "gobject-sys"
@@ -2888,7 +2896,7 @@ dependencies = [
  "base64 0.22.1",
  "getrandom 0.2.17",
  "js-sys",
- "pem",
+ "pem 3.0.6",
  "serde",
  "serde_json",
  "signature",
@@ -2971,7 +2979,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "aws-lc-rs",
- "base64 0.22.1",
+ "base64 0.23.1",
  "candle-core",
  "candle-nn",
  "candle-transformers",
@@ -2989,7 +2997,7 @@ dependencies = [
  "llama-cpp-2",
  "notify",
  "once_cell",
- "pem",
+ "pem 4.0.0",
  "rand 0.8.6",
  "regex",
  "reqwest 0.13.4",
@@ -3114,9 +3122,9 @@ dependencies = [
 
 [[package]]
 name = "libsqlite3-sys"
-version = "0.38.1"
+version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6c19a05435c21ac299d71b6a9c13db3e3f47c520517d58990a462a1397a61db"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
 dependencies = [
  "cc",
  "pkg-config",
@@ -3410,7 +3418,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3532,7 +3540,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3973,7 +3981,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
- "windows-sys 0.45.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4063,6 +4071,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
+ "serde_core",
+]
+
+[[package]]
+name = "pem"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d354a98a3d1251555de99e8fdd8afda05573c31b82f59063a7b0a29b5527f120"
+dependencies = [
+ "base64 0.23.1",
  "serde_core",
 ]
 
@@ -4896,9 +4914,9 @@ dependencies = [
 
 [[package]]
 name = "rusqlite"
-version = "0.40.1"
+version = "0.40.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11438310b19e3109b6446c33d1ed5e889428cf2e278407bc7896bc4aaea43323"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
 dependencies = [
  "bitflags 2.11.0",
  "fallible-iterator",
@@ -4944,7 +4962,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5001,7 +5019,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5035,13 +5053,15 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safetensors"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+checksum = "79b079b829cb27a1c3c374341345ed2e8b2c0c839034522cee576c140bd7f846"
 dependencies = [
  "hashbrown 0.16.1",
+ "libc",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -5527,7 +5547,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6296,7 +6316,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6806,7 +6826,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.20",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6841,7 +6861,7 @@ checksum = "51b70b87d15e91f553711b40df3048faf27a7a04e01e0ddc0cf9309f0af7c2ca"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7403,7 +7423,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8262,18 +8282,6 @@ dependencies = [
  "crc32fast",
  "indexmap 2.13.0",
  "memchr",
-]
-
-[[package]]
-name = "zip"
-version = "7.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
-dependencies = [
- "crc32fast",
- "indexmap 2.13.0",
- "memchr",
- "typed-path",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ reqwest = { version = "0.13", default-features = false, features = ["native-tls"
 dirs = "6"
 chrono = { version = "0.4", features = ["serde"] }
 url = "2"
-base64 = "0.22.1"
+base64 = "0.23.1"
 urlencoding = "2.1.3"
 uuid = { version = "1.23.2", features = ["v4"] }
 glob = "0.3"
@@ -57,9 +57,9 @@ llama-cpp-2 = { version = "0.1", default-features = false }
 
 # Embedding & semantic search
 sqlite-vec = "0.1.8-alpha.1"
-candle-core = "0.10"
-candle-nn = "0.10"
-candle-transformers = "0.10"
+candle-core = "0.11"
+candle-nn = "0.11"
+candle-transformers = "0.11"
 hf-hub = { version = "0.5", features = ["tokio"] }
 tokenizers = { version = "0.23", default-features = false, features = ["onig"] }
 
@@ -88,7 +88,7 @@ tempfile = "3"
 # tested without committing a private key to the repo. Both crates are already
 # in the tree via jsonwebtoken, so this adds no new dependencies.
 aws-lc-rs = "1"
-pem = "3"
+pem = "4"
 
 # Also needed at runtime for ghost rebase temp worktrees
 [dependencies.tempfile]


### PR DESCRIPTION
Four commits: the first clears the open Dependabot backlog, the second stops that backlog from forming again, and the last two fix problems that opening this PR exposed.

## 1. `deps:` apply the open Dependabot bumps except TypeScript 7

Consolidates eight of the nine open Dependabot PRs. They all branched from `50ff205` while `main` has since moved to `0e3589a`, which itself rewrote both lockfiles — so merging them individually would have forced a rebase-and-recheck of the remainder after every single merge.

| PR | Bump |
|---|---|
| #317 | globals 17.9.0 → 17.11.0 |
| #312 | zustand 5.0.14 → 5.0.15 |
| #310 | typescript-eslint 8.66.0 → 8.67.0 |
| #318 | glob 0.3.3 → 0.3.4 |
| #313 | rusqlite 0.40.1 → 0.40.2 |
| #314 | base64 0.22.1 → 0.23.1 |
| #311 | pem 3.0.6 → 4.0.0 (dev-dependency) |
| #316 | candle-core / -nn / -transformers 0.10.2 → 0.11.0 |

**#316 was wrong as Dependabot proposed it.** It bumped `candle-transformers` to 0.11 alone, leaving `candle-core` and `candle-nn` at 0.10. Those three exchange types across the `BertModel`/`VarBuilder` boundary in `src-tauri/src/services/embedding/onnx_engine.rs:8-10`, so taking it as written would very likely have failed to compile. All three move together here.

Despite two major bumps and the candle stack, no source changes were needed — the `Engine` API, `pem::Pem::new`, and candle's `bert` module are all unchanged at the call sites this repo uses.

**#315 (TypeScript 6.0.3 → 7.0.2) is deliberately left open.** Beyond being out of scope, typescript-eslint 8.67 declares a peer range of `>=4.8.4 <6.1.0`, so TypeScript 7 can't be taken until typescript-eslint supports it.

## 2. `ci:` merge Dependabot PRs once every check is green

### Why not `gh pr merge --auto`

`main` has no branch protection. GitHub's native auto-merge only *waits* for anything when the base branch has required status checks — so on an unprotected branch that call merges Dependabot PRs the moment they open, which is the opposite of the intent. This triggers on `workflow_run` instead, making CI passing the actual gate. It needs no repository settings changes.

### What auto-merges

Dependabot names a bump after whichever semver field moved, which is not the same question as whether it can break us. Below 1.0.0 both Cargo and npm treat the *minor* field as the compatibility boundary, so `base64 0.22.1 → 0.23.1` is breaking and Dependabot still labels it `semver-minor`. Most of the Rust tree is 0.x (git2, candle, rusqlite, base64), so this distinction decides most PRs.

The policy merges updates that stay inside their current compatibility range and holds the rest. Against the eight bumps in commit 1 it merges glob, rusqlite, globals, zustand and typescript-eslint, and holds base64, pem and candle-transformers — exactly the three that needed a human, one of them because Dependabot got it wrong. Held PRs get one comment saying why.

### Beyond the naive version

- **Judges readiness from workflow runs, not just check runs.** Check runs are named after jobs, so they cannot tell you a whole workflow has yet to report. Requiring at least one registered run for the head commit closes the window just after a push where "nothing has failed" is vacuously true. Check runs and commit statuses are still consulted, since that is how a non-Actions app reports — CodeQL's code-scanning result arrives that way.
- **Pins the merge to the tested commit** via the `sha` parameter, so a push landing mid-job cannot ride in untested.
- **Skips its own workflow run and check run**, which it would otherwise wait on forever.
- **Never fetches the PR.** The checkout is `ref: default_branch` with `sparse-checkout: .github/scripts`, so the writable token never sees Dependabot's branch contents.

## 3. `ci:` wait for CodeQL too, and sweep hourly

The first CI run on this PR turned up a third workflow running against PRs here: **CodeQL, via GitHub's default setup**. It has no file in `.github/workflows` — it lives at `dynamic/github-code-scanning/codeql` — which is exactly why the guard test, which reads workflow files, could not see it.

That was a real deadlock. A `workflow_run` trigger has to name the workflows it waits for, and CodeQL analyses Rust here, so it is slow enough to finish last easily. When it did, the PR would sit green and unmerged with nothing left to wake anything up.

So: CodeQL is now waited on by name, and there is an hourly sweep (plus a manual dispatch) that considers every open Dependabot PR rather than just the one whose checks finished. The sweep is the part that matters — it makes a missing trigger or a dropped webhook cost an hour instead of wedging the queue, for whatever workflow gets added next as well as this one.

## 4. `ci:` scope the readiness check to the commit under test

From Copilot's review. `checksAreGreen()` asked the API for runs with `head_sha` and trusted the response to be scoped; the filter is now also applied locally.

The API does honour the parameter — checked against this PR's own runs, where a `pull_request`-triggered run carries the PR head as its `head_sha`, not a merge commit — so this changes no behaviour today. It is worth doing anyway because "at least one workflow run has registered for this commit" is the single predicate the merge-safety argument rests on, and leaving it to a query parameter makes it unprovable from the code in front of you.

It also fixes something live that the review did not anticipate: `ci.yml` cancels superseded runs, so an earlier commit on a branch routinely leaves a `cancelled` run and an `in_progress` one behind. Neither counts as passing, so without the SHA filter both would have blocked every merge indefinitely — and both were sitting on this PR's previous commit at the time.

## Testing

The logic lives in `.github/scripts/` rather than inline in YAML so it can be tested: **41 tests** covering classification, merge orchestration, the sweep, and the readiness rules against a mocked Octokit, wired into the `lint-frontend` job. Five guard against coupling that would otherwise rot silently — the job name, the workflow name, the CodeQL entry, the presence of the schedule, and the wait list versus the workflow files. Every guard and every safety filter was mutation-tested to confirm it fails when the thing it guards is removed, rather than passing vacuously.

## Verification

Full gate run locally: lint 0 errors (200 warnings, unchanged from `main`), typecheck clean, `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean, 2077 Rust tests passing (including the JWT test that exercises pem 4), frontend build clean, 41 workflow-script tests passing.

Frontend unit tests: 4370 passed, 2 failed. Both failures are in `network-gate-coverage.test.ts` and reproduce identically on unmodified `main` — a 10-second Mocha timeout on a slow sweep test, unrelated to these changes.

## Notes for after merge

- The auto-merge workflow only starts working once it is on `main`; `workflow_run` and `schedule` workflows fire from the default branch only.
- The first Dependabot PR afterwards tests one assumption I could not verify: GitHub gives Dependabot-triggered `pull_request` workflows a read-only token, and whether that extends to a `workflow_run` fired by a Dependabot run is not covered in the docs. The failure is loud rather than silent — a 403 calls `core.setFailed` pointing at Settings → Actions → General → Workflow permissions, and the workflow already accepts an optional `DEPENDABOT_AUTOMERGE_TOKEN` secret that takes precedence over `GITHUB_TOKEN`. The hourly sweep runs on a `schedule` event, which is not Dependabot-triggered at all, so it is a useful cross-check if that turns out to be the problem.
- Merges performed with `GITHUB_TOKEN` do not trigger downstream workflows, so the push-to-`main` run of Build & Release will not fire after an auto-merge. The PR's own checks already tested the merge result; using a PAT restores it if you want that smoke build.

Merging this closes #310, #311, #312, #313, #314, #316, #317 and #318. #315 stays open by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LrFnHwpvt2GgMkDDPswrrH