### PR TITLE
Page the reflog dialog past its first 50 entries

### DIFF
--- a/e2e/tests/reflog-dialog.spec.ts
+++ b/e2e/tests/reflog-dialog.spec.ts
@@ -329,3 +329,44 @@ test.describe('Reflog Dialog - Extended Tests', () => {
     expect(args.reflogIndex).toBe(1);
   });
 });
+
+/**
+ * A first page that comes back completely full — the only signal available
+ * that older entries may exist, since get_reflog reports no total.
+ */
+const FIFTY_ENTRIES = Array.from({ length: 50 }, (_, i) => ({
+  oid: `oid${i}`.padEnd(12, '0'),
+  shortId: `oid${i}`.padEnd(7, '0').slice(0, 7),
+  index: i,
+  action: 'commit',
+  message: `commit: entry ${i}`,
+  timestamp: Date.now() / 1000 - i * 60,
+  author: 'Test User',
+}));
+
+test.describe('Reflog Dialog pagination', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+    await startCommandCaptureWithMocks(page, { get_reflog: FIFTY_ENTRIES });
+    await openReflogDialog(page);
+  });
+
+  test('offers older entries when the first page fills up', async ({ page }) => {
+    await expect(page.locator('lv-reflog-dialog .show-more-btn')).toBeVisible();
+    await expect(page.locator('lv-reflog-dialog .list-note')).toContainText('first 50');
+
+    await page.locator('lv-reflog-dialog .show-more-btn').click();
+
+    await expect
+      .poll(async () => {
+        const calls = await findCommand(page, 'get_reflog');
+        return (calls[calls.length - 1].args as { limit?: number }).limit;
+      })
+      .toBe(100);
+
+    // The mock returns the same 50 for a limit of 100, so the list is now
+    // known-complete and the control must retire rather than sit there dead.
+    await expect(page.locator('lv-reflog-dialog .show-more-btn')).toHaveCount(0);
+    await expect(page.locator('lv-reflog-dialog .list-note')).toContainText('Showing all 50');
+  });
+});

--- a/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
@@ -564,19 +564,23 @@ describe('lv-reflog-dialog', () => {
     describe('superseded reads', () => {
       /** get_reflog reads that are held open until the test releases them. */
       function deferredReflog(total: number): {
-        pending: Array<{ limit: number; release: () => void }>;
+        pending: Array<{ limit: number; release: () => void; fail: () => void }>;
         defer: () => void;
       } {
         const all = pageEntries(total);
-        const pending: Array<{ limit: number; release: () => void }> = [];
+        const pending: Array<{ limit: number; release: () => void; fail: () => void }> = [];
         let deferring = false;
         mockInvoke = async (command, args) => {
           if (command === 'get_reflog') {
             const limit = (args as { limit?: number }).limit ?? total;
             const page = all.slice(0, limit);
             if (!deferring) return page;
-            return new Promise((resolve) => {
-              pending.push({ limit, release: () => resolve(page) });
+            return new Promise((resolve, reject) => {
+              pending.push({
+                limit,
+                release: () => resolve(page),
+                fail: () => reject(new Error('reflog read failed')),
+              });
             });
           }
           if (command === 'plugin:dialog|message') return 'Ok';
@@ -667,6 +671,90 @@ describe('lv-reflog-dialog', () => {
         await el.updateComplete;
 
         expect(showMore(el)!.disabled, 'a read racing the reset is not a live option').to.be.true;
+      });
+
+      // `loadingMore` is per-request state, so a session that never sees its
+      // page land must not hand the flag to the next one: the reopened dialog
+      // came up with its only paging control stuck on a disabled "Loading..."
+      // for a request nobody was waiting on — on the app's recovery surface.
+      it('offers a usable Show more in a session reopened over an abandoned page', async () => {
+        const { pending, defer } = deferredReflog(120);
+        const el = await openDialog();
+
+        defer();
+        showMore(el)!.click();
+        await flush();
+        expect(pending.map((p) => p.limit), 'the 100-entry page is in flight').to.deep.equal([100]);
+
+        // The host closes this dialog by clearing `open` ("Show in graph"),
+        // then the user reopens it — the abandoned page is still out there.
+        el.open = false;
+        await el.updateComplete;
+        el.open = true;
+        await el.updateComplete;
+        await flush();
+        pending[1].release();
+        await settle(el);
+
+        expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(50);
+        expect(showMore(el)!.disabled, 'the new session can page').to.be.false;
+        expect(showMore(el)!.textContent?.trim()).to.equal('Show more');
+      });
+
+      it('keeps Show more busy when an abandoned page settles under a live one', async () => {
+        const { pending, defer } = deferredReflog(120);
+        const el = await openDialog();
+
+        defer();
+        showMore(el)!.click();
+        await flush();
+
+        el.open = false;
+        await el.updateComplete;
+        el.open = true;
+        await el.updateComplete;
+        await flush();
+        pending[1].release();
+        await settle(el);
+
+        // A page the user asked for in the NEW session.
+        showMore(el)!.click();
+        await flush();
+        expect(pending.map((p) => p.limit)).to.deep.equal([100, 50, 100]);
+
+        pending[0].release(); // the abandoned page finally settles
+        await settle(el);
+
+        expect(showMore(el)!.disabled, 'the live page is still loading').to.be.true;
+        expect(showMore(el)!.textContent?.trim()).to.equal('Loading...');
+      });
+
+      // The failure half of the same abandonment. invokeCommand turns every
+      // rejection into `{ success: false }`, so a failed page reports through
+      // the SAME branch that publishes a good one — behind the `open` check —
+      // and a session the host has already closed stays quiet.
+      it('does not report a failed page for a session the host already closed', async () => {
+        const { pending, defer } = deferredReflog(120);
+        const el = await openDialog();
+
+        defer();
+        showMore(el)!.click();
+        await flush();
+        expect(pending.map((p) => p.limit)).to.deep.equal([100]);
+
+        // "Show in graph" clears `open` without calling close(), so the fetch
+        // generation is untouched and only `open` marks the session as gone.
+        el.open = false;
+        await el.updateComplete;
+        uiStore.setState({ toasts: [] });
+
+        pending[0].fail();
+        await settle(el);
+
+        expect(
+          uiStore.getState().toasts.some((t) => /load more/i.test(t.message)),
+          'a page nobody is watching must not raise a toast'
+        ).to.be.false;
       });
     });
   });

--- a/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
@@ -49,6 +49,37 @@ function checkoutEntry(from: string, to: string): ReflogEntry {
   } as unknown as ReflogEntry;
 }
 
+/** `count` sequential reflog entries, newest first. */
+function pageEntries(count: number): ReflogEntry[] {
+  return Array.from({ length: count }, (_, i) => ({
+    oid: `oid${i}`.padEnd(12, '0'),
+    shortId: `oid${i}`.padEnd(7, '0').slice(0, 7),
+    index: i,
+    action: 'commit',
+    message: `commit: entry ${i}`,
+    timestamp: Math.floor(Date.now() / 1000),
+    author: 'T',
+  })) as unknown as ReflogEntry[];
+}
+
+/**
+ * A repo whose reflog holds `total` entries; get_reflog honours `limit` the
+ * way the backend does (it stops once `limit` entries have been collected).
+ * Every requested limit is recorded in `calls`.
+ */
+function mockReflogOfSize(total: number, calls: Array<{ limit?: number }>): void {
+  const all = pageEntries(total);
+  mockInvoke = async (command, args) => {
+    if (command === 'get_reflog') {
+      const limit = (args as { limit?: number }).limit;
+      calls.push({ limit });
+      return all.slice(0, limit ?? total);
+    }
+    if (command === 'plugin:dialog|message') return 'Ok';
+    return null;
+  };
+}
+
 /** An ordinary commit entry, which SHOULD still offer a reset. */
 function commitEntry(): ReflogEntry {
   return {
@@ -367,6 +398,162 @@ describe('lv-reflog-dialog', () => {
       expect(target(checkoutEntry('main', 'feature'))).to.equal('feature');
       expect(target(checkoutEntry('feature', 'release/2.0'))).to.equal('release/2.0');
       expect(target(commitEntry()), 'a commit entry is not a checkout').to.be.null;
+    });
+  });
+
+  // ── Reaching entries past the first page ─────────────────────────────────
+  //
+  // This dialog is the app's recovery surface, and it asked for exactly 50
+  // entries and rendered nothing else: a user whose lost commit sat at
+  // HEAD@{51} scrolled to the bottom, found nothing, and had no way to learn
+  // that older states existed — while git could still recover them.
+  describe('pagination', () => {
+    /** Open a real session so the dialog pins a repo and loads its first page. */
+    async function openDialog(repositoryPath = '/test/repo'): Promise<LvReflogDialog> {
+      const el = await fixture<LvReflogDialog>(
+        html`<lv-reflog-dialog ?open=${true} .repositoryPath=${repositoryPath}></lv-reflog-dialog>`
+      );
+      await settle(el);
+      return el;
+    }
+
+    async function settle(el: LvReflogDialog): Promise<void> {
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 0));
+      await el.updateComplete;
+    }
+
+    function showMore(el: LvReflogDialog): HTMLButtonElement | null {
+      return el.shadowRoot!.querySelector<HTMLButtonElement>('.show-more-btn');
+    }
+
+    function note(el: LvReflogDialog): string {
+      return el.shadowRoot!.querySelector('.list-note')?.textContent ?? '';
+    }
+
+    it('flags the list as truncated and offers a way to see older entries', async () => {
+      const calls: Array<{ limit?: number }> = [];
+      mockReflogOfSize(120, calls);
+
+      const el = await openDialog();
+
+      expect(calls[0].limit, 'the first page asks for 50').to.equal(50);
+      expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(50);
+      expect(showMore(el), 'a truncated list must offer more').to.not.be.null;
+      expect(note(el)).to.match(/first 50/);
+    });
+
+    it('Show more pulls the next page and stops once the whole reflog is listed', async () => {
+      const calls: Array<{ limit?: number }> = [];
+      mockReflogOfSize(120, calls);
+
+      const el = await openDialog();
+
+      showMore(el)!.click();
+      await settle(el);
+
+      // get_reflog has no skip parameter, so the next page is a re-read from
+      // HEAD@{0} with a bigger limit — replacing the list, not appending.
+      expect(calls[1].limit).to.equal(100);
+      expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(100);
+      expect(showMore(el), 'still more to come').to.not.be.null;
+
+      showMore(el)!.click();
+      await settle(el);
+
+      expect(calls[2].limit).to.equal(150);
+      expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(120);
+      expect(showMore(el), 'a complete list must not offer a dead control').to.be.null;
+      expect(note(el)).to.match(/Showing all 120/);
+    });
+
+    it('keeps the list and the control when a page fails to load, and says so', async () => {
+      let loads = 0;
+      mockInvoke = async (command) => {
+        if (command === 'get_reflog') {
+          loads++;
+          if (loads > 1) throw new Error('reflog read failed');
+          return pageEntries(50);
+        }
+        return null;
+      };
+
+      const el = await openDialog();
+      expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(50);
+
+      showMore(el)!.click();
+      await settle(el);
+
+      const toasts = uiStore.getState().toasts;
+      expect(
+        toasts.some((t) => t.type === 'error' && /load more/i.test(t.message)),
+        'a failed page must be reported'
+      ).to.be.true;
+      expect(
+        el.shadowRoot!.querySelectorAll('.entry').length,
+        'the failure must not wipe the list the user was reading'
+      ).to.equal(50);
+      expect(showMore(el), 'retry must stay available').to.not.be.null;
+    });
+
+    it('a short reflog says the list is complete instead of offering a dead control', async () => {
+      const calls: Array<{ limit?: number }> = [];
+      mockReflogOfSize(3, calls);
+
+      const el = await openDialog();
+
+      expect(showMore(el)).to.be.null;
+      expect(note(el)).to.match(/Showing all 3/);
+    });
+
+    // loadReflog doubles as the post-failed-reset refresh (the backend's
+    // "refresh and try again" advice), so it must NOT collapse the expansion
+    // at exactly the moment the user is hunting for a deep entry.
+    it('keeps the expanded listing when a failed reset reloads the entries', async () => {
+      const calls: Array<{ limit?: number }> = [];
+      const all = pageEntries(120);
+      resetRefOpLocks();
+      mockInvoke = async (command, args) => {
+        if (command === 'get_reflog') {
+          const limit = (args as { limit?: number }).limit;
+          calls.push({ limit });
+          return all.slice(0, limit ?? 120);
+        }
+        if (command === 'plugin:dialog|message') return 'Ok';
+        if (command === 'reset_to_reflog') throw new Error('reflog moved');
+        return null;
+      };
+
+      const el = await openDialog();
+      showMore(el)!.click();
+      await settle(el);
+      expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(100);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleReset(all[5], 'mixed');
+      await settle(el);
+
+      expect(calls[calls.length - 1].limit, 'the refresh keeps the expansion').to.equal(100);
+      expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(100);
+      resetRefOpLocks();
+    });
+
+    it('starts a reopened dialog back at the first page', async () => {
+      const calls: Array<{ limit?: number }> = [];
+      mockReflogOfSize(120, calls);
+
+      const el = await openDialog();
+      showMore(el)!.click();
+      await settle(el);
+      expect(calls[calls.length - 1].limit, 'expanded before closing').to.equal(100);
+
+      el.open = false;
+      await el.updateComplete;
+      el.open = true;
+      await settle(el);
+
+      expect(calls[calls.length - 1].limit, 'a new session starts fresh').to.equal(50);
+      expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(50);
     });
   });
 });

--- a/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-reflog-dialog.test.ts
@@ -555,5 +555,119 @@ describe('lv-reflog-dialog', () => {
       expect(calls[calls.length - 1].limit, 'a new session starts fresh').to.equal(50);
       expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(50);
     });
+
+    // Two reads of the SAME repo can be in flight at once, because every read
+    // here re-fetches from HEAD@{0} at the current limit. If the superseded one
+    // lands last, `entries` and `entryLimit` end up describing different reads
+    // and hasMoreEntries goes false on a list that is still truncated — the
+    // recovery surface then tells the user there is nothing older when there is.
+    describe('superseded reads', () => {
+      /** get_reflog reads that are held open until the test releases them. */
+      function deferredReflog(total: number): {
+        pending: Array<{ limit: number; release: () => void }>;
+        defer: () => void;
+      } {
+        const all = pageEntries(total);
+        const pending: Array<{ limit: number; release: () => void }> = [];
+        let deferring = false;
+        mockInvoke = async (command, args) => {
+          if (command === 'get_reflog') {
+            const limit = (args as { limit?: number }).limit ?? total;
+            const page = all.slice(0, limit);
+            if (!deferring) return page;
+            return new Promise((resolve) => {
+              pending.push({ limit, release: () => resolve(page) });
+            });
+          }
+          if (command === 'plugin:dialog|message') return 'Ok';
+          if (command === 'reset_to_reflog') throw new Error('reflog moved');
+          return null;
+        };
+        return { pending, defer: () => { deferring = true; } };
+      }
+
+      /** Let queued microtasks reach the mock before inspecting it. */
+      async function flush(): Promise<void> {
+        await new Promise((r) => setTimeout(r, 0));
+      }
+
+      it('discards a page belonging to a session the user already closed', async () => {
+        const { pending, defer } = deferredReflog(120);
+        const el = await openDialog();
+        expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(50);
+
+        defer();
+        showMore(el)!.click();
+        await flush();
+        expect(pending.map((p) => p.limit), 'the 100-entry page is in flight').to.deep.equal([100]);
+
+        // Escape, then reopen on the SAME repo: `open` and the pinned repo both
+        // match again, so the old guards no longer reject the stale page.
+        el.open = false;
+        await el.updateComplete;
+        el.open = true;
+        await el.updateComplete;
+        await flush();
+        expect(pending.map((p) => p.limit), 'the new session re-reads page one').to.deep.equal([100, 50]);
+
+        pending[0].release(); // the abandoned page lands first...
+        await settle(el);
+        pending[1].release(); // ...and the live one last.
+        await settle(el);
+
+        expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(50);
+        expect(showMore(el), 'a truncated list must keep offering older entries').to.not.be.null;
+        expect(note(el)).to.match(/first 50/);
+      });
+
+      it('keeps the footer honest when a failed reset refreshes over a page in flight', async () => {
+        resetRefOpLocks();
+        const all = pageEntries(120);
+        const { pending, defer } = deferredReflog(120);
+        const el = await openDialog();
+        expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(50);
+
+        defer();
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        void (el as any).loadMoreEntries();
+        await flush();
+        expect(pending.map((p) => p.limit)).to.deep.equal([100]);
+
+        // The reset fails, and its "refresh and try again" reload reads at the
+        // limit the in-flight page has not advanced yet.
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const reset = (el as any).handleReset(all[5], 'mixed') as Promise<void>;
+        await flush();
+        expect(pending.map((p) => p.limit), 'the refresh re-reads page one').to.deep.equal([100, 50]);
+
+        pending[0].release();
+        await settle(el);
+        pending[1].release();
+        await reset;
+        await settle(el);
+
+        expect(el.shadowRoot!.querySelectorAll('.entry').length).to.equal(50);
+        expect(showMore(el), 'a truncated list must keep offering older entries').to.not.be.null;
+        expect(note(el)).to.match(/first 50/);
+        resetRefOpLocks();
+      });
+
+      // Closing the trigger as well as the race: a click here starts a read the
+      // reset's own refresh will supersede, so the page the user asked for is
+      // thrown away and the control does nothing they can see.
+      it('does not offer Show more while a reset is running', async () => {
+        const calls: Array<{ limit?: number }> = [];
+        mockReflogOfSize(120, calls);
+        const el = await openDialog();
+
+        expect(showMore(el)!.disabled, 'available while the dialog is idle').to.be.false;
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        (el as any).resetting = true;
+        await el.updateComplete;
+
+        expect(showMore(el)!.disabled, 'a read racing the reset is not a live option').to.be.true;
+      });
+    });
   });
 });

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -26,6 +26,13 @@ interface ReflogContextMenuState {
   entry: ReflogEntry | null;
 }
 
+/**
+ * Entries one page of the listing asks for. HEAD reflogs routinely hold
+ * hundreds of entries and this dialog is the app's recovery surface, so the
+ * first page has to be followed by a way to reach the rest.
+ */
+const REFLOG_PAGE_SIZE = 50;
+
 @customElement('lv-reflog-dialog')
 export class LvReflogDialog extends LitElement {
   static styles = [
@@ -146,6 +153,41 @@ export class LvReflogDialog extends LitElement {
         display: flex;
         flex-direction: column;
         gap: 2px;
+      }
+
+      .list-footer {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: var(--spacing-sm);
+        padding: var(--spacing-sm);
+      }
+
+      .list-note {
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+      }
+
+      .show-more-btn {
+        padding: var(--spacing-xs) var(--spacing-sm);
+        font-size: var(--font-size-xs);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+        border: 1px solid var(--color-border);
+        background: var(--color-bg-tertiary);
+        color: var(--color-text-primary);
+      }
+
+      .show-more-btn:hover:not(:disabled) {
+        background: var(--color-primary);
+        border-color: var(--color-primary);
+        color: white;
+      }
+
+      .show-more-btn:disabled {
+        opacity: 0.5;
+        cursor: default;
       }
 
       .entry {
@@ -331,6 +373,10 @@ export class LvReflogDialog extends LitElement {
   @state() private selectedIndex: number | null = null;
   @state() private resetting = false;
 
+  /** Entries the CURRENT listing asked for; grows one page per "Show more". */
+  @state() private entryLimit = REFLOG_PAGE_SIZE;
+  @state() private loadingMore = false;
+
   /**
    * The OBSERVATION half of the shared lock, which this dialog was missing.
    *
@@ -394,6 +440,10 @@ export class LvReflogDialog extends LitElement {
       // session on top of it.
       if (this.resetting) return;
       this.pinnedRepoPath = this.repositoryPath;
+      // A new session starts at the first page. loadReflog deliberately does
+      // NOT reset this — it doubles as the post-failed-reset refresh, which
+      // must keep whatever the user has expanded to.
+      this.entryLimit = REFLOG_PAGE_SIZE;
       this.focusInitialControl();
       await this.loadReflog();
     }
@@ -420,6 +470,18 @@ export class LvReflogDialog extends LitElement {
     });
   }
 
+  /**
+   * get_reflog reports no total and takes no cursor — it just stops at
+   * `limit` — so a full page is the only signal that older entries may exist.
+   * A reflog whose length is an exact multiple of the page size therefore
+   * shows one "Show more" that comes back with nothing new; the footer then
+   * settles on "Showing all N". Same heuristic the graph canvas uses for its
+   * commit batches.
+   */
+  private get hasMoreEntries(): boolean {
+    return this.entries.length >= this.entryLimit;
+  }
+
   private async loadReflog(): Promise<void> {
     if (!this.pinnedRepoPath) return;
 
@@ -427,7 +489,7 @@ export class LvReflogDialog extends LitElement {
     this.entries = [];
 
     try {
-      const result = await gitService.getReflog(this.pinnedRepoPath, 50);
+      const result = await gitService.getReflog(this.pinnedRepoPath, this.entryLimit);
       if (result.success && result.data) {
         this.entries = result.data;
       } else if (!result.success) {
@@ -441,6 +503,49 @@ export class LvReflogDialog extends LitElement {
       );
     } finally {
       this.loading = false;
+    }
+  }
+
+  /**
+   * Pull the next page. get_reflog has no skip parameter, so this re-reads
+   * from HEAD@{0} with a bigger limit and REPLACES the list rather than
+   * appending — appending would duplicate every entry already on screen, and a
+   * fresh read keeps entry.index consistent with what a reset is sent.
+   *
+   * `entries` is deliberately not cleared and `entryLimit` only advances on
+   * success: a transient failure must leave the list and the control exactly
+   * as they were so the user can retry.
+   */
+  private async loadMoreEntries(): Promise<void> {
+    if (this.loading || this.loadingMore || !this.pinnedRepoPath) return;
+
+    // Pinned like every other fetch here: the dialog may be closed and
+    // reopened on another repo while this round trip is in flight, and the
+    // stale page must not overwrite the fresh listing.
+    const repoPath = this.pinnedRepoPath;
+    const nextLimit = this.entryLimit + REFLOG_PAGE_SIZE;
+    this.loadingMore = true;
+
+    try {
+      const result = await gitService.getReflog(repoPath, nextLimit);
+      if (!this.open || this.pinnedRepoPath !== repoPath) return;
+      if (result.success && result.data) {
+        this.entries = result.data;
+        this.entryLimit = nextLimit;
+      } else if (!result.success) {
+        showToast(
+          `Failed to load more reflog entries: ${result.error?.message ?? 'Unknown error'}`,
+          'error',
+        );
+      }
+    } catch (err) {
+      console.error('Failed to load more reflog entries:', err);
+      showToast(
+        `Failed to load more reflog entries: ${err instanceof Error ? err.message : 'Unknown error'}`,
+        'error',
+      );
+    } finally {
+      this.loadingMore = false;
     }
   }
 
@@ -859,6 +964,22 @@ export class LvReflogDialog extends LitElement {
               : html`
                   <div class="entry-list">
                     ${this.entries.map(entry => this.renderEntry(entry))}
+                  </div>
+                  <div class="list-footer">
+                    ${this.hasMoreEntries
+                      ? html`
+                          <span class="list-note">
+                            Showing the first ${this.entries.length} entries
+                          </span>
+                          <button
+                            class="show-more-btn"
+                            @click=${this.loadMoreEntries}
+                            ?disabled=${this.loadingMore}
+                          >
+                            ${this.loadingMore ? 'Loading...' : 'Show more'}
+                          </button>
+                        `
+                      : html`<span class="list-note">Showing all ${this.entries.length} entries</span>`}
                   </div>
                 `}
         </div>

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -510,6 +510,11 @@ export class LvReflogDialog extends LitElement {
 
     this.loading = true;
     this.entries = [];
+    // This read supersedes any "Show more" still in flight, and that page's
+    // own cleanup is generation-scoped so it will not run. Without clearing
+    // the flag here a reopened session renders its footer button as a
+    // disabled "Loading..." for a request nobody is waiting on any more.
+    this.loadingMore = false;
 
     try {
       const result = await gitService.getReflog(repoPath, requestedLimit);
@@ -576,7 +581,8 @@ export class LvReflogDialog extends LitElement {
         'error',
       );
     } finally {
-      this.loadingMore = false;
+      // A superseded page must not clear the flag the live read raised.
+      if (gen === this.fetchGeneration) this.loadingMore = false;
     }
   }
 

--- a/src/components/dialogs/lv-reflog-dialog.ts
+++ b/src/components/dialogs/lv-reflog-dialog.ts
@@ -415,6 +415,22 @@ export class LvReflogDialog extends LitElement {
    */
   private pinnedRepoPath = '';
 
+  /**
+   * Identifies the listing a reflog read belongs to, so a read that has been
+   * superseded cannot write its page into a listing that no longer wants it.
+   *
+   * Pinning the repo was not enough: every read here re-fetches from HEAD@{0}
+   * at the CURRENT limit, so two reads of the SAME repo can be in flight at
+   * once — a "Show more" (100) racing the fresh 50-entry read of a reopened
+   * session, or racing the refresh a failed reset fires. Whichever lands last
+   * wins `entries`, while `entryLimit` keeps the other read's number; the two
+   * then disagree and `hasMoreEntries` goes false on a list that is still
+   * truncated, so the footer claims "Showing all 50" and withdraws Show more
+   * on a reflog that demonstrably holds more. Every fetch takes a generation
+   * and discards its result if a newer one has started since.
+   */
+  private fetchGeneration = 0;
+
   /** The repo this dialog is pinned to while open, or null when closed. */
   public get pinnedRepositoryPathIfOpen(): string | null {
     return this.open ? this.pinnedRepoPath : null;
@@ -485,24 +501,36 @@ export class LvReflogDialog extends LitElement {
   private async loadReflog(): Promise<void> {
     if (!this.pinnedRepoPath) return;
 
+    const gen = ++this.fetchGeneration;
+    const repoPath = this.pinnedRepoPath;
+    // The limit this read actually asked for. `entryLimit` can move under the
+    // await (a concurrent "Show more" advances it on success), and publishing
+    // a page under someone else's number is exactly what makes the footer lie.
+    const requestedLimit = this.entryLimit;
+
     this.loading = true;
     this.entries = [];
 
     try {
-      const result = await gitService.getReflog(this.pinnedRepoPath, this.entryLimit);
+      const result = await gitService.getReflog(repoPath, requestedLimit);
+      if (gen !== this.fetchGeneration) return;
       if (result.success && result.data) {
         this.entries = result.data;
+        // Keep the two halves of `hasMoreEntries` describing the SAME read.
+        this.entryLimit = requestedLimit;
       } else if (!result.success) {
         showToast(`Failed to load reflog: ${result.error?.message ?? 'Unknown error'}`, 'error');
       }
     } catch (err) {
+      if (gen !== this.fetchGeneration) return;
       console.error('Failed to load reflog:', err);
       showToast(
         `Failed to load reflog: ${err instanceof Error ? err.message : 'Unknown error'}`,
         'error',
       );
     } finally {
-      this.loading = false;
+      // A superseded read must not clear the spinner the live read raised.
+      if (gen === this.fetchGeneration) this.loading = false;
     }
   }
 
@@ -524,10 +552,12 @@ export class LvReflogDialog extends LitElement {
     // stale page must not overwrite the fresh listing.
     const repoPath = this.pinnedRepoPath;
     const nextLimit = this.entryLimit + REFLOG_PAGE_SIZE;
+    const gen = ++this.fetchGeneration;
     this.loadingMore = true;
 
     try {
       const result = await gitService.getReflog(repoPath, nextLimit);
+      if (gen !== this.fetchGeneration) return;
       if (!this.open || this.pinnedRepoPath !== repoPath) return;
       if (result.success && result.data) {
         this.entries = result.data;
@@ -539,6 +569,7 @@ export class LvReflogDialog extends LitElement {
         );
       }
     } catch (err) {
+      if (gen !== this.fetchGeneration) return;
       console.error('Failed to load more reflog entries:', err);
       showToast(
         `Failed to load more reflog entries: ${err instanceof Error ? err.message : 'Unknown error'}`,
@@ -596,6 +627,11 @@ export class LvReflogDialog extends LitElement {
 
   public close(): void {
     this.open = false;
+    // Closing ends the session, so nothing still in flight for it may land:
+    // without this a "Show more" left running would be free to publish its
+    // page into the next session the moment that session reopens the SAME
+    // repo, since `open` and `pinnedRepoPath` both match again by then.
+    this.fetchGeneration++;
     // Only handleDocumentClick clears this, and Escape is not a click — so a
     // menu left open at dismissal was repainted at its old coordinates over
     // the next session's freshly loaded list, still holding the PREVIOUS
@@ -974,7 +1010,7 @@ export class LvReflogDialog extends LitElement {
                           <button
                             class="show-more-btn"
                             @click=${this.loadMoreEntries}
-                            ?disabled=${this.loadingMore}
+                            ?disabled=${this.loadingMore || this.resetting}
                           >
                             ${this.loadingMore ? 'Loading...' : 'Show more'}
                           </button>


### PR DESCRIPTION
## What was broken

The Undo History dialog is the app&#39;s designated recovery surface (&#34;Reflog - recover previous states&#34;), but `loadReflog()` asked for exactly 50 entries and `render()` drew only that list — no load-more control, no pagination state, and no indication anywhere that the list was truncated.

A user whose lost commit sits at `HEAD@{51}` or older scrolls to the bottom, sees nothing, and gets no signal that older states exist or how to reach them — a dead end in exactly the flow where the data still exists and git could recover it. Real HEAD reflogs routinely hold hundreds of entries.

The cap was purely frontend. `get_reflog` (`src-tauri/src/commands/reflog.rs`) already takes `limit: Option` and the service wrapper passes it straight through.

## The fix

All changes are in `src/components/dialogs/lv-reflog-dialog.ts`; the backend and the `getReflog` signature are untouched.

- The listing tracks the limit it asked for (`entryLimit`, starting at one `REFLOG_PAGE_SIZE` of 50) instead of hard-coding 50 at the fetch.
- A footer under the list always states where the user stands: **&#34;Showing the first N entries&#34;** with a **Show more** button when the result filled the requested limit, or **&#34;Showing all N entries&#34;** when it came back short.
- **Show more** re-reads with a limit one page larger. `get_reflog` has no `skip`/offset parameter, so the next page is a superset read from `HEAD@{0}` — the list is **replaced**, not appended, which avoids duplicating every visible row and keeps `entry.index` consistent with what `resetToReflog` is sent.
- On failure the entries and the control are left exactly as they were (the limit only advances on success) so the user can retry, and the error is toasted like the initial load&#39;s.
- The fetch is pinned to `pinnedRepoPath` and bails if the dialog was closed or re-pinned during the round trip, matching the existing idiom in this file.
- The page size resets only on the open transition in `updated()`, **not** inside `loadReflog()` — that method doubles as the post-failed-reset refresh, and collapsing the expansion there would undo the user&#39;s paging at the moment they are hunting for a deep entry.

Known, accepted imprecision: `hasMoreEntries` is `entries.length &gt;= entryLimit`, so a reflog whose length is an exact multiple of 50 shows one &#34;Show more&#34; that returns nothing new before the footer settles on &#34;Showing all N&#34;. There is no total-count API, and the graph canvas uses the same `length &gt;= batchSize` heuristic.

The control **is** disabled while a reset is in flight — the shipped binding is `?disabled=${this.loadingMore || this.resetting}`. A reset that fails runs its own &#34;refresh and try again&#34; reload of the listing, and that reload supersedes any page started alongside it, so a click during a reset would throw away the page the user asked for and do nothing they can see. It is deliberately **not** gated on `repositoryBusy`: reading more reflog is not a working-tree mutation, and `handleReset` captures the entry object before awaiting, so a re-listing cannot retarget an in-flight reset.

`loadingMore` is per-request state and is scoped to the read that raised it: `loadReflog()` clears it when it starts a superseding read, and `loadMoreEntries()` only clears it in `finally` when its own generation is still current. Without both, a session reopened over an abandoned page came up with its Show more button stuck on a disabled &#34;Loading...&#34;, and the abandoned page later cleared the flag belonging to a read that was genuinely still in flight.

## Tests

| Test | File | Covers | Fails without the fix |
| --- | --- | --- | --- |
| flags the list as truncated and offers a way to see older entries | `src/components/dialogs/__tests__/lv-reflog-dialog.test.ts` | truncation notice + control on a 120-entry reflog | yes — `AssertionError: a truncated list must offer more: expected null not to be null` |
| Show more pulls the next page and stops once the whole reflog is listed | same | happy path: limits 50 → 100 → 150, 50 → 100 → 120 rows, control retires, &#34;Showing all 120&#34; | yes — `TypeError: Cannot read properties of null (reading &#39;click&#39;)` |
| keeps the list and the control when a page fails to load, and says so | same | error path: error toast, list still 50 rows, retry still offered | yes — `TypeError: Cannot read properties of null (reading &#39;click&#39;)` |
| a short reflog says the list is complete instead of offering a dead control | same | edge case: 3 entries, no control, &#34;Showing all 3&#34; | yes — `AssertionError: expected &#39;&#39; to match /Showing all 3/` |
| keeps the expanded listing when a failed reset reloads the entries | same | regression guard: post-failure `loadReflog` re-reads at limit 100, not 50 | yes — `TypeError: Cannot read properties of null (reading &#39;click&#39;)` |
| starts a reopened dialog back at the first page | same | edge case: expand to 100, close, reopen → back to 50 | yes — `TypeError: Cannot read properties of null (reading &#39;click&#39;)` |
| offers a usable Show more in a session reopened over an abandoned page | same | `loadingMore` cleared by the superseding read: reopened footer is enabled and reads &#34;Show more&#34; | yes — `AssertionError: the new session can page: expected true to be false` |
| keeps Show more busy when an abandoned page settles under a live one | same | generation-scoped `finally`: an abandoned page must not clear a live read&#39;s flag | yes — `AssertionError: the live page is still loading: expected false to be true` |
| does not report a failed page for a session the host already closed | same | regression guard: a page abandoned by &#34;Show in graph&#34; that then fails raises no toast | no — guards existing behaviour |
| offers older entries when the first page fills up | `e2e/tests/reflog-dialog.spec.ts` | full stack: control visible, &#34;first 50&#34;, click issues `get_reflog` with `limit: 100`, control retires, &#34;Showing all 50&#34; | yes — `expect(locator).toBeVisible() failed … waiting for locator(&#39;lv-reflog-dialog .show-more-btn&#39;)` |

Each was verified to fail by reverting only the matching component change and re-running with the tests in place; the failure messages above are the actual output.

Gate: `npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_