### PR TITLE
Allow clearing a remote's push URL from the Edit Remote dialog

### DIFF
--- a/e2e/tests/remote-dialog.spec.ts
+++ b/e2e/tests/remote-dialog.spec.ts
@@ -494,6 +494,49 @@ test.describe('Remote Dialog - Extended Tests', () => {
     await expect(remoteDialog).toBeVisible();
   });
 
+  test('clearing the push URL removes it from the remote list', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {
+      'get_remotes': [
+        { name: 'origin', url: 'https://github.com/user/repo.git', pushUrl: 'git@github.com:user/repo.git' },
+      ],
+      'set_remote_url': { success: true },
+    });
+
+    await openRemoteDialog(page);
+
+    const remoteDialog = page.locator('lv-remote-dialog');
+    await expect(page.getByText('Push: git@github.com:user/repo.git')).toBeVisible();
+
+    const editButton = remoteDialog.locator('button[title*="Edit"]').first();
+    await expect(editButton).toBeVisible();
+    await editButton.click();
+
+    // Second text input in the edit form is the Push URL
+    const pushUrlInput = remoteDialog.locator('input[type="text"]').nth(1);
+    await expect(pushUrlInput).toBeVisible();
+    await pushUrlInput.fill('');
+
+    // The post-save reload should report the cleared remote
+    await injectCommandMock(page, {
+      'get_remotes': [{ name: 'origin', url: 'https://github.com/user/repo.git', pushUrl: null }],
+    });
+
+    const saveButton = remoteDialog.locator('button', { hasText: /save|confirm|update/i }).first();
+    await saveButton.click();
+
+    await waitForCommand(page, 'set_remote_url');
+
+    const setUrlCommands = await findCommand(page, 'set_remote_url');
+    const clearCall = setUrlCommands.find((c) => {
+      const args = c.args as Record<string, unknown>;
+      return args.push === true && args.url === '';
+    });
+    expect(clearCall).toBeDefined();
+
+    // UI outcome: the Push line is gone
+    await expect(page.getByText(/^Push: /)).toHaveCount(0);
+  });
+
   test('remote list should refresh after adding a new remote', async ({ page }) => {
     await startCommandCaptureWithMocks(page, {
       'get_remotes': [{ name: 'origin', url: 'https://github.com/user/repo.git', pushUrl: null }],

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -87,6 +87,10 @@ pub async fn rename_remote(path: String, old_name: String, new_name: String) -> 
 }
 
 /// Set the URL of a remote
+///
+/// An empty `url` with `push` set clears the push URL so pushes fall back to
+/// the fetch URL — that is the only way to undo a divergent push destination.
+/// An empty fetch URL is refused: a remote without one is unusable.
 #[command]
 pub async fn set_remote_url(
     path: String,
@@ -100,10 +104,22 @@ pub async fn set_remote_url(
     repo.find_remote(&name)
         .map_err(|_| LeviathanError::RemoteNotFound(name.clone()))?;
 
+    let url = url.trim();
+
     if push.unwrap_or(false) {
-        repo.remote_set_pushurl(&name, Some(&url))?;
+        match repo.remote_set_pushurl(&name, if url.is_empty() { None } else { Some(url) }) {
+            // Deleting an absent pushurl reports NotFound; the remote is
+            // already in the state the caller asked for.
+            Err(e) if url.is_empty() && e.code() == git2::ErrorCode::NotFound => {}
+            other => other?,
+        }
     } else {
-        repo.remote_set_url(&name, &url)?;
+        if url.is_empty() {
+            return Err(LeviathanError::OperationFailed(
+                "Remote URL cannot be empty".to_string(),
+            ));
+        }
+        repo.remote_set_url(&name, url)?;
     }
 
     // Get updated remote info
@@ -2727,6 +2743,109 @@ mod tests {
             remote.push_url,
             Some("git@github.com:test/repo.git".to_string())
         );
+    }
+
+    #[tokio::test]
+    async fn test_clear_remote_push_url() {
+        let repo = TestRepo::with_initial_commit();
+        add_remote(
+            repo.path_str(),
+            "origin".to_string(),
+            "https://github.com/test/repo.git".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let remote = set_remote_url(
+            repo.path_str(),
+            "origin".to_string(),
+            "git@github.com:test/repo.git".to_string(),
+            Some(true),
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            remote.push_url,
+            Some("git@github.com:test/repo.git".to_string())
+        );
+
+        // Clearing the field must remove the push URL, not store an empty one
+        let result = set_remote_url(
+            repo.path_str(),
+            "origin".to_string(),
+            String::new(),
+            Some(true),
+        )
+        .await;
+
+        assert!(result.is_ok(), "clearing push URL failed: {result:?}");
+        let remote = result.unwrap();
+        assert_eq!(remote.push_url, None);
+        assert_eq!(remote.url, "https://github.com/test/repo.git");
+
+        // And it must actually be gone from the config, not just the response
+        let remotes = get_remotes(repo.path_str()).await.unwrap();
+        let origin = remotes.iter().find(|r| r.name == "origin").unwrap();
+        assert_eq!(origin.push_url, None);
+        assert_eq!(origin.url, "https://github.com/test/repo.git");
+    }
+
+    #[tokio::test]
+    async fn test_set_remote_url_rejects_an_empty_fetch_url() {
+        let repo = TestRepo::with_initial_commit();
+        add_remote(
+            repo.path_str(),
+            "origin".to_string(),
+            "https://github.com/test/repo.git".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let result = set_remote_url(
+            repo.path_str(),
+            "origin".to_string(),
+            "   ".to_string(),
+            None,
+        )
+        .await;
+
+        assert!(result.is_err());
+        assert!(
+            result.unwrap_err().to_string().contains("cannot be empty"),
+            "expected an empty-URL error"
+        );
+
+        let remotes = get_remotes(repo.path_str()).await.unwrap();
+        let origin = remotes.iter().find(|r| r.name == "origin").unwrap();
+        assert_eq!(origin.url, "https://github.com/test/repo.git");
+    }
+
+    #[tokio::test]
+    async fn test_clearing_a_push_url_that_was_never_set_is_a_no_op() {
+        let repo = TestRepo::with_initial_commit();
+        add_remote(
+            repo.path_str(),
+            "origin".to_string(),
+            "https://github.com/test/repo.git".to_string(),
+        )
+        .await
+        .unwrap();
+
+        let result = set_remote_url(
+            repo.path_str(),
+            "origin".to_string(),
+            String::new(),
+            Some(true),
+        )
+        .await;
+
+        assert!(
+            result.is_ok(),
+            "clearing an unset push URL failed: {result:?}"
+        );
+        let remote = result.unwrap();
+        assert_eq!(remote.push_url, None);
+        assert_eq!(remote.url, "https://github.com/test/repo.git");
     }
 
     #[tokio::test]

--- a/src/components/__tests__/lv-remote-dialog-actions.test.ts
+++ b/src/components/__tests__/lv-remote-dialog-actions.test.ts
@@ -622,6 +622,120 @@ describe('lv-remote-dialog actions', () => {
         push: false,
       });
     });
+
+    // Push URL editing — `upstream` has pushUrl 'git@github.com:upstream/repo.git'
+    async function startEditingUpstream(el: LvRemoteDialog): Promise<NodeListOf<HTMLInputElement>> {
+      const items = getRemoteItems(el);
+      const upstreamItem = Array.from(items).find(
+        (item) => item.querySelector('.remote-name')?.textContent?.trim() === 'upstream'
+      )!;
+      getActionButton(upstreamItem, 'Edit URL')!.click();
+      await el.updateComplete;
+      return el.shadowRoot!.querySelectorAll('.form-input') as NodeListOf<HTMLInputElement>;
+    }
+
+    async function setPushUrlAndSave(el: LvRemoteDialog, value: string): Promise<void> {
+      const formInputs = await startEditingUpstream(el);
+      const pushInput = formInputs[1];
+      pushInput.value = value;
+      pushInput.dispatchEvent(new InputEvent('input', { bubbles: true }));
+      await el.updateComplete;
+
+      clearHistory();
+
+      const saveBtn = el.shadowRoot!.querySelector('.footer .btn-primary') as HTMLButtonElement;
+      saveBtn.click();
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+    }
+
+    it('clearing the push URL asks the backend to unset it', async () => {
+      const el = await renderDialog();
+
+      await setPushUrlAndSave(el, '');
+
+      const setCalls = findCommands('set_remote_url');
+      expect(setCalls.length).to.equal(2);
+      expect(setCalls[1].args).to.deep.include({
+        path: REPO_PATH,
+        name: 'upstream',
+        url: '',
+        push: true,
+      });
+    });
+
+    it('a push URL equal to the fetch URL clears it', async () => {
+      const el = await renderDialog();
+
+      await setPushUrlAndSave(el, 'https://github.com/upstream/repo.git');
+
+      const setCalls = findCommands('set_remote_url');
+      expect(setCalls.length).to.equal(2);
+      expect(setCalls[1].args).to.deep.include({
+        path: REPO_PATH,
+        name: 'upstream',
+        url: '',
+        push: true,
+      });
+    });
+
+    it('a failed push-URL clear keeps the dialog open and shows the error', async () => {
+      const el = await renderDialog();
+
+      let remotesChanged = false;
+      el.addEventListener('remotes-changed', () => { remotesChanged = true; });
+
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_remotes') return mockRemotes;
+        if (command === 'set_remote_url') {
+          if ((args as { push?: boolean }).push === true) {
+            throw new Error('cannot unset push url');
+          }
+          return { name: 'upstream', url: 'https://github.com/upstream/repo.git', pushUrl: null };
+        }
+        return null;
+      };
+
+      await setPushUrlAndSave(el, '');
+
+      const error = el.shadowRoot!.querySelector('.error');
+      expect(error).to.not.be.null;
+      expect(error!.textContent).to.contain('cannot unset push url');
+
+      // Still in edit mode, and no refresh was announced
+      const title = el.shadowRoot!.querySelector('.title');
+      expect(title!.textContent?.trim()).to.equal('Edit Remote URL');
+      expect(remotesChanged).to.be.false;
+    });
+
+    // Guard against over-reach: this passes with and without the fix — it exists
+    // so a future change cannot start issuing a clear for every fetch-URL edit.
+    it('leaves the push URL alone for a remote that never had one', async () => {
+      const el = await renderDialog();
+
+      const items = getRemoteItems(el);
+      const originItem = Array.from(items).find(
+        (item) => item.querySelector('.remote-name')?.textContent?.trim() === 'origin'
+      )!;
+      getActionButton(originItem, 'Edit URL')!.click();
+      await el.updateComplete;
+
+      const formInputs = el.shadowRoot!.querySelectorAll('.form-input') as NodeListOf<HTMLInputElement>;
+      formInputs[0].value = 'https://new-url.com/repo.git';
+      formInputs[0].dispatchEvent(new InputEvent('input', { bubbles: true }));
+      await el.updateComplete;
+
+      clearHistory();
+
+      const saveBtn = el.shadowRoot!.querySelector('.footer .btn-primary') as HTMLButtonElement;
+      saveBtn.click();
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const setCalls = findCommands('set_remote_url');
+      expect(setCalls.length).to.equal(1);
+      expect(setCalls[0].args).to.deep.include({ push: false });
+    });
   });
 
   // ── 7. Rename remote ──────────────────────────────────────────────────

--- a/src/components/dialogs/lv-remote-dialog.ts
+++ b/src/components/dialogs/lv-remote-dialog.ts
@@ -563,17 +563,26 @@ export class LvRemoteDialog extends LitElement {
         return;
       }
 
-      // Update push URL if different
-      if (this.formPushUrl.trim() && this.formPushUrl.trim() !== this.formUrl.trim()) {
+      // An empty push URL — or one equal to the fetch URL — means "push where
+      // you fetch". Send the empty URL through so the backend unsets it;
+      // skipping the write would silently leave the old push destination in
+      // place. Nothing to do when the remote never had a push URL.
+      const pushUrl = this.formPushUrl.trim();
+      const wantsPushUrl = pushUrl !== '' && pushUrl !== this.formUrl.trim();
+      const hadPushUrl = (this.editingRemote.pushUrl ?? '') !== '';
+
+      if (wantsPushUrl || hadPushUrl) {
         result = await gitService.setRemoteUrl(
           this.pinnedRepoPath,
           this.editingRemote.name,
-          this.formPushUrl.trim(),
+          wantsPushUrl ? pushUrl : '',
           true
         );
 
         if (!result.success) {
-          this.error = result.error?.message ?? 'Failed to update push URL';
+          this.error =
+            result.error?.message ??
+            (wantsPushUrl ? 'Failed to update push URL' : 'Failed to clear push URL');
           return;
         }
       }


### PR DESCRIPTION
## What was broken

The Push URL field in **Edit Remote URL** has the placeholder *"Same as fetch URL if empty"*, but clearing it was a silent no-op.

`handleSaveUrl()` (`src/components/dialogs/lv-remote-dialog.ts`) only issued the push-URL write when the field was non-empty **and** different from the fetch URL. `startEdit()` prefills the field with the remote's existing `pushUrl`, so a user editing a remote with a divergent push destination who cleared that field got:

- the fetch URL written,
- the push write skipped entirely,
- `loadRemotes()` + `resetForm()`, dialog back to the list, **no error**,
- and the list still rendering the old `Push: …` line.

Every subsequent push kept going to the URL the user believed they had removed.

The backend offered no unset path either: `set_remote_url` with `push = true` always ran `repo.remote_set_pushurl(&name, Some(&url))`, so even sending an empty string would have stored an invalid pushurl rather than deleting the config entry.

## The fix

**Backend — `src-tauri/src/commands/remote.rs`**

An empty `url` with `push = true` now passes `None` to `remote_set_pushurl`, deleting the config entry so pushes fall back to the fetch URL. libgit2 reports `NotFound` when the key is already absent — that is the state the caller asked for, so it is treated as success rather than an error. An empty **fetch** URL is refused with `OperationFailed("Remote URL cannot be empty")`: a remote without one is unusable, and the old code silently passed `"   "` down to libgit2.

**Frontend — `src/components/dialogs/lv-remote-dialog.ts`**

When the push field is empty (or equal to the fetch URL) *and* the remote currently has a push URL, the empty URL is sent through so the backend unsets it, with any failure surfaced in the dialog exactly like the fetch-URL failure path directly above it. A remote that never had a push URL still skips the write, so a plain fetch-URL edit costs no extra IPC.

`set_remote_url` has exactly one caller (`gitService.setRemoteUrl`, used only by this dialog), so the contract change is contained.

## Tests

| # | Test | File | Covers | Red without the fix |
|---|------|------|--------|---------------------|
| 1 | `test_clear_remote_push_url` | `src-tauri/src/commands/remote.rs` | happy path — set then clear, re-read via `get_remotes` to prove it left the config | Yes — `Err(Git(… "cannot set empty URL"))` |
| 2 | `test_set_remote_url_rejects_an_empty_fetch_url` | `src-tauri/src/commands/remote.rs` | error path — blank fetch URL refused, remote untouched | Yes — `assertion failed: result.is_err()` |
| 3 | `test_clearing_a_push_url_that_was_never_set_is_a_no_op` | `src-tauri/src/commands/remote.rs` | edge — idempotent unset | Yes — `Err(Git(… "cannot set empty URL"))` |
| 4 | `clearing the push URL asks the backend to unset it` | `src/components/__tests__/lv-remote-dialog-actions.test.ts` | happy path — second `set_remote_url` with `url: ''`, `push: true` | Yes — `expected 1 to equal 2` |
| 5 | `a push URL equal to the fetch URL clears it` | `src/components/__tests__/lv-remote-dialog-actions.test.ts` | edge — field equal to fetch URL | Yes — `expected 1 to equal 2` |
| 6 | `a failed push-URL clear keeps the dialog open and shows the error` | `src/components/__tests__/lv-remote-dialog-actions.test.ts` | error path — `.error` rendered, still in edit mode, no `remotes-changed` | Yes — `expected null not to be null` |
| 7 | `leaves the push URL alone for a remote that never had one` | `src/components/__tests__/lv-remote-dialog-actions.test.ts` | no-overreach guard — exactly one call, `push: false` | **No** — passes both ways by design; it pins the fix against issuing a clear on every fetch-URL edit |
| 8 | `clearing the push URL removes it from the remote list` | `e2e/tests/remote-dialog.spec.ts` | full stack — `Push:` line visible, cleared, gone from the list | Yes — `expect(clearCall).toBeDefined()` received `undefined` |

Each red result above was recorded by reverting the production hunk (frontend and Rust in turn), re-running, and restoring.

Note on the plan-vs-reality: `remote_set_pushurl(name, None)` is **not** silently idempotent in git2 — it returns `NotFound` (`code -3, klass 7, "could not find key 'remote.origin.pushurl' to delete"`) when the key is already absent. Test 3 caught this, and the backend now tolerates that one case.

## Gate

`npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` all green, plus the full `remote-dialog.spec.ts` E2E suite (22 passed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_