### PR TITLE
Validate the graph selection against every rebuilt layout

### DIFF
--- a/e2e/tests/graph.spec.ts
+++ b/e2e/tests/graph.spec.ts
@@ -436,6 +436,50 @@ test.describe('Graph Commit Selection', () => {
     expect(await getSelectedNodeOid(page)).toBeNull();
   });
 
+  test('a refresh that rewrites away the primary of a multi-selection shows a surviving commit', async ({ page }) => {
+    const handle = await getGraphCanvasHandle(page);
+    // commit2 is the primary of a two-commit selection (the canvas hit-test
+    // cannot be driven by a real ctrl+click in Playwright)
+    await page.evaluate(
+      (el) => {
+        const canvas = el as HTMLElement & {
+          selectCommit: (oid: string) => boolean;
+          selectedNodes?: Set<string>;
+        };
+        canvas?.selectCommit('commit2');
+        canvas?.selectedNodes?.add('commit1');
+      },
+      handle
+    );
+    await waitForSelectedNode(page, 'commit2');
+
+    // The tip is amended away; commit1 stays in the rewritten history
+    await injectCommandMock(page, {
+      get_commit_history: [makeCommit(3, ['commit1']), makeCommit(1, ['commit0']), makeCommit(0, [])],
+      get_refs_by_commit: {
+        commit3: [
+          { name: 'refs/heads/main', shorthand: 'main', refType: 'localBranch', isHead: true },
+        ],
+      },
+      get_commit_total: 3,
+    });
+    await page.evaluate(
+      (el) => {
+        const canvas = el as HTMLElement & { refresh: () => void };
+        canvas?.refresh();
+      },
+      handle
+    );
+    await waitForSelectedNode(page, 'commit1');
+
+    // The panel follows the survivor instead of going blank while the graph
+    // still highlights it
+    const commitDetails = page.locator('lv-commit-details');
+    await expect(commitDetails.locator('.commit-message')).toContainText('Commit 1');
+    await expect(commitDetails.locator('.empty-state')).toHaveCount(0);
+    expect(await getSelectedNodeOids(page)).toEqual(['commit1']);
+  });
+
   test('a refresh that keeps the selected commit keeps the commit details panel', async ({ page }) => {
     const handle = await getGraphCanvasHandle(page);
     await page.evaluate(

--- a/e2e/tests/graph.spec.ts
+++ b/e2e/tests/graph.spec.ts
@@ -395,6 +395,88 @@ test.describe('Graph Commit Selection', () => {
     await expect(commitMessage).toContainText('Commit 1');
   });
 
+  test('a refresh that rewrites away the selected commit empties the commit details panel', async ({ page }) => {
+    const handle = await getGraphCanvasHandle(page);
+    await page.evaluate(
+      (el) => {
+        const canvas = el as HTMLElement & { selectCommit: (oid: string) => boolean };
+        canvas?.selectCommit('commit1');
+      },
+      handle
+    );
+    await waitForSelectedNode(page, 'commit1');
+
+    const commitDetails = page.locator('lv-commit-details');
+    await expect(commitDetails.locator('.commit-message')).toContainText('Commit 1');
+
+    // The history is rewritten (amend/rebase/squash): commit1 and commit2 are
+    // gone, replaced by commit3 on top of commit0
+    await injectCommandMock(page, {
+      get_commit_history: [makeCommit(3, ['commit0']), makeCommit(0, [])],
+      get_refs_by_commit: {
+        commit3: [
+          { name: 'refs/heads/main', shorthand: 'main', refType: 'localBranch', isHead: true },
+        ],
+      },
+      get_commit_total: 2,
+    });
+    await page.evaluate(
+      (el) => {
+        const canvas = el as HTMLElement & { refresh: () => void };
+        canvas?.refresh();
+      },
+      handle
+    );
+    await waitForNodeCount(page, 2);
+
+    // The panel must not keep showing a commit that no longer exists
+    await expect(commitDetails.locator('.empty-state')).toBeVisible();
+    await expect(commitDetails.locator('.empty-state')).toContainText('Select a commit to view details');
+    await expect(commitDetails.locator('.commit-message')).toHaveCount(0);
+    expect(await getSelectedNodeOid(page)).toBeNull();
+  });
+
+  test('a refresh that keeps the selected commit keeps the commit details panel', async ({ page }) => {
+    const handle = await getGraphCanvasHandle(page);
+    await page.evaluate(
+      (el) => {
+        const canvas = el as HTMLElement & { selectCommit: (oid: string) => boolean };
+        canvas?.selectCommit('commit1');
+      },
+      handle
+    );
+    await waitForSelectedNode(page, 'commit1');
+
+    // An ordinary refresh (pull, fetch, watcher refs-changed): a new commit
+    // lands on top and every existing commit survives
+    await injectCommandMock(page, {
+      get_commit_history: [
+        makeCommit(3, ['commit2']),
+        makeCommit(2, ['commit1']),
+        makeCommit(1, ['commit0']),
+        makeCommit(0, []),
+      ],
+      get_refs_by_commit: {
+        commit3: [
+          { name: 'refs/heads/main', shorthand: 'main', refType: 'localBranch', isHead: true },
+        ],
+      },
+      get_commit_total: 4,
+    });
+    await page.evaluate(
+      (el) => {
+        const canvas = el as HTMLElement & { refresh: () => void };
+        canvas?.refresh();
+      },
+      handle
+    );
+    await waitForNodeCount(page, 4);
+
+    const commitDetails = page.locator('lv-commit-details');
+    await expect(commitDetails.locator('.commit-message')).toContainText('Commit 1');
+    expect(await getSelectedNodeOid(page)).toBe('commit1');
+  });
+
   test('Escape should deselect the current commit', async ({ page }) => {
     await graph.navigateDown();
     await waitForAnySelectedNode(page);

--- a/src/components/graph/__tests__/lv-graph-canvas.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas.test.ts
@@ -1431,6 +1431,125 @@ describe('lv-graph-canvas', () => {
       expect(internals.selectedNodes.size).to.equal(1);
       expect(events).to.have.length(0);
     });
+
+    it('promotes a surviving selected commit when the primary one is rewritten away', async () => {
+      setupDefaultMocks();
+      const el = await renderCanvas();
+      const internals = el as unknown as SelectionInternals;
+
+      // Multi-selection with commit3 primary and commit2 also selected
+      expect(el.selectCommit(commit3.oid)).to.be.true;
+      internals.selectedNodes.add(commit2.oid);
+      expect(internals.selectedNode?.oid).to.equal(commit3.oid);
+
+      // The tip is amended away; commit2 stays in the rewritten history
+      const amended = makeCommit({
+        oid: 'ddd4444444444444444444444444444444444444',
+        shortId: 'ddd4444',
+        summary: 'Third commit (amended)',
+        message: 'Third commit (amended)',
+        timestamp: 1700002500,
+        parentIds: [commit2.oid],
+      });
+      setupDefaultMocks({
+        commits: [amended, commit2, commit1],
+        refs: {
+          [amended.oid]: [
+            { name: 'refs/heads/main', shorthand: 'main', refType: 'localBranch', isHead: true },
+          ],
+        },
+      });
+
+      const events = captureSelectionEvents(el);
+      await reload(el);
+
+      // The survivor becomes the primary, so the highlighted graph and the
+      // details panel agree and keyboard navigation keeps its anchor
+      expect([...internals.selectedNodes]).to.deep.equal([commit2.oid]);
+      expect(internals.selectedNode?.oid).to.equal(commit2.oid);
+      expect(events).to.have.length(1);
+      expect(events[0].commit?.oid).to.equal(commit2.oid);
+      expect(events[0].commits).to.have.length(1);
+    });
+
+    it('keeps a selection from a later page when a reload only brings back the first page', async () => {
+      const deepCommit = makeCommit({
+        oid: 'ddd4444444444444444444444444444444444444',
+        shortId: 'ddd4444',
+        summary: 'Deep commit',
+        message: 'Deep commit',
+        timestamp: 1699999000,
+        parentIds: [],
+      });
+      // commitCount 3 == page size, so the reload comes back truncated
+      setupDefaultMocks({ moreCommits: [deepCommit], total: 4 });
+      const el = await renderCanvas(3);
+      const internals = el as unknown as SelectionInternals & {
+        loadMoreCommits(): Promise<void>;
+      };
+
+      await internals.loadMoreCommits();
+      await el.updateComplete;
+      expect(el.selectCommit(deepCommit.oid)).to.be.true;
+
+      setupDefaultMocks({ moreCommits: [deepCommit], total: 4 });
+      const events = captureSelectionEvents(el);
+      await reload(el);
+
+      // The commit is still in the repository — it just sits below the
+      // reloaded page, so the details panel must not be emptied
+      expect(internals.selectedNode?.oid).to.equal(deepCommit.oid);
+      expect([...internals.selectedNodes]).to.deep.equal([deepCommit.oid]);
+      expect(events).to.have.length(0);
+
+      // The catch-up page brings it back and confirms it is still there
+      await internals.loadMoreCommits();
+      await el.updateComplete;
+      expect(internals.selectedNode?.oid).to.equal(deepCommit.oid);
+      expect(events).to.have.length(0);
+    });
+
+    it('prunes a selection from a later page once the catch-up page proves it is gone', async () => {
+      const deepCommit = makeCommit({
+        oid: 'ddd4444444444444444444444444444444444444',
+        shortId: 'ddd4444',
+        summary: 'Deep commit',
+        message: 'Deep commit',
+        timestamp: 1699999000,
+        parentIds: [],
+      });
+      setupDefaultMocks({ moreCommits: [deepCommit], total: 4 });
+      const el = await renderCanvas(3);
+      const internals = el as unknown as SelectionInternals & {
+        loadMoreCommits(): Promise<void>;
+      };
+
+      await internals.loadMoreCommits();
+      await el.updateComplete;
+      expect(el.selectCommit(deepCommit.oid)).to.be.true;
+
+      // A rebase rewrites the deep commit: the catch-up page returns a
+      // different OID in its place
+      const rewritten = makeCommit({
+        oid: 'eee5555555555555555555555555555555555555',
+        shortId: 'eee5555',
+        summary: 'Deep commit (rewritten)',
+        message: 'Deep commit (rewritten)',
+        timestamp: 1699999000,
+        parentIds: [],
+      });
+      setupDefaultMocks({ moreCommits: [rewritten], total: 4 });
+
+      const events = captureSelectionEvents(el);
+      await reload(el);
+      await internals.loadMoreCommits();
+      await el.updateComplete;
+
+      expect(internals.selectedNode).to.be.null;
+      expect(internals.selectedNodes.size).to.equal(0);
+      expect(events).to.have.length(1);
+      expect(events[0].commit).to.be.null;
+    });
   });
 
   describe('pull request loading race', () => {

--- a/src/components/graph/__tests__/lv-graph-canvas.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas.test.ts
@@ -1277,6 +1277,162 @@ describe('lv-graph-canvas', () => {
     });
   });
 
+  // ── Selection validation after a reload ──────────────────────────────
+  describe('selection validation after reload', () => {
+    type SelectionInternals = {
+      selectedNode: { oid: string; row: number } | null;
+      selectedNodes: Set<string>;
+      lastClickedNode: { oid: string; row: number } | null;
+    };
+
+    /** Trigger refresh() and let the reload + relayout settle */
+    async function reload(el: LvGraphCanvas): Promise<void> {
+      el.refresh();
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 200));
+      await el.updateComplete;
+    }
+
+    function captureSelectionEvents(
+      el: LvGraphCanvas
+    ): Array<{ commit: Commit | null; commits: Commit[] }> {
+      const events: Array<{ commit: Commit | null; commits: Commit[] }> = [];
+      el.addEventListener('commit-selected', (e) => {
+        const detail = (e as CustomEvent<{ commit: Commit | null; commits: Commit[] }>).detail;
+        events.push({ commit: detail.commit, commits: detail.commits });
+      });
+      return events;
+    }
+
+    it('clears the selection and notifies listeners when a reload rewrites away the selected commit', async () => {
+      setupDefaultMocks();
+      const el = await renderCanvas();
+      expect(el.selectCommit(commit3.oid)).to.be.true;
+
+      // The tip commit is amended: the old OID is gone from the rewritten history
+      const amended = makeCommit({
+        oid: 'ddd4444444444444444444444444444444444444',
+        shortId: 'ddd4444',
+        summary: 'Third commit (amended)',
+        message: 'Third commit (amended)',
+        timestamp: 1700002500,
+        parentIds: [commit2.oid],
+      });
+      setupDefaultMocks({
+        commits: [amended, commit2, commit1],
+        refs: {
+          [amended.oid]: [
+            { name: 'refs/heads/main', shorthand: 'main', refType: 'localBranch', isHead: true },
+          ],
+        },
+      });
+
+      const events = captureSelectionEvents(el);
+      await reload(el);
+
+      expect(events).to.have.length(1);
+      expect(events[0].commit).to.be.null;
+      expect(events[0].commits).to.have.length(0);
+
+      const internals = el as unknown as SelectionInternals;
+      expect(internals.selectedNode).to.be.null;
+      expect(internals.selectedNodes.size).to.equal(0);
+      expect(internals.lastClickedNode).to.be.null;
+    });
+
+    it('prunes only the vanished OIDs from a multi-selection and keeps the rest', async () => {
+      setupDefaultMocks();
+      const el = await renderCanvas();
+      const internals = el as unknown as SelectionInternals;
+
+      expect(el.selectCommit(commit2.oid)).to.be.true;
+      internals.selectedNodes.add(commit3.oid);
+      expect(internals.selectedNodes.size).to.equal(2);
+
+      // The branch holding commit3 is deleted: only commit3 leaves the graph
+      setupDefaultMocks({
+        commits: [commit2, commit1],
+        refs: {
+          [commit2.oid]: [
+            { name: 'refs/heads/main', shorthand: 'main', refType: 'localBranch', isHead: true },
+          ],
+        },
+      });
+
+      const events = captureSelectionEvents(el);
+      await reload(el);
+
+      expect(events).to.have.length(1);
+      expect(events[0].commit?.oid).to.equal(commit2.oid);
+      expect(events[0].commits).to.have.length(1);
+      expect([...internals.selectedNodes]).to.deep.equal([commit2.oid]);
+      expect(internals.selectedNode?.oid).to.equal(commit2.oid);
+    });
+
+    it('rebinds a surviving selection to its node in the new layout', async () => {
+      setupDefaultMocks();
+      const el = await renderCanvas();
+      const internals = el as unknown as SelectionInternals;
+
+      expect(el.selectCommit(commit2.oid)).to.be.true;
+      expect(internals.selectedNode?.row).to.equal(1);
+
+      // A new commit lands on top, shifting every existing row down by one
+      const commit4 = makeCommit({
+        oid: 'ddd4444444444444444444444444444444444444',
+        shortId: 'ddd4444',
+        summary: 'Fourth commit',
+        message: 'Fourth commit',
+        timestamp: 1700003000,
+        parentIds: [commit3.oid],
+      });
+      setupDefaultMocks({
+        commits: [commit4, commit3, commit2, commit1],
+        refs: {
+          [commit4.oid]: [
+            { name: 'refs/heads/main', shorthand: 'main', refType: 'localBranch', isHead: true },
+          ],
+        },
+      });
+
+      const events = captureSelectionEvents(el);
+      await reload(el);
+
+      // Same commit, new row — range-select and the SR position read this row
+      expect(internals.selectedNode?.oid).to.equal(commit2.oid);
+      expect(internals.selectedNode?.row).to.equal(2);
+      expect(internals.lastClickedNode?.oid).to.equal(commit2.oid);
+      expect(internals.lastClickedNode?.row).to.equal(2);
+      // An ordinary reload that keeps the selection must not churn the panel
+      expect(events).to.have.length(0);
+    });
+
+    it('keeps the selection when a reload fails', async () => {
+      setupDefaultMocks();
+      const el = await renderCanvas();
+      const internals = el as unknown as SelectionInternals;
+
+      expect(el.selectCommit(commit2.oid)).to.be.true;
+
+      const previous = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_commit_history') {
+          throw new Error('walk failed');
+        }
+        return previous(command, args);
+      };
+
+      const events = captureSelectionEvents(el);
+      await reload(el);
+
+      // A failed load never rebuilds the layout, so the details panel must
+      // keep showing exactly what it showed before
+      expect(internals.selectedNode?.oid).to.equal(commit2.oid);
+      expect(internals.selectedNodes.size).to.equal(1);
+      expect(events).to.have.length(0);
+    });
+  });
+
   describe('pull request loading race', () => {
     it('discards PRs fetched for a previously active repository', async () => {
       let resolvePrs: ((v: unknown) => void) | null = null;

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -1591,6 +1591,9 @@ export class LvGraphCanvas extends LitElement {
     this.resizeMinimap();
     this.rebuildMinimapDots();
 
+    // Drop/rebind the selection against the new layout before painting
+    this.validateSelection();
+
     // Set highlighted commits for search results
     this.renderer?.setHighlightedCommits(this.matchedCommitOids);
 
@@ -1601,6 +1604,44 @@ export class LvGraphCanvas extends LitElement {
     // Fetch stats and signatures for the visible rows asynchronously
     // (don't block initial render). Debounced to let rapid changes settle.
     this.scheduleVisibleDataFetch();
+  }
+
+  /**
+   * Reconcile the selection with the layout that was just built. A reload
+   * after an amend, rebase, squash or branch delete (and a branch-filter
+   * change) rebuilds the graph around different OIDs and different rows:
+   * without this the details panel would keep showing a commit that is gone
+   * from the repository — and its actions would run against a dead OID —
+   * while survivors would keep pointing at their OLD nodes, so range-select
+   * and the screen-reader position would work off stale rows.
+   */
+  private validateSelection(): void {
+    if (!this.layout) return;
+
+    let selectionChanged = false;
+    for (const oid of [...this.selectedNodes]) {
+      if (!this.layout.nodes.has(oid)) {
+        this.selectedNodes.delete(oid);
+        selectionChanged = true;
+      }
+    }
+    if (this.selectedNode) {
+      // Rebind a survivor to its node in the NEW layout (same commit, new row)
+      const node = this.layout.nodes.get(this.selectedNode.oid) ?? null;
+      if (!node) selectionChanged = true;
+      this.selectedNode = node;
+    }
+    if (this.lastClickedNode) {
+      this.lastClickedNode = this.layout.nodes.get(this.lastClickedNode.oid) ?? null;
+    }
+
+    // Only a real change is announced — an ordinary reload that keeps the
+    // selection must not churn the details panel. markDirty/scheduleRender
+    // are left to applyLayout(), which runs them on the very next lines.
+    if (selectionChanged) {
+      this.dispatchSelectionEvent();
+      this.renderer?.setMultiSelection(this.selectedNodes, this.hoveredNode?.oid ?? null);
+    }
   }
 
   /**
@@ -2880,30 +2921,10 @@ export class LvGraphCanvas extends LitElement {
 
   private applyBranchFilter(): void {
     // processLayout() applies the branch-visibility filter via
-    // getVisibleCommits(), rebuilds the indices, and schedules a render
+    // getVisibleCommits(), rebuilds the indices, drops a selection the
+    // filter just hid (applyLayout -> validateSelection), and schedules a
+    // render
     this.processLayout();
-
-    // A commit hidden by the filter must not stay selected
-    if (this.layout) {
-      let selectionChanged = false;
-      for (const oid of [...this.selectedNodes]) {
-        if (!this.layout.nodes.has(oid)) {
-          this.selectedNodes.delete(oid);
-          selectionChanged = true;
-        }
-      }
-      if (this.selectedNode && !this.layout.nodes.has(this.selectedNode.oid)) {
-        this.selectedNode = null;
-        this.lastClickedNode = null;
-        selectionChanged = true;
-      }
-      if (selectionChanged) {
-        this.dispatchSelectionEvent();
-        this.renderer?.setMultiSelection(this.selectedNodes, this.hoveredNode?.oid ?? null);
-        this.renderer?.markDirty();
-        this.scheduleRender();
-      }
-    }
   }
 
   // Export methods

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -557,6 +557,10 @@ export class LvGraphCanvas extends LitElement {
   // True total commit count across all refs (null until fetched)
   @state() private commitTotal: number | null = null;
   private totalLoadedCommits = 0;
+  // How many commits were loaded the last time the selection was validated
+  // against the layout — the high-water mark validateSelection() needs to
+  // tell "this commit is gone" apart from "this page isn't back yet"
+  private validatedCommitCount = 0;
 
   // Screen-reader mirror of the visible rows + selection announcements.
   // The canvas itself has no DOM semantics, so a hidden listbox mirrors the
@@ -875,6 +879,9 @@ export class LvGraphCanvas extends LitElement {
       // A reload queued for the PREVIOUS repo must not leak into this one
       this.reloadQueued = false;
       this.commitTotal = null;
+      // The new repo's first page must be free to prune its own selection —
+      // the previous repo's paging depth says nothing about this one
+      this.validatedCommitCount = 0;
       // Clear any stats spinner owned by the previous repo — the new repo's
       // fetch (if any) will set it again; a repo with no stats to fetch must
       // not inherit the old spinner
@@ -1618,6 +1625,15 @@ export class LvGraphCanvas extends LitElement {
   private validateSelection(): void {
     if (!this.layout) return;
 
+    // A reload always restarts from the newest commitCount commits, so a
+    // graph that had already paged deeper is missing those rows only
+    // because they have not been fetched again yet — their absence is no
+    // proof the commits are gone. Wait for the catch-up pages (each append
+    // lands here too) to reach the depth the selection was last checked
+    // against before pruning anything.
+    if (this.hasMoreCommits && this.totalLoadedCommits < this.validatedCommitCount) return;
+    this.validatedCommitCount = this.totalLoadedCommits;
+
     let selectionChanged = false;
     for (const oid of [...this.selectedNodes]) {
       if (!this.layout.nodes.has(oid)) {
@@ -1627,8 +1643,18 @@ export class LvGraphCanvas extends LitElement {
     }
     if (this.selectedNode) {
       // Rebind a survivor to its node in the NEW layout (same commit, new row)
-      const node = this.layout.nodes.get(this.selectedNode.oid) ?? null;
-      if (!node) selectionChanged = true;
+      let node = this.layout.nodes.get(this.selectedNode.oid) ?? null;
+      if (!node) {
+        // The primary commit is gone but the rest of a multi-selection can
+        // survive: promote one (as ctrl+click does when it removes the
+        // primary) so the details panel and keyboard navigation keep an
+        // anchor matching what stays highlighted
+        const remaining = [...this.selectedNodes];
+        node = remaining.length > 0
+          ? this.layout.nodes.get(remaining[remaining.length - 1]) ?? null
+          : null;
+        selectionChanged = true;
+      }
       this.selectedNode = node;
     }
     if (this.lastClickedNode) {


### PR DESCRIPTION
## What was broken

### Selection is not validated after a reload — the details panel keeps showing a rewritten-away commit

In `src/components/graph/lv-graph-canvas.ts`, `applyBranchFilter()` owned the **only** selection-pruning logic in the component: it called `processLayout()`, then walked `selectedNodes`, deleted OIDs the new `this.layout.nodes` map no longer contained, nulled `selectedNode`/`lastClickedNode`, and on change dispatched `commit-selected` + `renderer.setMultiSelection(...)`.

The two sibling layout paths did **not**:

- `processLayout()` (`computeGraphLayout(...)` → `this.layout = result.layout` → `applyLayout()`), reached from `loadCommits()`, `applyCachedGraph()` and the filtered/searched load-more.
- The incremental `this.layout = appendLanes(...)` → `applyLayout()` branch of `loadMoreCommits()`.

`applyLayout()` rebuilt `sortedNodesByRow`, virtual scroll, the spatial index and the minimap, but never touched `selectedNode`/`selectedNodes`/`lastClickedNode`.

`loadCommits()` clears and repopulates `realCommits` and then calls `processLayout()`, so after `refresh()` following an **amend, rebase, squash or branch delete** the old OID is gone from both `realCommits` and `layout.nodes` — yet `selectedNode` still held the old `LayoutNode`. No `commit-selected` was dispatched, and `app-shell.handleCommitSelected` only ever sets `selectedCommit`/`selectedCommitRefs` from that event (it is otherwise cleared only on a repo tab switch), so `<lv-right-panel .commit=${this.selectedCommit}>` kept rendering a commit that no longer exists in the repository while the canvas showed no highlight — and the commit-detail actions (checkout, revert, tag) would fire against a dead OID.

Second half of the same staleness: even when the selected commit **survived** a reload, `selectedNode`/`lastClickedNode` kept pointing at the **old** `LayoutNode` object. Rows are assigned by array index in `layoutInto()` (`const row = startRow + i`), so a reload that prepends a commit shifts every row by one. `handleRangeSelect()` reads `this.lastClickedNode.row` and `dispatchSelectionEvent()` reads `this.selectedNode.row + 1` for the screen-reader announcement — both then off by the number of new commits.

## The fix

A single new private `validateSelection()`, called from `applyLayout()` right before it paints. `applyLayout()` has exactly two callers (`processLayout()` and the `appendLanes` branch of `loadMoreCommits()`), which makes it the one seam every rebuilt layout passes through.

`validateSelection()`:

- deletes from `selectedNodes` every OID the new layout no longer contains;
- rebinds `selectedNode` and `lastClickedNode` to their node in the **new** layout (same commit, new row), nulling them when the commit is gone;
- dispatches `commit-selected` and `renderer.setMultiSelection(...)` **only when the selection actually changed** — an ordinary refresh (pull, fetch, watcher refs-changed) that keeps the selection must not churn the details panel;
- leaves `markDirty()`/`scheduleRender()` to `applyLayout()`, which runs them on the very next lines, so each layout still paints exactly once.

`applyBranchFilter()` collapses to the `processLayout()` call — behavior is identical, the pruning now happens inside `applyLayout()` just before its own `markDirty()`+`scheduleRender()`.

A **failed** load never rebuilds `this.layout`, so `validateSelection()` never runs for it and the selection/details panel are left exactly as they were. `hoveredNode` is untouched (recomputed on the next mousemove). No public API, event shape, or Tauri call changed.

## Tests

| Test | File | Covers |
| --- | --- | --- |
| `clears the selection and notifies listeners when a reload rewrites away the selected commit` | `src/components/graph/__tests__/lv-graph-canvas.test.ts` | Happy path: amend drops the selected OID → one `commit-selected` with `commit: null`, empty `commits`, selection state cleared |
| `prunes only the vanished OIDs from a multi-selection and keeps the rest` | same | Edge: partial prune — only the deleted branch's OID leaves `selectedNodes`, primary selection survives, event reports 1 commit |
| `rebinds a surviving selection to its node in the new layout` | same | Edge: a new commit on top shifts rows — `selectedNode.row`/`lastClickedNode.row` follow the new layout, and **no** event is dispatched |
| `keeps the selection when a reload fails` | same | Error path: `get_commit_history` throws → selection untouched, no event |
| `clears the selection when the selected commit becomes hidden` / `keeps the selection when the selected commit stays visible` | same (existing, unchanged) | Regression guard for moving the pruning out of `applyBranchFilter()` |
| `a refresh that rewrites away the selected commit empties the commit details panel` | `e2e/tests/graph.spec.ts` | User-visible outcome: `lv-commit-details` shows the empty state instead of the vanished commit |
| `a refresh that keeps the selected commit keeps the commit details panel` | same | Guards against over-pruning / a spurious null dispatch on every ordinary refresh |

### Verified to fail without the fix

Reverting only the `this.validateSelection();` call in `applyLayout()` and re-running:

- `clears the selection and notifies listeners when a reload rewrites away the selected commit` — `AssertionError: expected [] to have a length of 1 but got 0` (no `commit-selected` is dispatched at all)
- `prunes only the vanished OIDs from a multi-selection and keeps the rest` — `AssertionError: expected [] to have a length of 1 but got 0`
- `rebinds a surviving selection to its node in the new layout` — `AssertionError: expected 1 to equal 2` (stale row from the previous layout)
- existing `clears the selection when the selected commit becomes hidden` — `AssertionError: expected { Object (oid, row, ...) } to be null`
- E2E `a refresh that rewrites away the selected commit empties the commit details panel` — `expect(locator).toBeVisible() failed / element(s) not found` for `.empty-state`; the panel still shows `Commit 1`

`keeps the selection when a reload fails` passes both with and without the fix by design — it is the constraint that forces the fix onto the layout seam rather than into `loadCommits()`'s `finally` or an up-front clear on reload.

Gate: `npm run lint`, `npm run typecheck`, `npm test` (93 canvas unit tests), `cargo fmt --check`, and `npx playwright test e2e/tests/graph.spec.ts` (37 passed) all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_