### PR TITLE
Show the rename diff when opening a renamed file from a commit

### DIFF
--- a/e2e/tests/commit-details.spec.ts
+++ b/e2e/tests/commit-details.spec.ts
@@ -1,7 +1,13 @@
 import { test, expect } from '@playwright/test';
 import { setupOpenRepository } from '../fixtures/tauri-mock';
 import { RightPanelPage } from '../pages/panels.page';
-import { startCommandCapture, injectCommandMock, injectCommandError } from '../fixtures/test-helpers';
+import {
+  startCommandCapture,
+  startCommandCaptureWithMocks,
+  findCommand,
+  injectCommandMock,
+  injectCommandError,
+} from '../fixtures/test-helpers';
 
 /**
  * Helper to select a commit by dispatching the commit-selected event on the graph canvas.
@@ -355,7 +361,7 @@ test.describe('Commit Details - UI Outcome Verification', () => {
     // Provide commit files
     await injectCommandMock(page, {
       get_commit_files: mockFiles,
-      get_commit_diff: {
+      get_commit_file_diff: {
         path: 'src/main.ts',
         oldPath: null,
         status: 'modified',
@@ -394,9 +400,12 @@ test.describe('Commit Details - UI Outcome Verification', () => {
     // Verify the file becomes selected
     await expect(rightPanel.commitFilesChanged.first()).toHaveClass(/selected/);
 
-    // Verify the diff view becomes visible with content
+    // Verify the diff view becomes visible with the mocked content
     const diffView = page.locator('lv-diff-view');
     await expect(diffView).toBeVisible({ timeout: 5000 });
+    await expect(diffView.locator('.line.code-addition')).toHaveCount(1);
+    await expect(diffView.locator('.line.code-deletion')).toHaveCount(1);
+    await expect(diffView.locator('.line.code-addition')).toContainText('const x = 2;');
   });
 
   test('merge commit with multiple parents should show merge info', async ({ page }) => {
@@ -462,5 +471,123 @@ test.describe('Commit Details - UI Outcome Verification', () => {
     // Verify no parent OID links are shown for a root commit
     const parentOids = rightPanel.commitDetails.locator('.parent-oid');
     await expect(parentOids).toHaveCount(0);
+  });
+});
+
+test.describe('Commit Details - Renamed Files', () => {
+  /** The rename entry the backend reports for a moved-and-edited file. */
+  const renamedEntry = {
+    path: 'src/new_name.ts',
+    oldPath: 'src/old_name.ts',
+    status: 'renamed',
+    additions: 1,
+    deletions: 1,
+  };
+
+  test('clicking a renamed file shows the rename diff, not the whole file as added', async ({
+    page,
+  }) => {
+    const rightPanel = new RightPanelPage(page);
+    await setupOpenRepository(page);
+
+    await startCommandCaptureWithMocks(page, {
+      get_commit_files: [renamedEntry],
+      get_commit_file_diff: {
+        path: 'src/new_name.ts',
+        oldPath: 'src/old_name.ts',
+        status: 'renamed',
+        hunks: [
+          {
+            header: '@@ -1,4 +1,4 @@',
+            oldStart: 1,
+            oldLines: 4,
+            newStart: 1,
+            newLines: 4,
+            lines: [
+              { content: 'alpha', origin: 'context', oldLineNo: 1, newLineNo: 1 },
+              { content: 'beta', origin: 'deletion', oldLineNo: 2, newLineNo: null },
+              { content: 'beta-edited', origin: 'addition', oldLineNo: null, newLineNo: 2 },
+              { content: 'gamma', origin: 'context', oldLineNo: 3, newLineNo: 3 },
+            ],
+          },
+        ],
+        isBinary: false,
+        isImage: false,
+        imageType: null,
+        additions: 1,
+        deletions: 1,
+      },
+    });
+
+    await selectCommit(page, defaultCommit);
+    await rightPanel.switchToDetails();
+
+    // The file list must badge the entry as a rename and name where it came from.
+    await expect(rightPanel.commitFilesChanged).toHaveCount(1);
+    await expect(rightPanel.commitFilesChanged.first().locator('.file-status')).toHaveText('R');
+    await expect(rightPanel.commitFilesChanged.first().locator('.file-renamed-from')).toContainText(
+      'src/old_name.ts'
+    );
+
+    await rightPanel.commitFilesChanged.first().click();
+
+    const diffView = page.locator('lv-diff-view');
+    await expect(diffView).toBeVisible({ timeout: 5000 });
+
+    // Only the edited pair renders — a whole-file add would show every line as
+    // an addition and none as a deletion.
+    await expect(diffView.locator('.line.code-addition')).toHaveCount(1);
+    await expect(diffView.locator('.line.code-addition')).toContainText('beta-edited');
+    await expect(diffView.locator('.line.code-deletion')).toHaveCount(1);
+    await expect(diffView.locator('.line.code-deletion')).toContainText('beta');
+
+    // The command must be asked for the file's current path in this commit.
+    const calls = await findCommand(page, 'get_commit_file_diff');
+    expect(calls.length).toBeGreaterThan(0);
+    expect((calls[0].args as { filePath: string }).filePath).toBe('src/new_name.ts');
+    expect((calls[0].args as { commitOid: string }).commitOid).toBe(defaultCommit.oid);
+  });
+
+  test('a pure rename shows the empty-diff notice rather than a blank pane', async ({ page }) => {
+    const rightPanel = new RightPanelPage(page);
+    await setupOpenRepository(page);
+
+    await injectCommandMock(page, {
+      get_commit_files: [{ ...renamedEntry, additions: 0, deletions: 0 }],
+      get_commit_file_diff: {
+        path: 'src/new_name.ts',
+        oldPath: 'src/old_name.ts',
+        status: 'renamed',
+        hunks: [],
+        isBinary: false,
+        isImage: false,
+        imageType: null,
+        additions: 0,
+        deletions: 0,
+      },
+    });
+
+    await selectCommit(page, defaultCommit);
+    await rightPanel.switchToDetails();
+    await rightPanel.commitFilesChanged.first().click();
+
+    const diffView = page.locator('lv-diff-view');
+    await expect(diffView.locator('.empty')).toHaveText('No changes in this file');
+    await expect(diffView.locator('.line.code-addition')).toHaveCount(0);
+  });
+
+  test('a failing rename diff shows an error instead of an empty pane', async ({ page }) => {
+    const rightPanel = new RightPanelPage(page);
+    await setupOpenRepository(page);
+
+    await injectCommandMock(page, { get_commit_files: [renamedEntry] });
+    await injectCommandError(page, 'get_commit_file_diff', 'File not found in commit');
+
+    await selectCommit(page, defaultCommit);
+    await rightPanel.switchToDetails();
+    await rightPanel.commitFilesChanged.first().click();
+
+    const diffView = page.locator('lv-diff-view');
+    await expect(diffView.locator('.error')).toContainText('File not found in commit');
   });
 });

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -2278,8 +2278,9 @@ mod tests {
         assert_eq!(stats[0].files_changed, 1);
     }
 
-    /// Clicking a file the commit's file list badges "renamed" must show the
-    /// rename diff (only the edited lines), not the whole file as added.
+    /// Clicking a file that the commit's file list badges as "renamed" must
+    /// show the rename diff (only the edited lines), not the whole file as
+    /// added.
     #[tokio::test]
     async fn test_get_commit_file_diff_renamed_with_edit() {
         let repo = TestRepo::with_initial_commit();

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -761,24 +761,82 @@ pub async fn get_commit_file_diff(
     // rename-aware result — the same view the file list gets from
     // `get_commit_files`. Only those two statuses can be half of a rename, so
     // every other file still costs a single path-filtered diff.
-    if filtered
-        .as_ref()
-        .is_some_and(|f| matches!(f.status, FileStatus::New | FileStatus::Deleted))
+    //
+    // A root commit has no parent tree, so its diff holds nothing but `Added`
+    // deltas; a rename needs a deleted side, and `detect_renames` does not
+    // enable copy detection, so no `Renamed`/`Copied` delta can exist. Skip the
+    // whole fallback there rather than re-diffing the largest tree in the repo
+    // only to hand back what `filtered` already holds.
+    if parent_tree.is_some()
+        && filtered
+            .as_ref()
+            .is_some_and(|f| matches!(f.status, FileStatus::New | FileStatus::Deleted))
     {
         let mut full_diff =
             repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)?;
         detect_renames(&mut full_diff)?;
 
-        // `parse_diff` fills `old_path` for every delta (libgit2 reports the
-        // new path there for a plain addition), so the old-path match must stay
-        // gated on Renamed/Copied or unrelated added files would match it.
-        let matched = parse_diff(&full_diff)?.into_iter().find(|f| {
-            f.path == normalized_file_path
-                || (matches!(f.status, FileStatus::Renamed | FileStatus::Copied)
-                    && f.old_path.as_deref() == Some(normalized_file_path.as_str()))
-        });
-        if let Some(found) = matched {
-            return Ok(maybe_truncate_diff(found, max_lines));
+        // Decide from delta metadata alone. `deltas()` walks the delta list
+        // without generating a patch, whereas `parse_diff` prints every hunk of
+        // every file in the commit — so resolving one path used to cost a full
+        // render of the whole commit, which `max_lines` (applied only after the
+        // parse) could not bound.
+        //
+        // libgit2 reports the new path in `old_file()` for a plain addition, so
+        // the old-path match must stay gated on Renamed/Copied or unrelated
+        // added files would match it. Prefer a delta owning this path as its
+        // new path: only when that delta is itself a rename/copy, or no such
+        // delta exists, does the old-path side apply.
+        let target = normalized_file_path.as_str();
+        let rename_paths = full_diff
+            .deltas()
+            .find(|delta| {
+                delta
+                    .new_file()
+                    .path()
+                    .map(|p| p.to_string_lossy())
+                    .as_deref()
+                    == Some(target)
+            })
+            .filter(|delta| matches!(delta.status(), git2::Delta::Renamed | git2::Delta::Copied))
+            .or_else(|| {
+                full_diff.deltas().find(|delta| {
+                    matches!(delta.status(), git2::Delta::Renamed | git2::Delta::Copied)
+                        && delta
+                            .old_file()
+                            .path()
+                            .map(|p| p.to_string_lossy())
+                            .as_deref()
+                            == Some(target)
+                })
+            })
+            .and_then(|delta| {
+                let old_path = delta.old_file().path()?.to_string_lossy().into_owned();
+                let new_path = delta.new_file().path()?.to_string_lossy().into_owned();
+                Some((old_path, new_path))
+            });
+
+        // Both halves of the pair are in this diff, so `find_similar` can still
+        // match them, but the patch we render is bounded to the one file.
+        if let Some((old_path, new_path)) = rename_paths {
+            let mut pair_opts = git2::DiffOptions::new();
+            pair_opts.pathspec(&old_path);
+            pair_opts.pathspec(&new_path);
+            let mut pair_diff = repo.diff_tree_to_tree(
+                parent_tree.as_ref(),
+                Some(&commit_tree),
+                Some(&mut pair_opts),
+            )?;
+            detect_renames(&mut pair_diff)?;
+
+            let matched = parse_diff(&pair_diff)?.into_iter().find(|f| {
+                f.path == normalized_file_path
+                    || (matches!(f.status, FileStatus::Renamed | FileStatus::Copied)
+                        && f.old_path.as_deref() == Some(target))
+            });
+            if let Some(found) = matched {
+                return Ok(maybe_truncate_diff(found, max_lines));
+            }
         }
     }
 
@@ -2315,6 +2373,148 @@ mod tests {
             "dissimilar add must not be paired as a rename"
         );
         assert_eq!(f.additions, 4);
+        assert_eq!(f.deletions, 0);
+    }
+
+    /// Build a commit that rewrites `bulk` large files wholesale and renames
+    /// `old` to `new`. Every bulk file is a full-file rewrite, so the commit's
+    /// patch is large while the rename's own patch stays tiny.
+    fn commit_bulk_rewrite_with_rename(
+        repo: &TestRepo,
+        bulk: usize,
+        lines: usize,
+        old: &str,
+        new: &str,
+        new_content: &str,
+    ) -> git2::Oid {
+        let git = repo.repo();
+        let mut index = git.index().unwrap();
+
+        for i in 0..bulk {
+            let name = format!("bulk/f{i:04}.txt");
+            let body: String = (0..lines)
+                .map(|l| format!("v2 file {i} line {l}\n"))
+                .collect();
+            repo.create_file(&name, &body);
+            index.add_path(Path::new(&name)).unwrap();
+        }
+
+        repo.create_file(new, new_content);
+        std::fs::remove_file(repo.path.join(old)).unwrap();
+        index.remove_path(Path::new(old)).unwrap();
+        index.add_path(Path::new(new)).unwrap();
+        index.write().unwrap();
+
+        let tree = git.find_tree(index.write_tree().unwrap()).unwrap();
+        let sig = git.signature().unwrap();
+        let parent = git.head().unwrap().peel_to_commit().unwrap();
+        git.commit(Some("HEAD"), &sig, &sig, "bulk rewrite", &tree, &[&parent])
+            .unwrap()
+    }
+
+    /// Opening one renamed file must not render the whole commit's patch. The
+    /// rename fallback used to `parse_diff` the entire whole-tree diff — every
+    /// hunk of every file — and throw all but one entry away, so viewing a
+    /// single file in a large commit cost as much as viewing the whole commit.
+    ///
+    /// The budget is measured against `get_diff` on the same commit rather than
+    /// a fixed duration, so it tracks the machine's own speed instead of
+    /// flaking on a slow runner. The single-file call runs first, on the colder
+    /// object cache, so the comparison never flatters it.
+    #[tokio::test]
+    async fn test_get_commit_file_diff_rename_does_not_render_whole_commit() {
+        const BULK_FILES: usize = 150;
+        const BULK_LINES: usize = 400;
+
+        let repo = TestRepo::with_initial_commit();
+
+        // Base commit: the bulk files plus the file that will be renamed.
+        {
+            let git = repo.repo();
+            let mut index = git.index().unwrap();
+            for i in 0..BULK_FILES {
+                let name = format!("bulk/f{i:04}.txt");
+                let body: String = (0..BULK_LINES)
+                    .map(|l| format!("v1 file {i} line {l}\n"))
+                    .collect();
+                repo.create_file(&name, &body);
+                index.add_path(Path::new(&name)).unwrap();
+            }
+            repo.create_file("old_name.txt", "alpha\nbeta\ngamma\ndelta\n");
+            index.add_path(Path::new("old_name.txt")).unwrap();
+            index.write().unwrap();
+            let tree = git.find_tree(index.write_tree().unwrap()).unwrap();
+            let sig = git.signature().unwrap();
+            let parent = git.head().unwrap().peel_to_commit().unwrap();
+            git.commit(Some("HEAD"), &sig, &sig, "base", &tree, &[&parent])
+                .unwrap();
+        }
+
+        let oid = commit_bulk_rewrite_with_rename(
+            &repo,
+            BULK_FILES,
+            BULK_LINES,
+            "old_name.txt",
+            "new_name.txt",
+            "alpha\nbeta-edited\ngamma\ndelta\n",
+        );
+
+        let started = std::time::Instant::now();
+        let f = get_commit_file_diff(
+            repo.path_str(),
+            oid.to_string(),
+            "new_name.txt".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+        let single_file = started.elapsed();
+
+        // The rename must still resolve correctly — the fast path is only worth
+        // anything if it returns the same answer.
+        assert_eq!(f.status, FileStatus::Renamed);
+        assert_eq!(f.path, "new_name.txt");
+        assert_eq!(f.old_path.as_deref(), Some("old_name.txt"));
+        assert_eq!(f.additions, 1, "only the edited line is added");
+        assert_eq!(f.deletions, 1, "only the edited line is removed");
+
+        let started = std::time::Instant::now();
+        let whole = get_diff(repo.path_str(), None, Some(oid.to_string()), None)
+            .await
+            .unwrap();
+        let whole_commit = started.elapsed();
+        assert_eq!(
+            whole.len(),
+            BULK_FILES + 1,
+            "whole-commit diff must cover every rewritten file plus the rename"
+        );
+
+        assert!(
+            single_file * 4 < whole_commit,
+            "one renamed file took {single_file:?}, nearly as long as rendering the \
+             whole {BULK_FILES}-file commit ({whole_commit:?}) — the fallback is \
+             still parsing the entire commit patch"
+        );
+    }
+
+    /// A root commit has no parent, so it can hold no rename: every file is an
+    /// addition. Skipping the rename fallback there must not change what the
+    /// caller sees for an added file in an initial commit.
+    #[tokio::test]
+    async fn test_get_commit_file_diff_added_file_in_root_commit() {
+        let repo = TestRepo::new();
+        let oid = repo.create_commit(
+            "initial",
+            &[("a.txt", "one\ntwo\nthree\n"), ("b.txt", "other\n")],
+        );
+
+        let f = get_commit_file_diff(repo.path_str(), oid.to_string(), "a.txt".to_string(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(f.status, FileStatus::New);
+        assert_eq!(f.path, "a.txt");
+        assert_eq!(f.additions, 3);
         assert_eq!(f.deletions, 0);
     }
 

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -741,18 +741,48 @@ pub async fn get_commit_file_diff(
     let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
     let commit_tree = commit.tree()?;
 
+    // Normalize path separators for git (always use forward slashes)
+    let normalized_file_path = file_path.replace('\\', "/");
+
     let mut opts = git2::DiffOptions::new();
-    opts.pathspec(&file_path);
+    opts.pathspec(&normalized_file_path);
 
     let mut diff =
         repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), Some(&mut opts))?;
 
     detect_renames(&mut diff)?;
 
-    let files = parse_diff(&diff)?;
-    files
-        .into_iter()
-        .next()
+    let filtered = parse_diff(&diff)?.into_iter().next();
+
+    // The two halves of a rename live at different paths, so the pathspec above
+    // keeps only one of them and `find_similar` has nothing left to pair it
+    // with: the file comes back as a whole-file add (or delete). Re-diff the
+    // whole tree, where both halves are present, and pick our file out of the
+    // rename-aware result — the same view the file list gets from
+    // `get_commit_files`. Only those two statuses can be half of a rename, so
+    // every other file still costs a single path-filtered diff.
+    if filtered
+        .as_ref()
+        .is_some_and(|f| matches!(f.status, FileStatus::New | FileStatus::Deleted))
+    {
+        let mut full_diff =
+            repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)?;
+        detect_renames(&mut full_diff)?;
+
+        // `parse_diff` fills `old_path` for every delta (libgit2 reports the
+        // new path there for a plain addition), so the old-path match must stay
+        // gated on Renamed/Copied or unrelated added files would match it.
+        let matched = parse_diff(&full_diff)?.into_iter().find(|f| {
+            f.path == normalized_file_path
+                || (matches!(f.status, FileStatus::Renamed | FileStatus::Copied)
+                    && f.old_path.as_deref() == Some(normalized_file_path.as_str()))
+        });
+        if let Some(found) = matched {
+            return Ok(maybe_truncate_diff(found, max_lines));
+        }
+    }
+
+    filtered
         .map(|f| maybe_truncate_diff(f, max_lines))
         .ok_or_else(|| {
             crate::error::LeviathanError::OperationFailed("File not found in commit".to_string())
@@ -2188,6 +2218,104 @@ mod tests {
         assert_eq!(stats[0].additions, 0);
         assert_eq!(stats[0].deletions, 0);
         assert_eq!(stats[0].files_changed, 1);
+    }
+
+    /// Clicking a file the commit's file list badges "renamed" must show the
+    /// rename diff (only the edited lines), not the whole file as added.
+    #[tokio::test]
+    async fn test_get_commit_file_diff_renamed_with_edit() {
+        let repo = TestRepo::with_initial_commit();
+        let before = "alpha\nbeta\ngamma\ndelta\nepsilon\nzeta\n";
+        let after = "alpha\nbeta\ngamma-edited\ndelta\nepsilon\nzeta\n";
+        repo.create_commit("add", &[("old_name.txt", before)]);
+        let oid = commit_rename(&repo, "old_name.txt", "new_name.txt", after);
+
+        let f = get_commit_file_diff(
+            repo.path_str(),
+            oid.to_string(),
+            "new_name.txt".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(f.status, FileStatus::Renamed);
+        assert_eq!(f.path, "new_name.txt");
+        assert_eq!(f.old_path.as_deref(), Some("old_name.txt"));
+        assert_eq!(f.additions, 1, "only the edited line is added");
+        assert_eq!(f.deletions, 1, "only the edited line is removed");
+    }
+
+    /// A rename with no content change must report no hunks and 0/0 stats,
+    /// matching `git show` for a pure rename.
+    #[tokio::test]
+    async fn test_get_commit_file_diff_pure_rename_has_no_hunks() {
+        let repo = TestRepo::with_initial_commit();
+        let content = "line1\nline2\nline3\nline4\nline5\n";
+        repo.create_commit("add", &[("a.txt", content)]);
+        let oid = commit_rename(&repo, "a.txt", "b.txt", content);
+
+        let f = get_commit_file_diff(repo.path_str(), oid.to_string(), "b.txt".to_string(), None)
+            .await
+            .unwrap();
+
+        assert_eq!(f.status, FileStatus::Renamed);
+        assert_eq!(f.old_path.as_deref(), Some("a.txt"));
+        assert_eq!(f.additions, 0, "a pure rename adds no lines");
+        assert_eq!(f.deletions, 0);
+        assert!(f.hunks.is_empty(), "a pure rename has no hunks");
+    }
+
+    /// Asking for the *old* path of a rename must resolve to the same rename
+    /// entry, not a whole-file deletion.
+    #[tokio::test]
+    async fn test_get_commit_file_diff_old_path_of_rename() {
+        let repo = TestRepo::with_initial_commit();
+        let content = "one\ntwo\nthree\nfour\nfive\nsix\n";
+        repo.create_commit("add", &[("src/old.txt", content)]);
+        let oid = commit_rename(&repo, "src/old.txt", "src/new.txt", content);
+
+        let f = get_commit_file_diff(
+            repo.path_str(),
+            oid.to_string(),
+            "src/old.txt".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(f.status, FileStatus::Renamed);
+        assert_eq!(f.path, "src/new.txt");
+        assert_eq!(f.old_path.as_deref(), Some("src/old.txt"));
+        assert_eq!(f.deletions, 0, "the file was moved, not deleted");
+    }
+
+    /// Guard: a file added alongside an unrelated deletion must stay a plain
+    /// addition — the rename fallback must never hand back the wrong file.
+    #[tokio::test]
+    async fn test_get_commit_file_diff_add_alongside_unrelated_delete_stays_new() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("add", &[("gone.txt", "qqq\nrrr\nsss\nttt\n")]);
+        // Delete gone.txt and add a wholly dissimilar file in the same commit.
+        let added = "totally\ndifferent\ncontent\nhere\n";
+        let oid = commit_rename(&repo, "gone.txt", "fresh.txt", added);
+
+        let f = get_commit_file_diff(
+            repo.path_str(),
+            oid.to_string(),
+            "fresh.txt".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            f.status,
+            FileStatus::New,
+            "dissimilar add must not be paired as a rename"
+        );
+        assert_eq!(f.additions, 4);
+        assert_eq!(f.deletions, 0);
     }
 
     /// Finding 62: a working-tree blame with an uncommitted inserted line must


### PR DESCRIPTION
## What was broken

`get_commit_file_diff` (`src-tauri/src/commands/diff.rs`) set `opts.pathspec(&file_path)` **before** calling `detect_renames(&mut diff)`.

libgit2 applies the pathspec while it generates deltas — it tests each side's iterator entry against the pathspec — so for a file renamed in the commit the old-side entry (the old path) is filtered out and no `Deleted` delta is ever created. `find_similar` can only pair deltas that exist inside the diff, so the surviving delta stays `Delta::Added` and the command returned the entire file as `+N/-0` "new" (with `old_path` set to the *new* path, since libgit2 fills `old_file().path()` with the new path for additions). Asking for the old path symmetrically returned a whole-file `Deleted`.

This directly contradicted the file list in the same panel: `get_commit_files` diffs the whole tree with no pathspec and detects renames correctly, so `lv-commit-details.ts` renders an `R` badge plus "from old/path" — then clicking that file opened a diff claiming the whole file was new, hiding what actually changed.

## The fix

Only an add or a delete can be half of a rename. When the path-filtered diff yields one of those, re-diff the whole tree — where both halves are present — run rename detection, and pick out the delta whose new path matches, or whose old path matches when the delta is a rename/copy. Every other file (modified, typechange, …) still costs a single path-filtered diff, and the extra pass is the same work `get_commit_files` already does once per commit for the very same panel.

Two details that matter:

- The old-path comparison stays gated on `Renamed`/`Copied`. `parse_diff` populates `old_path` for *every* delta and libgit2 reports the new path there for a plain addition, so an ungated comparison would match unrelated added files — the one place this change could silently return the wrong file. The guard test below pins that down.
- The requested path is normalized to forward slashes, matching the convention already used by `get_file_diff` and `get_diff_with_options`. The frontend already sends forward slashes, so this is a no-op for existing callers.

No frontend change — the `DiffFile` shape is unchanged.

One intended user-visible change: for a *pure* rename the diff view now correctly reports 0 hunks, so `lv-diff-view.ts` renders "No changes in this file" instead of the (wrong) whole file as added. That matches `git show`, and the "renamed from X" context is already visible in the file list.

## Tests

All in the existing `mod tests` in `src-tauri/src/commands/diff.rs`, reusing the `commit_rename` helper.

| Test | Covers | Fails without the fix |
| --- | --- | --- |
| `test_get_commit_file_diff_renamed_with_edit` | Happy path: rename + one edited line returns `Renamed`, `old_path`, `+1/-1` | Yes — `left: New, right: Renamed` |
| `test_get_commit_file_diff_pure_rename_has_no_hunks` | Edge case: rename with identical content → 0/0, no hunks | Yes — `left: New, right: Renamed` |
| `test_get_commit_file_diff_old_path_of_rename` | Requesting the *old* path of a rename resolves to the same rename entry | Yes — `left: Deleted, right: Renamed` |
| `test_get_commit_file_diff_add_alongside_unrelated_delete_stays_new` | Guard: a dissimilar add next to an unrelated delete must stay `New` | No, by design — it guards against implementing this by returning the first delta of the full-tree diff, or by dropping the pathspec pass |
| `test_get_commit_file_diff_not_found` (existing) | Error path: unknown file still errors "File not found in commit" | No — must keep passing, and does |

Verified by temporarily reverting only the production change and re-running `cargo test --lib commands::diff::tests::test_get_commit_file_diff`: `test result: FAILED. 3 passed; 3 failed`, with exactly the three assertion failures listed above. The guard test, the not-found test and the pre-existing `test_get_commit_file_diff` stayed green throughout. The fix was then restored.

Full gate green: lint, typecheck, unit, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_