### PR TITLE
Toast when opening a repository from the welcome screen fails

### DIFF
--- a/e2e/tests/welcome.spec.ts
+++ b/e2e/tests/welcome.spec.ts
@@ -123,6 +123,30 @@ test.describe('Welcome Screen with Recent Repositories', () => {
       await expect(app.welcomeScreen).toBeVisible();
     }
   });
+
+  test('surfaces an error toast when a recent repository can no longer be opened', async ({ page }) => {
+    // The recent list is restored from the persisted store, not from a command,
+    // so seed it directly to guarantee an entry to click.
+    await page.evaluate(() => {
+      const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as {
+        repositoryStore: { setState: (s: Record<string, unknown>) => void };
+      };
+      stores.repositoryStore.setState({
+        recentRepositories: [{ path: '/path/to/gone', name: 'gone', lastOpened: Date.now() }],
+      });
+    });
+    await expect(app.recentItems).toHaveCount(1);
+
+    await startCommandCapture(page);
+    await injectCommandError(page, 'open_repository', 'failed to open repository: /path/to/gone');
+
+    await app.recentItems.first().click();
+
+    // A moved or deleted repo must tell the user — repositoryStore.error is never rendered
+    const toastMessage = page.locator('lv-toast-container .toast.error .toast-message');
+    await expect(toastMessage).toContainText('failed to open repository', { timeout: 5000 });
+    await expect(app.welcomeScreen).toBeVisible();
+  });
 });
 
 test.describe('Clone Dialog', () => {

--- a/src/components/welcome/__tests__/lv-welcome-open.test.ts
+++ b/src/components/welcome/__tests__/lv-welcome-open.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Tests for the welcome screen's single-repository open flow: a repository
+ * that can no longer be opened (moved, deleted) must tell the user, since
+ * repositoryStore.error is never rendered anywhere.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
+const mockResponses: Record<string, (args: Record<string, unknown>) => unknown> = {};
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCallArgs.push({ command, args: args || {} });
+    const handler = mockResponses[command];
+    try {
+      return Promise.resolve(handler ? handler(args || {}) : null);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-welcome.ts';
+import { repositoryStore, uiStore } from '../../../stores/index.ts';
+
+function mockRepoPayload(path: string) {
+  return {
+    path,
+    name: path.split('/').pop(),
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+/** Polls until `predicate` holds, so async work started by Lit can settle. */
+async function waitUntil(predicate: () => boolean, what: string): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  throw new Error(`timed out waiting for ${what}`);
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('lv-welcome repository open', () => {
+  beforeEach(() => {
+    invokeCallArgs.length = 0;
+    for (const key of Object.keys(mockResponses)) {
+      delete mockResponses[key];
+    }
+    uiStore.setState({ toasts: [] });
+    repositoryStore.getState().reset();
+  });
+
+  it('toasts when the repository cannot be opened', async () => {
+    mockResponses['open_repository'] = () => {
+      throw new Error('failed to open repository: /gone');
+    };
+    const el = document.createElement('lv-welcome') as HTMLElement;
+
+    await (el as any).openRepoByPath('/gone');
+
+    const toasts = uiStore.getState().toasts;
+    expect(toasts.length).to.equal(1);
+    expect(toasts[0].type).to.equal('error');
+    expect(toasts[0].message).to.contain('failed to open repository');
+
+    // The store write is retained alongside the toast
+    expect(repositoryStore.getState().error).to.not.equal(null);
+    expect(repositoryStore.getState().openRepositories.length).to.equal(0);
+  });
+
+  it('toasts when the open throws after the command succeeds', async () => {
+    mockResponses['open_repository'] = (args) => mockRepoPayload(args.path as string);
+    const el = document.createElement('lv-welcome') as HTMLElement;
+
+    // reset() restores data fields only, so this stub would leak into later
+    // tests — restore it explicitly.
+    const originalAdd = repositoryStore.getState().addRepository;
+    repositoryStore.setState({
+      addRepository: () => {
+        throw new Error('store rejected the repository');
+      },
+    } as any);
+    try {
+      await (el as any).openRepoByPath('/ws/one');
+    } finally {
+      repositoryStore.setState({ addRepository: originalAdd } as any);
+    }
+
+    const toasts = uiStore.getState().toasts;
+    expect(toasts.length).to.equal(1);
+    expect(toasts[0].type).to.equal('error');
+    expect(toasts[0].message).to.equal('store rejected the repository');
+    expect(repositoryStore.getState().isLoading).to.equal(false);
+  });
+
+  it('opens the repository without an error toast on success', async () => {
+    mockResponses['open_repository'] = (args) => mockRepoPayload(args.path as string);
+    const el = document.createElement('lv-welcome') as HTMLElement;
+
+    await (el as any).openRepoByPath('/ws/one');
+
+    const state = repositoryStore.getState();
+    expect(state.openRepositories.length).to.equal(1);
+    expect(state.openRepositories[0].repository.path).to.equal('/ws/one');
+    expect(uiStore.getState().toasts.filter((t) => t.type === 'error').length).to.equal(0);
+  });
+
+  it('surfaces the failure when a recent repository is clicked', async () => {
+    repositoryStore.setState({
+      recentRepositories: [{ path: '/gone', name: 'gone', lastOpened: Date.now() }],
+    } as any);
+    mockResponses['open_repository'] = () => {
+      throw new Error('failed to open repository: /gone');
+    };
+
+    const el = await fixture<any>(html`<lv-welcome></lv-welcome>`);
+    await el.updateComplete;
+
+    const item = el.shadowRoot!.querySelector('.recent-item') as HTMLButtonElement;
+    item.click();
+
+    await waitUntil(() => uiStore.getState().toasts.length > 0, 'the failed recent-open toast');
+
+    const toasts = uiStore.getState().toasts;
+    expect(toasts[0].type).to.equal('error');
+    expect(toasts[0].message).to.contain('/gone');
+    expect(repositoryStore.getState().isLoading).to.equal(false);
+  });
+});

--- a/src/components/welcome/lv-welcome.ts
+++ b/src/components/welcome/lv-welcome.ts
@@ -381,10 +381,15 @@ export class LvWelcome extends LitElement {
         // Build search index in background (non-blocking)
         searchIndexService.buildIndex(path);
       } else {
-        store.setError(result.error?.message ?? 'Failed to open repository');
+        const message = result.error?.message ?? 'Failed to open repository';
+        store.setError(message);
+        // repositoryStore.error has no render sink, so surface it directly.
+        showToast(message, 'error');
       }
     } catch (err) {
-      store.setError(err instanceof Error ? err.message : 'Unknown error');
+      const message = err instanceof Error ? err.message : 'Unknown error';
+      store.setError(message);
+      showToast(message, 'error');
     } finally {
       store.setLoading(false);
     }


### PR DESCRIPTION
## What was broken

`LvWelcome.openRepoByPath()` (`src/components/welcome/lv-welcome.ts`) reported both of its failure paths only through `repositoryStore.setError(...)`. That field has no render sink anywhere in the app — `lv-toolbar.ts:442` documents this explicitly ("repositoryStore.error has no render sink, so surface it directly") and `lv-context-dashboard.ts:707` says the same — and `lv-welcome`'s own store subscription reads only `recentRepositories` and `isLoading`.

So a user on the welcome screen who clicked a recent repository that had been moved or deleted (`handleRecentClick` → `openRepoByPath`) saw **nothing at all**: no toast, no banner, no state change. The click looked like it had never registered. Nothing downstream toasts either — `git.service.openRepository` is a bare `invokeCommand` passthrough, and `invokeCommand` only writes the output panel. The toolbar's identical open path already toasts, so this was the one silent sibling.

## The fix

Hoist the message into a local and surface it with `showToast(message, 'error')` in both failure branches, mirroring `lv-toolbar.handleOpenRepo` verbatim. `showToast` was already imported; no new imports.

- The `store.setError` calls stay — `setError` also clears `isLoading`, and the toolbar keeps both.
- The success branch, `handleOpen` (whose `catch` only fires if the file dialog itself throws, before `openRepoByPath` runs) and `handleWorkspaceClick` (which deliberately aggregates per-repo failures into one toast and never routes through `openRepoByPath`) are untouched, so there is no double-toast path.

## Tests

| Test | File | Covers | Fails without the fix |
| --- | --- | --- | --- |
| toasts when the repository cannot be opened | `src/components/welcome/__tests__/lv-welcome-open.test.ts` | error path — command failure (`else` branch); also asserts `error` is still written to the store and no repo was opened | Yes — `expected 0 to equal 1` (toast count) |
| toasts when the open throws after the command succeeds | same | error path — the `catch` branch; also asserts `isLoading` was cleared by the `finally` | Yes — `expected 0 to equal 1` (toast count) |
| opens the repository without an error toast on success | same | happy path; overreach guard against toasting unconditionally | No, by design — it exists to catch an over-broad fix |
| surfaces the failure when a recent repository is clicked | same | edge case — real entry point, clicking a dead Recent entry through the rendered DOM | Yes — `timed out waiting for the failed recent-open toast` |
| surfaces an error toast when a recent repository can no longer be opened | `e2e/tests/welcome.spec.ts` | end-to-end: click a Recent entry whose `open_repository` errors, assert the error toast and that the welcome screen stays up | Yes — `expect(locator).toContainText(...) failed: element(s) not found` |

All five were run with the two `showToast` lines reverted to confirm the failures above, then restored.

Note on the e2e test: the `Welcome Screen with Recent Repositories` describe block mocks `get_recent_repositories`, but nothing in the app consumes that command — the recent list is restored from the persisted store — so the neighbouring test's `if (itemCount > 0)` guard was silently skipping its assertions. The new test seeds `recentRepositories` through the store exposed on `window.__LEVIATHAN_STORES__` and asserts the item rendered, so it cannot no-op. The stale existing test is left alone as out of scope.

Gate: `npm run lint`, `npm run typecheck`, `npm test` all green; `npx playwright test e2e/tests/welcome.spec.ts` → 35 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_