### PR TITLE
Close the .skip-link rule so the global loading bar is visible

### DIFF
--- a/src/__tests__/app-shell-loading-bar.test.ts
+++ b/src/__tests__/app-shell-loading-bar.test.ts
@@ -1,0 +1,81 @@
+/**
+ * The global loading bar must actually be styled.
+ *
+ * The `.skip-link` rule above it was never closed, so under CSS nesting — which
+ * the WebView2 and WKWebView engines Tauri uses both support — the loading-bar
+ * selectors compiled to `.skip-link .global-loading-bar` and matched nothing:
+ * the bar is a SIBLING of the skip link, not a descendant. The bar rendered but
+ * was invisible, so every long-running operation ran with no progress
+ * indicator at all. The skip link lost its own colours too, because its
+ * declarations were stranded after the @keyframes block.
+ *
+ * Asserted through computed style rather than by reading the stylesheet text,
+ * so it fails for a nesting mistake of any shape.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+const mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { AppShell } from '../app-shell.ts';
+import '../app-shell.ts';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+async function shellWithLoading(loading: boolean): Promise<AppShell> {
+  const el = await fixture<AppShell>(html`<lv-app-shell></lv-app-shell>`);
+  (el as any).globalLoading = loading;
+  await el.updateComplete;
+  return el;
+}
+
+describe('app-shell global loading bar', () => {
+  it('renders the bar only while an operation is running', async () => {
+    const idle = await shellWithLoading(false);
+    expect(idle.shadowRoot!.querySelector('.global-loading-bar')).to.be.null;
+
+    const busy = await shellWithLoading(true);
+    expect(busy.shadowRoot!.querySelector('.global-loading-bar')).to.not.be.null;
+  });
+
+  it('styles the bar, so it is actually visible', async () => {
+    const el = await shellWithLoading(true);
+    const bar = el.shadowRoot!.querySelector('.global-loading-bar') as HTMLElement;
+    expect(bar, 'the bar must be rendered').to.not.be.null;
+
+    const style = getComputedStyle(bar);
+
+    // Nested under .skip-link the rule never applied, leaving the div at its
+    // default `position: static` with no height — present in the DOM and
+    // invisible on screen.
+    expect(style.position, 'the loading bar must be positioned').to.equal('fixed');
+    expect(
+      parseFloat(style.height),
+      'the loading bar must have a height, or nothing is drawn',
+    ).to.be.greaterThan(0);
+  });
+
+  it('styles the skip link, whose declarations sat after the keyframes', async () => {
+    const el = await shellWithLoading(false);
+    const skip = el.shadowRoot!.querySelector('.skip-link') as HTMLElement;
+    expect(skip, 'the skip link must be rendered').to.not.be.null;
+
+    const style = getComputedStyle(skip);
+    expect(style.position, 'the skip link must be positioned').to.equal('absolute');
+    // Stranded after @keyframes, this declaration was dropped entirely.
+    expect(
+      style.textDecorationLine,
+      'the skip link must keep its own styling',
+    ).to.contain('none');
+  });
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -151,7 +151,20 @@ export class AppShell extends LitElement {
         left: 16px;
         z-index: 10000;
         padding: 8px 16px;
+        background: var(--color-accent);
+        color: white;
+        text-decoration: none;
+        border-radius: 0 0 6px 6px;
+        font-size: 14px;
+      }
 
+      /* Top level, NOT nested in .skip-link. The rule above was left unclosed,
+         so under CSS nesting — which the WebView2 and WKWebView engines Tauri
+         uses both support — these compiled to a descendant selector under
+         .skip-link and matched nothing: the bar is a SIBLING of the skip link,
+         not a descendant. The global progress indicator was invisible for
+         every long-running operation, and the skip link lost its own colours
+         to boot, since its declarations were stranded after the keyframes. */
       .global-loading-bar {
         position: fixed;
         top: 0;
@@ -176,12 +189,6 @@ export class AppShell extends LitElement {
         0% { transform: translateX(-100%); }
         50% { transform: translateX(150%); }
         100% { transform: translateX(350%); }
-      }
-        background: var(--color-accent);
-        color: white;
-        text-decoration: none;
-        border-radius: 0 0 6px 6px;
-        font-size: 14px;
       }
 
       .skip-link:focus {


### PR DESCRIPTION
## The problem

The `.skip-link` rule in `app-shell.ts` opens and is **never closed**:

```css
.skip-link {
  position: absolute;
  top: -100%;
  left: 16px;
  z-index: 10000;
  padding: 8px 16px;
                        /* ← no closing brace */
.global-loading-bar { … }
.global-loading-bar::after { … }
@keyframes loading-slide { … }
  background: var(--color-accent);   /* ← stranded after the keyframes */
  color: white;
  …
}
```

Two consequences, both user-visible:

1. **The global loading bar was invisible.** Under CSS nesting — supported by the WebView2 and WKWebView engines Tauri uses — the loading-bar selectors compile to a descendant selector under `.skip-link`. The bar is rendered as a **sibling** of the skip link, not a descendant, so nothing matched. The div was in the DOM at its default `position: static` with no height. Every long-running operation ran with no progress indicator at all.

2. **The skip link lost its own appearance.** Its `background`, `color`, `text-decoration`, `border-radius` and `font-size` sat *after* the `@keyframes` block, where they applied to nothing — so the accessibility skip link rendered unstyled.

## The change

Close `.skip-link` after its own declarations, move the stranded ones back inside it, and un-nest `.global-loading-bar`, its `::after` and `@keyframes loading-slide` to the top level. No behaviour or markup changes — this is the CSS finally applying.

## Tests

`src/__tests__/app-shell-loading-bar.test.ts` asserts **computed style**, not stylesheet text, so it fails for a nesting mistake of any shape:

- the bar renders only while `globalLoading` is set;
- the bar is `position: fixed` with a non-zero height (it was `static`/zero-height before);
- the skip link keeps `position: absolute` and its own `text-decoration`.

Verified the middle test fails against the original unclosed-rule CSS.

Full gate green: `npm run lint && npm run typecheck && npm test` — 4423 frontend tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_