### PR TITLE
Let the user name a stash on both creation surfaces

### DIFF
--- a/e2e/tests/output-panel.spec.ts
+++ b/e2e/tests/output-panel.spec.ts
@@ -374,6 +374,12 @@ test.describe('Output Panel - In-app integration', () => {
     // Run a state-changing git command through the real palette flow — the
     // IPC layer logs it into the panel
     await app.executeCommand('Create stash');
+    // Stashes are nameable now: the palette entry opens the themed prompt
+    // before it reaches the backend.
+    const promptInput = page.locator('lv-prompt-dialog .prompt-input');
+    await expect(promptInput).toBeVisible();
+    await promptInput.fill('panel probe');
+    await page.locator('lv-prompt-dialog .btn-primary').click();
     await expect(
       appPanel.locator('.entry-command', { hasText: 'create_stash' }).first()
     ).toBeVisible();

--- a/e2e/tests/stash-context-menu.spec.ts
+++ b/e2e/tests/stash-context-menu.spec.ts
@@ -443,3 +443,60 @@ test.describe('Stash Context Menu - Extended Tests', () => {
     expect(finalCount).toBe(2);
   });
 });
+
+test.describe('Stash creation', () => {
+  let leftPanel: LeftPanelPage;
+
+  test.beforeEach(async ({ page }) => {
+    leftPanel = new LeftPanelPage(page);
+
+    await setupOpenRepository(page, {
+      stashes: [
+        { index: 0, message: 'WIP on main: abc123 first stash', oid: 'stash1' },
+        { index: 1, message: 'WIP on feature: def456 second stash', oid: 'stash2' },
+        { index: 2, message: 'WIP on develop: ghi789 third stash', oid: 'stash3' },
+      ],
+    });
+
+    await startCommandCaptureWithMocks(page, {
+      create_stash: { index: 0, message: 'On main: fix parser', oid: 'stash-new' },
+    });
+  });
+
+  // Without a message every stash falls back to git's "WIP on <branch>: <sha>
+  // <subject>" — the commit it was based on, not the stashed work — so several
+  // stashes on one branch are indistinguishable before a destructive Pop/Drop.
+  test('naming a stash sends the message to create_stash', async ({ page }) => {
+    await leftPanel.expandStashes();
+
+    await page.locator('lv-stash-list .stash-btn').click();
+
+    const promptInput = page.locator('lv-prompt-dialog .prompt-input');
+    await expect(promptInput).toBeVisible();
+    await promptInput.fill('fix parser');
+    await page.locator('lv-prompt-dialog .btn-primary').click();
+
+    await expect
+      .poll(async () => (await findCommand(page, 'create_stash')).length)
+      .toBe(1);
+
+    const calls = await findCommand(page, 'create_stash');
+    expect((calls[0].args as { message?: string }).message).toBe('fix parser');
+
+    await expect(page.locator('lv-toast-container .toast.success')).toBeVisible();
+  });
+
+  test('cancelling the prompt creates no stash', async ({ page }) => {
+    await leftPanel.expandStashes();
+    expect(await leftPanel.getStashCount()).toBe(3);
+
+    await page.locator('lv-stash-list .stash-btn').click();
+
+    await expect(page.locator('lv-prompt-dialog .prompt-input')).toBeVisible();
+    await page.locator('lv-prompt-dialog .btn-secondary').click();
+    await expect(page.locator('lv-prompt-dialog .prompt-input')).toBeHidden();
+
+    expect(await findCommand(page, 'create_stash')).toHaveLength(0);
+    expect(await leftPanel.getStashCount()).toBe(3);
+  });
+});

--- a/src/__tests__/app-shell-destructive-guards.test.ts
+++ b/src/__tests__/app-shell-destructive-guards.test.ts
@@ -29,11 +29,33 @@ let cbId = 0;
 import { expect } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import '../app-shell.ts';
+// Side-effect import so showPrompt finds the singleton already in the DOM.
+import '../components/dialogs/lv-prompt-dialog.ts';
+import type { LvPromptDialog } from '../components/dialogs/lv-prompt-dialog.ts';
 import { uiStore, repositoryStore } from '../stores/index.ts';
 import type { Repository } from '../types/git.types.ts';
 import { tryAcquireRefOp, isRefOpRunning, resetRefOpLocks } from '../utils/ref-lock.ts';
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * The stash shortcut/palette path asks for an optional stash message. '' is
+ * "OK with nothing typed", which keeps git's default naming; null is a
+ * dismissal.
+ */
+function setupMockPrompt(value: string | null): void {
+  let dialog = document.querySelector<LvPromptDialog>('lv-prompt-dialog');
+  if (!dialog) {
+    dialog = document.createElement('lv-prompt-dialog') as LvPromptDialog;
+    document.body.appendChild(dialog);
+  }
+  dialog.open = async () => value;
+}
+
+function cleanupMockPrompt(): void {
+  const dialog = document.querySelector('lv-prompt-dialog');
+  if (dialog) dialog.remove();
+}
 
 function mockRepo(path: string, name: string, state = 'clean'): Repository {
   return {
@@ -60,10 +82,12 @@ describe('app-shell destructive guards', () => {
     for (const k of Object.keys(mockResponses)) delete mockResponses[k];
     uiStore.setState({ toasts: [] });
     repositoryStore.getState().reset();
+    setupMockPrompt('');
   });
 
   afterEach(() => {
     repositoryStore.getState().reset();
+    cleanupMockPrompt();
   });
 
   function shellOnRepo(state = 'clean'): AppShell {
@@ -504,6 +528,34 @@ describe('app-shell destructive guards', () => {
         uiStore.getState().toasts.some((t) => /already running/i.test(t.message)),
         'the refusal must be audible',
       ).to.equal(true);
+    });
+
+    // Without `-m` every stash falls back to git's "WIP on <branch>: <sha>
+    // <subject>" — the commit it was based on, not the stashed work. The panel
+    // button and this shortcut run the same operation and report the same
+    // "Stash created", so both must be nameable.
+    it('a stash started from the shortcut/palette can be named', async () => {
+      setupMockPrompt('hotfix wip');
+      const el = shellOnRepo();
+
+      await (el as any).handleCreateStash();
+
+      const calls = invokeCallArgs.filter((c) => c.command === 'create_stash');
+      expect(calls.length, 'the stash must still be created').to.equal(1);
+      expect(calls[0].args.message, 'the typed name must reach git').to.equal('hotfix wip');
+    });
+
+    it('cancelling the stash prompt creates no stash and frees the lock', async () => {
+      setupMockPrompt(null);
+      const el = shellOnRepo();
+
+      await (el as any).handleCreateStash();
+
+      expect(
+        invokeCallArgs.some((c) => c.command === 'create_stash'),
+        'a dismissed prompt must not reset the working tree',
+      ).to.equal(false);
+      expect(isRefOpRunning('/repo/one'), 'a stuck lock would wedge the repo').to.equal(false);
     });
 
     it('create stash holds and releases the lock', async () => {

--- a/src/__tests__/app-shell-pull-stash-copy.integration.test.ts
+++ b/src/__tests__/app-shell-pull-stash-copy.integration.test.ts
@@ -37,6 +37,30 @@ import { uiStore } from '../stores/ui.store.ts';
 // Import the real component
 import '../app-shell.ts';
 
+// Side-effect import so showPrompt finds the singleton already in the DOM.
+import '../components/dialogs/lv-prompt-dialog.ts';
+import type { LvPromptDialog } from '../components/dialogs/lv-prompt-dialog.ts';
+
+/**
+ * The stash shortcut/palette path now asks for an optional stash message, so
+ * these tests install a stub that answers it immediately. '' is "OK with
+ * nothing typed", which keeps git's default naming and the exact behaviour
+ * asserted below.
+ */
+function setupMockPrompt(value: string | null): void {
+  let dialog = document.querySelector<LvPromptDialog>('lv-prompt-dialog');
+  if (!dialog) {
+    dialog = document.createElement('lv-prompt-dialog') as LvPromptDialog;
+    document.body.appendChild(dialog);
+  }
+  dialog.open = async () => value;
+}
+
+function cleanupMockPrompt(): void {
+  const dialog = document.querySelector('lv-prompt-dialog');
+  if (dialog) dialog.remove();
+}
+
 // ── Test data ──────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
 
@@ -97,6 +121,11 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
     clearHistory();
     setupDefaultMocks();
     uiStore.setState({ toasts: [] });
+    setupMockPrompt('');
+  });
+
+  afterEach(() => {
+    cleanupMockPrompt();
   });
 
   describe('handlePull', () => {

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -4657,12 +4657,31 @@ export class AppShell extends LitElement {
   }
 
   private async createStashOnRepo(repoPath: string): Promise<void> {
+    // Prompted here too, not only in the stash panel: the shortcut, the palette
+    // and the panel button run the same operation and report the same "Stash
+    // created", so a keyboard-started stash must be nameable as well —
+    // otherwise it is an indistinguishable "WIP on <branch>". null is a
+    // dismissal; '' keeps git's default name. The lock is claimed by
+    // runRefExclusive before this runs and released in its finally, so the
+    // cancel path needs no extra bookkeeping.
+    const message = await showPrompt(
+      'Stash Changes',
+      'Message for this stash (optional):',
+      '',
+      'WIP'
+    );
+    if (message === null) return;
+    const stashMessage = message.trim();
+
     // includeUntracked matches the stash-list button (lv-stash-list.ts): both
     // surfaces report an identical "Stash created", so they must stash the same
     // set — otherwise the shortcut silently leaves untracked files behind and
     // the divergence only surfaces during a later checkout or clean.
     const result = await gitService.createStash({
       path: repoPath,
+      // Undefined, not '': the backend only falls back to git's WIP name when
+      // no message is sent (src-tauri/src/commands/stash.rs).
+      message: stashMessage || undefined,
       includeUntracked: true,
     });
     if (result.success) {

--- a/src/components/__tests__/lv-stash-list.test.ts
+++ b/src/components/__tests__/lv-stash-list.test.ts
@@ -25,7 +25,29 @@ let mockInvoke: MockInvoke = () => Promise.resolve(null);
 import { expect, fixture, html } from '@open-wc/testing';
 import type { LvStashList } from '../sidebar/lv-stash-list.ts';
 import '../sidebar/lv-stash-list.ts';
+// Side-effect import so showPrompt finds the singleton already in the DOM.
+import '../dialogs/lv-prompt-dialog.ts';
+import type { LvPromptDialog } from '../dialogs/lv-prompt-dialog.ts';
 import { tryAcquireRefOp, resetRefOpLocks } from '../../utils/ref-lock.ts';
+
+/**
+ * handleCreateStash now asks for an optional stash message, so these tests
+ * install a stub that answers it immediately. '' is "OK with nothing typed",
+ * which keeps git's default naming and the exact behaviour asserted below.
+ */
+function setupMockPrompt(value: string | null): void {
+  let dialog = document.querySelector<LvPromptDialog>('lv-prompt-dialog');
+  if (!dialog) {
+    dialog = document.createElement('lv-prompt-dialog') as LvPromptDialog;
+    document.body.appendChild(dialog);
+  }
+  dialog.open = async () => value;
+}
+
+function cleanupMockPrompt(): void {
+  const dialog = document.querySelector('lv-prompt-dialog');
+  if (dialog) dialog.remove();
+}
 
 // ── Test data ──────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
@@ -85,6 +107,11 @@ describe('lv-stash-list', () => {
     resetRefOpLocks();
     clearHistory();
     setupDefaultMocks();
+    setupMockPrompt('');
+  });
+
+  afterEach(() => {
+    cleanupMockPrompt();
   });
 
   // ── 1. Rendering ──────────────────────────────────────────────────────

--- a/src/components/sidebar/__tests__/lv-stash-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-stash-list-guards.test.ts
@@ -27,8 +27,30 @@ import type { LvStashList } from '../lv-stash-list.ts';
 
 // Import the actual component
 import '../lv-stash-list.ts';
+// Side-effect import so showPrompt finds the singleton already in the DOM.
+import '../../dialogs/lv-prompt-dialog.ts';
+import type { LvPromptDialog } from '../../dialogs/lv-prompt-dialog.ts';
 import { tryAcquireRefOp, resetRefOpLocks } from '../../../utils/ref-lock.ts';
 import { uiStore } from '../../../stores/ui.store.ts';
+
+/**
+ * handleCreateStash now asks for an optional stash message, so these tests
+ * install a stub that answers it immediately. '' is "OK with nothing typed",
+ * which keeps git's default naming and the exact behaviour asserted below.
+ */
+function setupMockPrompt(value: string | null): void {
+  let dialog = document.querySelector<LvPromptDialog>('lv-prompt-dialog');
+  if (!dialog) {
+    dialog = document.createElement('lv-prompt-dialog') as LvPromptDialog;
+    document.body.appendChild(dialog);
+  }
+  dialog.open = async () => value;
+}
+
+function cleanupMockPrompt(): void {
+  const dialog = document.querySelector('lv-prompt-dialog');
+  if (dialog) dialog.remove();
+}
 
 // ── Helpers ────────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
@@ -74,6 +96,11 @@ describe('lv-stash-list operationInProgress guards', () => {
   beforeEach(() => {
     resetRefOpLocks();
     invokeCalls.length = 0;
+    setupMockPrompt('');
+  });
+
+  afterEach(() => {
+    cleanupMockPrompt();
   });
 
   it('should have operationInProgress initially false', async () => {

--- a/src/components/sidebar/__tests__/lv-stash-list-message.test.ts
+++ b/src/components/sidebar/__tests__/lv-stash-list-message.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Naming a stash from the stash panel.
+ *
+ * `git stash push -m` exists precisely so stashes can be told apart. This
+ * surface sent `message: undefined`, so every entry fell back to git's
+ * "WIP on <branch>: <sha> <subject>" — the commit the stash was based on, not
+ * the stashed work — and three stashes on one branch were indistinguishable
+ * before a destructive Pop/Drop.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeCalls: Array<{ command: string; args?: unknown }> = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeCalls.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { LvStashList } from '../lv-stash-list.ts';
+
+import '../lv-stash-list.ts';
+// Side-effect import so showPrompt finds the singleton already in the DOM.
+import '../../dialogs/lv-prompt-dialog.ts';
+import type { LvPromptDialog } from '../../dialogs/lv-prompt-dialog.ts';
+import { resetRefOpLocks, isRefOpRunning } from '../../../utils/ref-lock.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+const REPO_PATH = '/test/repo';
+
+interface PromptRecord {
+  count: number;
+  lastTitle: string;
+}
+
+/** Stubs the themed prompt so it resolves with `value` instead of waiting. */
+function setupMockPrompt(value: string | null): PromptRecord {
+  let dialog = document.querySelector<LvPromptDialog>('lv-prompt-dialog');
+  if (!dialog) {
+    dialog = document.createElement('lv-prompt-dialog') as LvPromptDialog;
+    document.body.appendChild(dialog);
+  }
+  const record: PromptRecord = { count: 0, lastTitle: '' };
+  dialog.open = async (options: { title: string }) => {
+    record.count += 1;
+    record.lastTitle = options.title;
+    return value;
+  };
+  return record;
+}
+
+function cleanupMockPrompt(): void {
+  const dialog = document.querySelector('lv-prompt-dialog');
+  if (dialog) dialog.remove();
+}
+
+const NEW_STASH = { index: 0, message: 'On main: x', oid: 'new-oid' };
+let mockStashes: unknown[] = [NEW_STASH];
+
+function defaultMockInvoke(command: string): Promise<unknown> {
+  if (command === 'get_stashes') return Promise.resolve(mockStashes);
+  if (command === 'create_stash') return Promise.resolve(NEW_STASH);
+  return Promise.resolve(null);
+}
+
+async function createComponent(): Promise<LvStashList> {
+  mockStashes = [NEW_STASH];
+  mockInvoke = defaultMockInvoke;
+  const el = await fixture<LvStashList>(
+    html`<lv-stash-list .repositoryPath=${REPO_PATH}></lv-stash-list>`
+  );
+  await el.updateComplete;
+  invokeCalls.length = 0;
+  return el;
+}
+
+function createStashCalls(): Array<{ command: string; args?: unknown }> {
+  return invokeCalls.filter((c) => c.command === 'create_stash');
+}
+
+function messageOf(call: { args?: unknown }): string | undefined {
+  return (call.args as { message?: string }).message;
+}
+
+async function runCreateStash(el: LvStashList): Promise<void> {
+  await (el as unknown as { handleCreateStash: () => Promise<void> }).handleCreateStash();
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+describe('lv-stash-list stash message', () => {
+  beforeEach(() => {
+    resetRefOpLocks();
+    invokeCalls.length = 0;
+    uiStore.setState({ toasts: [] });
+  });
+
+  afterEach(() => {
+    cleanupMockPrompt();
+    resetRefOpLocks();
+  });
+
+  it('sends the typed message to create_stash', async () => {
+    const el = await createComponent();
+    setupMockPrompt('refactor parser');
+
+    await runCreateStash(el);
+
+    const calls = createStashCalls();
+    expect(calls, 'the stash must still be created').to.have.length(1);
+    expect(messageOf(calls[0]), 'the name the user typed must reach git').to.equal(
+      'refactor parser'
+    );
+  });
+
+  it('asks for a name and keeps git default naming when nothing is typed', async () => {
+    const el = await createComponent();
+    const prompt = setupMockPrompt('   ');
+
+    await runCreateStash(el);
+
+    expect(prompt.count, 'the user must be asked for a name').to.equal(1);
+    expect(prompt.lastTitle).to.equal('Stash Changes');
+
+    const calls = createStashCalls();
+    expect(calls, 'an empty message must still stash').to.have.length(1);
+    expect(
+      messageOf(calls[0]),
+      'whitespace is not a name — the backend must fall back to git’s WIP'
+    ).to.equal(undefined);
+  });
+
+  it('creates nothing and frees the shared lock when the prompt is cancelled', async () => {
+    const el = await createComponent();
+    setupMockPrompt(null);
+
+    await runCreateStash(el);
+
+    expect(createStashCalls(), 'a dismissed prompt must not stash').to.have.length(0);
+    expect(isRefOpRunning(REPO_PATH), 'a stuck lock would wedge the repo').to.equal(false);
+    expect((el as unknown as { isStashing: boolean }).isStashing).to.equal(false);
+    expect(
+      uiStore.getState().toasts.some((t) => /stash created/i.test(t.message)),
+      'nothing was created, so nothing may claim it was'
+    ).to.equal(false);
+  });
+
+  it('reports and releases when the backend fails after naming', async () => {
+    const el = await createComponent();
+    setupMockPrompt('wip parser');
+    mockInvoke = (command: string) =>
+      command === 'create_stash'
+        ? Promise.reject({ code: 'COMMAND_ERROR', message: 'disk full' })
+        : defaultMockInvoke(command);
+
+    await runCreateStash(el);
+
+    const calls = createStashCalls();
+    expect(calls).to.have.length(1);
+    expect(messageOf(calls[0])).to.equal('wip parser');
+    expect(
+      uiStore.getState().toasts.some((t) => /disk full/i.test(t.message)),
+      'the failure must be reported'
+    ).to.equal(true);
+    expect(isRefOpRunning(REPO_PATH), 'the lock must be released on failure too').to.equal(false);
+  });
+});

--- a/src/components/sidebar/lv-stash-list.ts
+++ b/src/components/sidebar/lv-stash-list.ts
@@ -7,7 +7,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
-import { showConfirm } from '../../services/dialog.service.ts';
+import { showConfirm, showPrompt } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import type { Stash } from '../../types/git.types.ts';
 import { isTopOverlay } from '../../utils/overlay-stack.ts';
@@ -417,12 +417,38 @@ export class LvStashList extends LitElement {
     // component.
     if (!this.claimOperation(repoPath)) return;
 
+    // Claimed BEFORE this prompt, like lv-branch-list's rename: showPrompt is
+    // an await, and a claim taken after it does not serialize a double-click.
+    // repoPath is already pinned above — showPrompt is an in-app Lit overlay,
+    // NOT a native modal, so the window stays interactive and the user can
+    // switch repo tabs while it is open.
+    //
+    // Without a message every stash git2 creates falls back to
+    // "WIP on <branch>: <sha> <subject>", which describes the commit the stash
+    // was based on and not the stashed work — three stashes on one branch were
+    // indistinguishable before a destructive Pop/Drop.
+    const message = await showPrompt(
+      'Stash Changes',
+      'Message for this stash (optional):',
+      '',
+      'WIP'
+    );
+    // null is a dismissal; '' is "OK with nothing typed" and must still stash,
+    // keeping git's default "WIP on <branch>" name.
+    if (message === null) {
+      this.releaseOperation(repoPath);
+      return;
+    }
+    const stashMessage = message.trim();
+
     this.isStashing = true;
 
     try {
       const result = await gitService.createStash({
         path: repoPath,
-        message: undefined,
+        // Undefined, not '': the backend only falls back to git's WIP name when
+        // no message is sent (src-tauri/src/commands/stash.rs).
+        message: stashMessage || undefined,
         includeUntracked: true,
       });
 


### PR DESCRIPTION
## What was broken

### Stashes cannot be named — every stash is created as "WIP"

Both routes to a stash sent no message:

- `lv-stash-list.ts` → `handleCreateStash()` (the `.stash-btn` "Stash Changes" button) called `gitService.createStash({ path, message: undefined, includeUntracked: true })`.
- `app-shell.ts` → `createStashOnRepo()` (reached from the Ctrl+Shift+S shortcut and the "Create stash" palette entry) omitted `message` entirely.

`src-tauri/src/commands/stash.rs` then does `repo.stash_save(&signature, message.as_deref().unwrap_or("WIP"), …)`, so git names the entry itself: **"WIP on &lt;branch&gt;: &lt;sha&gt; &lt;subject&gt;"** — a description of the commit the stash was *based on*, not of the stashed work. There was also no stash dialog anywhere in `src/components/dialogs/` and no `showPrompt` call site for stash. A user with three stashes on the same branch therefore had no way to tell them apart before a destructive **Pop** or **Drop**, even though `git stash push -m` exists for exactly this and the whole pipe was already in place (`CreateStashCommand.message?: string` in `api.types.ts`, passed straight through by `git.service.ts`, accepted as `Option<String>` by the backend). Only the UI never filled it in.

## The fix

Both surfaces now ask for an optional message through the app's existing themed prompt (`showPrompt` → `lv-prompt-dialog`) before stashing. No new dialog component, no backend change, no new command.

- **Enter on an empty field keeps today's behaviour.** A blank or whitespace-only answer is sent as `message: undefined`, not `''`, so the backend still falls back to git's default naming.
- **Cancel aborts and creates nothing.**
- Both surfaces are fixed, because both report an identical "Stash created" and app-shell already carries a comment requiring the two to behave the same — a keyboard-started stash must be nameable too.
- The prompt sits **inside** the already-claimed working-tree lock on both paths, matching `lv-branch-list`'s rename: a claim taken *after* an await does not serialize a double-click. The sidebar releases the lock on its cancel return; app-shell's `runRefExclusive` releases in its `finally`, so a dismissal cannot leave the repo wedged.

Deliberately out of scope: an "Include untracked" checkbox (both surfaces hard-code `includeUntracked: true` on purpose) and the stash content preview.

## Tests

| Test | File | Covers |
| --- | --- | --- |
| sends the typed message to `create_stash` | `src/components/sidebar/__tests__/lv-stash-list-message.test.ts` | happy path — the typed name reaches git |
| asks for a name and keeps git default naming when nothing is typed | same | edge case — prompt is shown, whitespace is sent as `undefined` |
| creates nothing and frees the shared lock when the prompt is cancelled | same | cancel path — no `create_stash`, lock released, `isStashing` false, no "Stash created" toast |
| reports and releases when the backend fails after naming | same | error path — message carried, error toast shown, lock released |
| a stash started from the shortcut/palette can be named | `src/__tests__/app-shell-destructive-guards.test.ts` | happy path on the second surface |
| cancelling the stash prompt creates no stash and frees the lock | same | cancel path — `runRefExclusive`'s `finally` still runs |
| naming a stash sends the message to `create_stash` | `e2e/tests/stash-context-menu.spec.ts` | full user flow: expand panel → click button → real prompt → success toast |
| cancelling the prompt creates no stash | same | full user flow: Cancel leaves the stash list at 3 |

Collateral test updates (mock installs, not weakened assertions — `handleCreateStash` now awaits a prompt): the existing create-stash tests in `lv-stash-list-guards.test.ts`, `lv-stash-list.test.ts`, `app-shell-pull-stash-copy.integration.test.ts` and `app-shell-destructive-guards.test.ts` install the repo's existing prompt stub answering `''`, so they keep asserting exactly what they asserted before. `e2e/tests/output-panel.spec.ts` fills the prompt after `executeCommand('Create stash')`.

### Verified to fail without the fix

All eight new tests were run against a reverted `lv-stash-list.ts` + `app-shell.ts`:

- `sends the typed message to create_stash` — `AssertionError: the name the user typed must reach git: expected undefined to equal 'refactor parser'`
- `asks for a name and keeps git default naming when nothing is typed` — `AssertionError: the user must be asked for a name: expected 0 to equal 1`
- `creates nothing and frees the shared lock when the prompt is cancelled` — `AssertionError: a dismissed prompt must not stash: expected [ Array(1) ] to have a length of 0 but got 1`
- `reports and releases when the backend fails after naming` — `AssertionError: expected undefined to equal 'wip parser'`
- `a stash started from the shortcut/palette can be named` — `AssertionError: the typed name must reach git: expected undefined to equal 'hotfix wip'`
- `cancelling the stash prompt creates no stash and frees the lock` — `AssertionError: a dismissed prompt must not reset the working tree: expected true to equal false`
- both E2E tests — `expect(locator).toBeVisible() failed / element(s) not found` on `lv-prompt-dialog .prompt-input` (no prompt is ever shown)
- the updated `output-panel.spec.ts` palette flow fails the same way

Full gate green: `npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, plus `npx playwright test e2e/tests/stash-context-menu.spec.ts e2e/tests/output-panel.spec.ts` (51 passed) and the CLAUDE.md snake_case grep (clean — `message` is already camelCase).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_