### PR TITLE
Keep the line selection only when a context-menu stage did not reload the diff

### DIFF
--- a/e2e/tests/diff.spec.ts
+++ b/e2e/tests/diff.spec.ts
@@ -638,6 +638,63 @@ test.describe('Diff View - Stage Hunk', () => {
     const stageLineCommands = await findCommand(page, 'stage_lines');
     expect(stageHunkCommands.length + stageFileCommands.length + stageLineCommands.length).toBeGreaterThan(0);
   });
+
+  test('should drop a line selection after staging a line from the context menu', async ({ page }) => {
+    // Selection keys are positional hunk/line indices. Staging reloads the diff
+    // and renumbers them, so keeping the old selection would point at other code.
+    await injectCommandMock(page, {
+      get_file_diff: {
+        path: 'src/main.ts',
+        oldPath: null,
+        status: 'modified',
+        hunks: [
+          {
+            header: '@@ -1,4 +1,4 @@',
+            oldStart: 1,
+            oldLines: 4,
+            newStart: 1,
+            newLines: 4,
+            lines: [
+              { content: 'line 1', origin: 'context', oldLineNo: 1, newLineNo: 1 },
+              { content: 'old a', origin: 'deletion', oldLineNo: 2, newLineNo: null },
+              { content: 'old b', origin: 'deletion', oldLineNo: 3, newLineNo: null },
+              { content: 'new a', origin: 'addition', oldLineNo: null, newLineNo: 2 },
+              { content: 'new b', origin: 'addition', oldLineNo: null, newLineNo: 3 },
+            ],
+          },
+        ],
+        isBinary: false,
+        isImage: false,
+        imageType: null,
+        additions: 2,
+        deletions: 2,
+      },
+      stage_hunk: null,
+    });
+
+    await startCommandCapture(page);
+
+    await rightPanel.getUnstagedFile('src/main.ts').click();
+    await expect(graph.diffOverlay).toBeVisible({ timeout: 5000 });
+
+    await page
+      .locator('lv-diff-view button.view-btn[title="Toggle line selection mode for staging individual lines"]')
+      .click();
+
+    // Select two lines the way a user would.
+    const checkboxes = page.locator('lv-diff-view .line-checkbox');
+    await checkboxes.nth(0).check();
+    await checkboxes.nth(1).check();
+    await expect(page.locator('lv-diff-view .selection-info')).toHaveText(/2 lines selected/);
+
+    // Stage a different line through the context menu.
+    await page.locator('lv-diff-view .line.code-addition').last().click({ button: 'right' });
+    await page.locator('lv-diff-view .context-menu-item', { hasText: 'Stage line' }).click();
+
+    // The reloaded diff invalidated the old keys, so the selection bar is gone.
+    await expect(page.locator('lv-diff-view .selection-actions')).toHaveCount(0);
+    expect((await findCommand(page, 'stage_hunk')).length).toBeGreaterThan(0);
+  });
 });
 
 test.describe('Diff Error Scenarios', () => {

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -1112,7 +1112,7 @@ describe('lv-diff-view', () => {
 
       clearHistory();
       mockInvoke = () => Promise.resolve(null);
-      await (el as unknown as { unstageSelectedLines: () => Promise<void> }).unstageSelectedLines();
+      await (el as unknown as { unstageSelectedLines: () => Promise<boolean> }).unstageSelectedLines();
 
       const calls = findCommands('unstage_hunk');
       expect(calls.length, 'unstage_hunk should have been invoked').to.equal(1);
@@ -1205,6 +1205,168 @@ describe('lv-diff-view', () => {
       const patch = (el as unknown as { buildSelectedLinesPatch: () => string }).buildSelectedLinesPatch();
       // No change selected → empty patch, and certainly no stray marker.
       expect(patch).to.not.contain('No newline at end of file');
+    });
+  });
+
+  // ── Context-menu line staging ────────────────────────────────────────────
+  // Selection keys are positional `${hunkIndex}-${lineIndex}` pairs. A stage or
+  // unstage reloads the diff and renumbers those positions, so a selection
+  // saved across the call would silently address different code.
+  describe('context-menu line staging', () => {
+    function stageableHunk(): DiffHunk {
+      return makeDiffHunk({
+        header: '@@ -1,4 +1,4 @@',
+        oldStart: 1,
+        oldLines: 4,
+        newStart: 1,
+        newLines: 4,
+        lines: [
+          makeDiffLine({ content: 'ctx\n', origin: 'context', oldLineNo: 1, newLineNo: 1 }),
+          makeDiffLine({ content: 'del-a\n', origin: 'deletion', oldLineNo: 2, newLineNo: null }),
+          makeDiffLine({ content: 'del-b\n', origin: 'deletion', oldLineNo: 3, newLineNo: null }),
+          makeDiffLine({ content: 'add-a\n', origin: 'addition', oldLineNo: null, newLineNo: 2 }),
+          makeDiffLine({ content: 'add-b\n', origin: 'addition', oldLineNo: null, newLineNo: 3 }),
+        ],
+      });
+    }
+
+    // The same file after one change was applied: one hunk line fewer, so the
+    // old key '0-2' now addresses an addition and '0-4' no longer exists.
+    function reloadedHunk(): DiffHunk {
+      return makeDiffHunk({
+        header: '@@ -1,3 +1,3 @@',
+        oldStart: 1,
+        oldLines: 3,
+        newStart: 1,
+        newLines: 3,
+        lines: [
+          makeDiffLine({ content: 'ctx\n', origin: 'context', oldLineNo: 1, newLineNo: 1 }),
+          makeDiffLine({ content: 'del-b\n', origin: 'deletion', oldLineNo: 2, newLineNo: null }),
+          makeDiffLine({ content: 'add-a\n', origin: 'addition', oldLineNo: null, newLineNo: 2 }),
+        ],
+      });
+    }
+
+    type Handlers = {
+      handleContextStageLine: () => Promise<void>;
+      handleContextUnstageLine: () => Promise<void>;
+      stageSelectedLines: () => Promise<boolean>;
+      selectedLines: Set<string>;
+      lineSelectionMode: boolean;
+      diff: DiffFile;
+      contextMenu: { visible: boolean; x: number; y: number; line: DiffLine | null; hunk: DiffHunk | null };
+    };
+
+    /**
+     * Renders the view with two lines already selected by the user ('0-2' and
+     * '0-4') and the context menu open on a third line.
+     */
+    async function viewWithOpenContextMenu(
+      opts: { isStaged?: boolean; hunkFails?: boolean } = {},
+    ): Promise<LvDiffView> {
+      const original = makeDiffFile({ hunks: [stageableHunk()] });
+      const reloaded = makeDiffFile({ hunks: [reloadedHunk()] });
+      let applied = false;
+
+      mockInvoke = async (command: string) => {
+        switch (command) {
+          case 'get_file_diff':
+            return applied ? reloaded : original;
+          case 'get_diff_tool':
+            return { tool: null };
+          case 'read_file_content':
+            return 'file content here';
+          case 'stage_hunk':
+          case 'unstage_hunk':
+            if (opts.hunkFails) throw { code: 'COMMAND_ERROR', message: 'patch does not apply' };
+            applied = true;
+            return null;
+          default:
+            return null;
+        }
+      };
+
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: opts.isStaged ?? false }) });
+      const view = el as unknown as Handlers;
+      const loaded = view.diff;
+      view.lineSelectionMode = true;
+      // The user's own multi-line selection: del-b and add-b.
+      view.selectedLines = new Set(['0-2', '0-4']);
+      // The objects MUST come from el.diff — the handler locates them by indexOf.
+      view.contextMenu = {
+        visible: true,
+        x: 0,
+        y: 0,
+        line: loaded.hunks[0].lines[1],
+        hunk: loaded.hunks[0],
+      };
+      await el.updateComplete;
+      return el;
+    }
+
+    it('clears the selection after a context-menu stage reloads the diff', async () => {
+      const el = await viewWithOpenContextMenu();
+      await (el as unknown as Handlers).handleContextStageLine();
+      await el.updateComplete;
+
+      expect(
+        (el as unknown as Handlers).selectedLines.size,
+        'a stale positional selection was restored after the diff reloaded',
+      ).to.equal(0);
+      expect(el.shadowRoot!.querySelector('.selection-actions')).to.be.null;
+      expect(el.shadowRoot!.querySelectorAll('.line.selected').length).to.equal(0);
+    });
+
+    it('clears the selection after a context-menu unstage reloads the diff', async () => {
+      const el = await viewWithOpenContextMenu({ isStaged: true });
+      await (el as unknown as Handlers).handleContextUnstageLine();
+      await el.updateComplete;
+
+      expect(
+        (el as unknown as Handlers).selectedLines.size,
+        'a stale positional selection was restored after the diff reloaded',
+      ).to.equal(0);
+      expect(el.shadowRoot!.querySelector('.selection-actions')).to.be.null;
+      expect(el.shadowRoot!.querySelectorAll('.line.selected').length).to.equal(0);
+    });
+
+    it('does not let a follow-up Stage Selected act on stale keys', async () => {
+      const el = await viewWithOpenContextMenu();
+      await (el as unknown as Handlers).handleContextStageLine();
+      await el.updateComplete;
+
+      clearHistory();
+      await (el as unknown as Handlers).stageSelectedLines();
+
+      expect(
+        findCommands('stage_hunk').length,
+        'a stale selection let a second stage send a patch built from renumbered keys',
+      ).to.equal(0);
+    });
+
+    it('keeps the previous selection when the stage fails', async () => {
+      const el = await viewWithOpenContextMenu({ hunkFails: true });
+      await (el as unknown as Handlers).handleContextStageLine();
+      await el.updateComplete;
+
+      // Nothing was applied, so the diff is untouched and the keys still valid.
+      expect([...(el as unknown as Handlers).selectedLines]).to.have.members(['0-2', '0-4']);
+      expect(findCommands('stage_hunk').length).to.equal(1);
+    });
+
+    it('keeps the previous selection when the clicked line produces no patch', async () => {
+      const el = await viewWithOpenContextMenu();
+      const view = el as unknown as Handlers;
+      // A context line yields an empty patch, so nothing is sent or reloaded.
+      view.contextMenu = { ...view.contextMenu, line: view.diff.hunks[0].lines[0] };
+      await el.updateComplete;
+
+      clearHistory();
+      await view.handleContextStageLine();
+      await el.updateComplete;
+
+      expect([...view.selectedLines]).to.have.members(['0-2', '0-4']);
+      expect(findCommands('stage_hunk').length).to.equal(0);
     });
   });
 });

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -1676,12 +1676,16 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
 
   /**
    * Stage selected lines
+   *
+   * Resolves to true only when the stage was applied and the diff reloaded.
+   * The reload renumbers hunks and lines, so every positional
+   * `${hunkIndex}-${lineIndex}` key a caller saved is stale after that.
    */
-  private async stageSelectedLines(): Promise<void> {
-    if (!this.repositoryPath || !this.file || this.selectedLines.size === 0) return;
+  private async stageSelectedLines(): Promise<boolean> {
+    if (!this.repositoryPath || !this.file || this.selectedLines.size === 0) return false;
 
     const patch = this.buildSelectedLinesPatch();
-    if (!patch) return;
+    if (!patch) return false;
 
     try {
       const result = await gitService.stageHunk(this.repositoryPath, patch);
@@ -1692,24 +1696,29 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           composed: true,
         }));
         await this.loadWorkingDiff();
-      } else {
-        console.error('Failed to stage selected lines:', result.error);
-        showToast(`Failed to stage lines: ${result.error?.message ?? 'Unknown error'}`, 'error');
+        return true;
       }
+      console.error('Failed to stage selected lines:', result.error);
+      showToast(`Failed to stage lines: ${result.error?.message ?? 'Unknown error'}`, 'error');
     } catch (err) {
       console.error('Failed to stage selected lines:', err);
       showToast(`Failed to stage lines: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error');
     }
+    return false;
   }
 
   /**
    * Unstage selected lines
+   *
+   * Resolves to true only when the unstage was applied and the diff reloaded.
+   * The reload renumbers hunks and lines, so every positional
+   * `${hunkIndex}-${lineIndex}` key a caller saved is stale after that.
    */
-  private async unstageSelectedLines(): Promise<void> {
-    if (!this.repositoryPath || !this.file || this.selectedLines.size === 0) return;
+  private async unstageSelectedLines(): Promise<boolean> {
+    if (!this.repositoryPath || !this.file || this.selectedLines.size === 0) return false;
 
     const patch = this.buildSelectedLinesPatch('unstage');
-    if (!patch) return;
+    if (!patch) return false;
 
     try {
       const result = await gitService.unstageHunk(this.repositoryPath, patch);
@@ -1720,14 +1729,15 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           composed: true,
         }));
         await this.loadWorkingDiff();
-      } else {
-        console.error('Failed to unstage selected lines:', result.error);
-        showToast(`Failed to unstage lines: ${result.error?.message ?? 'Unknown error'}`, 'error');
+        return true;
       }
+      console.error('Failed to unstage selected lines:', result.error);
+      showToast(`Failed to unstage lines: ${result.error?.message ?? 'Unknown error'}`, 'error');
     } catch (err) {
       console.error('Failed to unstage selected lines:', err);
       showToast(`Failed to unstage lines: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error');
     }
+    return false;
   }
 
   /**
@@ -1995,8 +2005,12 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     // Temporarily select just this line and stage it
     const prevSelected = this.selectedLines;
     this.selectedLines = new Set([this.getLineKey(hunkIndex, lineIndex)]);
-    await this.stageSelectedLines();
-    this.selectedLines = prevSelected;
+    // A successful stage reloads the diff, which renumbers hunks and lines, so
+    // the saved `${hunkIndex}-${lineIndex}` keys would point at different code.
+    // Put the previous selection back only when nothing was applied.
+    if (!(await this.stageSelectedLines())) {
+      this.selectedLines = prevSelected;
+    }
   }
 
   /**
@@ -2017,8 +2031,12 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     // Temporarily select just this line and unstage it
     const prevSelected = this.selectedLines;
     this.selectedLines = new Set([this.getLineKey(hunkIndex, lineIndex)]);
-    await this.unstageSelectedLines();
-    this.selectedLines = prevSelected;
+    // A successful unstage reloads the diff, which renumbers hunks and lines,
+    // so the saved `${hunkIndex}-${lineIndex}` keys would point at different
+    // code. Put the previous selection back only when nothing was applied.
+    if (!(await this.unstageSelectedLines())) {
+      this.selectedLines = prevSelected;
+    }
   }
 
   private buildFlatLines(): void {


### PR DESCRIPTION
## What was broken

Line selection keys in `lv-diff-view` are purely positional — `getLineKey()` returns `` `${hunkIndex}-${lineIndex}` ``.

`handleContextStageLine` (and its sibling `handleContextUnstageLine`) saved the user's selection, replaced it with the single right-clicked line, awaited `stageSelectedLines()`, then **unconditionally** restored the saved set:

```ts
const prevSelected = this.selectedLines;
this.selectedLines = new Set([this.getLineKey(hunkIndex, lineIndex)]);
await this.stageSelectedLines();
this.selectedLines = prevSelected;   // <- stale keys
```

On success `stageSelectedLines`/`unstageSelectedLines` call `loadWorkingDiff()`, which nulls `this.diff`, throws away the hunk/word-diff caches and re-fetches a `DiffFile` whose hunks and lines have been renumbered by the change just applied. The restored keys therefore addressed *different code*:

- `isLineSelected()` highlighted the wrong rows.
- `renderUnifiedView` still showed the "N lines selected" bar — even when the reloaded diff was empty.
- A follow-up click on **Stage Selected** ran `buildSelectedLinesPatch()` over the stale keys and staged lines the user never picked, with no warning.

Both helpers already clear the selection themselves on success; the restore was undoing exactly that.

## The fix

`stageSelectedLines`/`unstageSelectedLines` now return `Promise<boolean>` — true only on the applied-and-reloaded path. The two context-menu handlers put the previous selection back **only when nothing was applied**:

```ts
if (!(await this.stageSelectedLines())) {
  this.selectedLines = prevSelected;
}
```

Deleting the restore outright would have been wrong: on the failure path and the empty-patch path the diff is never reloaded, so the user's multi-line selection is still valid and dropping it would be a new UX regression. Tests 4 and 5 below pin that down.

Both methods remain bound directly as Lit click handlers (`@click=${this.stageSelectedLines}`) — a listener's return value is ignored, and there are no other call sites. Every existing `console.error` / `showToast` string and the `status-changed` dispatch are unchanged.

## Tests

| # | Test | Location | Covers |
|---|------|----------|--------|
| 1 | clears the selection after a context-menu stage reloads the diff | `src/components/panels/__tests__/lv-diff-view.test.ts` | happy path — selection empty, no `.selection-actions` bar, no `.line.selected` row |
| 2 | clears the selection after a context-menu unstage reloads the diff | same | sibling handler consistency |
| 3 | does not let a follow-up Stage Selected act on stale keys | same | the user-visible consequence — no `stage_hunk` from renumbered keys |
| 4 | keeps the previous selection when the stage fails | same | error path — selection survives a failed apply |
| 5 | keeps the previous selection when the clicked line produces no patch | same | edge case — context line, empty patch, no reload |
| 6 | should drop a line selection after staging a line from the context menu | `e2e/tests/diff.spec.ts` | full stack: toggle selection mode, check two lines, right-click a third, "Stage line", selection bar gone |

Test 1 uses a mocked reload that returns a diff with one change fewer, so the old key `0-2` addresses a *different* line and `0-4` no longer exists at all.

## Verified failing without the fix

Reverted only the production change (restoring the unconditional `this.selectedLines = prevSelected;`) and re-ran:

- Unit 1: `AssertionError: a stale positional selection was restored after the diff reloaded: expected 2 to equal 0`
- Unit 2: same assertion, `expected 2 to equal 0`
- Unit 3: `AssertionError: a stale selection let a second stage send a patch built from renumbered keys: expected 1 to equal 0`
- E2E 6: `expect(locator).toHaveCount(expected) failed — Expected: 0, Received: 1` on `lv-diff-view .selection-actions`

Then reverted to the naive "never restore" variant to confirm tests 4 and 5 guard against over-reaching:

- Unit 4: `expected [ '0-1' ] to have the same members as [ '0-2', '0-4' ]`
- Unit 5: `expected [ '0-0' ] to have the same members as [ '0-2', '0-4' ]`

Gate with the real fix in place: `npm run lint`, `npm run typecheck`, `npm test` all green (61 tests in `lv-diff-view.test.ts`), plus `npx playwright test e2e/tests/diff.spec.ts` — 33 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_