### PR TITLE
Allow a fixup to target the tip commit it is amending

### DIFF
--- a/src-tauri/src/commands/squash.rs
+++ b/src-tauri/src/commands/squash.rs
@@ -263,8 +263,13 @@ pub async fn fixup_commit(
     // Get the current HEAD
     let head_commit = repo.head()?.peel_to_commit()?;
 
-    // Verify that target_commit is an ancestor of HEAD
-    if !repo.graph_descendant_of(head_commit.id(), target_commit.id())? {
+    // The target must be HEAD itself or an ancestor of it. libgit2 does not
+    // consider a commit a descendant of itself, so the graph check alone would
+    // reject the most common target of all — the tip commit, i.e. `git commit
+    // --amend`, for which the replay below is simply a no-op.
+    if head_commit.id() != target_commit.id()
+        && !repo.graph_descendant_of(head_commit.id(), target_commit.id())?
+    {
         return Err(LeviathanError::OperationFailed(
             "Target commit is not an ancestor of HEAD".to_string(),
         ));
@@ -325,29 +330,21 @@ pub async fn fixup_commit(
     let commit_message =
         amend_message.unwrap_or_else(|| target_commit.message().unwrap_or("").to_string());
 
-    // Get parent of target commit
-    let target_parent = target_commit.parent(0).ok();
+    // Keep every parent of the target commit. The target may now be HEAD, so it
+    // may be a merge commit, and rewriting it must not silently flatten the
+    // merge — `git commit --amend` keeps both parents. A root commit yields an
+    // empty parent list, exactly as before.
+    let target_parents: Vec<git2::Commit> = target_commit.parents().collect();
+    let parent_refs: Vec<&git2::Commit> = target_parents.iter().collect();
 
-    let new_target_oid = if let Some(ref parent) = target_parent {
-        repo.commit(
-            None,
-            &target_commit.author(),
-            &signature,
-            &commit_message,
-            &new_target_tree,
-            &[parent],
-        )?
-    } else {
-        // Root commit
-        repo.commit(
-            None,
-            &target_commit.author(),
-            &signature,
-            &commit_message,
-            &new_target_tree,
-            &[],
-        )?
-    };
+    let new_target_oid = repo.commit(
+        None,
+        &target_commit.author(),
+        &signature,
+        &commit_message,
+        &new_target_tree,
+        &parent_refs,
+    )?;
 
     // Now replay all commits after target onto the new target
     let mut current_base_oid = new_target_oid;
@@ -753,6 +750,165 @@ mod tests {
         // Verify both files exist
         assert!(repo.path.join("file.txt").exists());
         assert!(repo.path.join("after.txt").exists());
+    }
+
+    /// Commit HEAD's tree with a second parent, producing a real merge tip.
+    fn commit_merge(repo: &TestRepo, message: &str, other_oid: git2::Oid) -> git2::Oid {
+        let git = repo.repo();
+        let head = git.head().unwrap().peel_to_commit().unwrap();
+        let other = git.find_commit(other_oid).unwrap();
+        let tree = head.tree().unwrap();
+        let sig = git.signature().unwrap();
+        git.commit(Some("HEAD"), &sig, &sig, message, &tree, &[&head, &other])
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_fixup_commit_into_head_amends_tip() {
+        // Fixing staged changes into the tip commit is `git commit --amend`,
+        // the most common target of all. libgit2 does not call a commit a
+        // descendant of itself, so the ancestor guard used to reject it.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Base", &[("b.txt", "base")]);
+        let target = repo.create_commit("Tip commit", &[("tip.txt", "original")]);
+
+        let parent_before = {
+            let git = repo.repo();
+            let id = git.find_commit(target).unwrap().parent(0).unwrap().id();
+            id
+        };
+
+        repo.create_file("tip.txt", "fixed");
+        repo.stage_file("tip.txt");
+
+        let result = fixup_commit(repo.path_str(), target.to_string(), None).await;
+        assert!(
+            result.is_ok(),
+            "fixup into HEAD must amend the tip: {:?}",
+            result.err()
+        );
+        let fixup_result = result.unwrap();
+
+        let git = repo.repo();
+        let new_head = git.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(new_head.summary().unwrap(), Some("Tip commit"));
+        assert_eq!(
+            new_head.parent(0).unwrap().id(),
+            parent_before,
+            "the tip was amended, not stacked on top of"
+        );
+        assert_eq!(new_head.id().to_string(), fixup_result.new_oid);
+
+        let content = std::fs::read_to_string(repo.path.join("tip.txt")).unwrap();
+        assert_eq!(content, "fixed");
+
+        let mut revwalk = git.revwalk().unwrap();
+        revwalk.push_head().unwrap();
+        assert_eq!(revwalk.count(), 3, "no commit was appended or lost");
+    }
+
+    #[tokio::test]
+    async fn test_fixup_commit_into_root_head() {
+        // The tip may also be the root commit: no parents at all.
+        let repo = TestRepo::with_initial_commit();
+        repo.create_file("extra.txt", "x");
+        repo.stage_file("extra.txt");
+
+        let head = repo.head_oid();
+        let result = fixup_commit(repo.path_str(), head.to_string(), None).await;
+        assert!(
+            result.is_ok(),
+            "fixup into a root HEAD must amend it: {:?}",
+            result.err()
+        );
+
+        let git = repo.repo();
+        let new_head = git.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(
+            new_head.parent_count(),
+            0,
+            "root commit stays a root commit"
+        );
+        assert_eq!(new_head.summary().unwrap(), Some("Initial commit"));
+        let tree = new_head.tree().unwrap();
+        assert!(tree.get_name("README.md").is_some());
+        assert!(tree.get_name("extra.txt").is_some());
+    }
+
+    #[tokio::test]
+    async fn test_fixup_commit_into_merge_head_keeps_both_parents() {
+        // Amending a merge tip must keep the merge, exactly as `git commit
+        // --amend` does — rebuilding it from parent 0 alone would silently
+        // drop the side branch from history.
+        let repo = TestRepo::with_initial_commit();
+        let default_branch = repo.current_branch();
+        repo.create_commit("Base", &[("b.txt", "base")]);
+
+        repo.create_branch("side");
+        repo.checkout_branch("side");
+        let side = repo.create_commit("Side work", &[("side.txt", "s")]);
+        repo.checkout_branch(&default_branch);
+
+        let merge = commit_merge(&repo, "Merge side", side);
+        let parents_before: Vec<git2::Oid> = {
+            let git = repo.repo();
+            let ids = git.find_commit(merge).unwrap().parent_ids().collect();
+            ids
+        };
+        assert_eq!(parents_before.len(), 2);
+
+        repo.create_file("b.txt", "fixed");
+        repo.stage_file("b.txt");
+
+        let result = fixup_commit(repo.path_str(), merge.to_string(), None).await;
+        assert!(
+            result.is_ok(),
+            "fixup into a merge tip must succeed: {:?}",
+            result.err()
+        );
+
+        let git = repo.repo();
+        let new_head = git.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(
+            new_head.parent_count(),
+            2,
+            "amending a merge tip must keep the merge"
+        );
+        assert_eq!(
+            new_head.parent_ids().collect::<Vec<_>>(),
+            parents_before,
+            "both parents are preserved, in order"
+        );
+        assert_eq!(new_head.summary().unwrap(), Some("Merge side"));
+
+        let content = std::fs::read_to_string(repo.path.join("b.txt")).unwrap();
+        assert_eq!(content, "fixed");
+    }
+
+    #[tokio::test]
+    async fn test_fixup_commit_rejects_unrelated_commit() {
+        // The guard is narrowed for HEAD, not removed: a commit on another
+        // branch is still not a legal fixup target.
+        let repo = TestRepo::with_initial_commit();
+        let default_branch = repo.current_branch();
+
+        repo.create_branch("side");
+        repo.checkout_branch("side");
+        let side_only = repo.create_commit("Side only", &[("side.txt", "s")]);
+
+        repo.checkout_branch(&default_branch);
+        repo.create_commit("Main work", &[("m.txt", "m")]);
+
+        repo.create_file("m.txt", "staged");
+        repo.stage_file("m.txt");
+
+        let head_before = repo.head_oid();
+        let result = fixup_commit(repo.path_str(), side_only.to_string(), None).await;
+
+        assert!(result.is_err(), "an unrelated commit is not a fixup target");
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("not an ancestor"), "unexpected message: {msg}");
+        assert_eq!(repo.head_oid(), head_before, "nothing was rewritten");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What was broken

### `fixup_commit` refused the HEAD commit as a target

In `src-tauri/src/commands/squash.rs`, `fixup_commit` guarded its target with:

```rust
if !repo.graph_descendant_of(head_commit.id(), target_commit.id())? {
    return Err(LeviathanError::OperationFailed(
        "Target commit is not an ancestor of HEAD".to_string(),
    ));
}
```

libgit2 does not consider a commit a descendant of itself, so passing the tip commit — the single most common fixup target, equivalent to `git commit --amend` — was rejected with the misleading message "Target commit is not an ancestor of HEAD".

Nothing downstream actually needed that refusal: the `target..HEAD` revwalk yields nothing when the target *is* HEAD, so the replay loop is a no-op and the rewritten tip is committed straight onto the target's own parent. The sibling function `squash_commits`, a hundred lines above in the same file, already carries the correct form (`if head_commit.id() != to && !repo.graph_descendant_of(head_commit.id(), to)?`).

The bug was invisible in the test module because every fixup test stacked an "After commit" on top of the target; the one test that did target HEAD bailed out earlier on the empty-index check and never reached the guard.

### Amending a merge tip would have flattened the merge

Allowing `target == HEAD` newly exposes the commit-recreation path to merge commits. It rebuilt the rewritten target from `target_commit.parent(0).ok()` only, so amending staged changes into a merge tip would have silently dropped the second parent and erased the side branch from history — a corruption the (wrong) refusal happened to prevent. That had to be fixed in the same change, not after it.

## The fix

1. **Narrow the guard, don't remove it.** The target must be HEAD itself *or* a genuine ancestor:

   ```rust
   if head_commit.id() != target_commit.id()
       && !repo.graph_descendant_of(head_commit.id(), target_commit.id())?
   ```

   The error message is unchanged and still correct for the case it now exclusively covers: a commit that is genuinely not on HEAD's history.

2. **Preserve every parent of the rewritten target.** `target_commit.parents().collect()` replaces the `parent(0)`/root-commit if-else. This is what `git commit --amend` does on a merge, and a root commit simply yields an empty parent list — exactly the previous behaviour for that case, with the special case collapsed into the same call.

The replay loop's own `commit.parent(0)?` handling of merges is deliberately untouched — that is a separate finding with its own PR.

No TypeScript or UI changes: `fixup_commit` is already registered in `lib.rs` and the service wrapper already passes camelCase `targetOid`/`amendMessage`. `src/services/__tests__/squash.service.test.ts` only asserts the invoke payload shape and is unaffected.

## Tests

All in the existing `#[cfg(test)] mod tests` in `src-tauri/src/commands/squash.rs`, using `TestRepo` with real git2 operations.

| Test | Covers | Fails without the fix? |
| --- | --- | --- |
| `test_fixup_commit_into_head_amends_tip` | Happy path: staged fix into the tip; asserts the message is kept, the new HEAD's parent is the target's old parent (amended, not stacked), `new_oid` matches HEAD, the file reads `"fixed"`, and the commit count is still 3 | **Yes** — `fixup into HEAD must amend the tip: Some(OperationFailed("Target commit is not an ancestor of HEAD"))` |
| `test_fixup_commit_into_root_head` | Edge case: target is HEAD *and* the root commit; asserts `parent_count() == 0`, the tree holds both files, message preserved | **Yes** — `fixup into a root HEAD must amend it: Some(OperationFailed("Target commit is not an ancestor of HEAD"))` |
| `test_fixup_commit_into_merge_head_keeps_both_parents` | Edge case: amending a real merge tip; asserts `parent_count() == 2` and both parent ids in order | **Yes**, twice: with neither hunk, `fixup into a merge tip must succeed: Some(OperationFailed("Target commit is not an ancestor of HEAD"))`; with only the guard hunk, `assertion left == right failed: amending a merge tip must keep the merge / left: 1 / right: 2` |
| `test_fixup_commit_rejects_unrelated_commit` | Error path: a commit on another branch is still refused, message contains "not an ancestor", HEAD unmoved | Passes before and after **by design** — it is the regression proof that the guard was narrowed rather than deleted. Deleting the whole `if` block makes it fail while the three above still pass (verified). |

Each claim above was produced by reverting the corresponding production hunk, re-running `cargo test --lib commands::squash`, and recording the real failure output, then restoring.

Full gate green: lint, typecheck, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --lib`. This change parses no git CLI output, so it is unaffected by the git 2.43/2.55 quoting skew.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_