### PR TITLE
Refuse a release/hotfix finish that would adopt an unrelated version tag

### DIFF
--- a/e2e/tests/gitflow-panel.spec.ts
+++ b/e2e/tests/gitflow-panel.spec.ts
@@ -632,6 +632,86 @@ test.describe('GitFlow Panel - Finish Feature Failure', () => {
 });
 
 // --------------------------------------------------------------------------
+// Operations - Release Finish Refused (version tag collision)
+// --------------------------------------------------------------------------
+test.describe('GitFlow Panel - Release Finish Tag Collision', () => {
+  const COLLISION =
+    "Tag 'v2.0.0' already exists and does not contain 'release/2.0.0'. "
+    + 'Delete or rename the tag, or finish with a different version.';
+
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+
+    await startCommandCaptureWithMocks(page, {
+      get_gitflow_config: {
+        initialized: true,
+        masterBranch: 'main',
+        developBranch: 'develop',
+        featurePrefix: 'feature/',
+        releasePrefix: 'release/',
+        hotfixPrefix: 'hotfix/',
+        supportPrefix: 'support/',
+        versionTagPrefix: 'v',
+      },
+      get_branches: [
+        {
+          name: 'main',
+          shorthand: 'main',
+          isHead: false,
+          isRemote: false,
+          upstream: null,
+          targetOid: 'abc123',
+          isStale: false,
+        },
+        {
+          name: 'develop',
+          shorthand: 'develop',
+          isHead: true,
+          isRemote: false,
+          upstream: null,
+          targetOid: 'def456',
+          isStale: false,
+        },
+        {
+          name: 'release/2.0.0',
+          shorthand: 'release/2.0.0',
+          isHead: false,
+          isRemote: false,
+          upstream: null,
+          targetOid: 'rel1',
+          isStale: false,
+        },
+      ],
+      gitflow_finish_release: { __error__: COLLISION },
+    });
+
+    await injectGitflowPanel(page);
+  });
+
+  test('should show the tag-collision error and keep the release listed', async ({ page }) => {
+    const releaseSection = page.locator('lv-gitflow-panel#e2e-gitflow .section').nth(1);
+    await expect(releaseSection.locator('.item-name')).toHaveText('2.0.0');
+
+    await releaseSection.locator('.item-finish-btn:not(.item-squash-btn)').first().click();
+
+    // Finishing a release prompts for the tag message first.
+    const promptInput = page.locator('lv-prompt-dialog .prompt-input');
+    await expect(promptInput).toBeVisible({ timeout: 3000 });
+    await page.locator('lv-prompt-dialog .btn-primary').click();
+
+    const banner = page.locator('lv-gitflow-panel#e2e-gitflow .error-banner');
+    await expect(banner).toBeVisible();
+    await expect(banner).toContainText("Tag 'v2.0.0' already exists");
+
+    // The refusal is not a merge conflict — no resolution dialog.
+    await expect(page.locator('lv-conflict-resolution-dialog[open]')).toHaveCount(0);
+
+    // The release survives the refused finish.
+    await expect(releaseSection.locator('.item-name')).toHaveText('2.0.0');
+  });
+});
+
+// --------------------------------------------------------------------------
 // Loading State
 // --------------------------------------------------------------------------
 test.describe('GitFlow Panel - Loading State', () => {

--- a/src-tauri/src/commands/gitflow.rs
+++ b/src-tauri/src/commands/gitflow.rs
@@ -566,6 +566,35 @@ async fn finish_release_like(
         .map_err(|_| LeviathanError::BranchNotFound(branch_name.clone()))?;
     let release_commit = release_branch.get().peel_to_commit()?;
 
+    // A version tag left behind by an EARLIER pass of this same finish is
+    // expected — the develop side conflicted, the user resolved it and re-ran —
+    // and the tag block below adopts it. Any OTHER pre-existing tag belongs to
+    // someone else: a teammate's tag, an old cycle reusing the number, or the
+    // release/hotfix collision both flows produce because they share
+    // gitflow.prefix.versiontag. Adopting one of those merges, deletes the
+    // branch and reports success while the release ships untagged and the
+    // version resolves to unrelated code. A tag from our own pass always
+    // CONTAINS the release tip (it sits on the master merge commit, or on a
+    // master tip that already merged it); anything else is refused here, before
+    // any mutation, so the repository is left exactly as it was.
+    if let Ok(tag_ref) = repo.find_reference(&format!("refs/tags/{}", tag_name)) {
+        let from_this_finish = match tag_ref.peel_to_commit() {
+            Ok(tagged) => {
+                tagged.id() == release_commit.id()
+                    || repo.graph_descendant_of(tagged.id(), release_commit.id())?
+            }
+            // A tag that does not resolve to a commit is certainly not ours.
+            Err(_) => false,
+        };
+        if !from_this_finish {
+            return Err(LeviathanError::OperationFailed(format!(
+                "Tag '{}' already exists and does not contain '{}'. \
+                 Delete or rename the tag, or finish with a different version.",
+                tag_name, branch_name
+            )));
+        }
+    }
+
     // Merge into master
     let master_branch = repo
         .find_branch(&master, git2::BranchType::Local)
@@ -613,7 +642,8 @@ async fn finish_release_like(
         Some(merge_oid)
     };
 
-    // Create the tag on master. Skip when it already exists (re-run after the
+    // Create the tag on master. Skip when it already exists — validated above
+    // as this finish's own tag from an earlier pass (re-run after the
     // develop-side conflict was resolved and tagged on the first pass) so we
     // don't fail with "tag already exists". When it is MISSING we must still
     // tag: on a re-run after a MASTER-side conflict was resolved via the dialog,
@@ -1837,6 +1867,252 @@ mod tests {
         // Branch was deleted.
         assert!(git_repo
             .find_branch("release/3.0.0", git2::BranchType::Local)
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_finish_release_refuses_a_version_tag_on_an_unrelated_commit() {
+        // A tag with the release's version already exists on an UNRELATED
+        // commit (a teammate's tag, or an old cycle reusing the number).
+        // Finishing must refuse before touching anything — silently adopting
+        // it would merge, delete the branch and report success while the
+        // version tag still resolves to the old code.
+        let repo = TestRepo::with_initial_commit();
+        let master = repo.current_branch();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        // Unrelated work on master, tagged with the version we are about to
+        // release.
+        repo.checkout_branch(&master);
+        repo.create_commit("Unrelated work", &[("other.txt", "x")]);
+        let stale = repo.head_oid();
+        repo.create_tag("v2.0.0");
+
+        gitflow_start_release(repo.path_str(), "2.0.0".to_string())
+            .await
+            .unwrap();
+        repo.create_commit("Release change", &[("release.txt", "r")]);
+
+        let master_before = count_reachable_commits(&repo, &master);
+
+        let result =
+            gitflow_finish_release(repo.path_str(), "2.0.0".to_string(), None, Some(true)).await;
+
+        match &result {
+            Err(LeviathanError::OperationFailed(msg)) => {
+                assert!(
+                    msg.contains("v2.0.0") && msg.contains("release/2.0.0"),
+                    "error must name the colliding tag and branch: {}",
+                    msg
+                );
+            }
+            other => panic!("expected the finish to be refused, got {:?}", other),
+        }
+
+        let git_repo = repo.repo();
+        // Nothing was mutated: branch alive, master untouched, HEAD unmoved,
+        // and the tag still points where it did.
+        assert!(
+            git_repo
+                .find_branch("release/2.0.0", git2::BranchType::Local)
+                .is_ok(),
+            "release branch must survive a refused finish"
+        );
+        assert_eq!(
+            count_reachable_commits(&repo, &master),
+            master_before,
+            "master must not gain a merge commit"
+        );
+        assert_eq!(repo.current_branch(), "release/2.0.0", "HEAD must not move");
+        assert_eq!(
+            git_repo
+                .find_reference("refs/tags/v2.0.0")
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .id(),
+            stale,
+            "the pre-existing tag must be left alone"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_finish_hotfix_refuses_when_the_release_of_the_same_version_owns_the_tag() {
+        // release/1.0.1 and hotfix/1.0.1 both resolve to the tag v1.0.1
+        // because the two flows share gitflow.prefix.versiontag. Once the
+        // release has claimed it, the hotfix finish must refuse rather than
+        // ship the hotfix untagged.
+        let repo = TestRepo::with_initial_commit();
+        let master = repo.current_branch();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        repo.checkout_branch("develop");
+        gitflow_start_release(repo.path_str(), "1.0.1".to_string())
+            .await
+            .unwrap();
+        repo.create_commit("Release change", &[("rel.txt", "r")]);
+        gitflow_finish_release(repo.path_str(), "1.0.1".to_string(), None, Some(true))
+            .await
+            .unwrap();
+
+        let tag_before = repo
+            .repo()
+            .find_reference("refs/tags/v1.0.1")
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .id();
+        let master_before = count_reachable_commits(&repo, &master);
+
+        gitflow_start_hotfix(repo.path_str(), "1.0.1".to_string())
+            .await
+            .unwrap();
+        let hotfix_commit = repo.create_commit("Hotfix change", &[("fix.txt", "f")]);
+
+        let result =
+            gitflow_finish_hotfix(repo.path_str(), "1.0.1".to_string(), None, Some(true)).await;
+
+        match &result {
+            Err(LeviathanError::OperationFailed(msg)) => {
+                assert!(
+                    msg.contains("v1.0.1") && msg.contains("hotfix/1.0.1"),
+                    "error must name the colliding tag and branch: {}",
+                    msg
+                );
+            }
+            other => panic!("expected the hotfix finish to be refused, got {:?}", other),
+        }
+
+        let git_repo = repo.repo();
+        assert!(
+            git_repo
+                .find_branch("hotfix/1.0.1", git2::BranchType::Local)
+                .is_ok(),
+            "hotfix branch must survive a refused finish"
+        );
+        assert_eq!(
+            count_reachable_commits(&repo, &master),
+            master_before,
+            "master must not gain a merge commit"
+        );
+
+        let tag_now = git_repo
+            .find_reference("refs/tags/v1.0.1")
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .id();
+        assert_eq!(tag_now, tag_before, "the release's tag must be left alone");
+        assert!(
+            !git_repo
+                .graph_descendant_of(tag_now, hotfix_commit)
+                .unwrap(),
+            "the hotfix must not end up shipped under a tag that does not contain it"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_finish_release_adopts_its_own_tag_from_a_prior_pass() {
+        // Same shape as test_finish_release_idempotent_after_develop_conflict:
+        // the first pass tags master and then conflicts on develop. The tag
+        // left behind IS this finish's own, so the re-run must still adopt it
+        // rather than be refused by the collision guard.
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        repo.checkout_branch("develop");
+        repo.create_commit("Develop base", &[("shared.txt", "develop base")]);
+        gitflow_start_release(repo.path_str(), "3.0.0".to_string())
+            .await
+            .unwrap();
+        repo.create_commit("Release change", &[("shared.txt", "release content")]);
+        repo.checkout_branch("develop");
+        repo.create_commit("Develop divergent", &[("shared.txt", "develop divergent")]);
+
+        let result =
+            gitflow_finish_release(repo.path_str(), "3.0.0".to_string(), None, Some(true)).await;
+        assert!(matches!(result, Err(LeviathanError::MergeConflict)));
+
+        let tag_before = repo
+            .repo()
+            .find_reference("refs/tags/v3.0.0")
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .id();
+
+        crate::commands::merge::resolve_conflict(
+            repo.path_str(),
+            "shared.txt".to_string(),
+            "resolved".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+        crate::commands::merge::commit_merge(repo.path_str(), None, None)
+            .await
+            .unwrap();
+
+        let result =
+            gitflow_finish_release(repo.path_str(), "3.0.0".to_string(), None, Some(true)).await;
+        assert!(result.is_ok(), "re-run finish failed: {:?}", result.err());
+
+        let git_repo = repo.repo();
+        assert_eq!(
+            git_repo
+                .find_reference("refs/tags/v3.0.0")
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .id(),
+            tag_before,
+            "the finish's own tag must be adopted unchanged"
+        );
+        assert!(git_repo
+            .find_branch("release/3.0.0", git2::BranchType::Local)
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_finish_release_accepts_a_lightweight_tag_on_the_release_tip() {
+        // The tag sits exactly ON the release tip (and is lightweight, so it
+        // peels straight to a commit). That contains the release, so the
+        // finish must proceed — the guard is about unrelated tags, not about
+        // every pre-existing tag.
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        gitflow_start_release(repo.path_str(), "6.0.0".to_string())
+            .await
+            .unwrap();
+        let release_tip = repo.create_commit("Release change", &[("release.txt", "r")]);
+        repo.create_lightweight_tag("v6.0.0");
+
+        let result =
+            gitflow_finish_release(repo.path_str(), "6.0.0".to_string(), None, Some(true)).await;
+        assert!(result.is_ok(), "finish was refused: {:?}", result.err());
+
+        let git_repo = repo.repo();
+        assert_eq!(
+            git_repo
+                .find_reference("refs/tags/v6.0.0")
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .id(),
+            release_tip,
+            "the existing tag must be left where it was"
+        );
+        assert!(git_repo
+            .find_branch("release/6.0.0", git2::BranchType::Local)
             .is_err());
     }
 }

--- a/src/components/__tests__/lv-gitflow-panel.test.ts
+++ b/src/components/__tests__/lv-gitflow-panel.test.ts
@@ -878,6 +878,55 @@ describe('lv-gitflow-panel', () => {
         cleanupMockPrompt();
       }
     });
+
+    it('shows the tag-collision error in the banner and does not open the conflict dialog when finish release fails', async () => {
+      // The backend refuses a finish whose version tag already exists on an
+      // unrelated commit. That is OPERATION_FAILED, not MERGE_CONFLICT, so it
+      // must land in the inline banner — routing it to the conflict dialog
+      // would offer a resolution flow for a merge that never started.
+      const collision =
+        "Tag 'v1.0.0' already exists and does not contain 'release/1.0.0'. "
+        + 'Delete or rename the tag, or finish with a different version.';
+      setupMockPrompt('Release 1.0.0');
+      mockInvoke = async (command: string) => {
+        switch (command) {
+          case 'get_gitflow_config':
+            return DEFAULT_CONFIG;
+          case 'get_branches':
+            return releaseBranches;
+          case 'gitflow_finish_release':
+            throw { code: 'OPERATION_FAILED', message: collision };
+          default:
+            return null;
+        }
+      };
+
+      const el = await renderPanel();
+
+      let conflictOpened = false;
+      el.addEventListener('open-conflict-dialog', () => {
+        conflictOpened = true;
+      });
+
+      try {
+        const finishBtns = el.shadowRoot!.querySelectorAll('.item-finish-btn:not(.item-squash-btn)');
+        (finishBtns[0] as HTMLButtonElement).click();
+        await new Promise((r) => setTimeout(r, 150));
+        await el.updateComplete;
+
+        const errorEl = el.shadowRoot!.querySelector('.error-banner');
+        expect(errorEl, 'error banner should be shown').to.not.be.null;
+        expect(errorEl!.textContent).to.include("Tag 'v1.0.0' already exists");
+        expect(conflictOpened, 'conflict dialog must not open').to.be.false;
+
+        // The release is still listed — the finish was refused, not applied.
+        const items = Array.from(el.shadowRoot!.querySelectorAll('.item-name'))
+          .map((n) => n.textContent?.trim());
+        expect(items).to.include('1.0.0');
+      } finally {
+        cleanupMockPrompt();
+      }
+    });
   });
 
   // ── Loading state ──────────────────────────────────────────────────────


### PR DESCRIPTION
## What was broken

### Pre-existing unrelated tag silently adopted by release/hotfix finish

`finish_release_like` in `src-tauri/src/commands/gitflow.rs` creates the version tag only when `refs/tags/<versiontag><version>` does not already exist. That skip exists for a good reason — the documented recovery path is "master merged and tagged, develop conflicted, user resolved it and re-ran the finish", and on the re-run the tag is already there.

But the check was `is_err()` and nothing else, so **any** pre-existing tag was adopted as if it were ours:

- a tag a teammate pushed,
- a tag from an older cycle that reused the number,
- the release/hotfix collision the two flows produce by construction, since both read `gitflow.prefix.versiontag` — `release/1.0.1` and `hotfix/1.0.1` both resolve to `v1.0.1`.

In each of those cases the finish merged into master, merged into develop, deleted the branch and returned `GitFlowFinishResult { branch_deleted: true }` — a clean success — while the version tag still pointed at unrelated code. The release shipped untagged, and the user only discovered it later when `v1.0.1` resolved to the wrong commit. Canonical git flow refuses this outright.

## The fix

A single guard in `finish_release_like`, placed **before any mutation** — next to the two `ensure_not_checked_out_elsewhere` calls, which the file already establishes as the place for checks that must leave the repository exactly as it was. A tag from this finish's own earlier pass always *contains* the release tip: it sits on the master merge commit, or on a master tip that already merged the release. So the guard accepts a tag whose target is the release tip or a descendant of it, and refuses anything else with an error naming both the tag and the branch:

> Tag 'v1.0.1' already exists and does not contain 'hotfix/1.0.1'. Delete or rename the tag, or finish with a different version.

Because the guard runs before the first `checkout_tree`, a refused finish leaves the branch alive, master with no extra merge commit, HEAD where it was, and the tag untouched. `Reference::peel_to_commit` covers both annotated and lightweight tags; the explicit equality arm is needed because `graph_descendant_of` is false for equal oids. The tag-creation block itself is unchanged — only its comment now points at the validation above.

No frontend production change: `LeviathanError::OperationFailed` serializes to `OPERATION_FAILED`, and `handleFinishRelease` / `handleFinishHotfix` in `src/components/sidebar/lv-gitflow-panel.ts` already route every non-`MERGE_CONFLICT` failure into `this.error`, rendered by the dismissable `.error-banner`. The conflict dialog is opened only for `MERGE_CONFLICT`, so the new error correctly does not open it. Two tests pin that contract so it cannot drift.

## Tests

| # | Test | File | Covers |
|---|---|---|---|
| T1 | `test_finish_release_refuses_a_version_tag_on_an_unrelated_commit` | `src-tauri/src/commands/gitflow.rs` | Error path: tag on unrelated master commit. Asserts the refusal names tag + branch, the release branch survives, master gains no commit, HEAD does not move, and the stale tag still points where it did. |
| T2 | `test_finish_hotfix_refuses_when_the_release_of_the_same_version_owns_the_tag` | `src-tauri/src/commands/gitflow.rs` | Edge case: the cross-flow `v1.0.1` collision. Asserts the refusal, the surviving hotfix branch, unchanged master, and — the concrete symptom — that the hotfix commit is not reachable from the tag. |
| T3 | `test_finish_release_adopts_its_own_tag_from_a_prior_pass` | `src-tauri/src/commands/gitflow.rs` | Happy path: develop-side conflict resolved, re-run. The finish's own tag is adopted unchanged and the branch is deleted. |
| T4 | `test_finish_release_accepts_a_lightweight_tag_on_the_release_tip` | `src-tauri/src/commands/gitflow.rs` | Edge case: a lightweight tag sitting exactly on the release tip is accepted (exercises the equality arm and the lightweight peel path). |
| T5 | `shows the tag-collision error in the banner and does not open the conflict dialog when finish release fails` | `src/components/__tests__/lv-gitflow-panel.test.ts` | FE contract: `OPERATION_FAILED` lands in `.error-banner`, no `open-conflict-dialog` event, release still listed. |
| T6 | `should show the tag-collision error and keep the release listed` | `e2e/tests/gitflow-panel.spec.ts` | E2E through the real prompt → finish → banner flow; asserts no `lv-conflict-resolution-dialog` and that `release/2.0.0` survives. |

### Verified to fail without the fix

The production guard was removed and the Rust tests re-run:

- **T1** — `panicked: expected the finish to be refused, got Ok(GitFlowFinishResult { branch_deleted: true, branch_kept_reason: None })`
- **T2** — `panicked: expected the hotfix finish to be refused, got Ok(GitFlowFinishResult { branch_deleted: true, branch_kept_reason: None })`

T3 and T4 pass with the guard removed by design — their job is the opposite one, guarding against an over-broad fix. Both were verified against a naive "tag exists ⇒ refuse" implementation, where **T3, T4 and the pre-existing `test_finish_release_idempotent_after_develop_conflict` all fail** (the naive version breaks the documented conflict-recovery flow).

T5 pins FE routing that this PR does not change; it fails if the new error is ever mis-routed to the conflict dialog or swallowed.

## Gate

`npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` — all green. `npx playwright test e2e/tests/gitflow-panel.spec.ts` — 20 passed. The change touches no git CLI output, but the gitflow suite was also run against git 2.55 (34 passed) to rule out version skew.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_