### PR TITLE
Stop Vibe Check reporting &#34;No issues found&#34; when the AI never ran

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -397,6 +397,9 @@ pub async fn analyze_staged_changes(
             findings: vec![],
             summary: "No staged changes".to_string(),
             risk_level: RiskLevel::Low,
+            // Nothing to analyse, so nothing failed.
+            ai_analysis_ran: true,
+            ai_error: None,
         });
     }
 
@@ -407,14 +410,26 @@ pub async fn analyze_staged_changes(
     let truncated = truncate_content(&diff, MAX_DIFF_BYTES);
     let service = state.read().await;
 
-    if let Ok(response) = service
+    // Both failure arms used to be dropped on the floor. A provider that had
+    // stopped since the availability check, a missing model, a dead network or
+    // an unparseable response all left the command returning success with only
+    // the regex secret findings — rendered as a completed check reading "No
+    // issues found". The user was told their staged changes had been reviewed
+    // when nothing had reviewed them.
+    let ai_error = match service
         .generate_text(VIBE_CHECK_PROMPT, truncated, Some(1000))
         .await
     {
-        if let Ok(ai_analysis) = parse_vibe_check_response(&response) {
-            findings.extend(ai_analysis.findings);
-        }
-    }
+        Ok(response) => match parse_vibe_check_response(&response) {
+            Ok(ai_analysis) => {
+                findings.extend(ai_analysis.findings);
+                None
+            }
+            Err(e) => Some(format!("could not read the model's response: {}", e)),
+        },
+        Err(e) => Some(e.to_string()),
+    };
+    let ai_analysis_ran = ai_error.is_none();
 
     let risk_level = if findings
         .iter()
@@ -430,7 +445,7 @@ pub async fn analyze_staged_changes(
         RiskLevel::Low
     };
 
-    let summary = if findings.is_empty() {
+    let found = if findings.is_empty() {
         "No issues found".to_string()
     } else {
         format!(
@@ -439,11 +454,20 @@ pub async fn analyze_staged_changes(
             if findings.len() == 1 { "" } else { "s" }
         )
     };
+    // Say what was actually checked. "No issues found" over a failed AI pass
+    // is the false assurance this exists to prevent.
+    let summary = if ai_analysis_ran {
+        found
+    } else {
+        format!("{} (secret scan only — AI analysis failed)", found)
+    };
 
     Ok(StagedAnalysis {
         findings,
         summary,
         risk_level,
+        ai_analysis_ran,
+        ai_error,
     })
 }
 
@@ -1026,6 +1050,21 @@ mod tests {
         assert!(result.is_ok());
         let analysis = result.unwrap();
         assert_eq!(analysis.findings.len(), 1);
+    }
+
+    /// The model's JSON does not carry the reporting fields, and must not have
+    /// to.
+    ///
+    /// StagedAnalysis is both the command's RESULT type and the shape the
+    /// model's response is parsed into. Adding a required field to it would
+    /// make every model response fail to parse — taking down the AI pass, which
+    /// is exactly the failure those fields exist to report.
+    #[test]
+    fn test_parse_vibe_check_tolerates_a_response_without_the_reporting_fields() {
+        let response = r#"{"findings": [], "summary": "No issues", "riskLevel": "low"}"#;
+        let analysis = parse_vibe_check_response(response)
+            .expect("a model response without the reporting fields must still parse");
+        assert!(analysis.findings.is_empty());
     }
 
     #[test]

--- a/src-tauri/src/services/ai/mod.rs
+++ b/src-tauri/src/services/ai/mod.rs
@@ -262,6 +262,23 @@ pub struct StagedAnalysis {
     pub findings: Vec<AnalysisFinding>,
     pub summary: String,
     pub risk_level: RiskLevel,
+    /// Whether the AI half of the check actually ran and parsed.
+    ///
+    /// `serde(default)`: this same struct is what the MODEL's JSON is parsed
+    /// into, and the model does not report on its own liveness. Without the
+    /// default a missing field would fail the parse and take the AI pass down
+    /// with it — the very failure this field exists to report.
+    ///
+    /// The regex secret scan always runs; the AI pass can fail (provider
+    /// stopped after the availability check, model missing, network down,
+    /// unparseable response). Both failures used to be discarded, so a check
+    /// that had done nothing but grep for secrets still reported "No issues
+    /// found" — false assurance that a review had happened.
+    #[serde(default)]
+    pub ai_analysis_ran: bool,
+    /// Why the AI pass did not run, when it did not.
+    #[serde(default)]
+    pub ai_error: Option<String>,
 }
 
 /// Generated PR description result

--- a/src/components/sidebar/__tests__/lv-commit-panel-vibe-failure.test.ts
+++ b/src/components/sidebar/__tests__/lv-commit-panel-vibe-failure.test.ts
@@ -1,0 +1,100 @@
+/**
+ * A Vibe Check whose AI pass failed must say so.
+ *
+ * analyze_staged_changes discarded both AI failure arms — a provider that had
+ * stopped since the availability check, a missing model, a dead network, an
+ * unparseable response — and still returned success carrying only the regex
+ * secret findings. The panel rendered that as a completed check reading "No
+ * issues found", telling the user their staged changes had been reviewed when
+ * nothing had reviewed them.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-commit-panel.ts';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const REPO_PATH = '/test/repo';
+
+interface Panel extends HTMLElement {
+  updateComplete: Promise<unknown>;
+}
+
+async function panelWithVibeResult(result: Record<string, unknown>): Promise<Panel> {
+  const el = await fixture<Panel>(html`
+    <lv-commit-panel .repositoryPath=${REPO_PATH} .stagedCount=${2}></lv-commit-panel>
+  `);
+  await el.updateComplete;
+  // The whole AI section is gated on a configured provider.
+  (el as any).aiAvailable = true;
+  (el as any).vibeCheckResult = result;
+  await el.updateComplete;
+  return el;
+}
+
+function warningText(el: Panel): string | null {
+  const node = el.shadowRoot!.querySelector('.vibe-ai-warning');
+  return node ? node.textContent!.replace(/\s+/g, ' ').trim() : null;
+}
+
+describe('lv-commit-panel vibe check AI failure', () => {
+  beforeEach(() => {
+    mockInvoke = async (command: string) => {
+      if (command === 'plugin:notification|is_permission_granted') return false;
+      if (command === 'get_status') return { staged: [], unstaged: [], untracked: [] };
+      return null;
+    };
+  });
+
+  it('warns that only the secret scan ran when the AI pass failed', async () => {
+    const el = await panelWithVibeResult({
+      findings: [],
+      summary: 'No issues found (secret scan only — AI analysis failed)',
+      riskLevel: 'low',
+      aiAnalysisRan: false,
+      aiError: 'connection refused',
+    });
+
+    const warning = warningText(el);
+    expect(warning, 'a failed AI pass must be visible, not silent').to.not.be.null;
+    expect(warning!).to.contain('secret scan');
+    expect(warning!, 'the reason helps the user fix it').to.contain('connection refused');
+  });
+
+  it('still warns when no reason was reported', async () => {
+    const el = await panelWithVibeResult({
+      findings: [],
+      summary: 'No issues found (secret scan only — AI analysis failed)',
+      riskLevel: 'low',
+      aiAnalysisRan: false,
+      aiError: null,
+    });
+
+    expect(warningText(el), 'the warning does not depend on having a reason').to.not.be.null;
+  });
+
+  it('shows no warning when the AI pass ran', async () => {
+    const el = await panelWithVibeResult({
+      findings: [],
+      summary: 'No issues found',
+      riskLevel: 'low',
+      aiAnalysisRan: true,
+      aiError: null,
+    });
+
+    expect(warningText(el), 'a complete check must not cry wolf').to.be.null;
+  });
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/components/sidebar/lv-commit-panel.ts
+++ b/src/components/sidebar/lv-commit-panel.ts
@@ -335,6 +335,17 @@ export class LvCommitPanel extends LitElement {
 
       .vibe-summary:hover { background: var(--color-bg-hover); }
 
+      /* A failed AI pass leaves the regex secret scan alone, and saying so is
+         the whole point — a clean-looking result over a check that never ran
+         is worse than no check. */
+      .vibe-ai-warning {
+        padding: 6px 8px;
+        border-top: 1px solid var(--color-border);
+        color: var(--color-warning);
+        font-size: 11px;
+        line-height: 1.4;
+      }
+
       .risk-badge {
         padding: 1px 6px;
         border-radius: 8px;
@@ -1391,6 +1402,12 @@ export class LvCommitPanel extends LitElement {
                 <span class="risk-badge ${this.vibeCheckResult.riskLevel}">${this.vibeCheckResult.riskLevel}</span>
                 <span>${this.vibeCheckResult.summary}</span>
               </div>
+              ${this.vibeCheckResult.aiAnalysisRan === false ? html`
+                <div class="vibe-ai-warning" role="status">
+                  AI analysis did not run, so only the secret scan was
+                  performed${this.vibeCheckResult.aiError ? html`: ${this.vibeCheckResult.aiError}` : nothing}
+                </div>
+              ` : nothing}
               ${this.showVibeDetails && this.vibeCheckResult.findings.length > 0 ? html`
                 <div class="findings-list">
                   ${this.vibeCheckResult.findings.map(f => html`

--- a/src/services/ai.service.ts
+++ b/src/services/ai.service.ts
@@ -175,6 +175,11 @@ export interface StagedAnalysis {
   findings: AnalysisFinding[];
   summary: string;
   riskLevel: RiskLevel;
+  /** Whether the AI half of the check ran and parsed. False means the result
+   *  is the regex secret scan alone. */
+  aiAnalysisRan: boolean;
+  /** Why the AI pass did not run, when it did not. */
+  aiError: string | null;
 }
 
 export interface GeneratedPrDescription {


### PR DESCRIPTION
## The problem

`analyze_staged_changes` wrapped the AI call and the response parse in `if let Ok(...)`, discarding **both** failure paths:

```rust
if let Ok(response) = service.generate_text(VIBE_CHECK_PROMPT, truncated, Some(1000)).await {
    if let Ok(ai_analysis) = parse_vibe_check_response(&response) {
        findings.extend(ai_analysis.findings);
    }
}
```

So when the provider errored — Ollama stopped after the availability check, model missing, network down — or the model returned unparseable JSON, the command still returned **success**, carrying only the regex secret-scan findings. With no secrets present that is `summary: "No issues found", riskLevel: low`.

The commit panel renders that as a completed check. The user is told their staged changes were reviewed, when nothing reviewed them. False assurance is worse than no check at all.

## The change

The failure is now reported instead of swallowed:

- `StagedAnalysis` carries `aiAnalysisRan: bool` and `aiError: string | null`.
- The summary becomes `"… (secret scan only — AI analysis failed)"`.
- The panel renders a warning line with the reason, so it is actionable.

The secret findings are still returned — they are still real, and still worth showing. This is about not claiming more than was actually done.

## One trap worth flagging

`StagedAnalysis` is *both* the command's result type **and** the shape the model's JSON response is deserialized into. Adding required fields to it would make **every** model response fail to parse — taking down the AI pass that these fields exist to report on.

Both new fields are therefore `#[serde(default)]`, and `test_parse_vibe_check_tolerates_a_response_without_the_reporting_fields` pins it so a later change cannot quietly reintroduce the trap.

## Tests

- `test_parse_vibe_check_tolerates_a_response_without_the_reporting_fields` (Rust) — the serde-default trap above.
- `lv-commit-panel-vibe-failure.test.ts` — warns with the reason when `aiAnalysisRan: false`; still warns when no reason was reported; shows **no** warning when the AI pass ran, so a complete check does not cry wolf. The first two fail against the old render.

Full gate green: `npm run lint && npm run typecheck && npm test && cargo fmt --check && cargo clippy --all-targets -- -D warnings` — 2129 Rust tests, 4423 frontend tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_