### PR TITLE
Keep a finished bisect on its result screen when the dialog reopens

### DIFF
--- a/e2e/tests/bisect-dialog.spec.ts
+++ b/e2e/tests/bisect-dialog.spec.ts
@@ -544,6 +544,42 @@ test.describe('Bisect Dialog - Complete State', () => {
     // Verify the dialog closes after finishing bisect
     await expect(page.locator('lv-bisect-dialog .dialog')).not.toBeVisible({ timeout: 5000 });
   });
+
+  // The session stays active in git until Finish runs `bisect reset`, so a
+  // dialog closed at the result screen (X, Escape, overlay click) must reopen
+  // ON the result. It used to come back on Good/Bad/Skip with the answer gone.
+  test('a completed bisect reopens on the result screen', async ({ page }) => {
+    await injectCommandMock(page, {
+      get_bisect_status: {
+        active: true,
+        currentCommit: 'culprit_abc123def456',
+        badCommit: 'culprit_abc123def456',
+        goodCommit: 'good_ref',
+        remaining: 0,
+        currentStep: 7,
+        totalSteps: 7,
+        log: [],
+        culprit: {
+          oid: 'culprit_abc123def456',
+          summary: 'This commit introduced the bug',
+          author: 'Test User',
+          email: 'test@example.com',
+        },
+      },
+    });
+
+    // No Good/Bad clicks: this is the reopen path, straight from status.
+    await openBisectDialog(page);
+
+    await expect(page.locator('lv-bisect-dialog .culprit-card')).toBeVisible();
+    await expect(page.locator('lv-bisect-dialog .culprit-oid')).toContainText(
+      'culprit_abc123def456'
+    );
+    await expect(
+      page.locator('lv-bisect-dialog .btn-primary', { hasText: 'Finish' })
+    ).toBeVisible();
+    await expect(page.locator('lv-bisect-dialog .action-btn')).toHaveCount(0);
+  });
 });
 
 test.describe('Bisect Dialog - Error Handling', () => {

--- a/e2e/tests/bisect-dialog.spec.ts
+++ b/e2e/tests/bisect-dialog.spec.ts
@@ -580,6 +580,59 @@ test.describe('Bisect Dialog - Complete State', () => {
     ).toBeVisible();
     await expect(page.locator('lv-bisect-dialog .action-btn')).toHaveCount(0);
   });
+
+  // A range holding a single candidate converges inside `git bisect start`
+  // itself, and the session stays active until reset. The start used to read
+  // only `active`, so it asked for a Good/Bad verdict git no longer needed.
+  test('a start that converges immediately shows the result', async ({ page }) => {
+    await injectCommandMock(page, {
+      get_bisect_status: {
+        active: false,
+        currentCommit: null,
+        badCommit: null,
+        goodCommit: null,
+        remaining: null,
+        totalSteps: null,
+        currentStep: null,
+        log: [],
+        culprit: null,
+      },
+      bisect_start: {
+        status: {
+          active: true,
+          currentCommit: 'culprit_abc123def456',
+          badCommit: 'culprit_abc123def456',
+          goodCommit: 'good_ref',
+          remaining: 0,
+          currentStep: 1,
+          totalSteps: 0,
+          log: [],
+          culprit: {
+            oid: 'culprit_abc123def456',
+            summary: 'This commit introduced the bug',
+            author: 'Test User',
+            email: 'test@example.com',
+          },
+        },
+        // git converged in the start itself, so the step output carries no
+        // culprit of its own — only the refreshed status does.
+        culprit: null,
+        message: 'Bisect session started',
+      },
+    });
+
+    await openBisectDialog(page);
+
+    await page.locator('lv-bisect-dialog .commit-input input').first().fill('HEAD');
+    await page.locator('lv-bisect-dialog .commit-input input').nth(1).fill('HEAD~1');
+    await page.locator('lv-bisect-dialog .btn-primary', { hasText: 'Start Bisect' }).click();
+
+    await expect(page.locator('lv-bisect-dialog .culprit-card')).toBeVisible();
+    await expect(page.locator('lv-bisect-dialog .culprit-oid')).toContainText(
+      'culprit_abc123def456'
+    );
+    await expect(page.locator('lv-bisect-dialog .action-btn')).toHaveCount(0);
+  });
 });
 
 test.describe('Bisect Dialog - Error Handling', () => {

--- a/src-tauri/src/commands/bisect.rs
+++ b/src-tauri/src/commands/bisect.rs
@@ -1348,6 +1348,37 @@ Date:   Mon Jan 1 12:00:00 2024 +0000
         let _ = run_git_command(&repo.path, &["bisect", "reset"]);
     }
 
+    // `git bisect start` converges on the spot when the range holds a single
+    // candidate, and the session stays active until reset. The dialog builds
+    // its screen out of what this call returns, so the answer has to be on it
+    // — otherwise the start lands the user on Good/Bad/Skip for a search git
+    // has already finished.
+    #[tokio::test]
+    async fn test_bisect_start_carries_the_culprit_when_it_converges_immediately() {
+        let repo = TestRepo::with_initial_commit();
+        let good = repo.head_oid().to_string();
+        repo.create_commit("Bug introduced", &[("bug.txt", "bug")]);
+        let bad = repo.head_oid().to_string();
+
+        let result = bisect_start(repo.path_str(), Some(bad.clone()), Some(good))
+            .await
+            .unwrap();
+
+        assert!(
+            result.status.active,
+            "git holds the session open until reset"
+        );
+        let culprit = result
+            .status
+            .culprit
+            .as_ref()
+            .expect("a start that already converged must carry the answer");
+        assert_eq!(culprit.oid, bad);
+        assert_eq!(culprit.summary, "Bug introduced");
+
+        let _ = run_git_command(&repo.path, &["bisect", "reset"]);
+    }
+
     // The guard against reporting the range endpoint as the answer on step one.
     #[tokio::test]
     async fn test_get_bisect_status_has_no_culprit_mid_search() {

--- a/src-tauri/src/commands/bisect.rs
+++ b/src-tauri/src/commands/bisect.rs
@@ -27,6 +27,10 @@ pub struct BisectStatus {
     pub current_step: Option<u32>,
     /// Log of bisect operations
     pub log: Vec<BisectLogEntry>,
+    /// The first bad commit, once the search has converged. The session stays
+    /// active in git until `bisect reset`, so without this the result is lost
+    /// the moment the dialog is closed at its result screen.
+    pub culprit: Option<CulpritCommit>,
 }
 
 /// A single entry in the bisect log
@@ -219,6 +223,44 @@ fn parse_bisect_log(repo_path: &Path) -> Vec<BisectLogEntry> {
         .collect()
 }
 
+/// Whether git has already announced the answer for this session.
+///
+/// Once the search converges git appends its result to BISECT_LOG as a comment
+/// (`# first <term_bad> commit: [<oid>] <subject>`) and leaves the session
+/// ACTIVE until `git bisect reset`. That comment is the only on-disk record
+/// that the search finished, so it is what tells a reopened dialog to show the
+/// result rather than another Good/Bad/Skip round.
+fn bisect_finished(git_dir: &Path, term_bad: &str) -> bool {
+    let marker = format!("# first {} commit:", term_bad);
+    std::fs::read_to_string(git_dir.join("BISECT_LOG"))
+        .map(|c| c.lines().any(|l| l.trim_start().starts_with(&marker)))
+        .unwrap_or(false)
+}
+
+/// Describe `oid` for the culprit card. Unit-separated so an empty subject
+/// cannot shift the fields.
+fn culprit_commit(repo_path: &Path, oid: &str) -> Option<CulpritCommit> {
+    let out = run_git_command(
+        repo_path,
+        &["log", "-1", "--format=%H%x1f%s%x1f%an%x1f%ae", oid, "--"],
+    )
+    .ok()?;
+    let mut parts = out.split('\u{1f}');
+    let oid = parts.next()?.trim().to_string();
+    let summary = parts.next()?.to_string();
+    let author = parts.next()?.to_string();
+    let email = parts.next()?.trim().to_string();
+    if oid.is_empty() {
+        return None;
+    }
+    Some(CulpritCommit {
+        oid,
+        summary,
+        author,
+        email,
+    })
+}
+
 /// The status returned when no bisect session is in progress.
 fn inactive_status() -> BisectStatus {
     BisectStatus {
@@ -230,6 +272,7 @@ fn inactive_status() -> BisectStatus {
         total_steps: None,
         current_step: None,
         log: Vec::new(),
+        culprit: None,
     }
 }
 
@@ -282,6 +325,18 @@ pub async fn get_bisect_status(path: String) -> Result<BisectStatus> {
     // Parse the log
     let log = parse_bisect_log(repo_path);
 
+    // git records the answer against refs/bisect/<term_bad> — already resolved
+    // into `bad_commit` above; the log comment is only the signal that the
+    // search got there. Do not parse the oid out of that comment: its bracket
+    // formatting has drifted across git versions.
+    let culprit = if bisect_finished(&gdir, &term_bad) {
+        bad_commit
+            .as_deref()
+            .and_then(|oid| culprit_commit(repo_path, oid))
+    } else {
+        None
+    };
+
     // Estimate remaining work exactly as git prints it:
     //   "Bisecting: N revisions left to test after this (roughly M steps)"
     // where N = all - reaches - 1 (all = candidate commits in the range,
@@ -317,6 +372,7 @@ pub async fn get_bisect_status(path: String) -> Result<BisectStatus> {
         total_steps: remaining_info.map(|(_, t)| t),
         current_step: Some(log.len() as u32),
         log,
+        culprit,
     })
 }
 
@@ -1187,5 +1243,112 @@ Date:   Mon Jan 1 12:00:00 2024 +0000
         );
 
         let _ = run_git_command(&repo.path, &["bisect", "reset"]);
+    }
+
+    // The session stays active in git until `bisect reset`, so a status that
+    // cannot say the search is over presents a finished bisect as unfinished —
+    // the dialog reopens on Good/Bad/Skip and the answer is gone.
+    #[tokio::test]
+    async fn test_get_bisect_status_reports_the_culprit_once_the_search_converges() {
+        let repo = TestRepo::with_initial_commit();
+        let good = repo.head_oid().to_string();
+        repo.create_commit("Bug introduced", &[("bug.txt", "bug")]);
+        let bad = repo.head_oid().to_string();
+
+        // With a single candidate git converges inside the start itself.
+        bisect_start(repo.path_str(), Some(bad.clone()), Some(good))
+            .await
+            .unwrap();
+
+        let status = get_bisect_status(repo.path_str()).await.unwrap();
+        assert!(
+            status.active,
+            "git keeps the session open until reset, which is exactly the problem"
+        );
+        let culprit = status
+            .culprit
+            .as_ref()
+            .expect("a converged search must report its answer");
+        assert_eq!(culprit.oid, bad);
+        assert_eq!(culprit.summary, "Bug introduced");
+
+        let _ = run_git_command(&repo.path, &["bisect", "reset"]);
+    }
+
+    // The guard against reporting the range endpoint as the answer on step one.
+    #[tokio::test]
+    async fn test_get_bisect_status_has_no_culprit_mid_search() {
+        let repo = TestRepo::with_initial_commit();
+        let good = repo.head_oid().to_string();
+        for i in 2..=5 {
+            repo.create_commit(
+                &format!("Commit {}", i),
+                &[(format!("f{}.txt", i).as_str(), "x")],
+            );
+        }
+        let bad = repo.head_oid().to_string();
+
+        bisect_start(repo.path_str(), Some(bad), Some(good))
+            .await
+            .unwrap();
+
+        let status = get_bisect_status(repo.path_str()).await.unwrap();
+        assert!(status.active);
+        assert!(
+            status.culprit.is_none(),
+            "a search still in flight has no answer to report"
+        );
+
+        let _ = run_git_command(&repo.path, &["bisect", "reset"]);
+    }
+
+    #[test]
+    fn test_bisect_finished_matches_the_recorded_term() {
+        let repo = TestRepo::with_initial_commit();
+        let gdir = repo.path.join(".git");
+        std::fs::write(
+            gdir.join("BISECT_LOG"),
+            "git bisect start\n# first broken commit: [abc123] Broke it\n",
+        )
+        .unwrap();
+
+        assert!(
+            bisect_finished(&gdir, "broken"),
+            "a --term-new=broken session records its result under that term"
+        );
+        assert!(
+            !bisect_finished(&gdir, "bad"),
+            "a mismatched term must not be read as a result"
+        );
+        assert!(
+            parse_bisect_log(&repo.path)
+                .iter()
+                .all(|e| e.action != "first"),
+            "the result comment must stay out of the Bisect History list"
+        );
+
+        // Skip-exhaustion writes "# possible first bad commit:" for EACH
+        // candidate — git has no answer there, and reading one as final would
+        // put the dialog on a result screen naming an arbitrary candidate.
+        std::fs::write(
+            gdir.join("BISECT_LOG"),
+            "git bisect start\n# only skipped commits left to test\n\
+             # possible first bad commit: [abc123] Maybe\n\
+             # possible first bad commit: [def456] Or maybe\n",
+        )
+        .unwrap();
+        assert!(
+            !bisect_finished(&gdir, "bad"),
+            "\"only skipped commits left\" is not a converged search"
+        );
+    }
+
+    #[test]
+    fn test_culprit_commit_ignores_an_unresolvable_oid() {
+        let repo = TestRepo::with_initial_commit();
+        assert!(
+            culprit_commit(&repo.path, "0000000000000000000000000000000000000000").is_none(),
+            "status must stay Ok with no culprit rather than erroring"
+        );
     }
 }

--- a/src-tauri/src/commands/bisect.rs
+++ b/src-tauri/src/commands/bisect.rs
@@ -223,17 +223,47 @@ fn parse_bisect_log(repo_path: &Path) -> Vec<BisectLogEntry> {
         .collect()
 }
 
+/// Whether one BISECT_LOG line is git's converged-result comment for `term_bad`.
+///
+/// git quotes the term in this comment as of 2.44 and did not before, so the
+/// same converged session writes either of:
+///
+/// ```text
+/// # first bad commit: [<oid>] <subject>      (git 2.43)
+/// # first 'bad' commit: [<oid>] <subject>    (git 2.55)
+/// ```
+///
+/// Matching the line's SHAPE and comparing the term with any quoting stripped
+/// reads both. An exact-string marker read only whichever git the author
+/// happened to have: built against 2.43, it silently reported every converged
+/// search as unfinished on 2.44+.
+fn log_announces_culprit(line: &str, term_bad: &str) -> bool {
+    let Some(comment) = line.trim_start().strip_prefix('#') else {
+        return false;
+    };
+    let mut tokens = comment.split_whitespace();
+    if tokens.next() != Some("first") {
+        return false;
+    }
+    // git rejects a term containing whitespace, so the term is always one token.
+    let Some(term) = tokens.next() else {
+        return false;
+    };
+    if term.trim_matches('\'') != term_bad {
+        return false;
+    }
+    tokens.next() == Some("commit:")
+}
+
 /// Whether git has already announced the answer for this session.
 ///
 /// Once the search converges git appends its result to BISECT_LOG as a comment
-/// (`# first <term_bad> commit: [<oid>] <subject>`) and leaves the session
-/// ACTIVE until `git bisect reset`. That comment is the only on-disk record
-/// that the search finished, so it is what tells a reopened dialog to show the
-/// result rather than another Good/Bad/Skip round.
+/// and leaves the session ACTIVE until `git bisect reset`. That comment is the
+/// only on-disk record that the search finished, so it is what tells a reopened
+/// dialog to show the result rather than another Good/Bad/Skip round.
 fn bisect_finished(git_dir: &Path, term_bad: &str) -> bool {
-    let marker = format!("# first {} commit:", term_bad);
     std::fs::read_to_string(git_dir.join("BISECT_LOG"))
-        .map(|c| c.lines().any(|l| l.trim_start().starts_with(&marker)))
+        .map(|c| c.lines().any(|l| log_announces_culprit(l, term_bad)))
         .unwrap_or(false)
 }
 
@@ -1243,6 +1273,49 @@ Date:   Mon Jan 1 12:00:00 2024 +0000
         );
 
         let _ = run_git_command(&repo.path, &["bisect", "reset"]);
+    }
+
+    /// Both spellings git has used for the converged-result comment must read as
+    /// converged. The unquoted form is what git <= 2.43 writes and the quoted
+    /// form is what 2.44+ writes; a build that understands only the local git's
+    /// spelling reports every converged search as unfinished on the other, which
+    /// is exactly how this shipped red.
+    #[test]
+    fn test_log_announces_culprit_reads_both_git_spellings() {
+        let oid = "d2598a42cba989fc57a7dd16fe321404bfa66177";
+
+        assert!(
+            log_announces_culprit(&format!("# first bad commit: [{}] Bug", oid), "bad"),
+            "git 2.43 writes the term unquoted"
+        );
+        assert!(
+            log_announces_culprit(&format!("# first 'bad' commit: [{}] Bug", oid), "bad"),
+            "git 2.55 writes the term quoted"
+        );
+        assert!(
+            log_announces_culprit(&format!("# first 'broken' commit: [{}] Bug", oid), "broken"),
+            "a custom --term-new is quoted the same way"
+        );
+
+        // The other comments in BISECT_LOG must not read as the result, or a
+        // session would look converged the moment it started.
+        assert!(!log_announces_culprit(
+            &format!("# bad: [{}] Bug", oid),
+            "bad"
+        ));
+        assert!(!log_announces_culprit(
+            &format!("# good: [{}] initial", oid),
+            "bad"
+        ));
+        assert!(!log_announces_culprit(
+            &format!("git bisect start '{}' 'x'", oid),
+            "bad"
+        ));
+        // A different session's term is not this session's answer.
+        assert!(!log_announces_culprit(
+            &format!("# first 'broken' commit: [{}] Bug", oid),
+            "bad"
+        ));
     }
 
     // The session stays active in git until `bisect reset`, so a status that

--- a/src/components/dialogs/__tests__/lv-bisect-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-bisect-dialog.test.ts
@@ -395,6 +395,60 @@ describe('lv-bisect-dialog repository targeting', () => {
       ).to.equal(2);
     });
 
+    // A single-candidate range converges inside `git bisect start` itself, and
+    // git leaves the session active until reset. Reading only `active` here put
+    // the finished search on Good/Bad/Skip asking for a verdict git already had.
+    it('a start that converges immediately lands on the result', async () => {
+      statusByPath = { [REPO_A]: { active: false } };
+      const el = await openOn(REPO_A);
+
+      const inputs = el.shadowRoot!.querySelectorAll<HTMLInputElement>('.commit-input input');
+      inputs[0].value = 'HEAD';
+      inputs[0].dispatchEvent(new Event('input'));
+      inputs[1].value = 'HEAD~1';
+      inputs[1].dispatchEvent(new Event('input'));
+      await el.updateComplete;
+
+      // What the backend reports back from the start: active, with the answer.
+      statusByPath[REPO_A] = status({ culprit: CULPRIT });
+      const startBtn = [...el.shadowRoot!.querySelectorAll('button')].find((b) =>
+        b.textContent?.includes('Start Bisect')
+      );
+      expect(startBtn, 'Start Bisect button present').to.not.be.undefined;
+      startBtn!.click();
+      await settle(el);
+
+      expect(el.shadowRoot!.querySelector('.culprit-card'), 'the answer is shown').to.not.be.null;
+      expect(el.shadowRoot!.querySelector('.culprit-oid')!.textContent).to.contain(CULPRIT.oid);
+      expect(
+        el.shadowRoot!.querySelectorAll('.action-btn').length,
+        'and no further verdict is asked for',
+      ).to.equal(0);
+    });
+
+    // handleClose leaves component state alone, so the info banner captioning
+    // the last step outlived the session that produced it.
+    it('drops the previous step message when the dialog is reopened', async () => {
+      const el = await openOn(REPO_A);
+
+      clickAction(el, 'Good');
+      await settle(el);
+      expect(
+        el.shadowRoot!.querySelectorAll('.message.info').length,
+        'the step reports what it did',
+      ).to.equal(1);
+
+      el.open = false;
+      await settle(el);
+      el.open = true;
+      await settle(el);
+
+      expect(
+        el.shadowRoot!.querySelectorAll('.message.info').length,
+        'a recomputed status must not be captioned by the old step',
+      ).to.equal(0);
+    });
+
     it('uses the recorded culprit when the step output could not be parsed', async () => {
       const el = await openOn(REPO_A);
 

--- a/src/components/dialogs/__tests__/lv-bisect-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-bisect-dialog.test.ts
@@ -39,6 +39,13 @@ import '../lv-bisect-dialog.ts';
 const REPO_A = '/repo/a';
 const REPO_B = '/repo/b';
 
+interface CulpritCommit {
+  oid: string;
+  summary: string;
+  author: string;
+  email: string;
+}
+
 interface BisectStatus {
   active: boolean;
   currentCommit?: string | null;
@@ -47,6 +54,8 @@ interface BisectStatus {
   remaining?: number | null;
   currentStep?: number | null;
   totalSteps?: number | null;
+  /** Set by git once the search has converged; the session stays active. */
+  culprit?: CulpritCommit | null;
 }
 
 function status(overrides: Partial<BisectStatus> = {}): BisectStatus {
@@ -58,9 +67,17 @@ function status(overrides: Partial<BisectStatus> = {}): BisectStatus {
     remaining: 3,
     currentStep: 1,
     totalSteps: 2,
+    culprit: null,
     ...overrides,
   };
 }
+
+const CULPRIT: CulpritCommit = {
+  oid: 'deadbeefcafe',
+  summary: 'Broke the parser',
+  author: 'A',
+  email: 'a@b.c',
+};
 
 /** Status per repository path, so a tab switch yields a different session. */
 let statusByPath: Record<string, BisectStatus> = {};
@@ -319,6 +336,76 @@ describe('lv-bisect-dialog repository targeting', () => {
 
       expect(dialogPrompts.length, 'one prompt, not two').to.equal(1);
       expect(invokeCalls.filter((c) => c.command === 'bisect_reset').length).to.equal(1);
+    });
+  });
+
+  /**
+   * git keeps the session active until `bisect reset`, which only Finish runs.
+   * Closing the result screen any other way (X, Escape, overlay click) left the
+   * culprit in component state alone, so reopening — including from the
+   * operation banner's "Manage Bisect" — showed Good/Bad/Skip again and the
+   * answer the whole search existed to produce was gone.
+   */
+  describe('reopening a finished search', () => {
+    beforeEach(() => {
+      invokeCalls.length = 0;
+      statusByPath = { [REPO_A]: status(), [REPO_B]: { active: false } };
+      installMock();
+    });
+
+    it('reopens on the result, not back on Good/Bad/Skip', async () => {
+      statusByPath = { [REPO_A]: status({ culprit: CULPRIT }) };
+      const el = await openOn(REPO_A);
+
+      const card = el.shadowRoot!.querySelector('.culprit-card');
+      expect(card, 'the recorded culprit is shown again').to.not.be.null;
+      expect(el.shadowRoot!.querySelector('.culprit-oid')!.textContent).to.contain(CULPRIT.oid);
+      expect(
+        el.shadowRoot!.querySelectorAll('.action-btn').length,
+        'a finished search must not ask for another verdict',
+      ).to.equal(0);
+
+      const footer = [...el.shadowRoot!.querySelectorAll('.dialog-footer button')];
+      expect(footer.map((b) => b.textContent?.trim()).join(' ')).to.contain('Finish');
+    });
+
+    it('a search still in flight stays on Good/Bad/Skip', async () => {
+      statusByPath = { [REPO_A]: status() };
+      const el = await openOn(REPO_A);
+
+      expect(el.shadowRoot!.querySelector('.current-commit'), 'still testing').to.not.be.null;
+      expect(el.shadowRoot!.querySelector('.culprit-card')).to.be.null;
+
+      const footer = [...el.shadowRoot!.querySelectorAll('.dialog-footer button')];
+      expect(footer.map((b) => b.textContent?.trim()).join(' ')).to.contain('Abort Bisect');
+    });
+
+    it('switching repositories drops the finished session', async () => {
+      statusByPath = { [REPO_A]: status({ culprit: CULPRIT }), [REPO_B]: { active: false } };
+      const el = await openOn(REPO_A);
+      expect(el.shadowRoot!.querySelector('.culprit-card')).to.not.be.null;
+
+      el.repositoryPath = REPO_B;
+      await settle(el);
+
+      expect(el.shadowRoot!.querySelector('.culprit-card'), 'repo B has no result').to.be.null;
+      expect(
+        el.shadowRoot!.querySelectorAll('.commit-input input').length,
+        'repo B is back at setup',
+      ).to.equal(2);
+    });
+
+    it('uses the recorded culprit when the step output could not be parsed', async () => {
+      const el = await openOn(REPO_A);
+
+      // The step reports no culprit of its own (git's wording changed, say),
+      // but the refreshed status carries git's record of the result.
+      statusByPath[REPO_A] = status({ culprit: CULPRIT });
+      clickAction(el, 'Good');
+      await settle(el);
+
+      expect(el.shadowRoot!.querySelector('.culprit-card'), 'the answer is shown').to.not.be.null;
+      expect(el.shadowRoot!.querySelector('.culprit-oid')!.textContent).to.contain(CULPRIT.oid);
     });
   });
 });

--- a/src/components/dialogs/lv-bisect-dialog.ts
+++ b/src/components/dialogs/lv-bisect-dialog.ts
@@ -524,10 +524,23 @@ export class LvBisectDialog extends LitElement {
     if (result.success && result.data) {
       this.status = result.data;
       if (result.data.active) {
-        this.step = 'in-progress';
-        // Fetch current commit info
-        if (result.data.currentCommit) {
-          await this.fetchCurrentCommitInfo(result.data.currentCommit);
+        // The session stays active in git until Finish runs `bisect reset`, so
+        // a dialog closed at the result screen (X, Escape, overlay click) must
+        // reopen ON the result. Mapping every active session to 'in-progress'
+        // presented the finished search as unfinished and lost the answer.
+        // Only when a culprit is actually recorded, though: renderComplete
+        // shows nothing but the log without one.
+        if (result.data.culprit) {
+          this.culprit = result.data.culprit;
+          this.currentCommitInfo = null;
+          this.step = 'complete';
+        } else {
+          this.culprit = null;
+          this.step = 'in-progress';
+          // Fetch current commit info
+          if (result.data.currentCommit) {
+            await this.fetchCurrentCommitInfo(result.data.currentCommit);
+          }
         }
       } else {
         this.step = 'setup';
@@ -632,8 +645,13 @@ export class LvBisectDialog extends LitElement {
         this.status = result.data.status;
         this.message = result.data.message;
 
-        if (result.data.culprit) {
-          this.culprit = result.data.culprit;
+        // Either source: the parsed step output, or git's own record of the
+        // result on the refreshed status. Reading only the output meant a
+        // format git changed left the live step disagreeing with what a reopen
+        // would show.
+        const culprit = result.data.culprit ?? result.data.status.culprit;
+        if (culprit) {
+          this.culprit = culprit;
           this.step = 'complete';
         } else if (result.data.status.currentCommit) {
           await this.fetchCurrentCommitInfo(result.data.status.currentCommit);
@@ -671,8 +689,10 @@ export class LvBisectDialog extends LitElement {
         this.status = result.data.status;
         this.message = result.data.message;
 
-        if (result.data.culprit) {
-          this.culprit = result.data.culprit;
+        // Either source — see handleBad.
+        const culprit = result.data.culprit ?? result.data.status.culprit;
+        if (culprit) {
+          this.culprit = culprit;
           this.step = 'complete';
         } else if (result.data.status.currentCommit) {
           await this.fetchCurrentCommitInfo(result.data.status.currentCommit);

--- a/src/components/dialogs/lv-bisect-dialog.ts
+++ b/src/components/dialogs/lv-bisect-dialog.ts
@@ -514,6 +514,12 @@ export class LvBisectDialog extends LitElement {
     const loadedPath = this.repositoryPath;
     this.loading = true;
     this.error = '';
+    // The step messages ("Marked as good", "Bisect session started") describe
+    // the action that produced them, and handleClose leaves component state
+    // alone. Without clearing it here the previous session's last step is
+    // still on screen when the dialog is reopened — or when the repo switches
+    // — captioning a status that was just recomputed from scratch.
+    this.message = '';
 
     const result = await gitService.getBisectStatus(loadedPath);
 
@@ -598,7 +604,16 @@ export class LvBisectDialog extends LitElement {
         this.status = result.data.status;
         this.message = result.data.message;
 
-        if (result.data.status.active) {
+        // A range with a single candidate converges inside `git bisect start`
+        // itself, and the session stays active until reset — so the answer can
+        // already be recorded here. Reading only `active` put that result on a
+        // Good/Bad/Skip screen asking for a verdict git no longer needs.
+        // Same two sources as the step handlers — see handleBad.
+        const culprit = result.data.culprit ?? result.data.status.culprit;
+        if (culprit) {
+          this.culprit = culprit;
+          this.step = 'complete';
+        } else if (result.data.status.active) {
           this.step = 'in-progress';
           if (result.data.status.currentCommit) {
             await this.fetchCurrentCommitInfo(result.data.status.currentCommit);

--- a/src/services/__tests__/bisect.service.test.ts
+++ b/src/services/__tests__/bisect.service.test.ts
@@ -46,6 +46,7 @@ describe('git.service - Bisect operations', () => {
         totalSteps: null,
         currentStep: null,
         log: [],
+        culprit: null,
       };
       mockInvoke = () => Promise.resolve(mockStatus);
 
@@ -118,6 +119,7 @@ describe('git.service - Bisect operations', () => {
           totalSteps: null,
           currentStep: null,
           log: [],
+          culprit: null,
         },
         culprit: null,
         message: 'Bisect started',

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -2102,6 +2102,8 @@ export interface BisectStatus {
   totalSteps: number | null;
   currentStep: number | null;
   log: BisectLogEntry[];
+  /** Set once git has recorded the first bad commit; the session stays active until reset. */
+  culprit: CulpritCommit | null;
 }
 
 export interface CulpritCommit {


### PR DESCRIPTION
## What was broken

git leaves a bisect session **active** until `git bisect reset`, which only the result screen's "Finish" button runs. The culprit, meanwhile, lived exclusively in the dialog's own `@state()` — it reached the component from a step result (`result.data.culprit`) and from nowhere else. `checkBisectStatus` mapped *every* active session to step `'in-progress'`; there was no branch that could reach `'complete'`.

Closing the result screen is completely ungated: the X button, the overlay click and Escape all just dispatch `close`, and the footer at step `'complete'` offers only "Finish". So closing the result any way other than Finish and then reopening the dialog — via the command palette, or via the operation banner's "Manage Bisect", which is shown *precisely because* the repository state is still `Bisect` — ran `checkBisectStatus` and put the user back on Good/Bad/Skip with a "Current Commit to Test" card. The answer the whole search existed to produce was gone, unless the user guessed to re-mark the current commit.

`BisectStatus` had no field that could carry the result, so the backend could not tell the dialog the search was over.

## The fix

git *does* record the result. When the search converges it appends

```
# first <term_bad> commit: [<oid>] <subject>
```

to `BISECT_LOG` and points `refs/bisect/<term_bad>` at the answer.

- **`get_bisect_status`** uses that comment purely as the *signal* that the search finished (`bisect_finished`). The oid comes from `refs/bisect/<term_bad>`, which `get_bisect_status` already resolves into `bad_commit` — the comment's bracket formatting has drifted across git versions, so it is not parsed. `culprit_commit` then describes that oid with one `git log -1`, unit-separated so an empty subject cannot shift the fields. The result rides back on a new `culprit: Option<CulpritCommit>` field on `BisectStatus`.
- **`checkBisectStatus`** moves to `'complete'` when — and only when — a culprit is actually present. `renderComplete` shows nothing but the log without one, so flipping on `active` alone would turn an in-flight search into a blank pane with a Finish button and no way to answer.
- **`handleBad` / `handleGood`** read the culprit from the step output *or* the refreshed status (`result.data.culprit ?? result.data.status.culprit`), so the live step and a reopen can never disagree.

Deliberately left alone:

- The marker is matched against the session's **recorded term** (`read_bisect_terms`), so `--term-new=broken` sessions reach the result screen too.
- It does **not** match skip-exhaustion's `# possible first bad commit:` lines — git has no answer there, and treating one as final would name an arbitrary candidate as the culprit.
- `parse_bisect_log`'s `#`-line filter is untouched, so the result comment stays out of the "Bisect History" list.
- `parse_culprit_from_output`, `bisect_reset`, `handleReset`, `handleClose`, the Escape/overlay gating and the app-shell banner are unchanged. The banner still reads "Bisect in progress" from `repository.state`, which is correct — git's session genuinely is still open until Finish.

The field is additive: existing mocks that omit `culprit` yield `undefined`, which is falsy, so every current test keeps its in-progress behavior.

## Tests

| # | Test | Layer | Covers | Fails without the fix |
|---|------|-------|--------|-----------------------|
| 1 | `test_get_bisect_status_reports_the_culprit_once_the_search_converges` | Rust | Happy path: a converged session is still `active`, and now reports oid + summary | **Verified** — `a converged search must report its answer` |
| 2 | `test_get_bisect_status_has_no_culprit_mid_search` | Rust | Over-reach guard: a search in flight reports no culprit | **Verified** against a naive "active ⇒ culprit = bad_commit" implementation — `a search still in flight has no answer to report` |
| 3 | `test_bisect_finished_matches_the_recorded_term` | Rust | Custom `--term-new`; a mismatched term; skip-exhaustion's `# possible first bad commit:`; the comment staying out of Bisect History | — (unit guard on the new helper) |
| 4 | `test_culprit_commit_ignores_an_unresolvable_oid` | Rust | Error path: status stays `Ok` with `culprit: None` rather than erroring | — (unit guard on the new helper) |
| 5 | `reopens on the result, not back on Good/Bad/Skip` | TS unit | The defect itself: culprit card, no `.action-btn`s, Finish in the footer | **Verified** — `the recorded culprit is shown again: expected null not to be null` |
| 6 | `a search still in flight stays on Good/Bad/Skip` | TS unit | Guard: the fix must not fire on every active session | — |
| 7 | `switching repositories drops the finished session` | TS unit | Cross-repo: repo B (inactive) returns to setup, no stale culprit | **Verified** — `expected null not to be null` |
| 8 | `uses the recorded culprit when the step output could not be parsed` | TS unit | The `?? status.culprit` fallback in `handleGood` | **Verified** — `the answer is shown: expected null not to be null` |
| 9 | `a completed bisect reopens on the result screen` | E2E | Full stack, straight from status with no Good/Bad clicks — this is the reopen path | **Verified** — `locator('lv-bisect-dialog .culprit-card')` element(s) not found |

Reverting only the corresponding production hunk (Rust population / the `checkBisectStatus` branch / the `??` fallback) and re-running produced the failures quoted above; the fix was then restored.

Gate: lint, typecheck, unit, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --lib` all green, plus `e2e/tests/bisect-dialog.spec.ts` (17 passed).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_