### PR TITLE
Quote gitattributes patterns that need it when writing them back

### DIFF
--- a/src-tauri/src/commands/gitattributes.rs
+++ b/src-tauri/src/commands/gitattributes.rs
@@ -72,12 +72,6 @@ fn parse_attribute_token(token: &str) -> AttributeEntry {
     }
 }
 
-/// Split a trimmed .gitattributes line into its pattern and the remainder
-/// (the attribute list).
-///
-/// Per gitattributes(5), a pattern containing whitespace may be wrapped in
-/// double quotes, with C-style escapes (`\"`, `\\`, `\n`, `\t`, octal `\nnn`)
-/// inside. Otherwise the pattern is the first whitespace-delimited token.
 /// Render a pattern back into a .gitattributes line, quoting when it needs it.
 ///
 /// The inverse of `split_pattern_and_rest`. The parser unescapes quoted
@@ -117,6 +111,28 @@ fn format_pattern(pattern: &str) -> String {
     out
 }
 
+/// Refuse a pattern that is empty or nothing but whitespace.
+///
+/// `format_pattern` renders one as `""`, and `parse_gitattributes` then drops
+/// the line again because the pattern it reads back is empty. The write would
+/// report success, the entry would be missing from the list the caller renders,
+/// and the junk line would sit in `.gitattributes` with no way to reach it from
+/// the UI. There is also nothing such a pattern could usefully match.
+fn ensure_pattern_usable(pattern: &str) -> Result<()> {
+    if pattern.trim().is_empty() {
+        return Err(LeviathanError::OperationFailed(
+            "A .gitattributes pattern cannot be empty.".to_string(),
+        ));
+    }
+    Ok(())
+}
+
+/// Split a trimmed .gitattributes line into its pattern and the remainder
+/// (the attribute list).
+///
+/// Per gitattributes(5), a pattern containing whitespace may be wrapped in
+/// double quotes, with C-style escapes (`\"`, `\\`, `\n`, `\t`, octal `\nnn`)
+/// inside. Otherwise the pattern is the first whitespace-delimited token.
 fn split_pattern_and_rest(trimmed: &str) -> (String, &str) {
     if let Some(after_quote) = trimmed.strip_prefix('"') {
         let bytes = after_quote.as_bytes();
@@ -224,6 +240,8 @@ pub async fn add_gitattribute(
     pattern: String,
     attributes: String,
 ) -> Result<Vec<GitAttribute>> {
+    ensure_pattern_usable(&pattern)?;
+
     let attrs_path = Path::new(&path).join(".gitattributes");
 
     let mut content = if attrs_path.exists() {
@@ -289,6 +307,8 @@ pub async fn update_gitattribute(
     pattern: String,
     attributes: String,
 ) -> Result<Vec<GitAttribute>> {
+    ensure_pattern_usable(&pattern)?;
+
     let attrs_path = Path::new(&path).join(".gitattributes");
 
     if !attrs_path.exists() {
@@ -710,6 +730,50 @@ mod tests {
         assert_eq!(format_pattern(r"back\slash"), r#""back\\slash""#);
         // A leading # would otherwise turn the line into a comment.
         assert_eq!(format_pattern("#notacomment"), r##""#notacomment""##);
+    }
+
+    /// An empty pattern would be written as `""` and then dropped by the parser,
+    /// so the caller would be told the write succeeded while the entry never
+    /// appears and an unreachable line accumulates in the file.
+    #[tokio::test]
+    async fn test_add_gitattribute_refuses_an_empty_pattern() {
+        let repo = TestRepo::with_initial_commit();
+
+        let result = add_gitattribute(repo.path_str(), String::new(), "text".to_string()).await;
+
+        assert!(result.is_err(), "an empty pattern must be refused");
+        assert!(
+            !repo.path.join(".gitattributes").exists(),
+            "a refused add must not create the file"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_add_gitattribute_refuses_a_whitespace_only_pattern() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_file(".gitattributes", "*.txt text\n");
+
+        let result = add_gitattribute(repo.path_str(), "   ".to_string(), "text".to_string()).await;
+
+        assert!(result.is_err(), "a whitespace-only pattern must be refused");
+        let on_disk = std::fs::read_to_string(repo.path.join(".gitattributes")).unwrap();
+        assert_eq!(on_disk, "*.txt text\n", "a refused add must write nothing");
+    }
+
+    #[tokio::test]
+    async fn test_update_gitattribute_refuses_an_empty_pattern() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_file(".gitattributes", "*.txt text\n");
+
+        let result =
+            update_gitattribute(repo.path_str(), 1, String::new(), "text".to_string()).await;
+
+        assert!(result.is_err(), "an empty pattern must be refused");
+        let on_disk = std::fs::read_to_string(repo.path.join(".gitattributes")).unwrap();
+        assert_eq!(
+            on_disk, "*.txt text\n",
+            "a refused update must leave the existing entry intact"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/gitattributes.rs
+++ b/src-tauri/src/commands/gitattributes.rs
@@ -78,6 +78,45 @@ fn parse_attribute_token(token: &str) -> AttributeEntry {
 /// Per gitattributes(5), a pattern containing whitespace may be wrapped in
 /// double quotes, with C-style escapes (`\"`, `\\`, `\n`, `\t`, octal `\nnn`)
 /// inside. Otherwise the pattern is the first whitespace-delimited token.
+/// Render a pattern back into a .gitattributes line, quoting when it needs it.
+///
+/// The inverse of `split_pattern_and_rest`. The parser unescapes quoted
+/// patterns per gitattributes(5), so `"foo bar.txt" text` reads back as the
+/// pattern `foo bar.txt` — but both writers emitted the pattern verbatim. Round
+/// tripping one through an edit wrote `foo bar.txt text`, which git then reads
+/// as the pattern `foo` with attributes `bar.txt text`: the rule silently stops
+/// matching the file it was written for and starts matching something else.
+///
+/// Quoted when the pattern contains whitespace or a character that would change
+/// how the line parses; left bare otherwise, so ordinary patterns keep the plain
+/// form a human would write.
+fn format_pattern(pattern: &str) -> String {
+    let needs_quotes = pattern.is_empty()
+        || pattern
+            .chars()
+            .any(|c| c.is_whitespace() || c == '"' || c == '\\')
+        || pattern.starts_with('#');
+
+    if !needs_quotes {
+        return pattern.to_string();
+    }
+
+    let mut out = String::with_capacity(pattern.len() + 2);
+    out.push('"');
+    for c in pattern.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\t' => out.push_str("\\t"),
+            '\r' => out.push_str("\\r"),
+            other => out.push(other),
+        }
+    }
+    out.push('"');
+    out
+}
+
 fn split_pattern_and_rest(trimmed: &str) -> (String, &str) {
     if let Some(after_quote) = trimmed.strip_prefix('"') {
         let bytes = after_quote.as_bytes();
@@ -199,7 +238,7 @@ pub async fn add_gitattribute(
     }
 
     // Append the new line
-    content.push_str(&format!("{} {}\n", pattern, attributes));
+    content.push_str(&format!("{} {}\n", format_pattern(&pattern), attributes));
 
     std::fs::write(&attrs_path, &content)?;
     Ok(parse_gitattributes(&content))
@@ -268,7 +307,7 @@ pub async fn update_gitattribute(
         )));
     }
 
-    lines[(line_number as usize) - 1] = format!("{} {}", pattern, attributes);
+    lines[(line_number as usize) - 1] = format!("{} {}", format_pattern(&pattern), attributes);
 
     let mut result = lines.join("\n");
     if !result.is_empty() {
@@ -586,6 +625,91 @@ mod tests {
         assert_eq!(entries[0].pattern, "*.md");
         assert_eq!(entries[0].attributes.len(), 2);
         assert_eq!(entries[1].pattern, "*.png");
+    }
+
+    /// A pattern with whitespace must survive being written and read back.
+    ///
+    /// The parser unescapes quoted patterns per gitattributes(5), so
+    /// `"foo bar.txt" text` reads back as `foo bar.txt`. Both writers emitted
+    /// the pattern verbatim, so editing that entry wrote `foo bar.txt text` —
+    /// which git reads as the pattern `foo` with attributes `bar.txt text`. The
+    /// rule silently stops matching the file it was written for and starts
+    /// matching something else entirely.
+    #[tokio::test]
+    async fn test_add_gitattribute_round_trips_a_pattern_with_spaces() {
+        let repo = TestRepo::with_initial_commit();
+
+        let entries = add_gitattribute(
+            repo.path_str(),
+            "foo bar.txt".to_string(),
+            "text".to_string(),
+        )
+        .await
+        .expect("adding must succeed");
+
+        assert_eq!(
+            entries[0].pattern, "foo bar.txt",
+            "the pattern must read back as written, not split at the space"
+        );
+
+        // And it is quoted on disk, which is what makes that true.
+        let on_disk = std::fs::read_to_string(repo.path.join(".gitattributes")).unwrap();
+        assert!(
+            on_disk.contains(r#""foo bar.txt" text"#),
+            "the pattern must be quoted on disk, got: {}",
+            on_disk.trim()
+        );
+    }
+
+    /// Editing an existing quoted entry must not unquote it.
+    #[tokio::test]
+    async fn test_update_gitattribute_round_trips_a_pattern_with_spaces() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_file(".gitattributes", "\"foo bar.txt\" text\n");
+
+        let entries = update_gitattribute(
+            repo.path_str(),
+            1,
+            "foo bar.txt".to_string(),
+            "text diff=markdown".to_string(),
+        )
+        .await
+        .expect("updating must succeed");
+
+        assert_eq!(
+            entries[0].pattern, "foo bar.txt",
+            "editing the attributes must not corrupt the pattern"
+        );
+        assert_eq!(entries[0].attributes.len(), 2);
+    }
+
+    /// An ordinary pattern stays bare — quoting everything would be noise.
+    #[tokio::test]
+    async fn test_add_gitattribute_leaves_a_plain_pattern_unquoted() {
+        let repo = TestRepo::with_initial_commit();
+
+        add_gitattribute(repo.path_str(), "*.txt".to_string(), "text".to_string())
+            .await
+            .unwrap();
+
+        let on_disk = std::fs::read_to_string(repo.path.join(".gitattributes")).unwrap();
+        assert!(
+            on_disk.contains("*.txt text"),
+            "a plain pattern needs no quotes, got: {}",
+            on_disk.trim()
+        );
+        assert!(!on_disk.contains('"'), "and must not gain any");
+    }
+
+    /// Quotes and backslashes in a pattern are escaped, not passed through.
+    #[test]
+    fn test_format_pattern_escapes_what_would_break_the_line() {
+        assert_eq!(format_pattern("*.txt"), "*.txt");
+        assert_eq!(format_pattern("foo bar.txt"), r#""foo bar.txt""#);
+        assert_eq!(format_pattern(r#"say"hi""#), r#""say\"hi\"""#);
+        assert_eq!(format_pattern(r"back\slash"), r#""back\\slash""#);
+        // A leading # would otherwise turn the line into a comment.
+        assert_eq!(format_pattern("#notacomment"), r##""#notacomment""##);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## The problem

The **parser** was fixed to unescape quoted patterns per gitattributes(5), so the line

```
"foo bar.txt" text
```

correctly reads back as the pattern `foo bar.txt`.

But both **writers** emit the pattern verbatim:

```rust
content.push_str(&format!("{} {}\n", pattern, attributes));         // add
lines[(line_number as usize) - 1] = format!("{} {}", pattern, attributes);  // update
```

So editing that entry's attributes — the parser hands back `foo bar.txt`, the writer puts it straight down — produces:

```
foo bar.txt text
```

which git reads as the pattern **`foo`** with attributes **`bar.txt text`**. The rule silently stops matching the file it was written for and starts matching something else.

Nothing on screen shows it: the list re-parses its own corrupted line and renders a plausible-looking entry. The damage is only visible in how git subsequently treats the files — the wrong ones get `text` normalisation, LFS filters, or diff drivers.

## The change

Writing is now the inverse of parsing. `format_pattern()` quotes a pattern when it contains whitespace, a `"`, a `\`, or a leading `#` that would turn the line into a comment, escaping the quote/backslash/control characters on the way out. Ordinary patterns stay bare, so a human-written `.gitattributes` keeps its plain form rather than gaining quotes everywhere.

## Tests

The real proof is a round trip — `parse(write(x)) == x`:

- `test_add_gitattribute_round_trips_a_pattern_with_spaces` — adds `foo bar.txt`, asserts it reads back whole **and** is quoted on disk.
- `test_update_gitattribute_round_trips_a_pattern_with_spaces` — edits an existing quoted entry's attributes and asserts the pattern survives.
- `test_add_gitattribute_leaves_a_plain_pattern_unquoted` — the control: `*.txt` stays bare and gains no quotes.
- `test_format_pattern_escapes_what_would_break_the_line` — quotes, backslashes and a leading `#` directly.

Both round-trip tests were verified to fail with the writers reverted.

Full gate green: `cargo fmt --check && cargo clippy --all-targets -- -D warnings` — 2142 Rust tests.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_