### PR TITLE
Number tree-view file rows by what is actually rendered

### DIFF
--- a/src/components/sidebar/__tests__/lv-file-status-tree-focus.test.ts
+++ b/src/components/sidebar/__tests__/lv-file-status-tree-focus.test.ts
@@ -80,6 +80,29 @@ function indices(el: LvFileStatus): (string | null)[] {
   return rows(el).map((r) => r.getAttribute('data-index'));
 }
 
+/**
+ * Wrap the panel's tree builder with a counter. Returns a getter for the number
+ * of buildFileTree calls made since wrapping.
+ */
+function countTreeBuilds(el: LvFileStatus): () => number {
+  const host = el as unknown as {
+    buildFileTree: (files: StatusEntry[]) => unknown;
+  };
+  const original = host.buildFileTree.bind(el);
+  let calls = 0;
+  host.buildFileTree = (files: StatusEntry[]) => {
+    calls += 1;
+    return original(files);
+  };
+  return () => calls;
+}
+
+/** Force one render pass without changing any state. */
+async function rerender(el: LvFileStatus): Promise<void> {
+  el.requestUpdate();
+  await el.updateComplete;
+}
+
 describe('lv-file-status tree view row indices', () => {
   it('a collapsed folder does not inflate the row indices', async () => {
     const el = await renderWith([
@@ -184,5 +207,54 @@ describe('lv-file-status tree view row indices', () => {
       'flat view keeps the same row order',
     ).to.deep.equal(['lib/x.ts', 'src/a.ts', 'docs/readme.md']);
     expect(indices(el), 'flat view numbers 0..n-1').to.deep.equal(['0', '1', '2']);
+  });
+});
+
+describe('lv-file-status tree view render cost', () => {
+  it('builds each section tree once per render', async () => {
+    const el = await renderWith([
+      entry('lib/x.ts', true),
+      entry('lib/y.ts', true),
+      entry('src/a.ts'),
+    ]);
+    await clickViewToggle(el);
+
+    const builds = countTreeBuilds(el);
+    await rerender(el);
+
+    expect(
+      builds(),
+      'one buildFileTree per section — counting the staged rows reuses the tree the staged rows were rendered from',
+    ).to.equal(2);
+  });
+
+  it('builds each section tree once per render with a folder collapsed', async () => {
+    const el = await renderWith([
+      entry('lib/x.ts', true),
+      entry('lib/y.ts', true),
+      entry('top.txt'),
+    ]);
+    await clickViewToggle(el);
+    await collapseFolder(el, 'lib');
+
+    const builds = countTreeBuilds(el);
+    await rerender(el);
+
+    expect(builds(), 'still one buildFileTree per section').to.equal(2);
+    expect(
+      rows(el).map((r) => r.getAttribute('data-index')),
+      'and the reused tree still yields the visible-row offset',
+    ).to.deep.equal(['0']);
+  });
+
+  // No-regression guard: flat view never built a tree and still must not — it
+  // passes with and without the render-cost fix.
+  it('builds no tree at all in flat view', async () => {
+    const el = await renderWith([entry('lib/x.ts', true), entry('src/a.ts')]);
+
+    const builds = countTreeBuilds(el);
+    await rerender(el);
+
+    expect(builds(), 'flat view renders straight from the file arrays').to.equal(0);
   });
 });

--- a/src/components/sidebar/__tests__/lv-file-status-tree-focus.test.ts
+++ b/src/components/sidebar/__tests__/lv-file-status-tree-focus.test.ts
@@ -1,0 +1,188 @@
+/**
+ * lv-file-status tree view: the row numbering the DOM carries must match the
+ * numbering the keyboard uses.
+ *
+ * Rendered rows got their `data-index` from a counter that walked EVERY file in
+ * a subtree, collapsed folders included, while the keyboard model
+ * (getAllVisibleFiles) only counts files under expanded folders. Collapse one
+ * folder and the two numberings drift apart: the `.focused` highlight lands on
+ * the wrong row or on no row at all, while Enter / s / u act on a file the user
+ * never saw highlighted.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-file-status.ts';
+import type { LvFileStatus } from '../lv-file-status.ts';
+import type { StatusEntry } from '../../../types/git.types.ts';
+
+const REPO_PATH = '/test/repo';
+
+function entry(path: string, isStaged = false): StatusEntry {
+  return { path, status: 'modified', isStaged, isConflicted: false };
+}
+
+/** Render the panel with `entries` as the repository status. */
+async function renderWith(entries: StatusEntry[]): Promise<LvFileStatus> {
+  mockInvoke = async (command: string) => {
+    if (command === 'get_status') return entries;
+    return null;
+  };
+
+  const el = await fixture<LvFileStatus>(html`
+    <lv-file-status .repositoryPath=${REPO_PATH}></lv-file-status>
+  `);
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+  return el;
+}
+
+/** Click the flat/tree toggle (switching TO tree also expands every folder). */
+async function clickViewToggle(el: LvFileStatus): Promise<void> {
+  const toggle = el.shadowRoot!.querySelector('.view-toggle')!;
+  toggle.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  await el.updateComplete;
+}
+
+/** Collapse the folder row whose name label is `name`. */
+async function collapseFolder(el: LvFileStatus, name: string): Promise<void> {
+  const folder = Array.from(el.shadowRoot!.querySelectorAll('.folder-item')).find(
+    (item) => item.querySelector('.folder-name')!.textContent!.trim() === name,
+  );
+  expect(folder, `folder row "${name}" is rendered`).to.not.be.undefined;
+  folder!.dispatchEvent(new MouseEvent('click', { bubbles: true }));
+  await el.updateComplete;
+}
+
+async function pressArrowDown(el: LvFileStatus): Promise<void> {
+  el.dispatchEvent(
+    new KeyboardEvent('keydown', { key: 'ArrowDown', bubbles: true, cancelable: true }),
+  );
+  await el.updateComplete;
+}
+
+function rows(el: LvFileStatus): HTMLElement[] {
+  return Array.from(el.shadowRoot!.querySelectorAll<HTMLElement>('.file-item'));
+}
+
+function indices(el: LvFileStatus): (string | null)[] {
+  return rows(el).map((r) => r.getAttribute('data-index'));
+}
+
+describe('lv-file-status tree view row indices', () => {
+  it('a collapsed folder does not inflate the row indices', async () => {
+    const el = await renderWith([
+      entry('src/a.ts'),
+      entry('src/b.ts'),
+      entry('docs/readme.md'),
+    ]);
+    await clickViewToggle(el);
+    await collapseFolder(el, 'src');
+
+    const rendered = rows(el);
+    expect(rendered, 'only the file outside the collapsed folder renders').to.have.length(1);
+    expect(rendered[0].getAttribute('title')).to.equal('docs/readme.md');
+    expect(
+      rendered[0].getAttribute('data-index'),
+      'the first rendered row is row 0, not row 2',
+    ).to.equal('0');
+  });
+
+  it('the highlighted row is the row the keyboard is on', async () => {
+    const el = await renderWith([
+      entry('src/a.ts'),
+      entry('src/b.ts'),
+      entry('docs/readme.md'),
+    ]);
+    await clickViewToggle(el);
+    await collapseFolder(el, 'src');
+
+    await pressArrowDown(el);
+
+    const focused = el.shadowRoot!.querySelectorAll<HTMLElement>('.file-item.focused');
+    expect(focused, 'exactly one row is highlighted').to.have.length(1);
+    expect(
+      focused[0].getAttribute('title'),
+      'the highlight is on the file s/u/Enter would act on',
+    ).to.equal('docs/readme.md');
+  });
+
+  it('the unstaged section starts after the VISIBLE staged rows', async () => {
+    const el = await renderWith([
+      entry('lib/x.ts', true),
+      entry('lib/y.ts', true),
+      entry('top.txt'),
+    ]);
+    await clickViewToggle(el);
+    await collapseFolder(el, 'lib');
+
+    await pressArrowDown(el);
+
+    const rendered = rows(el);
+    expect(rendered, 'the staged section renders no rows while lib is collapsed').to.have.length(1);
+    expect(rendered[0].getAttribute('title')).to.equal('top.txt');
+    expect(
+      rendered[0].getAttribute('data-index'),
+      'the unstaged offset counts visible staged rows (0), not stagedFiles.length (2)',
+    ).to.equal('0');
+    expect(rendered[0].classList.contains('focused'), 'and it is the highlighted row').to.be.true;
+  });
+
+  it('handles a collapsed folder nested inside an expanded one', async () => {
+    const el = await renderWith([
+      entry('src/deep/a.ts'),
+      entry('src/deep/b.ts'),
+      entry('src/top.ts'),
+    ]);
+    await clickViewToggle(el);
+    await collapseFolder(el, 'deep');
+
+    await pressArrowDown(el);
+
+    const rendered = rows(el);
+    expect(rendered, 'only src/top.ts renders').to.have.length(1);
+    expect(rendered[0].getAttribute('title')).to.equal('src/top.ts');
+    expect(
+      rendered[0].getAttribute('data-index'),
+      'the nested collapsed folder contributes 0 to the sibling offset',
+    ).to.equal('0');
+    expect(rendered[0].classList.contains('focused'), 'and it is the highlighted row').to.be.true;
+  });
+
+  // No-regression guard: with nothing collapsed the two numberings already
+  // agreed, so this case passes both with and WITHOUT the fix — it is here to
+  // prove the fix did not disturb the fully-expanded tree or flat view.
+  it('numbers rows contiguously when every folder is expanded, and in flat view', async () => {
+    const el = await renderWith([
+      entry('src/a.ts'),
+      entry('docs/readme.md'),
+      entry('lib/x.ts', true),
+    ]);
+
+    await clickViewToggle(el);
+    expect(
+      rows(el).map((r) => r.getAttribute('title')),
+      'staged rows come first in DOM order',
+    ).to.deep.equal(['lib/x.ts', 'src/a.ts', 'docs/readme.md']);
+    expect(indices(el), 'tree view numbers 0..n-1').to.deep.equal(['0', '1', '2']);
+
+    // Back to flat view
+    await clickViewToggle(el);
+    expect(
+      rows(el).map((r) => r.getAttribute('title')),
+      'flat view keeps the same row order',
+    ).to.deep.equal(['lib/x.ts', 'src/a.ts', 'docs/readme.md']);
+    expect(indices(el), 'flat view numbers 0..n-1').to.deep.equal(['0', '1', '2']);
+  });
+});

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -684,11 +684,25 @@ export class LvFileStatus extends LitElement {
     return count;
   }
 
-  /** How many rows a section actually renders (collapsed folders hide theirs) */
-  private visibleFileCount(files: StatusEntry[]): number {
+  /**
+   * How many rows a section actually renders (collapsed folders hide theirs).
+   * `prebuiltTree` lets a caller that has already built this section's tree
+   * hand it over, so one render pass does not build the same tree twice.
+   */
+  private visibleFileCount(
+    files: StatusEntry[],
+    prebuiltTree?: Map<
+      string,
+      { file?: StatusEntry; children: Map<string, unknown> }
+    >,
+  ): number {
     if (this.viewMode !== "tree") return files.length;
     const visible: StatusEntry[] = [];
-    this.collectVisibleTreeFiles(files, visible);
+    this.collectVisibleFromNode(
+      prebuiltTree ?? this.buildFileTree(files),
+      "",
+      visible,
+    );
     return visible.length;
   }
 
@@ -2221,9 +2235,13 @@ export class LvFileStatus extends LitElement {
     files: StatusEntry[],
     staged: boolean,
     indexOffset: number,
+    prebuiltTree?: Map<
+      string,
+      { file?: StatusEntry; children: Map<string, unknown> }
+    >,
   ) {
     if (this.viewMode === "tree") {
-      const tree = this.buildFileTree(files);
+      const tree = prebuiltTree ?? this.buildFileTree(files);
       let currentIndex = indexOffset;
 
       return html`
@@ -2416,6 +2434,13 @@ export class LvFileStatus extends LitElement {
       `;
     }
 
+    // The staged tree is needed twice below — once to render the staged rows,
+    // once to count them for the unstaged section's index offset. Build it once.
+    const stagedTree =
+      this.viewMode === "tree"
+        ? this.buildFileTree(this.stagedFiles)
+        : undefined;
+
     return html`
       <!-- Toolbar -->
       <div class="toolbar">
@@ -2497,7 +2522,7 @@ export class LvFileStatus extends LitElement {
         </div>
         ${this.stagedExpanded ? this.renderSelectionActions(true) : nothing}
         ${this.stagedFiles.length > 0 && this.stagedExpanded
-          ? this.renderFileList(this.stagedFiles, true, 0)
+          ? this.renderFileList(this.stagedFiles, true, 0, stagedTree)
           : nothing}
       </div>
 
@@ -2556,7 +2581,9 @@ export class LvFileStatus extends LitElement {
           ? this.renderFileList(
               this.unstagedFiles,
               false,
-              this.stagedExpanded ? this.visibleFileCount(this.stagedFiles) : 0,
+              this.stagedExpanded
+                ? this.visibleFileCount(this.stagedFiles, stagedTree)
+                : 0,
             )
           : nothing}
       </div>

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -661,6 +661,37 @@ export class LvFileStatus extends LitElement {
     return count;
   }
 
+  /**
+   * Count only the files a tree node actually RENDERS — a collapsed folder
+   * renders none. The keyboard model (getAllVisibleFiles) numbers rows this
+   * way, so the data-index the rows carry has to be counted the same way;
+   * counting hidden files here put `.focused` on a different row than the one
+   * Enter/s/u acted on. `path` is the node's own full path.
+   */
+  private countVisibleTreeNodeFiles(
+    node: { file?: StatusEntry; children: Map<string, unknown> },
+    path: string,
+  ): number {
+    if (node.file) return 1;
+    if (!this.expandedFolders.has(path)) return 0;
+    let count = 0;
+    for (const [childName, child] of node.children.entries()) {
+      count += this.countVisibleTreeNodeFiles(
+        child as { file?: StatusEntry; children: Map<string, unknown> },
+        path ? `${path}/${childName}` : childName,
+      );
+    }
+    return count;
+  }
+
+  /** How many rows a section actually renders (collapsed folders hide theirs) */
+  private visibleFileCount(files: StatusEntry[]): number {
+    if (this.viewMode !== "tree") return files.length;
+    const visible: StatusEntry[] = [];
+    this.collectVisibleTreeFiles(files, visible);
+    return visible.length;
+  }
+
   /** Collect all file paths under a given directory prefix */
   private getFilesUnderPath(
     files: StatusEntry[],
@@ -2131,11 +2162,12 @@ export class LvFileStatus extends LitElement {
                   staged,
                   currentIndex,
                 );
-                currentIndex += this.countTreeNodeFiles(
+                currentIndex += this.countVisibleTreeNodeFiles(
                   childNode as {
                     file?: StatusEntry;
                     children: Map<string, unknown>;
                   },
+                  childPath,
                 );
                 return result;
               })}
@@ -2205,7 +2237,7 @@ export class LvFileStatus extends LitElement {
               staged,
               currentIndex,
             );
-            currentIndex += this.countTreeNodeFiles(node);
+            currentIndex += this.countVisibleTreeNodeFiles(node, name);
             return result;
           })}
         </ul>
@@ -2524,7 +2556,7 @@ export class LvFileStatus extends LitElement {
           ? this.renderFileList(
               this.unstagedFiles,
               false,
-              this.stagedExpanded ? this.stagedFiles.length : 0,
+              this.stagedExpanded ? this.visibleFileCount(this.stagedFiles) : 0,
             )
           : nothing}
       </div>


### PR DESCRIPTION
## What was broken

In tree view, the `data-index` a rendered file row carries came from `countTreeNodeFiles()`, which counts **every** file in a subtree regardless of whether the folder is expanded:

- `renderFileList` — `currentIndex += this.countTreeNodeFiles(node)`
- `renderTreeNode` — same, once per child
- the unstaged section's offset — `this.stagedExpanded ? this.stagedFiles.length : 0`

The keyboard model numbers rows a different way: `getAllVisibleFiles()` → `collectVisibleTreeFiles` → `collectVisibleFromNode`, which descends into a folder **only** when `expandedFolders.has(nodePath)`.

The two numberings agree only while every folder is expanded. Collapse one and they drift apart:

- `isFocused = this.focusedIndex === index` compares the keyboard's visible-list index against the inflated render index, so the `.focused` highlight lands on the wrong row — or, commonly, on **no row at all**.
- `scrollFocusedIntoView()` queries `[data-index="${this.focusedIndex}"]` and scrolls to the wrong row or nowhere.
- Enter / space / `s` / `u` act on `allFiles[this.focusedIndex]`, i.e. the *correct* visible file — so keyboard staging in tree view visibly targets a row the user never selected.

Concrete case: unstaged `src/a.ts`, `src/b.ts`, `docs/readme.md` in tree view with `src` collapsed. The only rendered row (`docs/readme.md`) gets `data-index="2"`, while the keyboard's visible list is `[docs/readme.md]` at index 0. Nothing is highlighted, yet `s` stages `readme.md`.

## The fix

Add `countVisibleTreeNodeFiles(node, path)` next to `countTreeNodeFiles`. It mirrors `collectVisibleFromNode`: a node carrying a file counts 1, a folder not in `expandedFolders` counts 0, otherwise it recurses over children with each child's own full path. The two render-time counters now use it, so `data-index` is assigned by the same traversal the keyboard walks. Both traversals already visited `buildFileTree` insertion order depth-first, so ordering was never the problem — only the count was.

The unstaged section's offset becomes `this.visibleFileCount(this.stagedFiles)`, a small helper that returns `files.length` in flat view (where every file renders) and the visible-tree count in tree view.

`countTreeNodeFiles` and its use in the folder row are **deliberately untouched** — that feeds `title="path (N files)"` and the `.folder-count` badge, which must keep counting the files hidden inside a collapsed folder.

## Tests

New file `src/components/sidebar/__tests__/lv-file-status-tree-focus.test.ts`. Every case is driven through real gestures — mock `get_status`, click `.view-toggle` to enter tree view, click a `.folder-item` to collapse, dispatch a real `ArrowDown` keydown — and asserts on the DOM (`data-index`, which row carries `.focused`), because an assertion on which path reaches `stage_files` would pass with and without the fix.

| # | Test | Covers | Fails without the fix? |
|---|------|--------|------------------------|
| 1 | a collapsed folder does not inflate the row indices | happy path; top-level counter | Yes — `expected '2' to equal '0'` |
| 2 | the highlighted row is the row the keyboard is on | the user-visible defect | Yes — `expected empty NodeList to have 1 children but it had 0 children` |
| 3 | the unstaged section starts after the VISIBLE staged rows | cross-section offset | Yes — `expected '2' to equal '0'` |
| 4 | handles a collapsed folder nested inside an expanded one | edge case; per-child counter | Yes — `expected '2' to equal '0'` |
| 5 | numbers rows contiguously when every folder is expanded, and in flat view | no-regression guard | No — passes both ways *by design* (noted in a comment in the file) |

Verified by reverting only the production edits (tests left in place) and re-running: 4 failed, 1 passed, with the messages above. Fix restored, then the full gate: `npm run lint`, `npm run typecheck`, `npm test` all green, plus `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` (no Rust touched).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_