### PR TITLE
Stop the window-focus fetch toasting on every alt-tab

### DIFF
--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -138,6 +138,7 @@ pub async fn get_remotes(path: String) -> Result<Vec<Remote>> {
 }
 
 /// Fetch from remote
+#[allow(clippy::too_many_arguments)]
 #[command]
 pub async fn fetch(
     app_handle: AppHandle,
@@ -146,8 +147,16 @@ pub async fn fetch(
     prune: Option<bool>,
     token: Option<String>,
     timeout_secs: Option<u64>,
+    quiet: Option<bool>,
     _operation_id: Option<String>,
 ) -> Result<()> {
+    // A fetch the user did not ask for must not announce itself. The
+    // window-focus refresh runs this same command, and the success event below
+    // is toasted by setupRemoteOperationListeners — so with fetch-on-focus
+    // enabled, "Fetched from origin" appeared every single time the user
+    // alt-tabbed back into the app. That is exactly the noise the background
+    // fetch is documented to avoid.
+    let quiet = quiet.unwrap_or(false);
     let do_fetch = async move {
         let path_clone = path.clone();
         let prune_val = prune.unwrap_or(false);
@@ -180,16 +189,18 @@ pub async fn fetch(
         .await
         .map_err(|e| LeviathanError::Custom(format!("Fetch task failed: {}", e)))??;
 
-        // Emit success event
-        let _ = app_handle.emit(
-            "remote-operation-completed",
-            RemoteOperationResult {
-                operation: "fetch".to_string(),
-                remote: remote_name_for_event,
-                success: true,
-                message: "Fetch completed successfully".to_string(),
-            },
-        );
+        // Emit success event, unless this fetch is a background one.
+        if !quiet {
+            let _ = app_handle.emit(
+                "remote-operation-completed",
+                RemoteOperationResult {
+                    operation: "fetch".to_string(),
+                    remote: remote_name_for_event,
+                    success: true,
+                    message: "Fetch completed successfully".to_string(),
+                },
+            );
+        }
 
         Ok(())
     };

--- a/src/services/__tests__/remote.service.test.ts
+++ b/src/services/__tests__/remote.service.test.ts
@@ -23,6 +23,7 @@ import {
   renameRemote,
   setRemoteUrl,
   fetch,
+  fetchInBackground,
   pull,
   push,
   pushToMultipleRemotes,
@@ -267,6 +268,28 @@ describe('git.service - Remote operations', () => {
       await fetch({ path: '/test/repo', remote: 'upstream', silent: true });
       const args = lastInvokedArgs as Record<string, unknown>;
       expect(args.remote).to.equal('upstream');
+    });
+
+    // The window-focus refresh runs this same backend command, and the
+    // backend's success event is toasted by setupRemoteOperationListeners. So
+    // with fetch-on-focus enabled, "Fetched from origin" appeared every single
+    // time the user alt-tabbed back into the app — exactly the noise the
+    // background fetch is documented to avoid.
+    it('marks a background fetch quiet so it does not toast', async () => {
+      mockInvoke = () => Promise.resolve(null);
+
+      await fetchInBackground('/test/repo');
+      expect(lastInvokedCommand).to.equal('fetch');
+      const args = lastInvokedArgs as Record<string, unknown>;
+      expect(args.quiet, 'the background fetch must suppress the success event').to.be.true;
+    });
+
+    it('leaves a user-initiated fetch loud', async () => {
+      mockInvoke = () => Promise.resolve(null);
+
+      await fetch({ path: '/test/repo', silent: true });
+      const args = lastInvokedArgs as Record<string, unknown>;
+      expect(args.quiet, 'a fetch the user asked for still reports itself').to.not.be.true;
     });
 
     it('supports prune option', async () => {

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -110,6 +110,10 @@ export async function fetchInBackground(
   return invokeCommand<void>("fetch", {
     path: repoPath,
     token,
+    // Suppresses the backend's success event, which
+    // setupRemoteOperationListeners toasts. Without it this "silent" fetch
+    // popped "Fetched from origin" every time the user alt-tabbed back in.
+    quiet: true,
     ...(timeoutSecs > 0 ? { timeoutSecs } : {}),
   });
 }

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -182,6 +182,9 @@ export interface FetchCommand {
   prune?: boolean;
   token?: string;
   timeoutSecs?: number;
+  /** Suppress the success event a user-initiated fetch emits. Set by the
+   *  window-focus background fetch, which must not toast. */
+  quiet?: boolean;
 }
 
 export interface PullCommand {


### PR DESCRIPTION
## The problem

`fetchInBackground` is documented as deliberately silent — *"it just doesn't shout"* — and runs on **every window focus** when the fetch-on-focus setting is enabled.

But it invokes the same `fetch` command a user-initiated fetch does, and the backend emits `remote-operation-completed` unconditionally on success. `setupRemoteOperationListeners` toasts every one of those.

Net effect: **"Fetched from origin" pops every single time the user alt-tabs back into the app** — precisely the noise the silent background fetch exists to avoid.

## The change

The `fetch` command takes a `quiet` flag that suppresses the success event; `fetchInBackground` sets it. A fetch the user actually asked for still reports itself, unchanged.

Chose the flag over tagging the emit with `_operation_id` and filtering in the listener: the event is never wanted for a background fetch, so not emitting it is simpler than emitting and discarding — and it keeps the decision on the side that knows why the fetch is happening.

`#[allow(clippy::too_many_arguments)]` on the command matches what `push` and `clone_repository` already carry — Tauri commands take their parameters flat.

## Tests

In `remote.service.test.ts`, next to the existing fetch coverage:

- `marks a background fetch quiet so it does not toast` — fails without the flag.
- `leaves a user-initiated fetch loud` — the control, so this cannot be "fixed" by silencing everything.

Full gate green: `npm run lint && npm run typecheck && npm test && cargo fmt --check && cargo clippy --all-targets -- -D warnings` — 2133 Rust tests, 4422 frontend tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_