### PR TITLE
Show a load error instead of the init prompt when gitflow config fails

### DIFF
--- a/e2e/tests/gitflow-panel.spec.ts
+++ b/e2e/tests/gitflow-panel.spec.ts
@@ -4,6 +4,7 @@ import {
   startCommandCaptureWithMocks,
   findCommand,
   injectCommandMock,
+  injectCommandError,
 } from '../fixtures/test-helpers';
 
 /**
@@ -48,7 +49,7 @@ async function injectGitflowPanel(page: import('@playwright/test').Page): Promis
 
   // Wait for the component to finish rendering with Playwright auto-piercing locators
   await page
-    .locator('lv-gitflow-panel#e2e-gitflow .init-section, lv-gitflow-panel#e2e-gitflow .section, lv-gitflow-panel#e2e-gitflow .loading')
+    .locator('lv-gitflow-panel#e2e-gitflow .init-section, lv-gitflow-panel#e2e-gitflow .section, lv-gitflow-panel#e2e-gitflow .load-error, lv-gitflow-panel#e2e-gitflow .loading')
     .first()
     .waitFor({ state: 'visible' });
 }
@@ -658,5 +659,57 @@ test.describe('GitFlow Panel - Loading State', () => {
 
     const commands = await findCommand(page, 'get_gitflow_config');
     expect(commands.length).toBeGreaterThan(0);
+  });
+});
+
+// --------------------------------------------------------------------------
+// Config Load Failure
+// --------------------------------------------------------------------------
+// A failed get_gitflow_config must not be presented as "not initialized" —
+// the Initialize button rewrites the repo's gitflow config with the defaults.
+test.describe('GitFlow Panel - Config Load Failure', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+    await startCommandCaptureWithMocks(page, { get_branches: [] });
+    await injectCommandError(page, 'get_gitflow_config', 'failed to open repository');
+    await injectGitflowPanel(page);
+  });
+
+  test('shows the load error instead of the initialize prompt', async ({ page }) => {
+    await expect(
+      page.locator('lv-gitflow-panel#e2e-gitflow .load-error-message')
+    ).toContainText('failed to open repository');
+    await expect(page.locator('lv-gitflow-panel#e2e-gitflow .init-section')).toHaveCount(0);
+  });
+
+  test('Retry re-runs the config load', async ({ page }) => {
+    await injectCommandMock(page, {
+      get_gitflow_config: {
+        initialized: true,
+        masterBranch: 'main',
+        developBranch: 'develop',
+        featurePrefix: 'feature/',
+        releasePrefix: 'release/',
+        hotfixPrefix: 'hotfix/',
+        supportPrefix: 'support/',
+        versionTagPrefix: 'v',
+      },
+      get_branches: [
+        {
+          name: 'feature/x',
+          shorthand: 'feature/x',
+          isHead: false,
+          isRemote: false,
+          upstream: null,
+          targetOid: 'abc123',
+          isStale: false,
+        },
+      ],
+    });
+
+    await page.locator('lv-gitflow-panel#e2e-gitflow .load-error .btn').click();
+
+    await expect(page.locator('lv-gitflow-panel#e2e-gitflow .section').first()).toBeVisible();
+    await expect(page.locator('lv-gitflow-panel#e2e-gitflow .item-name')).toContainText('x');
   });
 });

--- a/e2e/tests/profiles-integrations.spec.ts
+++ b/e2e/tests/profiles-integrations.spec.ts
@@ -1320,8 +1320,16 @@ test.describe('Profile CRUD Operations', () => {
     const saveButton = page.getByRole('button', { name: 'Save Profile' });
     await saveButton.click();
 
-    // Error feedback should appear as a toast notification
-    await expect(page.locator('.toast, .error-banner, [class*="error"]').first()).toBeVisible({ timeout: 5000 });
+    // Error feedback should appear as a toast notification. Filtered to visible
+    // before .first(): `[class*="error"]` matches any element whose class merely
+    // CONTAINS "error" anywhere on the page, and .first() takes them in DOM
+    // order, so a hidden error element in an unrelated panel shadowed the toast.
+    await expect(
+      page
+        .locator('.toast, .error-banner, [class*="error"]')
+        .filter({ visible: true })
+        .first()
+    ).toBeVisible({ timeout: 5000 });
   });
 
   test('color picker should highlight selected color', async ({ page }) => {

--- a/e2e/tests/remote-dialog.spec.ts
+++ b/e2e/tests/remote-dialog.spec.ts
@@ -290,7 +290,15 @@ test.describe('Remote Dialog - Add Remote E2E', () => {
     const saveButton = remoteDialog.locator('button', { hasText: /save|add/i }).last();
     await saveButton.click();
 
-    const errorIndicator = page.locator('.toast, .error, [class*="error"]').first();
+    // Filter to visible before taking .first(): `[class*="error"]` matches any
+    // element on the page whose class merely CONTAINS "error", and .first()
+    // takes them in DOM order. A hidden error element in a sidebar panel
+    // therefore shadowed the toast this test is about, failing it from across
+    // the app.
+    const errorIndicator = page
+      .locator('.toast, .error, [class*="error"]')
+      .filter({ visible: true })
+      .first();
     await expect(errorIndicator).toBeVisible({ timeout: 3000 });
   });
 

--- a/src/components/__tests__/lv-gitflow-panel.test.ts
+++ b/src/components/__tests__/lv-gitflow-panel.test.ts
@@ -657,10 +657,11 @@ describe('lv-gitflow-panel', () => {
 
   // ── Error handling ─────────────────────────────────────────────────────
   describe('error handling', () => {
-    it('shows init section when config load returns failure', async () => {
+    it('shows the load error, not the init section, when config load fails', async () => {
       // When get_gitflow_config throws, invokeCommand catches it and returns
-      // { success: false }. loadConfig sees !result.success, sets config=null,
-      // so the init section renders.
+      // { success: false }. That is a FAILED load, not "not initialized" — the
+      // Initialize button would rewrite the repo's gitflow config with the
+      // defaults, so it must not be offered here.
       mockInvoke = async (command: string) => {
         if (command === 'get_gitflow_config') {
           throw new Error('Config load failed');
@@ -670,8 +671,10 @@ describe('lv-gitflow-panel', () => {
 
       const el = await renderPanel();
 
-      const initSection = el.shadowRoot!.querySelector('.init-section');
-      expect(initSection).to.not.be.null;
+      expect(el.shadowRoot!.querySelectorAll('.init-section').length).to.equal(0);
+      expect(el.shadowRoot!.querySelector('.load-error-message')?.textContent ?? '').to.contain(
+        'Config load failed',
+      );
     });
 
     it('shows error when init_gitflow fails', async () => {

--- a/src/components/sidebar/__tests__/lv-gitflow-panel-config-error.test.ts
+++ b/src/components/sidebar/__tests__/lv-gitflow-panel-config-error.test.ts
@@ -1,0 +1,168 @@
+/**
+ * Tests for lv-gitflow-panel config-load failure handling.
+ *
+ * `invokeCommand` turns every backend rejection into `success === false`, so a
+ * failed `get_gitflow_config` used to null the config and render the
+ * "Git Flow is not initialized" prompt — offering an Initialize button that
+ * rewrites an already-initialized repo's gitflow config with the defaults.
+ * A failed load must be reported as a failure, and must never carry another
+ * repo's active items across.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { LvGitflowPanel } from '../lv-gitflow-panel.ts';
+import '../lv-gitflow-panel.ts';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+const REPO_A = '/test/repo-a';
+
+function initializedConfig(): Record<string, unknown> {
+  return {
+    initialized: true,
+    masterBranch: 'main',
+    developBranch: 'develop',
+    featurePrefix: 'feature/',
+    releasePrefix: 'release/',
+    hotfixPrefix: 'hotfix/',
+    supportPrefix: 'support/',
+    versionTagPrefix: 'v',
+  };
+}
+
+function featureBranch(name: string): Record<string, unknown> {
+  return {
+    name,
+    shorthand: name,
+    isHead: false,
+    isRemote: false,
+    upstream: null,
+    targetOid: 'a1',
+    isStale: false,
+  };
+}
+
+/** Flush the component's async config load. */
+async function flush(el: LvGitflowPanel): Promise<void> {
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 20));
+  await el.updateComplete;
+}
+
+async function createPanel(path: string): Promise<LvGitflowPanel> {
+  const el = await fixture<LvGitflowPanel>(
+    html`<lv-gitflow-panel .repositoryPath=${path}></lv-gitflow-panel>`
+  );
+  await flush(el);
+  return el;
+}
+
+describe('lv-gitflow-panel config load failure', () => {
+  afterEach(() => {
+    mockInvoke = () => Promise.resolve(null);
+  });
+
+  it('shows the error instead of the init section when the config load fails', async () => {
+    mockInvoke = (command) => {
+      if (command === 'get_gitflow_config') {
+        return Promise.reject(new Error('failed to open repository'));
+      }
+      if (command === 'get_branches') return Promise.resolve([]);
+      return Promise.resolve(null);
+    };
+
+    const el = await createPanel(REPO_A);
+
+    // The Initialize button would overwrite the repo's gitflow config.
+    expect(el.shadowRoot!.querySelectorAll('.init-section').length).to.equal(0);
+    expect(el.shadowRoot!.querySelector('.load-error-message')?.textContent ?? '').to.contain(
+      'failed to open repository'
+    );
+  });
+
+  it('keeps the initialized panel and surfaces the error when a reload fails', async () => {
+    mockInvoke = (command) => {
+      if (command === 'get_gitflow_config') return Promise.resolve(initializedConfig());
+      if (command === 'get_branches') return Promise.resolve([featureBranch('feature/x')]);
+      return Promise.resolve(null);
+    };
+
+    const el = await createPanel(REPO_A);
+    expect(el.shadowRoot!.querySelector('.item-name')?.textContent ?? '').to.contain('x');
+
+    mockInvoke = (command) => {
+      if (command === 'get_gitflow_config') {
+        return Promise.reject(new Error('index.lock exists'));
+      }
+      if (command === 'get_branches') return Promise.resolve([featureBranch('feature/x')]);
+      return Promise.resolve(null);
+    };
+    await el.refresh();
+    await flush(el);
+
+    expect(el.shadowRoot!.querySelectorAll('.init-section').length).to.equal(0);
+    expect(el.shadowRoot!.querySelector('.error-banner-message')?.textContent ?? '').to.contain(
+      'index.lock'
+    );
+    // The panel itself survives a transient failure.
+    expect(el.shadowRoot!.querySelector('.item-name')?.textContent ?? '').to.contain('x');
+  });
+
+  it('never shows the previous repo items when a new repo fails to load', async () => {
+    mockInvoke = (command) => {
+      if (command === 'get_gitflow_config') return Promise.resolve(initializedConfig());
+      if (command === 'get_branches') return Promise.resolve([featureBranch('feature/x')]);
+      return Promise.resolve(null);
+    };
+
+    const el = await createPanel(REPO_A);
+    expect(el.shadowRoot!.querySelector('.item-name')?.textContent ?? '').to.contain('x');
+
+    mockInvoke = (command) => {
+      if (command === 'get_gitflow_config') {
+        return Promise.reject(new Error('failed to open repository'));
+      }
+      if (command === 'get_branches') return Promise.resolve([]);
+      return Promise.resolve(null);
+    };
+    el.repositoryPath = '/test/repo-b';
+    await flush(el);
+
+    expect(el.shadowRoot!.querySelectorAll('.load-error-message').length).to.equal(1);
+    expect(el.shadowRoot!.querySelectorAll('.init-section').length).to.equal(0);
+    // Repo A's Finish buttons run against `repositoryPath` — showing them
+    // under repo B would finish a branch in the wrong repository.
+    expect(el.shadowRoot!.querySelectorAll('.item-name').length).to.equal(0);
+    expect(el.shadowRoot!.querySelectorAll('.section').length).to.equal(0);
+  });
+
+  // Regression guard for the untouched happy path: passes before and after the fix.
+  it('still shows the init section for a genuinely uninitialized repo', async () => {
+    mockInvoke = (command) => {
+      if (command === 'get_gitflow_config') {
+        return Promise.resolve({ ...initializedConfig(), initialized: false });
+      }
+      if (command === 'get_branches') return Promise.resolve([]);
+      return Promise.resolve(null);
+    };
+
+    const el = await createPanel(REPO_A);
+
+    expect(el.shadowRoot!.querySelectorAll('.init-section').length).to.equal(1);
+    expect(el.shadowRoot!.querySelector('.init-description')?.textContent ?? '').to.contain(
+      'not initialized'
+    );
+    expect(el.shadowRoot!.querySelectorAll('.load-error').length).to.equal(0);
+  });
+});

--- a/src/components/sidebar/__tests__/lv-sidebar-lock-rerender.test.ts
+++ b/src/components/sidebar/__tests__/lv-sidebar-lock-rerender.test.ts
@@ -74,8 +74,20 @@ function defaultMockInvoke(command: string): Promise<unknown> {
     case 'get_branch_sort_mode':
     case 'get_tag_sort_mode':
       return Promise.resolve('name');
+    case 'get_gitflow_config':
+      // A repo where git flow is genuinely not initialized — that, not a
+      // failed load, is what renders the Initialize button this test drives.
+      return Promise.resolve({
+        initialized: false,
+        masterBranch: 'main',
+        developBranch: 'develop',
+        featurePrefix: 'feature/',
+        releasePrefix: 'release/',
+        hotfixPrefix: 'hotfix/',
+        supportPrefix: 'support/',
+        versionTagPrefix: 'v',
+      });
     default:
-      // get_git_flow_config included: null config renders the init section.
       return Promise.resolve(null);
   }
 }

--- a/src/components/sidebar/lv-gitflow-panel.ts
+++ b/src/components/sidebar/lv-gitflow-panel.ts
@@ -54,6 +54,20 @@ export class LvGitflowPanel extends LitElement {
         color: var(--color-text-muted);
       }
 
+      .load-error {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: var(--spacing-sm);
+        padding: var(--spacing-md);
+        text-align: center;
+      }
+
+      .load-error-message {
+        font-size: var(--font-size-sm);
+        color: var(--color-error);
+      }
+
       .section {
         margin-bottom: var(--spacing-sm);
       }
@@ -281,6 +295,20 @@ export class LvGitflowPanel extends LitElement {
   @state() private config: GitFlowConfig | null = null;
   @state() private loading = true;
   @state() private error: string | null = null;
+  /**
+   * A config load that FAILED, as opposed to one that reported "not
+   * initialized". The two must render differently: only the second may offer
+   * the Initialize button, which rewrites the repo's gitflow config with the
+   * defaults and would silently discard custom branch names and prefixes.
+   */
+  @state() private configLoadFailed = false;
+  /**
+   * The repo path `config` and the active item lists were loaded from. A
+   * failed load keeps the last good data for the SAME repo, but never carries
+   * another repo's items across — their Finish buttons run against
+   * `repositoryPath`, so that would finish the wrong branch.
+   */
+  private configPath: string | null = null;
   @state() private activeFeatures: ActiveItem[] = [];
   @state() private activeReleases: ActiveItem[] = [];
   @state() private activeHotfixes: ActiveItem[] = [];
@@ -376,24 +404,55 @@ export class LvGitflowPanel extends LitElement {
 
     this.loading = true;
     this.error = null;
+    this.configLoadFailed = false;
 
     try {
       const result = await gitService.getGitFlowConfig(loadedPath);
       if (!isLatest()) return;
       if (result.success && result.data) {
         this.config = result.data;
+        this.configPath = loadedPath;
         if (this.config.initialized) {
           await this.loadActiveItems(loadedPath, isLatest);
         }
       } else {
-        this.config = null;
+        // invokeCommand turns every backend failure into success === false, so
+        // this — not the catch — is the normal failure path. Nulling the config
+        // here rendered the "Git Flow is not initialized" prompt, inviting the
+        // user to re-initialize an already-initialized repo and overwrite its
+        // custom branch names and prefixes with the defaults.
+        this.markConfigLoadFailed(
+          loadedPath,
+          result.error?.message || 'Failed to load Git Flow configuration',
+        );
       }
     } catch (err) {
       console.error('Failed to load git flow config:', err);
-      if (isLatest()) this.error = 'Failed to load Git Flow configuration';
+      if (isLatest()) {
+        this.markConfigLoadFailed(loadedPath, 'Failed to load Git Flow configuration');
+      }
     } finally {
       if (isLatest()) this.loading = false;
     }
+  }
+
+  /**
+   * Record a failed config load: surface `message` and keep whatever this
+   * repo's last successful load produced, so a transient failure (repo lock,
+   * filesystem error) does not present an initialized repo as uninitialized.
+   * A config loaded from a DIFFERENT path is dropped instead of kept — the
+   * Finish buttons bound to its items run against `repositoryPath`.
+   */
+  private markConfigLoadFailed(loadedPath: string, message: string): void {
+    if (this.configPath !== loadedPath) {
+      this.config = null;
+      this.configPath = null;
+      this.activeFeatures = [];
+      this.activeReleases = [];
+      this.activeHotfixes = [];
+    }
+    this.configLoadFailed = true;
+    this.error = message;
   }
 
   private async loadActiveItems(
@@ -1030,6 +1089,23 @@ export class LvGitflowPanel extends LitElement {
   render() {
     if (this.loading) {
       return html`<div class="loading">Loading Git Flow...</div>`;
+    }
+
+    // A load that FAILED is not the same as "not initialized": the Initialize
+    // button would rewrite this repo's gitflow config with the defaults. The
+    // message is the section's own text rather than a dismissible banner, so
+    // dismissing it cannot leave a blank panel.
+    if (this.configLoadFailed && !this.config?.initialized) {
+      return html`
+        <div class="load-error">
+          <div class="load-error-message">
+            ${this.error ?? 'Failed to load Git Flow configuration'}
+          </div>
+          <button class="btn btn-secondary" @click=${() => void this.loadConfig()}>
+            Retry
+          </button>
+        </div>
+      `;
     }
 
     if (!this.config || !this.config.initialized) {


### PR DESCRIPTION
## What was broken

`invokeCommand` (`src/services/tauri-api.ts`) converts every backend rejection into `result.success === false`. That makes the `else` branch in `lv-gitflow-panel`'s `loadConfig` — not the `catch` — the normal failure path for `get_gitflow_config`. That branch set `this.config = null` and never touched `this.error`:

```ts
} else {
  this.config = null;
}
```

`render()` then hit `if (!this.config || !this.config.initialized)` and drew `renderInitSection()`, with `renderErrorBanner()` returning `nothing` because `this.error` was still null. So an already-initialized repo whose config read transiently failed (repo lock, `index.lock`, filesystem error) was presented as **"Git Flow is not initialized for this repository"** with an inviting **Initialize Git Flow** button and no error shown at all.

Clicking that button runs `init_gitflow`, which writes the default master/develop branch names and prefixes over the repo's real gitflow config — silently discarding custom branch names and prefixes.

A genuinely uninitialized repo is a different case: `src-tauri/src/commands/gitflow.rs` returns `Ok(GitFlowConfig::default())` with `initialized: false`, i.e. a *success*. So this was a silent error path (against the project rule that error paths must never be silent) dressed up as an invitation to a destructive, state-modifying action.

## The fix

All changes are in `src/components/sidebar/lv-gitflow-panel.ts`; no Rust, service, or store changes.

- A failed load now calls a new `markConfigLoadFailed()`, which sets `configLoadFailed` and surfaces the backend's message in `this.error`. Both the `else` branch and the `catch` route through it.
- `render()` gets a `.load-error` branch — the message plus a **Retry** button — placed ahead of the not-initialized check, so the Initialize button is never offered for a load that *failed*. The message is the section's own text rather than a dismissible banner, so dismissing cannot leave a blank panel.
- When the **same** repo already had a good config, that config and its active items are kept: the panel keeps working and the failure shows in the existing error banner. A failure for a **different** repo path drops the previous data instead (tracked via a new `configPath` field) — the Finish buttons bound to those items run against `this.repositoryPath`, so carrying repo A's items under repo B would finish a branch in the wrong repository. This guard is load-bearing, not polish, and is covered by its own test.
- `loadConfig` resets `configLoadFailed` at its start alongside `error`, so an operation error is never mistaken for a load failure or vice versa. `handleInitialize`, `dismissError` and the start/finish handlers are untouched.

The not-initialized flow is unchanged: the new branch is gated on `configLoadFailed`, which is only true after an actual failure.

## Tests

| Test | File | Covers | Fails without the fix |
| --- | --- | --- | --- |
| shows the error instead of the init section when the config load fails | `src/components/sidebar/__tests__/lv-gitflow-panel-config-error.test.ts` | Error path — the reported defect | Yes — `expected 1 to equal 0` (init section renders) |
| keeps the initialized panel and surfaces the error when a reload fails | same | The real-world regression: transient failure on an initialized repo | Yes — `expected 1 to equal 0` (config nulled → init section) |
| never shows the previous repo items when a new repo fails to load | same | Edge case — cross-repo data must not carry over | Yes — `expected 0 to equal 1` (no load error at all) |
| still shows the init section for a genuinely uninitialized repo | same | Regression guard for the untouched happy path | No, by design — labelled as a guard |
| shows the load error, not the init section, when config load fails | `src/components/__tests__/lv-gitflow-panel.test.ts` | Existing test that asserted the old buggy behaviour, updated | n/a |
| shows the load error instead of the initialize prompt | `e2e/tests/gitflow-panel.spec.ts` | E2E error path | Yes — `element(s) not found` for `.load-error-message` |
| Retry re-runs the config load | same | E2E recovery: Retry reloads and the panel renders | Yes — click times out, no Retry button exists |

Verification performed:

- Reverted **only** the `loadConfig`/`render` production hunks (keeping the tests) and re-ran the new unit file: tests 1–3 failed with the messages above, test 4 passed. Restored the fix — all four pass.
- Separately neutered **just** the `configPath` guard inside `markConfigLoadFailed` (keeping everything else): the cross-repo test failed with `expected 0 to equal 1`, confirming the guard is actually tested rather than incidental.
- Reverted the fix again and ran the E2E `Config Load Failure` group: both new specs failed. With the fix, the full `gitflow-panel.spec.ts` suite passes — 21 tests, including the pre-existing not-initialized and init-failure specs.

Two existing tests encoded the old behaviour by making `get_gitflow_config` fail or return `null` while actually being about the *not-initialized* flow (`lv-sidebar-lock-rerender.test.ts` drives the Initialize button; the `lv-gitflow-panel.test.ts` case asserted the init section appears on a failed load). Their mocks now return a genuine `initialized: false` config, and the second was rewritten to assert the corrected behaviour.

Gate: `npm run lint`, `npm run typecheck`, `npm test` (4446 tests) all green. `e2e/tests/gitflow-panel.spec.ts` green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_