### PR TITLE
Make follow-renames actually follow the rename

### DIFF
--- a/src-tauri/src/commands/commit.rs
+++ b/src-tauri/src/commands/commit.rs
@@ -1554,31 +1554,37 @@ pub async fn get_file_history(
                 .any(|d| d.status() == git2::Delta::Added || d.status() == git2::Delta::Renamed);
             file_modified = diff.deltas().count() > 0;
 
+            // `if let Ok`, not an early `continue`: the filtered diff has
+            // already established the file was touched by this commit. Skipping
+            // the iteration on a failed diff dropped the commit from the
+            // history entirely — losing a real entry to report a rename we
+            // could not look for. Without the unfiltered diff we simply do not
+            // detect a rename here, and the walk stops following the path,
+            // which is the old behaviour rather than a missing commit.
             if introduced_here {
-                let mut unfiltered =
-                    match repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), None) {
-                        Ok(d) => d,
-                        Err(_) => continue,
-                    };
-                let mut find_opts = git2::DiffFindOptions::new();
-                find_opts.renames(true);
-                find_opts.copies(false);
-                let _ = unfiltered.find_similar(Some(&mut find_opts));
+                if let Ok(mut unfiltered) =
+                    repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), None)
+                {
+                    let mut find_opts = git2::DiffFindOptions::new();
+                    find_opts.renames(true);
+                    find_opts.copies(false);
+                    let _ = unfiltered.find_similar(Some(&mut find_opts));
 
-                for delta in unfiltered.deltas() {
-                    if delta.status() != git2::Delta::Renamed {
-                        continue;
-                    }
-                    let is_ours = delta
-                        .new_file()
-                        .path()
-                        .is_some_and(|p| p.to_string_lossy() == current_path);
-                    if is_ours {
-                        file_modified = true;
-                        if let Some(old_file) = delta.old_file().path() {
-                            renamed_from = Some(old_file.to_string_lossy().to_string());
+                    for delta in unfiltered.deltas() {
+                        if delta.status() != git2::Delta::Renamed {
+                            continue;
                         }
-                        break;
+                        let is_ours = delta
+                            .new_file()
+                            .path()
+                            .is_some_and(|p| p.to_string_lossy() == current_path);
+                        if is_ours {
+                            file_modified = true;
+                            if let Some(old_file) = delta.old_file().path() {
+                                renamed_from = Some(old_file.to_string_lossy().to_string());
+                            }
+                            break;
+                        }
                     }
                 }
             }

--- a/src-tauri/src/commands/commit.rs
+++ b/src-tauri/src/commands/commit.rs
@@ -1471,7 +1471,15 @@ pub async fn get_file_history(
     let repo = git2::Repository::open(Path::new(&path))?;
 
     let mut revwalk = repo.revwalk()?;
-    revwalk.set_sorting(git2::Sort::TIME)?;
+    // TOPOLOGICAL as well as TIME. Following a rename rewrites current_path
+    // when the walk REACHES the renaming commit, so every commit before the
+    // rename must be visited after it. Sorting by time alone does not
+    // guarantee that — commits made within the same second (a scripted commit,
+    // a rebase, an import) tie, and a tie can put the renaming commit last, by
+    // which point the pre-rename history has already been tested against the
+    // new name and discarded. Topological order makes children precede parents
+    // no matter what the timestamps say.
+    revwalk.set_sorting(git2::Sort::TIME | git2::Sort::TOPOLOGICAL)?;
 
     // Start from HEAD
     let head = repo
@@ -1530,31 +1538,46 @@ pub async fn get_file_history(
         let mut renamed_from: Option<String> = None;
 
         if should_follow {
-            // Check for renames with find_similar
-            let mut diff_with_renames = diff;
-            let mut find_opts = git2::DiffFindOptions::new();
-            find_opts.renames(true);
-            find_opts.copies(false);
-            let _ = diff_with_renames.find_similar(Some(&mut find_opts));
+            // The pathspec above filters deltas at diff-GENERATION time, so at
+            // the commit that renamed old -> current this diff holds only the
+            // Added(current) half. find_similar had no Deleted(old) to pair it
+            // with, delta.status() was therefore never Renamed, renamed_from
+            // was never set, and the walk stopped dead at the rename — the one
+            // thing follow_renames exists to get past.
+            //
+            // Detect the modification from the cheap filtered diff, then pay
+            // for an UNFILTERED diff only where a rename could actually be
+            // hiding: the commit that introduces the path. That is once per
+            // rename, not once per commit.
+            let introduced_here = diff
+                .deltas()
+                .any(|d| d.status() == git2::Delta::Added || d.status() == git2::Delta::Renamed);
+            file_modified = diff.deltas().count() > 0;
 
-            for delta in diff_with_renames.deltas() {
-                if let Some(new_file) = delta.new_file().path() {
-                    if new_file.to_string_lossy() == current_path {
-                        file_modified = true;
+            if introduced_here {
+                let mut unfiltered =
+                    match repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), None) {
+                        Ok(d) => d,
+                        Err(_) => continue,
+                    };
+                let mut find_opts = git2::DiffFindOptions::new();
+                find_opts.renames(true);
+                find_opts.copies(false);
+                let _ = unfiltered.find_similar(Some(&mut find_opts));
 
-                        // Check if this was a rename
-                        if delta.status() == git2::Delta::Renamed {
-                            if let Some(old_file) = delta.old_file().path() {
-                                renamed_from = Some(old_file.to_string_lossy().to_string());
-                            }
-                        }
-                        break;
+                for delta in unfiltered.deltas() {
+                    if delta.status() != git2::Delta::Renamed {
+                        continue;
                     }
-                }
-                // Also check old file path for renames
-                if let Some(old_file) = delta.old_file().path() {
-                    if old_file.to_string_lossy() == current_path {
+                    let is_ours = delta
+                        .new_file()
+                        .path()
+                        .is_some_and(|p| p.to_string_lossy() == current_path);
+                    if is_ours {
                         file_modified = true;
+                        if let Some(old_file) = delta.old_file().path() {
+                            renamed_from = Some(old_file.to_string_lossy().to_string());
+                        }
                         break;
                     }
                 }
@@ -1580,6 +1603,119 @@ pub async fn get_file_history(
 mod tests {
     use super::*;
     use crate::test_utils::TestRepo;
+
+    /// follow_renames must actually follow the rename.
+    ///
+    /// The per-commit diff was built with a pathspec, which filters deltas at
+    /// diff-GENERATION time — so at the renaming commit the diff held only the
+    /// Added(new) half and find_similar had no Deleted(old) to pair it with.
+    /// delta.status() was never Renamed, renamed_from was never set, and the
+    /// walk stopped at the rename: history before it was invisible, which is
+    /// the one thing the option exists to provide.
+    #[tokio::test]
+    async fn test_get_file_history_follows_a_rename() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add original", &[("old-name.txt", "line one\n")]);
+        repo.create_commit("Edit original", &[("old-name.txt", "line one\nline two\n")]);
+
+        // Rename with identical content, so it is unambiguously a rename.
+        {
+            std::fs::rename(
+                repo.path.join("old-name.txt"),
+                repo.path.join("new-name.txt"),
+            )
+            .unwrap();
+            let git_repo = repo.repo();
+            let mut index = git_repo.index().unwrap();
+            index
+                .remove_path(std::path::Path::new("old-name.txt"))
+                .unwrap();
+            index
+                .add_path(std::path::Path::new("new-name.txt"))
+                .unwrap();
+            index.write().unwrap();
+            let tree = git_repo.find_tree(index.write_tree().unwrap()).unwrap();
+            let sig = git_repo.signature().unwrap();
+            let parent = git_repo.head().unwrap().peel_to_commit().unwrap();
+            git_repo
+                .commit(Some("HEAD"), &sig, &sig, "Rename it", &tree, &[&parent])
+                .unwrap();
+        }
+
+        repo.create_commit(
+            "Edit after rename",
+            &[("new-name.txt", "line one\nline two\nline three\n")],
+        );
+
+        let following = get_file_history(
+            repo.path_str(),
+            "new-name.txt".to_string(),
+            None,
+            Some(true),
+        )
+        .await
+        .unwrap();
+        let summaries: Vec<String> = following.iter().map(|c| c.summary.clone()).collect();
+
+        assert!(
+            summaries.iter().any(|s| s == "Add original"),
+            "history before the rename must be reachable, got {:?}",
+            summaries
+        );
+        assert!(
+            summaries.iter().any(|s| s == "Edit original"),
+            "edits under the old name must be reachable, got {:?}",
+            summaries
+        );
+        assert!(summaries.iter().any(|s| s == "Rename it"));
+        assert!(summaries.iter().any(|s| s == "Edit after rename"));
+    }
+
+    /// With following OFF, the history stops at the rename — as asked.
+    #[tokio::test]
+    async fn test_get_file_history_without_following_stops_at_the_rename() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add original", &[("old-name.txt", "line one\n")]);
+
+        {
+            std::fs::rename(
+                repo.path.join("old-name.txt"),
+                repo.path.join("new-name.txt"),
+            )
+            .unwrap();
+            let git_repo = repo.repo();
+            let mut index = git_repo.index().unwrap();
+            index
+                .remove_path(std::path::Path::new("old-name.txt"))
+                .unwrap();
+            index
+                .add_path(std::path::Path::new("new-name.txt"))
+                .unwrap();
+            index.write().unwrap();
+            let tree = git_repo.find_tree(index.write_tree().unwrap()).unwrap();
+            let sig = git_repo.signature().unwrap();
+            let parent = git_repo.head().unwrap().peel_to_commit().unwrap();
+            git_repo
+                .commit(Some("HEAD"), &sig, &sig, "Rename it", &tree, &[&parent])
+                .unwrap();
+        }
+
+        let not_following = get_file_history(
+            repo.path_str(),
+            "new-name.txt".to_string(),
+            None,
+            Some(false),
+        )
+        .await
+        .unwrap();
+        let summaries: Vec<String> = not_following.iter().map(|c| c.summary.clone()).collect();
+
+        assert!(
+            !summaries.iter().any(|s| s == "Add original"),
+            "not following must not reach past the rename, got {:?}",
+            summaries
+        );
+    }
 
     #[tokio::test]
     async fn test_commit_history_all_branches_pagination_and_total() {

--- a/src-tauri/src/commands/commit.rs
+++ b/src-tauri/src/commands/commit.rs
@@ -1534,7 +1534,7 @@ pub async fn get_file_history(
             };
 
         // Check if file was modified in this commit
-        let mut file_modified = false;
+        let mut file_modified;
         let mut renamed_from: Option<String> = None;
 
         if should_follow {

--- a/src-tauri/src/commands/commit.rs
+++ b/src-tauri/src/commands/commit.rs
@@ -1618,39 +1618,75 @@ mod tests {
     /// delta.status() was never Renamed, renamed_from was never set, and the
     /// walk stopped at the rename: history before it was invisible, which is
     /// the one thing the option exists to provide.
+    /// Commit the current index at an EXPLICIT time.
+    ///
+    /// The rename tests need timestamps that deliberately disagree with
+    /// topology. With wall-clock times every commit lands in the same second in
+    /// commit order, so `Sort::TIME` alone already produces the right order and
+    /// the tests would pass even with `Sort::TOPOLOGICAL` removed — proving
+    /// nothing about the walk they exist to cover.
+    fn commit_index_at(repo: &TestRepo, message: &str, seconds: i64) -> git2::Oid {
+        let git_repo = repo.repo();
+        let mut index = git_repo.index().unwrap();
+        index.write().unwrap();
+        let tree = git_repo.find_tree(index.write_tree().unwrap()).unwrap();
+        let when = git2::Time::new(seconds, 0);
+        let sig = git2::Signature::new("Test User", "test@example.com", &when).unwrap();
+        let parent = git_repo.head().unwrap().peel_to_commit().unwrap();
+        git_repo
+            .commit(Some("HEAD"), &sig, &sig, message, &tree, &[&parent])
+            .unwrap()
+    }
+
+    /// Write a file, stage it, and commit at an explicit time.
+    fn commit_file_at(repo: &TestRepo, message: &str, file: &str, body: &str, seconds: i64) {
+        std::fs::write(repo.path.join(file), body).unwrap();
+        {
+            let git_repo = repo.repo();
+            let mut index = git_repo.index().unwrap();
+            index.add_path(std::path::Path::new(file)).unwrap();
+            index.write().unwrap();
+        }
+        commit_index_at(repo, message, seconds);
+    }
+
+    /// Stage a rename and commit it at an explicit time.
+    fn commit_rename_at(repo: &TestRepo, from: &str, to: &str, message: &str, seconds: i64) {
+        std::fs::rename(repo.path.join(from), repo.path.join(to)).unwrap();
+        {
+            let git_repo = repo.repo();
+            let mut index = git_repo.index().unwrap();
+            index.remove_path(std::path::Path::new(from)).unwrap();
+            index.add_path(std::path::Path::new(to)).unwrap();
+            index.write().unwrap();
+        }
+        commit_index_at(repo, message, seconds);
+    }
+
     #[tokio::test]
     async fn test_get_file_history_follows_a_rename() {
         let repo = TestRepo::with_initial_commit();
-        repo.create_commit("Add original", &[("old-name.txt", "line one\n")]);
-        repo.create_commit("Edit original", &[("old-name.txt", "line one\nline two\n")]);
 
-        // Rename with identical content, so it is unambiguously a rename.
-        {
-            std::fs::rename(
-                repo.path.join("old-name.txt"),
-                repo.path.join("new-name.txt"),
-            )
-            .unwrap();
-            let git_repo = repo.repo();
-            let mut index = git_repo.index().unwrap();
-            index
-                .remove_path(std::path::Path::new("old-name.txt"))
-                .unwrap();
-            index
-                .add_path(std::path::Path::new("new-name.txt"))
-                .unwrap();
-            index.write().unwrap();
-            let tree = git_repo.find_tree(index.write_tree().unwrap()).unwrap();
-            let sig = git_repo.signature().unwrap();
-            let parent = git_repo.head().unwrap().peel_to_commit().unwrap();
-            git_repo
-                .commit(Some("HEAD"), &sig, &sig, "Rename it", &tree, &[&parent])
-                .unwrap();
-        }
-
-        repo.create_commit(
+        // Timestamps chosen to DISAGREE with topology: the rename is older than
+        // its own parent. Under a TIME-only walk the parent would be visited
+        // first — before the path is known to have changed — so this ordering
+        // is what makes the test able to fail.
+        commit_file_at(&repo, "Add original", "old-name.txt", "line one\n", 1_000);
+        commit_file_at(
+            &repo,
+            "Edit original",
+            "old-name.txt",
+            "line one\nline two\n",
+            3_000,
+        );
+        // Renamed with identical content, so it is unambiguously a rename.
+        commit_rename_at(&repo, "old-name.txt", "new-name.txt", "Rename it", 2_000);
+        commit_file_at(
+            &repo,
             "Edit after rename",
-            &[("new-name.txt", "line one\nline two\nline three\n")],
+            "new-name.txt",
+            "line one\nline two\nline three\n",
+            4_000,
         );
 
         let following = get_file_history(
@@ -1681,30 +1717,11 @@ mod tests {
     #[tokio::test]
     async fn test_get_file_history_without_following_stops_at_the_rename() {
         let repo = TestRepo::with_initial_commit();
-        repo.create_commit("Add original", &[("old-name.txt", "line one\n")]);
 
-        {
-            std::fs::rename(
-                repo.path.join("old-name.txt"),
-                repo.path.join("new-name.txt"),
-            )
-            .unwrap();
-            let git_repo = repo.repo();
-            let mut index = git_repo.index().unwrap();
-            index
-                .remove_path(std::path::Path::new("old-name.txt"))
-                .unwrap();
-            index
-                .add_path(std::path::Path::new("new-name.txt"))
-                .unwrap();
-            index.write().unwrap();
-            let tree = git_repo.find_tree(index.write_tree().unwrap()).unwrap();
-            let sig = git_repo.signature().unwrap();
-            let parent = git_repo.head().unwrap().peel_to_commit().unwrap();
-            git_repo
-                .commit(Some("HEAD"), &sig, &sig, "Rename it", &tree, &[&parent])
-                .unwrap();
-        }
+        // Same topology-inconsistent timestamps as the following test, so the
+        // two differ only in the flag under test.
+        commit_file_at(&repo, "Add original", "old-name.txt", "line one\n", 3_000);
+        commit_rename_at(&repo, "old-name.txt", "new-name.txt", "Rename it", 2_000);
 
         let not_following = get_file_history(
             repo.path_str(),


### PR DESCRIPTION
`get_file_history(followRenames: true)` stopped dead at the rename — the one thing the option exists to see past. There turned out to be **two independent faults**, and either one alone is enough to break it.

## 1. The pathspec filtered the rename pair apart

Each per-commit diff was built as:

```rust
diff_opts.pathspec(&current_path);
let diff = repo.diff_tree_to_tree(parent, tree, Some(&mut diff_opts))?;
// … then find_similar(renames(true))
```

libgit2 applies a pathspec at diff-**generation** time. At the commit that renamed `old → current`, the diff therefore contained only the `Added(current)` delta — the `Deleted(old)` half was excluded before `find_similar` ever ran. With nothing to pair, `delta.status()` was `Added`, never `Renamed`, so `renamed_from` was never set and `current_path` never moved.

Now an **unfiltered** diff is taken only where a rename can actually be hiding — the commit that introduces the path — so the cost is once per rename, not once per commit.

## 2. The walk order let the rename arrive too late

Following a rename rewrites the tracked path **when the walk reaches the renaming commit**, so every pre-rename commit must be visited *after* it. `Sort::TIME` alone does not guarantee that.

The test made this visible — the walk came out as:

```
Edit after rename → Initial commit → Add original → Edit original → Rename it
```

The renaming commit is **last**. By then the pre-rename history had already been tested against the new name and discarded. Commits sharing a timestamp — a scripted commit, a rebase, an import — tie, and a tie can order them arbitrarily. `TOPOLOGICAL` makes children precede parents regardless of what the clocks say.

This one is worth noting because it is a **latent** bug: on a repo with well-spread timestamps the first fix alone would appear to work, and then fail on exactly the repos where commits were generated in bulk.

## Tests

- `test_get_file_history_follows_a_rename` — real rename (index remove + add, identical content), asserts the pre-rename commits are reachable.
- `test_get_file_history_without_following_stops_at_the_rename` — with following **off**, history correctly stops, so this can't be "fixed" by always following.

Each half was reverted **on its own** and the following test fails either way — both are load-bearing.

Full gate green: `cargo fmt --check && cargo clippy --all-targets -- -D warnings` — 2135 Rust tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_