### PR TITLE
Badge merged pull requests as merged, not closed

### DIFF
--- a/src/components/dialogs/__tests__/lv-github-dialog-pr-state.test.ts
+++ b/src/components/dialogs/__tests__/lv-github-dialog-pr-state.test.ts
@@ -1,0 +1,84 @@
+/**
+ * A merged pull request must be badged "merged", not "closed".
+ *
+ * GitHub's REST API reports a merged PR with `state: "closed"` — merged-ness
+ * lives in `merged_at`, which the backend already carries through as
+ * `mergedAt`. getPrState() read only `state`, so every merged PR got the red
+ * "closed" badge under the Closed and All filters, saying the work had been
+ * abandoned when it had actually landed. The `.pr-state.merged` style existed
+ * and nothing could reach it.
+ */
+
+// Mock Tauri API before importing any modules that use it
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+let cbId = 0;
+const mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-github-dialog.ts';
+import type { LvGitHubDialog } from '../lv-github-dialog.ts';
+import type { PullRequestSummary } from '../../../services/git.service.ts';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+function pr(overrides: Partial<PullRequestSummary>): PullRequestSummary {
+  return {
+    number: 1,
+    title: 'A change',
+    state: 'open',
+    user: { login: 'octocat', id: 1, avatarUrl: '', name: null, email: null } as any,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    mergedAt: null,
+    headRef: 'feature',
+    headSha: 'abc123',
+    baseRef: 'main',
+    draft: false,
+    mergeable: true,
+    htmlUrl: 'https://github.com/o/r/pull/1',
+    additions: 1,
+    deletions: 0,
+    changedFiles: 1,
+    ...overrides,
+  } as PullRequestSummary;
+}
+
+async function stateOf(summary: PullRequestSummary): Promise<string> {
+  const el = await fixture<LvGitHubDialog>(html`<lv-github-dialog></lv-github-dialog>`);
+  return (el as any).getPrState(summary);
+}
+
+describe('lv-github-dialog pull request state badge', () => {
+  it('badges a merged PR as merged, though GitHub calls its state closed', async () => {
+    const state = await stateOf(
+      pr({ state: 'closed', mergedAt: '2026-01-02T00:00:00Z' }),
+    );
+    expect(state, 'merged-ness comes from mergedAt, not state').to.equal('merged');
+  });
+
+  it('still badges a genuinely closed PR as closed', async () => {
+    const state = await stateOf(pr({ state: 'closed', mergedAt: null }));
+    expect(state).to.equal('closed');
+  });
+
+  it('badges an open PR as open', async () => {
+    expect(await stateOf(pr({ state: 'open' }))).to.equal('open');
+  });
+
+  it('badges an open draft as draft', async () => {
+    expect(await stateOf(pr({ state: 'open', draft: true }))).to.equal('draft');
+  });
+
+  // GitHub leaves `draft` set on a draft that was closed without merging, so
+  // checking it first would label a dead PR "draft" forever.
+  it('badges a closed draft as closed, not draft', async () => {
+    const state = await stateOf(pr({ state: 'closed', draft: true, mergedAt: null }));
+    expect(state).to.equal('closed');
+  });
+});
+/* eslint-enable @typescript-eslint/no-explicit-any */

--- a/src/components/dialogs/lv-github-dialog.ts
+++ b/src/components/dialogs/lv-github-dialog.ts
@@ -1819,12 +1819,20 @@ export class LvGitHubDialog extends LitElement {
     openExternalUrl(url);
   }
 
+  /// The badge to show for a pull request.
+  ///
+  /// GitHub's REST API reports a MERGED pull request with `state: "closed"` —
+  /// merged-ness lives in `merged_at`, which the backend already carries all
+  /// the way here. Reading only `state` gave every merged PR the red "closed"
+  /// badge, saying the work was abandoned when it had actually landed. The
+  /// `.pr-state.merged` style existed and nothing could ever reach it.
+  ///
+  /// `draft` is only meaningful while the PR is open: GitHub leaves the flag
+  /// set on a draft that was closed without merging, so checking it first would
+  /// label a dead PR "draft" forever.
   private getPrState(pr: PullRequestSummary): string {
-    if (pr.draft) return 'draft';
-    if (pr.state === 'closed') {
-      // Check if merged based on URL pattern (GitHub PRs have /pull/N for open, merged shows differently)
-      return 'closed';
-    }
+    if (pr.draft && pr.state === 'open') return 'draft';
+    if (pr.mergedAt) return 'merged';
     return pr.state;
   }
 

--- a/src/components/dialogs/lv-github-dialog.ts
+++ b/src/components/dialogs/lv-github-dialog.ts
@@ -1819,17 +1819,19 @@ export class LvGitHubDialog extends LitElement {
     openExternalUrl(url);
   }
 
-  /// The badge to show for a pull request.
-  ///
-  /// GitHub's REST API reports a MERGED pull request with `state: "closed"` —
-  /// merged-ness lives in `merged_at`, which the backend already carries all
-  /// the way here. Reading only `state` gave every merged PR the red "closed"
-  /// badge, saying the work was abandoned when it had actually landed. The
-  /// `.pr-state.merged` style existed and nothing could ever reach it.
-  ///
-  /// `draft` is only meaningful while the PR is open: GitHub leaves the flag
-  /// set on a draft that was closed without merging, so checking it first would
-  /// label a dead PR "draft" forever.
+  /**
+   * The badge to show for a pull request.
+   *
+   * GitHub's REST API reports a MERGED pull request with `state: "closed"` —
+   * merged-ness lives in `merged_at`, which the backend already carries all the
+   * way here. Reading only `state` gave every merged PR the red "closed" badge,
+   * saying the work was abandoned when it had actually landed. The
+   * `.pr-state.merged` style existed and nothing could ever reach it.
+   *
+   * `draft` is only meaningful while the PR is open: GitHub leaves the flag set
+   * on a draft that was closed without merging, so checking it first would
+   * label a dead PR "draft" forever.
+   */
   private getPrState(pr: PullRequestSummary): string {
     if (pr.draft && pr.state === 'open') return 'draft';
     if (pr.mergedAt) return 'merged';


### PR DESCRIPTION
## The problem

GitHub's REST API reports a **merged** pull request with `state: "closed"`. Merged-ness lives in `merged_at` — which the backend already surfaces (`PullRequestSummary.merged_at`) and the frontend type already carries as `mergedAt`.

`getPrState()` read only `state`, and its own comment admitted defeat:

```ts
if (pr.draft) return 'draft';
if (pr.state === 'closed') {
  // Check if merged based on URL pattern (GitHub PRs have /pull/N for open, merged shows differently)
  return 'closed';
}
```

So under the **Closed** and **All** filters, every merged PR wore the red "closed" badge — saying the work was abandoned when it had actually landed. The `.pr-state.merged` purple style was already defined and **nothing could ever reach it**.

## A second bug in the same three lines

`draft` was checked first, unconditionally. GitHub leaves the `draft` flag set on a draft that was **closed without merging**, so such a PR was badged "draft" forever — as though it were still awaiting work.

## The change

```ts
if (pr.draft && pr.state === 'open') return 'draft';
if (pr.mergedAt) return 'merged';
return pr.state;
```

Display-only — the data was already there end to end, all the way from `github.rs`.

## Tests

`lv-github-dialog-pr-state.test.ts` covers all five states: merged (`state: 'closed'` + `mergedAt`), genuinely closed, open, open draft, and closed draft.

The **merged** and **closed draft** cases both fail against the old logic; the other three pass either way, so they pin the behaviour that must not change.

Full gate green: `npm run lint && npm run typecheck && npm test` — 4425 frontend tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_