### PR TITLE
Cull graph lanes in lane space, never cull commit rows

### DIFF
--- a/src/graph/__tests__/virtual-scroll.test.ts
+++ b/src/graph/__tests__/virtual-scroll.test.ts
@@ -4,7 +4,13 @@
  */
 import { expect } from '@open-wc/testing';
 import { VirtualScrollManager, ScrollStateManager } from '../virtual-scroll.ts';
-import { assignLanes, type GraphCommit } from '../lane-assignment.ts';
+import {
+  assignLanes,
+  type GraphCommit,
+  type GraphLayout,
+  type LayoutEdge,
+  type LayoutNode,
+} from '../lane-assignment.ts';
 
 function makeCommit(oid: string, parentIds: string[], timestamp: number): GraphCommit {
   return { oid, parentIds, timestamp, message: `Commit ${oid}`, author: 'Test' };
@@ -170,5 +176,156 @@ describe('VirtualScrollManager virtual total rows', () => {
     });
     expect(data.nodes).to.have.length(0);
     expect(data.edges).to.have.length(0);
+  });
+});
+
+/**
+ * The graph is drawn mirrored — lane 0 (the HEAD mainline) sits at the RIGHT
+ * edge of the graph and higher lanes extend left — so the visible range has to
+ * be converted out of drawn-column space before anything is culled by lane.
+ */
+describe('VirtualScrollManager wide-graph lane culling', () => {
+  const ROW_HEIGHT = 22;
+  const LANE_WIDTH = 14;
+  const PADDING = 20;
+  const MAX_LANE = 60; // content width = 61 * 14 + 40 = 894
+  const VIEW_W = 400; // maxScrollX = 494
+  const SCROLL_RIGHT = 494; // scrolled fully right, to the message column
+
+  /**
+   * Wide layout: rows alternate between the mainline (lane 0, drawn at the
+   * right of the mirrored graph) and a far side branch (lane maxLane, drawn at
+   * the far left), each with a straight edge to the previous row in its lane.
+   */
+  function makeWideLayout(rows: number, maxLane: number): GraphLayout {
+    const nodes = new Map<string, LayoutNode>();
+    const edges: LayoutEdge[] = [];
+
+    for (let row = 0; row < rows; row++) {
+      const lane = row % 2 === 0 ? 0 : maxLane;
+      const colorIndex = row % 2 === 0 ? 0 : 1;
+      const oid = `n${row}`;
+      nodes.set(oid, {
+        oid,
+        row,
+        lane,
+        commit: {
+          oid,
+          parentIds: [],
+          timestamp: rows - row,
+          message: `Commit ${row}`,
+          author: 'Test',
+        },
+        childLanes: [],
+        parentLanes: [],
+        colorIndex,
+        hasMissingParents: false,
+      });
+      if (row >= 2) {
+        edges.push({
+          fromOid: oid,
+          toOid: `n${row - 2}`,
+          fromRow: row,
+          toRow: row - 2,
+          fromLane: lane,
+          toLane: lane,
+          isMerge: false,
+          colorIndex,
+        });
+      }
+    }
+
+    return { nodes, edges, maxLane, totalRows: rows };
+  }
+
+  function makeManager(rows: number, maxLane: number): VirtualScrollManager {
+    const manager = new VirtualScrollManager({
+      rowHeight: ROW_HEIGHT,
+      laneWidth: LANE_WIDTH,
+      padding: PADDING,
+      overscanRows: 2,
+    });
+    manager.setLayout(makeWideLayout(rows, maxLane));
+    return manager;
+  }
+
+  it('reports the visible range in lane space, not drawn columns', () => {
+    const range = makeManager(40, MAX_LANE).getVisibleRange({
+      scrollTop: 0,
+      scrollLeft: SCROLL_RIGHT,
+      width: VIEW_W,
+      height: 10 * ROW_HEIGHT,
+    });
+
+    // Columns 31..65 are on screen; mirrored, those are lanes 0..29
+    expect(range.startLane).to.equal(0);
+    expect(range.endLane).to.equal(29);
+  });
+
+  it('keeps the mainline visible when scrolled right on a wide graph', () => {
+    const data = makeManager(40, MAX_LANE).getRenderData({
+      scrollTop: 0,
+      scrollLeft: SCROLL_RIGHT,
+      width: VIEW_W,
+      height: 10 * ROW_HEIGHT,
+    });
+
+    expect(data.nodes.some((n) => n.lane === 0)).to.be.true;
+    expect(data.edges.length).to.be.greaterThan(0);
+    expect(data.edges.every((e) => e.fromLane === 0 && e.toLane === 0)).to.be.true;
+  });
+
+  it("returns every visible row's node at any horizontal scroll", () => {
+    const manager = makeManager(40, MAX_LANE);
+
+    for (const scrollLeft of [0, 250, SCROLL_RIGHT]) {
+      const data = manager.getRenderData({
+        scrollTop: 4 * ROW_HEIGHT,
+        scrollLeft,
+        width: VIEW_W,
+        height: 10 * ROW_HEIGHT,
+      });
+
+      // A node carries its whole row's text, so no row may be lane-culled
+      const expectedRows = data.range.endRow - data.range.startRow + 1;
+      expect(data.nodes.length, `scrollLeft ${scrollLeft}`).to.equal(expectedRows);
+      expect(new Set(data.nodes.map((n) => n.row)).size).to.equal(expectedRows);
+    }
+  });
+
+  it('culls the mainline edges when scrolled to the far left of a wide graph', () => {
+    const data = makeManager(40, MAX_LANE).getRenderData({
+      scrollTop: 0,
+      scrollLeft: 0,
+      width: VIEW_W,
+      height: 10 * ROW_HEIGHT,
+    });
+
+    // Only the far side branch is drawn on screen at the left end
+    expect(data.edges.length).to.be.greaterThan(0);
+    expect(data.edges.every((e) => e.fromLane === MAX_LANE)).to.be.true;
+    // ...but the rows themselves still render
+    expect(data.nodes.some((n) => n.lane === 0)).to.be.true;
+  });
+
+  it('does not cull horizontally when the whole graph fits the viewport', () => {
+    const data = makeManager(20, 1).getRenderData({
+      scrollTop: 0,
+      scrollLeft: 0,
+      width: 800,
+      height: 10 * ROW_HEIGHT,
+    });
+
+    expect(data.nodes.length).to.equal(data.range.endRow - data.range.startRow + 1);
+    expect(data.edges.length).to.be.greaterThan(0);
+    expect(data.edges.some((e) => e.fromLane === 0)).to.be.true;
+    expect(data.edges.some((e) => e.fromLane === 1)).to.be.true;
+    expect(
+      data.edges.every(
+        (e) =>
+          Math.min(e.fromRow, e.toRow) <= data.range.endRow &&
+          Math.max(e.fromRow, e.toRow) >= data.range.startRow
+      )
+    ).to.be.true;
   });
 });

--- a/src/graph/__tests__/virtual-scroll.test.ts
+++ b/src/graph/__tests__/virtual-scroll.test.ts
@@ -188,9 +188,10 @@ describe('VirtualScrollManager wide-graph lane culling', () => {
   const ROW_HEIGHT = 22;
   const LANE_WIDTH = 14;
   const PADDING = 20;
-  const MAX_LANE = 60; // content width = 61 * 14 + 40 = 894
-  const VIEW_W = 400; // maxScrollX = 494
-  const SCROLL_RIGHT = 494; // scrolled fully right, to the message column
+  const MAX_LANE = 60;
+  const VIEW_W = 400;
+  const CONTENT_W = (MAX_LANE + 1) * LANE_WIDTH + PADDING * 2;
+  const SCROLL_RIGHT = CONTENT_W - VIEW_W; // scrolled fully right, to the message column
 
   /**
    * Wide layout: rows alternate between the mainline (lane 0, drawn at the
@@ -257,7 +258,10 @@ describe('VirtualScrollManager wide-graph lane culling', () => {
       height: 10 * ROW_HEIGHT,
     });
 
-    // Columns 31..65 are on screen; mirrored, those are lanes 0..29
+    // The computed column window is 31..65 (viewport plus the +/-2 overscan and
+    // ceil() slack; the graph itself only has drawn columns 0..60). Mirrored
+    // back, maxLane - endColumn clamps to lane 0 and maxLane - startColumn
+    // gives lane 29.
     expect(range.startLane).to.equal(0);
     expect(range.endLane).to.equal(29);
   });

--- a/src/graph/virtual-scroll.ts
+++ b/src/graph/virtual-scroll.ts
@@ -35,9 +35,12 @@ export interface VisibleRange {
   startRow: number;
   /** Last visible row (inclusive) */
   endRow: number;
-  /** First visible lane (inclusive) */
+  /**
+   * First visible lane (inclusive). A lane number, NOT a drawn column — the
+   * graph is mirrored, so lane 0 is drawn at the far right.
+   */
   startLane: number;
-  /** Last visible lane (inclusive) */
+  /** Last visible lane (inclusive). A lane number, not a drawn column. */
   endLane: number;
 }
 
@@ -227,15 +230,18 @@ export class VirtualScrollManager {
       Math.ceil((viewport.scrollTop + viewport.height - padding) / rowHeight) + overscanRows
     );
 
-    // Calculate visible lanes
-    const startLane = Math.max(
-      0,
-      Math.floor((viewport.scrollLeft - padding) / laneWidth) - 2
-    );
-    const endLane = Math.min(
-      this.layout.maxLane,
-      Math.ceil((viewport.scrollLeft + viewport.width - padding) / laneWidth) + 2
-    );
+    // Visible drawn columns, measured from the left edge of the graph, +/-2
+    // columns of overscan
+    const startColumn = Math.floor((viewport.scrollLeft - padding) / laneWidth) - 2;
+    const endColumn =
+      Math.ceil((viewport.scrollLeft + viewport.width - padding) / laneWidth) + 2;
+
+    // The graph is mirrored — lane L is DRAWN at column (maxLane - L), lane 0
+    // on the right (see renderEdges/renderNodes in canvas-renderer) — so the
+    // visible columns are converted back to lanes before anything is culled
+    const { maxLane } = this.layout;
+    const startLane = Math.max(0, maxLane - endColumn);
+    const endLane = Math.min(maxLane, maxLane - startColumn);
 
     return { startRow, endRow, startLane, endLane };
   }
@@ -262,7 +268,14 @@ export class VirtualScrollManager {
   }
 
   /**
-   * Get nodes in visible range
+   * Get nodes in visible range.
+   *
+   * Rows are deliberately NOT culled by lane. A node carries its whole row —
+   * avatar, refs, message, stats and time are drawn per-node in fixed columns
+   * to the right of the graph, regardless of the node's lane — so dropping a
+   * node whose dot is scrolled out of view would blank the commit row (and
+   * drop it from the screen-reader mirror). There is exactly one node per row,
+   * so the lane test saved nothing anyway.
    */
   private getVisibleNodes(range: VisibleRange): LayoutNode[] {
     const nodes: LayoutNode[] = [];
@@ -271,9 +284,7 @@ export class VirtualScrollManager {
       const rowNodes = this.nodesByRow.get(row);
       if (rowNodes) {
         for (const node of rowNodes) {
-          if (node.lane >= range.startLane && node.lane <= range.endLane) {
-            nodes.push(node);
-          }
+          nodes.push(node);
         }
       }
     }


### PR DESCRIPTION
## What was broken

The graph is drawn **mirrored**: lane 0 (the HEAD mainline) sits at the *right* edge of the graph and higher lanes extend left. `canvas-renderer.ts` computes `x = offsetX + (maxLane - lane) * laneWidth + laneWidth/2` in both `renderEdges` and `renderNodes`, so **drawn column = maxLane - lane**.

`VirtualScrollManager.getVisibleRange()` derived `startLane`/`endLane` straight from `scrollLeft`, which makes them *drawn column* indices measured from the graph's left edge. But `getVisibleNodes()` and `getVisibleEdges()` compared raw `node.lane` / `edge.fromLane` / `edge.toLane` against that range — the wrong variable. Horizontal culling was therefore **exactly inverted**.

Concretely, with `maxLane 60`, `laneWidth 14`, `padding 20` and a 400px pane scrolled fully right (`scrollLeft 494`), the range came out `startLane 31, endLane 60`: it kept the lane-60 branch, which is drawn off-screen to the *left*, and dropped lane 0, the column actually on screen.

There is a second, independent half to the defect. `nodesByRow` holds exactly one node per row, and each node carries its whole row's text — avatar, refs, message, stats and time are all drawn per-node in `renderRefLabels` at fixed columns to the right of the graph, independent of the node's lane. So lane-culling a node bought zero perf and **blanked the entire commit row** (and dropped it from the screen-reader mirror built from `renderData.nodes`). Since the message column sits past the graph on a wide repo, the commit list went patchily blank exactly when the user scrolled right to read it.

## The fix

Both changes are in `src/graph/virtual-scroll.ts`:

1. **`getVisibleRange()`** computes the visible drawn columns (with the same ±2 overscan), then converts them back to lane numbers via `maxLane - column` before returning. `startLane`/`endLane` are now genuinely lane numbers, as the doc comments on `VisibleRange` now state.
2. **`getVisibleNodes()`** no longer lane-culls at all — every node on a visible row is returned, with a comment explaining why (one node per row, and the node carries the row's text).

`getVisibleEdges()` needed **no change**: its `minLane`/`maxLane` overlap test becomes correct for free now that both sides are lane numbers. Edge culling is graph-only geometry and is deliberately kept — it is the remaining horizontal culling and matters on large graphs.

Accepted behavioural consequence: at most one extra node dot per visible row is handed to the renderer when it is scrolled out of view horizontally (the canvas clips it), and `renderRefLabels` now pushes an avatar hitbox for every visible row — which is the point, since those rows are on screen.

Scope note: `graphToScreen`/`screenToGraph`/`scrollToNode` also compute x without mirroring, so scroll-to-node moves the wrong way on wide graphs. That is a separate defect and is intentionally left alone here.

## Tests

All in `src/graph/__tests__/virtual-scroll.test.ts`, in a new `VirtualScrollManager wide-graph lane culling` block. It builds a deterministic hand-made layout (rows alternating between lane 0 and lane 60, each with a straight edge to the previous row in its lane) so lane numbers are exact.

| Test | Covers | Fails without the fix |
| --- | --- | --- |
| reports the visible range in lane space, not drawn columns | The mirroring conversion itself | Yes — `AssertionError: expected 31 to equal 0` |
| keeps the mainline visible when scrolled right on a wide graph | Happy path / the reported symptom | Yes — `expected false to be true` (no lane-0 node survives) |
| returns every visible row's node at any horizontal scroll | The row-text half, at 3 scroll positions | Yes — `scrollLeft 0: expected 8 to equal 16` (half the rows culled) |
| culls the mainline edges when scrolled to the far left of a wide graph | Edge case: opposite scroll end, edge culling still works and is now the right way round | Yes — `expected false to be true` (inverted code returns the lane-0 edges) |
| does not cull horizontally when the whole graph fits the viewport | Regression guard against over-culling narrow graphs | No — passes before and after, by design |

Verified by reverting only the `virtual-scroll.ts` production hunks (leaving the tests) and re-running the file: the first four tests failed with the messages above, the guard passed, and all nine pre-existing tests in the file passed (they use single-lane chains, where `maxLane` is 0 and the conversion is a no-op).

Gate: `npm run lint`, `npm run typecheck` and `npm test` all pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_