### PR TITLE
Key the redo marker to the ref the undo moved, not just its commit

### DIFF
--- a/src-tauri/src/commands/undo.rs
+++ b/src-tauri/src/commands/undo.rs
@@ -53,14 +53,40 @@ fn parse_checkout_source(message: &str) -> Option<String> {
     }
 }
 
+/// The ref HEAD currently points at: `refs/heads/<branch>` when attached, and
+/// `HEAD` itself when detached.
+fn head_ref_name(repo: &git2::Repository) -> Option<String> {
+    // Reference::name() is Result-wrapped in this git2 binding, not Option.
+    repo.head().ok()?.name().ok().map(|n| n.to_string())
+}
+
 /// Record a marker in repo config so `redo_last_action` can distinguish an
 /// app-performed undo from a user-initiated reset. `redo_target` is the state
 /// redo should restore (HEAD before the undo); `undo_head` is HEAD immediately
 /// after the undo, used to detect whether anything changed since.
+///
+/// The ref HEAD was on is recorded alongside them, because an OID alone does not
+/// identify a branch: any number of branches can sit on the same commit. Undo on
+/// `main`, create a branch at the undo point and switch to it — exactly what a
+/// cautious user does before experimenting — and a redo would otherwise pass the
+/// OID check and reset that OTHER branch to the redo target.
 fn set_redo_marker(repo: &git2::Repository, redo_target: &str, undo_head: &str) {
     if let Ok(mut cfg) = repo.config() {
         let _ = cfg.set_str("leviathan.redotarget", redo_target);
         let _ = cfg.set_str("leviathan.redohead", undo_head);
+        match head_ref_name(repo) {
+            // A mixed reset does not change which ref HEAD points at, so reading
+            // it after the undo names the ref the undo actually moved.
+            Some(name) => {
+                let _ = cfg.set_str("leviathan.redoref", &name);
+            }
+            // Without a recorded ref, redo_last_action refuses rather than
+            // falling back to the OID-only check that lets it hit the wrong
+            // branch. Remove any stale value so it cannot be inherited.
+            None => {
+                let _ = cfg.remove("leviathan.redoref");
+            }
+        }
     }
 }
 
@@ -68,6 +94,7 @@ fn clear_redo_marker(repo: &git2::Repository) {
     if let Ok(mut cfg) = repo.config() {
         let _ = cfg.remove("leviathan.redotarget");
         let _ = cfg.remove("leviathan.redohead");
+        let _ = cfg.remove("leviathan.redoref");
     }
 }
 
@@ -457,12 +484,13 @@ pub async fn redo_last_action(path: String) -> Result<UndoAction> {
 
     // Read the app-undo marker. Absent marker => the last action was not an
     // app undo, so there is nothing to redo.
-    let (redo_target, undo_head) = {
+    let (redo_target, undo_head, undo_ref) = {
         let cfg = repo.config()?;
         let target = cfg.get_string("leviathan.redotarget").ok();
         let head = cfg.get_string("leviathan.redohead").ok();
+        let reference = cfg.get_string("leviathan.redoref").ok();
         match (target, head) {
-            (Some(t), Some(h)) if !t.is_empty() && !h.is_empty() => (t, h),
+            (Some(t), Some(h)) if !t.is_empty() && !h.is_empty() => (t, h, reference),
             _ => {
                 return Err(LeviathanError::OperationFailed(
                     "Nothing to redo: the last action was not an undo.".to_string(),
@@ -479,6 +507,20 @@ pub async fn redo_last_action(path: String) -> Result<UndoAction> {
         .and_then(|h| h.target())
         .map(|o| o.to_string());
     if current_head.as_deref() != Some(undo_head.as_str()) {
+        return Err(LeviathanError::OperationFailed(
+            "Nothing to redo: the repository has changed since the last undo.".to_string(),
+        ));
+    }
+
+    // The OID matching is not enough on its own: branches share commits, so the
+    // check above passes just as happily on a DIFFERENT branch that happens to
+    // point at the undo position. The reset below moves whatever ref HEAD is on,
+    // so redo must be on the same ref the undo moved. A marker with no recorded
+    // ref (written before this was tracked) is treated as stale for the same
+    // reason — the marker only ever spans a single undo/redo pair, so refusing
+    // costs at most one redo and never resets a branch the undo never touched.
+    let current_ref = head_ref_name(&repo);
+    if undo_ref.is_none() || current_ref != undo_ref {
         return Err(LeviathanError::OperationFailed(
             "Nothing to redo: the repository has changed since the last undo.".to_string(),
         ));
@@ -788,6 +830,101 @@ mod tests {
         let result = redo_last_action(repo.path_str()).await;
         assert!(result.is_err());
         assert!(result.unwrap_err().to_string().contains("Nothing to redo"));
+    }
+
+    /// Tip of a local branch, for asserting that a ref did or did not move.
+    fn branch_tip(repo: &TestRepo, name: &str) -> git2::Oid {
+        repo.repo()
+            .find_branch(name, git2::BranchType::Local)
+            .unwrap()
+            .get()
+            .target()
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_redo_is_refused_on_a_different_branch_at_the_same_commit() {
+        // Branching at the undo point before experimenting is exactly what a
+        // cautious user does. The redo marker's OID check cannot tell that
+        // branch apart from the one the undo moved — both point at the same
+        // commit — so redo would reset a branch it never touched.
+        let repo = TestRepo::with_initial_commit();
+        let first_oid = repo.head_oid();
+
+        repo.create_commit("Second commit", &[("file2.txt", "content2")]);
+
+        undo_last_action(repo.path_str()).await.unwrap();
+        assert_eq!(repo.head_oid(), first_oid);
+
+        let default_branch = repo.current_branch();
+        repo.create_branch("experiment");
+        repo.checkout_branch("experiment");
+
+        let result = redo_last_action(repo.path_str()).await;
+
+        assert!(
+            result.is_err(),
+            "redo must refuse on a branch the undo never moved"
+        );
+        assert_eq!(
+            branch_tip(&repo, "experiment"),
+            first_oid,
+            "the branch the user switched to must not be reset by redo"
+        );
+        assert_eq!(
+            branch_tip(&repo, &default_branch),
+            first_oid,
+            "the undone branch must be left for a redo on that branch"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_redo_is_refused_on_a_detached_head_at_the_same_commit() {
+        // Same hole, reached by detaching instead of branching.
+        let repo = TestRepo::with_initial_commit();
+        let first_oid = repo.head_oid();
+
+        repo.create_commit("Second commit", &[("file2.txt", "content2")]);
+        undo_last_action(repo.path_str()).await.unwrap();
+
+        let default_branch = repo.current_branch();
+        repo.repo().set_head_detached(first_oid).unwrap();
+
+        let result = redo_last_action(repo.path_str()).await;
+
+        assert!(result.is_err(), "redo must refuse on a detached HEAD");
+        assert_eq!(
+            branch_tip(&repo, &default_branch),
+            first_oid,
+            "the undone branch must not move while HEAD is detached"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_redo_still_fires_on_the_undone_branch_when_a_sibling_shares_the_commit() {
+        // The refusal keys on the ref, not on whether other branches exist: a
+        // sibling sitting on the same commit must not block a legitimate redo.
+        let repo = TestRepo::with_initial_commit();
+
+        repo.create_commit("Second commit", &[("file2.txt", "content2")]);
+        let second_oid = repo.head_oid();
+
+        undo_last_action(repo.path_str()).await.unwrap();
+        let first_oid = repo.head_oid();
+
+        // A sibling at the undo point, but the user stays where they were.
+        repo.create_branch("experiment");
+
+        redo_last_action(repo.path_str())
+            .await
+            .expect("redo on the branch the undo moved must still work");
+
+        assert_eq!(repo.head_oid(), second_oid, "redo must restore the commit");
+        assert_eq!(
+            branch_tip(&repo, "experiment"),
+            first_oid,
+            "the sibling branch must be untouched by the redo"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## The problem

`set_redo_marker` recorded only two OIDs, and `redo_last_action` validated staleness by comparing the current HEAD OID to the stored `undo_head` (`undo.rs:481`). The HEAD ref name was never recorded or checked.

An OID does not identify a branch — any number of branches can sit on the same commit:

1. Undo a commit on `main`. The marker records `redohead = A`.
2. Create a branch at the undo point and check it out — exactly what a cautious user does before experimenting. It also points at `A`.
3. Redo.

The OID check passes, `ensure_resettable` passes, and the mixed reset at `undo.rs:493` moves the **other** branch's ref to the redo target. A branch the undo never touched now silently points at the undone commit.

## The fix

`set_redo_marker` records the ref HEAD is on — `refs/heads/<branch>` when attached, `HEAD` when detached — alongside the OIDs. A mixed reset does not change which ref HEAD points at, so reading it after the undo names the ref the undo actually moved. `redo_last_action` then refuses when HEAD is somewhere else, with the same "the repository has changed since the last undo" message.

A marker carrying no recorded ref — one written before this was tracked — is treated as stale rather than falling back to the OID-only check. The marker only ever spans a single undo/redo pair, so that costs at most one redo and never resets a branch the undo never touched.

## Tests

| Test | Covers |
| --- | --- |
| `test_redo_is_refused_on_a_different_branch_at_the_same_commit` | the reported case; asserts *neither* branch moved |
| `test_redo_is_refused_on_a_detached_head_at_the_same_commit` | the same hole reached by detaching |
| `test_redo_still_fires_on_the_undone_branch_when_a_sibling_shares_the_commit` | the refusal keys on the ref, so a sibling at the same commit does not block a legitimate redo |

The first two were verified to **fail** with the fix reverted.

## Note on reachability

`redo_last_action` has no UI caller today — `redoLastAction` exists only in `src/services/git.service.ts:1956` and its tests — so this ships the correct behaviour ahead of the intended Ctrl+Shift+Z wiring rather than fixing something users hit now. The command is registered and tested as correct, which is precisely why it should be correct.

Full gate green: lint, typecheck, unit tests, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_