### PR TITLE
Record a Git Flow master branch that actually exists

### DIFF
--- a/src-tauri/src/commands/gitflow.rs
+++ b/src-tauri/src/commands/gitflow.rs
@@ -90,7 +90,6 @@ pub async fn init_gitflow(
     let repo = git2::Repository::open(Path::new(&path))?;
     let mut config = repo.config()?;
 
-    let master = master_branch.unwrap_or_else(|| "main".to_string());
     let develop = develop_branch.unwrap_or_else(|| "develop".to_string());
     let feature = feature_prefix.unwrap_or_else(|| "feature/".to_string());
     let release = release_prefix.unwrap_or_else(|| "release/".to_string());
@@ -98,7 +97,51 @@ pub async fn init_gitflow(
     let support = support_prefix.unwrap_or_else(|| "support/".to_string());
     let version_tag = version_tag_prefix.unwrap_or_else(|| "v".to_string());
 
-    // Set git flow config values
+    // gitflow.branch.master must name a branch that EXISTS. Every hotfix start
+    // and every release/hotfix finish resolves it and fails with
+    // BranchNotFound when it does not, and get_gitflow_config keys
+    // `initialized` off this very entry — so once a wrong name is written the
+    // panel never offers the init section again and there is no way back
+    // inside the app. Writing the "main" default on a repository whose default
+    // branch is "master" did exactly that: develop was cut from master through
+    // the fallback below, but the name the fallback resolved was thrown away.
+    let master = match master_branch {
+        // An explicitly requested branch is honoured or refused — never
+        // silently swapped for a different one.
+        Some(requested) => {
+            if repo
+                .find_branch(&requested, git2::BranchType::Local)
+                .is_err()
+            {
+                return Err(LeviathanError::BranchNotFound(requested));
+            }
+            requested
+        }
+        None => ["main", "master"]
+            .into_iter()
+            .find(|name| repo.find_branch(name, git2::BranchType::Local).is_ok())
+            .map(str::to_string)
+            .ok_or_else(|| {
+                LeviathanError::OperationFailed(
+                    "Cannot find a main or master branch to base Git Flow on".to_string(),
+                )
+            })?,
+    };
+
+    // Ensure develop branch exists
+    if repo.find_branch(&develop, git2::BranchType::Local).is_err() {
+        // Create develop from the resolved master
+        let base = repo
+            .find_branch(&master, git2::BranchType::Local)
+            .map_err(|_| LeviathanError::BranchNotFound(master.clone()))?;
+        let commit = base.get().peel_to_commit()?;
+        repo.branch(&develop, &commit, false)?;
+    }
+
+    // Written last, once every branch this config names is known to exist. A
+    // half-written gitflow config still reads as initialized, so an init that
+    // errored after this point used to leave the repository permanently stuck
+    // with a config pointing at branches that were never created.
     config.set_str("gitflow.branch.master", &master)?;
     config.set_str("gitflow.branch.develop", &develop)?;
     config.set_str("gitflow.prefix.feature", &feature)?;
@@ -106,25 +149,6 @@ pub async fn init_gitflow(
     config.set_str("gitflow.prefix.hotfix", &hotfix)?;
     config.set_str("gitflow.prefix.support", &support)?;
     config.set_str("gitflow.prefix.versiontag", &version_tag)?;
-
-    // Ensure develop branch exists
-    let develop_exists = repo.find_branch(&develop, git2::BranchType::Local).is_ok();
-
-    if !develop_exists {
-        // Create develop from master/main
-        let master_branch = repo
-            .find_branch(&master, git2::BranchType::Local)
-            .or_else(|_| repo.find_branch("master", git2::BranchType::Local))
-            .or_else(|_| repo.find_branch("main", git2::BranchType::Local))
-            .map_err(|_| {
-                LeviathanError::OperationFailed(
-                    "Cannot find master/main branch to create develop from".to_string(),
-                )
-            })?;
-
-        let commit = master_branch.get().peel_to_commit()?;
-        repo.branch(&develop, &commit, false)?;
-    }
 
     Ok(GitFlowConfig {
         initialized: true,
@@ -782,6 +806,23 @@ mod tests {
     use super::*;
     use crate::test_utils::TestRepo;
 
+    /// A repository whose default branch is "master" — still the case for any
+    /// repo created before git 2.28, and the setup init_gitflow got wrong.
+    fn repo_on_master() -> TestRepo {
+        let test_repo = TestRepo::with_initial_commit();
+        {
+            let repo = test_repo.repo();
+            let mut main = repo
+                .find_branch("main", git2::BranchType::Local)
+                .expect("with_initial_commit leaves HEAD on main");
+            // libgit2 moves HEAD along with the branch; with_initial_commit
+            // relies on the same rename in the other direction.
+            main.rename("master", false).expect("rename main -> master");
+        }
+        assert_eq!(test_repo.current_branch(), "master");
+        test_repo
+    }
+
     #[tokio::test]
     async fn test_get_gitflow_config_not_initialized() {
         let repo = TestRepo::with_initial_commit();
@@ -1077,9 +1118,116 @@ mod tests {
         assert!(develop.is_ok());
     }
 
+    /// The name recorded in gitflow.branch.master has to be the branch develop
+    /// was actually cut from. Recording the "main" default on a master-default
+    /// repository left every later hotfix and finish looking for a branch that
+    /// was never there.
+    #[tokio::test]
+    async fn test_init_gitflow_records_the_master_branch_that_exists() {
+        let repo = repo_on_master();
+
+        let config = init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .expect("init must succeed on a repo whose default branch is master");
+
+        assert_eq!(config.master_branch, "master");
+        assert_eq!(
+            repo.repo()
+                .config()
+                .unwrap()
+                .get_string("gitflow.branch.master")
+                .unwrap(),
+            "master",
+            "the persisted name must be the branch that exists"
+        );
+        assert!(
+            repo.repo()
+                .find_branch("develop", git2::BranchType::Local)
+                .is_ok(),
+            "develop must still be created"
+        );
+    }
+
+    /// The user-visible consequence: the panel's Initialize button passes no
+    /// config at all, so a master-default repo used to end up with a hotfix
+    /// button that could only ever fail.
+    #[tokio::test]
+    async fn test_gitflow_hotfix_works_after_init_on_a_master_repo() {
+        let repo = repo_on_master();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        let branch = gitflow_start_hotfix(repo.path_str(), "1.0.1".to_string())
+            .await
+            .expect("hotfix start must work on a repo initialized by the panel");
+
+        assert_eq!(branch.name, "hotfix/1.0.1");
+        assert!(branch.is_head);
+    }
+
+    /// A gitflow config reads as initialized the moment gitflow.branch.master
+    /// exists, so writing the keys before the branch lookup turned a failed
+    /// init into a repository permanently stuck on a broken config.
+    #[tokio::test]
+    async fn test_init_gitflow_failure_leaves_the_repo_uninitialized() {
+        // No commit, so there is no branch to base anything on.
+        let repo = TestRepo::new();
+
+        let err = init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .expect_err("init must fail with no branch to base on");
+
+        let config = get_gitflow_config(repo.path_str()).await.unwrap();
+        assert!(
+            !config.initialized,
+            "a failed init must not leave the repo looking initialized"
+        );
+        assert!(
+            err.to_string().contains("main or master"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    #[tokio::test]
+    async fn test_init_gitflow_refuses_a_master_branch_that_does_not_exist() {
+        let repo = TestRepo::with_initial_commit();
+
+        let err = init_gitflow(
+            repo.path_str(),
+            Some("nope".to_string()),
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("init must refuse a master branch that does not exist");
+        assert!(
+            err.to_string().contains("Branch not found: nope"),
+            "unexpected error: {}",
+            err
+        );
+
+        let config = get_gitflow_config(repo.path_str()).await.unwrap();
+        assert!(!config.initialized);
+        assert!(
+            repo.repo()
+                .find_branch("develop", git2::BranchType::Local)
+                .is_err(),
+            "a refused init must not create develop"
+        );
+    }
+
     #[tokio::test]
     async fn test_init_gitflow_custom_branches() {
         let repo = TestRepo::with_initial_commit();
+        // The custom master must exist — init_gitflow refuses to record a
+        // branch that does not.
+        repo.create_branch("production");
         let result = init_gitflow(
             repo.path_str(),
             Some("production".to_string()),

--- a/src-tauri/src/commands/gitflow.rs
+++ b/src-tauri/src/commands/gitflow.rs
@@ -142,13 +142,23 @@ pub async fn init_gitflow(
     // half-written gitflow config still reads as initialized, so an init that
     // errored after this point used to leave the repository permanently stuck
     // with a config pointing at branches that were never created.
-    config.set_str("gitflow.branch.master", &master)?;
+    //
+    // Each set_str is its own write to .git/config, so the sequence is not
+    // atomic: any of them can fail on its own (a lock held by another process,
+    // a disk that just filled, a key a hand-edit left as a multivar).
+    // gitflow.branch.master is the key get_gitflow_config keys `initialized`
+    // off, so it goes LAST — writing the marker before the six values it
+    // vouches for would let a failure part-way through leave the repository
+    // flagged initialized while develop and the prefixes silently fall back to
+    // defaults at read time, and the panel would never offer the init section
+    // again.
     config.set_str("gitflow.branch.develop", &develop)?;
     config.set_str("gitflow.prefix.feature", &feature)?;
     config.set_str("gitflow.prefix.release", &release)?;
     config.set_str("gitflow.prefix.hotfix", &hotfix)?;
     config.set_str("gitflow.prefix.support", &support)?;
     config.set_str("gitflow.prefix.versiontag", &version_tag)?;
+    config.set_str("gitflow.branch.master", &master)?;
 
     Ok(GitFlowConfig {
         initialized: true,
@@ -1187,6 +1197,52 @@ mod tests {
             err.to_string().contains("main or master"),
             "unexpected error: {}",
             err
+        );
+    }
+
+    /// The seven config writes are seven separate writes to .git/config, so
+    /// one of them can fail on its own. gitflow.branch.master is the key
+    /// `initialized` is read off, so it has to be the last one written — if it
+    /// goes first, a failure part-way through leaves the repo flagged
+    /// initialized while develop and the prefixes fall back to defaults, and
+    /// the panel never offers the init section again.
+    ///
+    /// A duplicated key is the cheapest real way to make exactly one write
+    /// fail: libgit2 refuses set_str on a multivar.
+    #[tokio::test]
+    async fn test_init_gitflow_partial_config_write_leaves_the_repo_uninitialized() {
+        let repo = TestRepo::with_initial_commit();
+
+        // A hand-edited (or merge-mangled) config with gitflow.prefix.feature
+        // listed twice. Every other gitflow write still succeeds.
+        let config_path = repo.path.join(".git").join("config");
+        let mut existing = std::fs::read_to_string(&config_path).unwrap();
+        existing.push_str("[gitflow \"prefix\"]\n\tfeature = a/\n\tfeature = b/\n");
+        std::fs::write(&config_path, existing).unwrap();
+
+        let err = init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .expect_err("init must fail when a gitflow config key cannot be written");
+        assert!(
+            err.to_string().contains("multivar"),
+            "expected the multivar write to be what failed, got: {}",
+            err
+        );
+
+        let config = get_gitflow_config(repo.path_str()).await.unwrap();
+        assert!(
+            !config.initialized,
+            "an init that failed part-way through the config writes must not \
+             leave the repo looking initialized — the panel would never offer \
+             the init section again"
+        );
+        assert!(
+            repo.repo()
+                .config()
+                .unwrap()
+                .get_string("gitflow.branch.master")
+                .is_err(),
+            "the initialized marker must not be persisted by a failed init"
         );
     }
 

--- a/src-tauri/src/commands/gitflow.rs
+++ b/src-tauri/src/commands/gitflow.rs
@@ -88,7 +88,12 @@ pub async fn init_gitflow(
     version_tag_prefix: Option<String>,
 ) -> Result<GitFlowConfig> {
     let repo = git2::Repository::open(Path::new(&path))?;
-    let mut config = repo.config()?;
+    // The local level specifically. set_str already landed here, but the
+    // rollback below also has to READ what .git/config holds: repo.config()
+    // resolves through the user's global and system files too, so a snapshot
+    // taken from it would "restore" an inherited value by writing it into the
+    // repository, inventing a local key that was never there.
+    let mut config = repo.config()?.open_level(git2::ConfigLevel::Local)?;
 
     let develop = develop_branch.unwrap_or_else(|| "develop".to_string());
     let feature = feature_prefix.unwrap_or_else(|| "feature/".to_string());
@@ -128,7 +133,11 @@ pub async fn init_gitflow(
             })?,
     };
 
-    // Ensure develop branch exists
+    // Ensure develop branch exists. Whether THIS call created it matters: if
+    // the config below cannot be persisted the branch has to go back, or a
+    // retry would silently reuse a develop cut from a base the user may no
+    // longer have selected. A develop that was already there is left alone.
+    let mut created_develop = false;
     if repo.find_branch(&develop, git2::BranchType::Local).is_err() {
         // Create develop from the resolved master
         let base = repo
@@ -136,6 +145,7 @@ pub async fn init_gitflow(
             .map_err(|_| LeviathanError::BranchNotFound(master.clone()))?;
         let commit = base.get().peel_to_commit()?;
         repo.branch(&develop, &commit, false)?;
+        created_develop = true;
     }
 
     // Written last, once every branch this config names is known to exist. A
@@ -145,20 +155,51 @@ pub async fn init_gitflow(
     //
     // Each set_str is its own write to .git/config, so the sequence is not
     // atomic: any of them can fail on its own (a lock held by another process,
-    // a disk that just filled, a key a hand-edit left as a multivar).
+    // a disk that just filled, a key a hand-edit left as a multivar). Persist
+    // them as a unit instead — snapshot what the local config holds now, and
+    // on the first failure put every key back the way this call found it and
+    // drop a develop this call created, so a failed init leaves the repository
+    // as it was rather than half-configured.
+    //
     // gitflow.branch.master is the key get_gitflow_config keys `initialized`
     // off, so it goes LAST — writing the marker before the six values it
     // vouches for would let a failure part-way through leave the repository
     // flagged initialized while develop and the prefixes silently fall back to
     // defaults at read time, and the panel would never offer the init section
     // again.
-    config.set_str("gitflow.branch.develop", &develop)?;
-    config.set_str("gitflow.prefix.feature", &feature)?;
-    config.set_str("gitflow.prefix.release", &release)?;
-    config.set_str("gitflow.prefix.hotfix", &hotfix)?;
-    config.set_str("gitflow.prefix.support", &support)?;
-    config.set_str("gitflow.prefix.versiontag", &version_tag)?;
-    config.set_str("gitflow.branch.master", &master)?;
+    let entries = [
+        ("gitflow.branch.develop", develop.as_str()),
+        ("gitflow.prefix.feature", feature.as_str()),
+        ("gitflow.prefix.release", release.as_str()),
+        ("gitflow.prefix.hotfix", hotfix.as_str()),
+        ("gitflow.prefix.support", support.as_str()),
+        ("gitflow.prefix.versiontag", version_tag.as_str()),
+        ("gitflow.branch.master", master.as_str()),
+    ];
+    let snapshot: Vec<(&str, Option<String>)> = entries
+        .iter()
+        .map(|(key, _)| (*key, config.get_string(key).ok()))
+        .collect();
+
+    if let Err(err) = entries
+        .iter()
+        .try_for_each(|(key, value)| config.set_str(key, value))
+    {
+        // Best effort, and deliberately so: the write error is what the user
+        // needs to see, and a rollback step that also fails must not mask it.
+        for (key, previous) in snapshot {
+            let _ = match previous {
+                Some(value) => config.set_str(key, &value),
+                None => config.remove(key),
+            };
+        }
+        if created_develop {
+            if let Ok(mut branch) = repo.find_branch(&develop, git2::BranchType::Local) {
+                let _ = branch.delete();
+            }
+        }
+        return Err(err.into());
+    }
 
     Ok(GitFlowConfig {
         initialized: true,
@@ -1243,6 +1284,70 @@ mod tests {
                 .get_string("gitflow.branch.master")
                 .is_err(),
             "the initialized marker must not be persisted by a failed init"
+        );
+        // The keys written before the failure are rolled back, not left
+        // lying around: gitflow.branch.develop is written first and succeeds.
+        assert!(
+            repo.repo()
+                .config()
+                .unwrap()
+                .get_string("gitflow.branch.develop")
+                .is_err(),
+            "a key this attempt wrote must be removed again when a later write fails"
+        );
+        // And the branch this attempt cut goes back too. Left behind, a retry
+        // would reuse it instead of cutting develop from the selected base.
+        assert!(
+            repo.repo()
+                .find_branch("develop", git2::BranchType::Local)
+                .is_err(),
+            "a failed init must not leave the develop branch it created behind"
+        );
+    }
+
+    /// Re-initializing an already-configured repository must not shred the
+    /// configuration it already had. The rollback restores each key to the
+    /// value this call found rather than deleting it, and leaves a develop it
+    /// did not create alone.
+    #[tokio::test]
+    async fn test_init_gitflow_failed_reinit_restores_the_previous_config() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .expect("first init must succeed");
+
+        // Duplicate gitflow.prefix.release so that exactly one write of the
+        // re-init fails — the two keys written before it succeed first.
+        let config_path = repo.path.join(".git").join("config");
+        let mut existing = std::fs::read_to_string(&config_path).unwrap();
+        existing.push_str("[gitflow \"prefix\"]\n\trelease = duplicate/\n");
+        std::fs::write(&config_path, existing).unwrap();
+
+        init_gitflow(
+            repo.path_str(),
+            None,
+            None,
+            Some("feat/".to_string()),
+            None,
+            None,
+            None,
+            None,
+        )
+        .await
+        .expect_err("re-init must fail when a gitflow config key cannot be written");
+
+        let config = get_gitflow_config(repo.path_str()).await.unwrap();
+        assert!(config.initialized, "the repo stays initialized as it was");
+        assert_eq!(
+            config.feature_prefix, "feature/",
+            "a key the failed attempt overwrote must be restored to its previous value"
+        );
+        assert_eq!(config.master_branch, "main");
+        assert!(
+            repo.repo()
+                .find_branch("develop", git2::BranchType::Local)
+                .is_ok(),
+            "a develop this attempt did not create must be left alone"
         );
     }
 


### PR DESCRIPTION
## What was broken

`init_gitflow` wrote `gitflow.branch.master` verbatim from its argument, or from the `"main"` default when no argument was given — with **no check that such a branch exists**. The existence fallback chain further down (`requested` → `"master"` → `"main"`) ran only inside the `if !develop_exists` block, and existed purely to pick the commit `develop` was cut from; the `git2::Branch` it resolved was dropped and its name never stored.

The panel's Initialize button (`lv-gitflow-panel.ts` → `gitService.initGitFlow`) sends every field as `undefined`, i.e. `None`. So on a repository whose default branch is `master`, Initialize **succeeded**: `develop` was created from `master` through the fallback, but the config recorded `gitflow.branch.master = "main"` — a branch that was never there.

From then on:

- every `gitflow_start_hotfix` fails with `BranchNotFound("main")`
- every release/hotfix finish (`finish_release_like`) fails the same way
- the panel shows "Master: main" for a branch that does not exist
- `get_gitflow_config` reports `initialized: true` purely because the key is present, so the init section never renders again — **there is no in-app recovery**; the user has to hand-edit git config

A second symptom on the same lines: the seven `config.set_str` calls happened **before** the branch lookup, so an init that failed at the lookup (a repository with no commits) still left all seven keys written, permanently marking the repo "initialized" with a config pointing at branches that were never created.

## The fix

`src-tauri/src/commands/gitflow.rs`, `init_gitflow` only. Master is resolved **before** anything is written:

- An explicitly requested branch is **honoured or refused** with `BranchNotFound` — never silently swapped for a different one.
- With no request, `"main"` then `"master"` is tried and **the resolved name is what gets recorded**. This preserves today's effective order for repos that already have `main`, so nothing changes for them.
- If neither exists, init fails with `OperationFailed("Cannot find a main or master branch to base Git Flow on")`.
- The config writes moved to **after** develop creation, so a failed init leaves the repository untouched and simply uninitialized.

No frontend change: the panel already sends `None` for every field, and resolution now happens in the backend. Deliberately **not** done: creating the master branch when missing (canonical `git flow init` offers to, but that would silently mint branches from the Initialize button); adding a second resolution path in `git.service.ts`; loosening the master lookup in `gitflow_start_hotfix` / `finish_release_like`, which correctly error once the config is right.

### Intentional behavior changes

- An explicitly requested master branch that does not exist is now refused instead of silently recorded. This is the only existing test affected — `test_init_gitflow_custom_branches` previously passed `Some("production")` for a branch it never created and asserted it was recorded, i.e. it documented the bug. It now creates the branch first; all its assertions still hold.
- `init_gitflow` on a repository with no branches now fails **before** writing any config rather than after.

Repos already initialized with a wrong `"main"` value are not migrated — that is a separate concern and a silent config rewrite is not something this change should do.

## Tests

All in `mod tests` in `src-tauri/src/commands/gitflow.rs`, using `TestRepo`. A new `repo_on_master()` helper builds the master-default repository that older repos still are.

| Test | Covers | Fails without the fix? |
| --- | --- | --- |
| `test_init_gitflow_records_the_master_branch_that_exists` | Happy path on a master-default repo: returned and **persisted** name is `master`, develop still created | Yes — `assertion left == right failed / left: "main" / right: "master"` |
| `test_gitflow_hotfix_works_after_init_on_a_master_repo` | The user-visible consequence: hotfix start after a panel init | Yes — `hotfix start must work on a repo initialized by the panel: BranchNotFound("main")` |
| `test_init_gitflow_failure_leaves_the_repo_uninitialized` | Edge case: repo with no commits, so no branch to base on | Yes — `a failed init must not leave the repo looking initialized` |
| `test_init_gitflow_refuses_a_master_branch_that_does_not_exist` | Error path for an explicit name; no `develop` created, repo stays uninitialized | Yes — `init must refuse a master branch that does not exist: GitFlowConfig { initialized: true, master_branch: "nope", ... }` |
| `test_init_gitflow_custom_branches` (updated) | Regression guard: explicitly named, **existing** custom branches still work | No, by design — it guards the fix rather than detecting the bug |

Each of the four new tests was verified by reverting only the `init_gitflow` body (keeping the tests) and re-running; the failure messages above are the actual output. The fix was then restored and the suite is green.

Full gate: lint, typecheck, unit, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_