### PR TITLE
Move the whole selection when right-clicking a commit in the graph

### DIFF
--- a/e2e/tests/context-menus.spec.ts
+++ b/e2e/tests/context-menus.spec.ts
@@ -16,7 +16,11 @@ import {
  *
  * Uses Playwright's auto-piercing locator to find elements inside shadow DOM.
  */
-async function rightClickOnCommitRow(page: import('@playwright/test').Page, rowIndex: number = 0) {
+async function rightClickOnCommitRow(
+  page: import('@playwright/test').Page,
+  rowIndex: number = 0,
+  button: 'left' | 'right' = 'right'
+) {
   const graphCanvas = page.locator('lv-graph-canvas');
   await expect(graphCanvas).toBeVisible();
 
@@ -43,7 +47,23 @@ async function rightClickOnCommitRow(page: import('@playwright/test').Page, rowI
   const commitX = box.x + 400; // Click in the commit message area
   const commitY = box.y + headerHeight + (rowIndex * rowHeight) + (rowHeight / 2);
 
-  await page.mouse.click(commitX, commitY, { button: 'right' });
+  await page.mouse.click(commitX, commitY, { button });
+}
+
+/**
+ * Read the oid of the commit laid out at a given graph row.
+ */
+async function oidAtRow(page: import('@playwright/test').Page, rowIndex: number): Promise<string> {
+  const graphHandle = await page.locator('lv-graph-canvas').elementHandle();
+  const oid = await page.evaluate(
+    ([el, row]) => {
+      const canvas = el as HTMLElement & { sortedNodesByRow?: Array<{ oid: string }> };
+      return canvas?.sortedNodesByRow?.[row as number]?.oid ?? null;
+    },
+    [graphHandle, rowIndex] as const
+  );
+  if (!oid) throw new Error(`No commit laid out at row ${rowIndex}`);
+  return oid;
 }
 
 test.describe('Commit Context Menu', () => {
@@ -76,6 +96,54 @@ test.describe('Commit Context Menu', () => {
     const menuItems = contextMenu.locator('.context-menu-item');
     const count = await menuItems.count();
     expect(count).toBeGreaterThan(0);
+  });
+
+  test('right-clicking a commit moves the highlight off the previously selected one', async ({ page }) => {
+    // Left-click the first commit so there is a previous selection to move off.
+    await rightClickOnCommitRow(page, 0, 'left');
+    const firstOid = await oidAtRow(page, 0);
+    const secondOid = await oidAtRow(page, 1);
+    expect(secondOid).not.toBe(firstOid);
+
+    const graphHandle = await page.locator('lv-graph-canvas').elementHandle();
+    await page.waitForFunction(
+      ([el, expectedOid]) => {
+        const canvas = el as HTMLElement & { selectedNode?: { oid: string } | null };
+        return canvas?.selectedNode?.oid === expectedOid;
+      },
+      [graphHandle, firstOid] as const
+    );
+
+    // Right-click a different commit: the menu targets it, so the graph must
+    // highlight it too rather than leaving the highlight on the first one.
+    await rightClickOnCommitRow(page, 1);
+    await expect(page.locator('.context-menu')).toBeVisible({ timeout: 3000 });
+
+    await page.waitForFunction(
+      ([el, expectedOid]) => {
+        const canvas = el as HTMLElement & { selectedNode?: { oid: string } | null };
+        return canvas?.selectedNode?.oid === expectedOid;
+      },
+      [graphHandle, secondOid] as const
+    );
+
+    const state = await page.evaluate(
+      (el) => {
+        const canvas = el as HTMLElement & {
+          selectedNode?: { oid: string } | null;
+          selectedNodes?: Set<string>;
+        };
+        return {
+          primary: canvas?.selectedNode?.oid ?? null,
+          selected: canvas?.selectedNodes ? Array.from(canvas.selectedNodes) : [],
+        };
+      },
+      graphHandle
+    );
+
+    expect(state.primary).toBe(secondOid);
+    expect(state.selected).toEqual([secondOid]);
+    expect(state.selected).not.toContain(firstOid);
   });
 
   test('should close context menu on Escape key', async ({ page }) => {

--- a/src/components/graph/__tests__/lv-graph-canvas-context-menu-selection.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas-context-menu-selection.test.ts
@@ -1,0 +1,265 @@
+/**
+ * Right-clicking a commit has to move the WHOLE selection, not just the
+ * primary one.
+ *
+ * `handleContextMenu` used to set only `selectedNode`. Everything the graph
+ * actually paints as selected comes from `selectedNodes` (the renderer's
+ * `setMultiSelection`), and the `commits` array on `commit-selected` is built
+ * from the same set — so right-clicking commit C while commit A was selected
+ * left the highlight on A while the context menu and the details panel both
+ * named C. `lastClickedNode` (the Shift+click range anchor) was stale too, so
+ * the next Shift+click ranged from a commit the user had left two actions ago.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { Commit } from '../../../types/git.types.ts';
+import '../lv-graph-canvas.ts';
+import type { LvGraphCanvas } from '../lv-graph-canvas.ts';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const REPO_PATH = '/test/repo/context-menu-selection';
+
+function makeCommit(oid: string, summary: string, parentIds: string[], timestamp: number): Commit {
+  return {
+    oid,
+    shortId: oid.substring(0, 7),
+    message: summary,
+    summary,
+    body: '',
+    author: { name: 'Test Author', email: 'test@example.com', timestamp },
+    committer: { name: 'Test Author', email: 'test@example.com', timestamp },
+    parentIds,
+    timestamp,
+  };
+}
+
+const commitA = makeCommit('aaaaaaa111111111111111111111111111111111', 'Commit A', [], 1700000000);
+const commitB = makeCommit('bbbbbbb222222222222222222222222222222222', 'Commit B', [commitA.oid], 1700001000);
+const commitC = makeCommit('ccccccc333333333333333333333333333333333', 'Commit C', [commitB.oid], 1700002000);
+
+/** An oid the component never loaded, so `realCommits` has no entry for it. */
+const UNKNOWN_OID = 'fffffff999999999999999999999999999999999';
+
+interface HitTestResultLike {
+  type: string;
+  node?: unknown;
+  distance: number;
+}
+
+interface Harness {
+  el: LvGraphCanvas;
+  /** What the stubbed hitTest reports under the cursor for the next event. */
+  setHit: (oid: string | null) => void;
+  /** Look a laid-out node up by oid. */
+  nodeFor: (oid: string) => any;
+  rightClick: () => Promise<void>;
+  click: (modifiers?: { ctrlKey?: boolean; shiftKey?: boolean }) => Promise<void>;
+  selectedOids: () => string[];
+  primaryOid: () => string | null;
+  anchorOid: () => string | null;
+  rendererOids: () => string[];
+}
+
+async function mountCanvas(): Promise<Harness> {
+  mockInvoke = async (command: string) => {
+    switch (command) {
+      case 'get_commit_history':
+        return [commitC, commitB, commitA];
+      case 'get_commit_total':
+        return 3;
+      case 'get_refs_by_commit':
+        return {};
+      case 'detect_github_repo':
+        return null;
+      case 'get_commits_stats':
+      case 'get_commits_signatures':
+      case 'search_commits':
+        return [];
+      default:
+        return null;
+    }
+  };
+
+  const el = await fixture<LvGraphCanvas>(
+    html`<lv-graph-canvas .repositoryPath=${REPO_PATH} .commitCount=${100}></lv-graph-canvas>`
+  );
+  await el.updateComplete;
+
+  // firstUpdated() creates the renderer and attaches the listeners
+  // asynchronously, and the layout lands after get_commit_history resolves —
+  // one tick is not enough. Poll until both exist.
+  const deadline = Date.now() + 4000;
+  while (!(el as any).renderer || (el as any).sortedNodesByRow.length < 3) {
+    if (Date.now() > deadline) throw new Error('graph never finished laying out');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  await el.updateComplete;
+
+  // Never report a ref label under the cursor — this suite is about commits.
+  (el as any).renderer.getRefLabelAtPoint = () => null;
+
+  const nodeFor = (oid: string): any =>
+    (el as any).sortedNodesByRow.find((n: any) => n.oid === oid) ?? null;
+
+  let hit: HitTestResultLike = { type: 'none', distance: Infinity };
+  (el as any).hitTest = (): HitTestResultLike => hit;
+
+  const setHit = (oid: string | null): void => {
+    if (oid === null) {
+      hit = { type: 'none', distance: Infinity };
+      return;
+    }
+    const node = nodeFor(oid) ?? { ...nodeFor(commitC.oid), oid };
+    hit = { type: 'node', node, distance: 0 };
+  };
+
+  const canvas = el.shadowRoot!.querySelector('canvas');
+  expect(canvas, 'the canvas must be rendered').to.not.be.null;
+
+  const dispatch = async (type: string, init: MouseEventInit = {}): Promise<void> => {
+    canvas!.dispatchEvent(new MouseEvent(type, { clientX: 40, clientY: 40, bubbles: true, ...init }));
+    await el.updateComplete;
+  };
+
+  return {
+    el,
+    setHit,
+    nodeFor,
+    rightClick: () => dispatch('contextmenu'),
+    click: (modifiers = {}) => dispatch('click', modifiers),
+    selectedOids: () => Array.from((el as any).selectedNodes as Set<string>),
+    primaryOid: () => ((el as any).selectedNode?.oid as string) ?? null,
+    anchorOid: () => ((el as any).lastClickedNode?.oid as string) ?? null,
+    rendererOids: () => Array.from((el as any).renderer.selectedOids as Set<string>),
+  };
+}
+
+describe('lv-graph-canvas right-click selection', () => {
+  it('replaces the previous selection when right-clicking another commit', async () => {
+    const h = await mountCanvas();
+
+    h.el.selectCommit(commitA.oid);
+    expect(h.selectedOids(), 'precondition: A is the whole selection').to.deep.equal([commitA.oid]);
+
+    h.setHit(commitC.oid);
+    await h.rightClick();
+
+    expect(
+      h.selectedOids(),
+      'the right-clicked commit must become the selection, not just the primary',
+    ).to.deep.equal([commitC.oid]);
+    expect(h.primaryOid()).to.equal(commitC.oid);
+  });
+
+  it('paints the highlight on the commit the menu is for', async () => {
+    const h = await mountCanvas();
+
+    h.el.selectCommit(commitA.oid);
+    h.setHit(commitC.oid);
+    await h.rightClick();
+
+    expect(
+      h.rendererOids(),
+      'the graph must highlight the commit whose context menu just opened',
+    ).to.deep.equal([commitC.oid]);
+    expect((h.el as any).renderer.selectedOid).to.equal(commitC.oid);
+  });
+
+  it('carries the right-clicked commit in the multi-select payload', async () => {
+    const h = await mountCanvas();
+
+    h.el.selectCommit(commitA.oid);
+
+    const selections: CustomEvent[] = [];
+    h.el.addEventListener('commit-selected', (e) => selections.push(e as CustomEvent));
+
+    h.setHit(commitC.oid);
+    await h.rightClick();
+
+    expect(selections.length, 'right-click must announce the new selection').to.equal(1);
+    const detail = selections[0].detail as { commit: Commit; commits: Commit[] };
+    expect(detail.commit.oid).to.equal(commitC.oid);
+    expect(
+      detail.commits.map((c) => c.oid),
+      'commits[] must agree with commit — not still list the old selection',
+    ).to.deep.equal([commitC.oid]);
+  });
+
+  it('keeps an existing multi-selection and moves the anchor into it', async () => {
+    const h = await mountCanvas();
+
+    h.setHit(commitC.oid);
+    await h.click();
+    h.setHit(commitB.oid);
+    await h.click({ ctrlKey: true });
+
+    expect(h.selectedOids().sort(), 'precondition: B and C are both selected').to.deep.equal(
+      [commitB.oid, commitC.oid].sort()
+    );
+    expect(h.anchorOid(), 'precondition: the anchor is the last Ctrl+clicked commit').to.equal(commitB.oid);
+
+    h.setHit(commitC.oid);
+    await h.rightClick();
+
+    expect(
+      h.selectedOids().sort(),
+      'right-clicking inside a deliberate multi-selection must not collapse it',
+    ).to.deep.equal([commitB.oid, commitC.oid].sort());
+    expect(h.primaryOid()).to.equal(commitC.oid);
+    expect(h.anchorOid(), 'the anchor follows the commit the user just right-clicked').to.equal(commitC.oid);
+  });
+
+  it('ranges from the right-clicked commit on a later Shift+click', async () => {
+    const h = await mountCanvas();
+
+    h.el.selectCommit(commitA.oid);
+    h.setHit(commitC.oid);
+    await h.rightClick();
+
+    h.setHit(commitA.oid);
+    await h.click({ shiftKey: true });
+
+    const selected = h.selectedOids();
+    expect(selected.length, 'the range must run from C down to A, not A to A').to.equal(3);
+    expect(selected).to.include(commitA.oid);
+    expect(selected).to.include(commitB.oid);
+    expect(selected).to.include(commitC.oid);
+  });
+
+  it('changes nothing when the right-click misses a commit', async () => {
+    const h = await mountCanvas();
+
+    h.el.selectCommit(commitA.oid);
+
+    const selections: CustomEvent[] = [];
+    const menus: CustomEvent[] = [];
+    h.el.addEventListener('commit-selected', (e) => selections.push(e as CustomEvent));
+    h.el.addEventListener('commit-context-menu', (e) => menus.push(e as CustomEvent));
+
+    // Empty space.
+    h.setHit(null);
+    await h.rightClick();
+
+    // A laid-out node whose commit was never loaded.
+    h.setHit(UNKNOWN_OID);
+    await h.rightClick();
+
+    expect(h.selectedOids(), 'a miss must leave the selection alone').to.deep.equal([commitA.oid]);
+    expect(h.primaryOid()).to.equal(commitA.oid);
+    expect(selections.length, 'a miss announces no selection change').to.equal(0);
+    expect(menus.length, 'a miss opens no commit context menu').to.equal(0);
+  });
+});

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -2272,8 +2272,20 @@ export class LvGraphCanvas extends LitElement {
     if (result.type === 'node' && result.node) {
       const commit = this.realCommits.get(result.node.oid);
       if (commit) {
-        // Select the commit on right-click
+        // A right-click is a selection too, so it has to move ALL of the
+        // selection state, not just the primary one. `selectedNodes` drives
+        // both the painted highlight and the `commits` array on
+        // `commit-selected`, and `lastClickedNode` is the Shift+click range
+        // anchor — leaving them behind highlighted one commit while the menu
+        // and the details panel named another. Right-clicking a commit that is
+        // already part of a multi-selection keeps that selection: acting on the
+        // whole set is exactly why the user built it.
         this.selectedNode = result.node;
+        if (!this.selectedNodes.has(result.node.oid)) {
+          this.selectedNodes.clear();
+          this.selectedNodes.add(result.node.oid);
+        }
+        this.lastClickedNode = result.node;
         this.dispatchSelectionEvent();
 
         // Dispatch context menu event


### PR DESCRIPTION
## What was broken

### Right-click set the primary selection but nothing else

In `src/components/graph/lv-graph-canvas.ts`, `handleContextMenu`'s node branch read:

```ts
if (commit) {
  // Select the commit on right-click
  this.selectedNode = result.node;
  this.dispatchSelectionEvent();
```

It moved `selectedNode` and nothing else. `selectedNodes` and `lastClickedNode` were never touched — unlike every sibling selection path in the same file (`handleClick`'s regular-click branch, `selectCommit`, the arrow-key handler, and Escape), all of which move all three.

Three consequences, all user-visible or contract-visible:

1. **The highlight went stale.** Right after `dispatchSelectionEvent()` the handler calls `this.renderer?.setMultiSelection(this.selectedNodes, ...)`, and `canvas-renderer.ts`'s `setMultiSelection()` stores `selectedOids` and derives `selectedOid` from the last member of that set. Everything the graph paints as selected comes from `selectedNodes`. So right-clicking commit B while commit A was selected left the row highlight on **A** while the context menu targeted **B** and the details panel (`app-shell.handleCommitSelected` → `this.selectedCommit = e.detail.commit`) showed **B**. Three surfaces, two different commits. With nothing selected yet, the right-clicked commit got no highlight at all.

2. **The multi-select payload disagreed with itself.** `dispatchSelectionEvent()` builds `detail.commits` by iterating `selectedNodes`, so `commit-selected` fired with `commit = B` alongside `commits = [A]`. `app-shell` only reads `commit`/`refs` today, so this half is latent — but the event contract was inconsistent at the source.

3. **The Shift+click range anchor went stale.** `handleRangeSelect` ranges from `lastClickedNode`, which was still A, so the next Shift+click measured its range from a commit the user had left two actions earlier instead of the one they just right-clicked.

## The fix

Mirror `handleClick`'s regular-click branch inside `handleContextMenu`: collapse the selection onto the right-clicked commit and move the range anchor to it, before dispatching.

```ts
this.selectedNode = result.node;
if (!this.selectedNodes.has(result.node.oid)) {
  this.selectedNodes.clear();
  this.selectedNodes.add(result.node.oid);
}
this.lastClickedNode = result.node;
this.dispatchSelectionEvent();
```

Right-clicking a commit that is **already** part of a multi-selection deliberately keeps that selection — acting on the whole set is exactly why the user built it — but still moves the primary and the anchor onto the commit the menu is for.

Nothing else changes. The existing `commit-context-menu` dispatch, `setMultiSelection(this.selectedNodes, ...)`, `markDirty()` and `scheduleRender()` calls that follow already read the updated state, so the highlight repaints with no extra plumbing. No Rust, no type changes, no new events, no `app-shell` change — `detail.commits` simply stops carrying the previous selection. The ref-label branch above is untouched, and `handleContextMenu` still does not call `canvasEl.focus()` (that asymmetry with `handleClick` is a separate question, deliberately left alone).

## Tests

New unit file `src/components/graph/__tests__/lv-graph-canvas-context-menu-selection.test.ts`, plus one E2E in the spec that already owns graph right-clicks.

| Test | Covers | Fails without the fix |
| --- | --- | --- |
| `replaces the previous selection when right-clicking another commit` | happy path — `selectedNodes` and `selectedNode` both land on the right-clicked commit | Yes — `selectedNodes` is still `[A]` |
| `paints the highlight on the commit the menu is for` | the visible symptom — `renderer.selectedOids` / `selectedOid` | Yes — renderer still holds A |
| `carries the right-clicked commit in the multi-select payload` | `commit-selected` contract: `detail.commit` vs `detail.commits` | Yes — `commits` is `[A]` while `commit` is C |
| `keeps an existing multi-selection and moves the anchor into it` | edge case — right-click inside a real two-commit Ctrl+click selection; also guards the fix from collapsing a deliberate multi-selection | Yes — the anchor is still B |
| `ranges from the right-clicked commit on a later Shift+click` | consequence 3 — the range after a right-click covers C..A | Yes — the range is A..A, size 1 |
| `changes nothing when the right-click misses a commit` | no-op path — empty space, and a node whose commit was never loaded into `realCommits`; no `commit-selected`, no `commit-context-menu` | No, by design — this is the scope guard proving the new clearing only runs on a real commit hit |
| E2E `right-clicking a commit moves the highlight off the previously selected one` (`e2e/tests/context-menus.spec.ts`) | full-stack flow — left-click row 0, right-click row 1, assert the menu is visible and the highlighted set is exactly the menu's target commit | Yes — `selectedNodes` still held row 0's oid while `selectedNode` was row 1's |

Verified by reverting **only** the production hunk and re-running. Unit: 5 failed, 1 passed (the scope guard), e.g. `AssertionError: the right-clicked commit must become the selection, not just the primary: expected [ "aaaaaaa1…" ] to deeply equal [ "ccccccc3…" ]` and `the range must run from C down to A, not A to A: expected 1 to equal 3`. E2E: `expect(received).toEqual(expected) — Array [ - "abc123def456", + "def456abc789" ]` at the `selectedNodes` assertion. Fix restored, all green.

The E2E change also gives the existing `rightClickOnCommitRow` helper an optional `button: 'left' | 'right' = 'right'` parameter so the same row geometry can left-click; existing callers are unaffected. No `waitForTimeout` — auto-retrying assertions and `page.waitForFunction` only.

## Gate

`npm run lint` OK · `npm run typecheck` OK · `npm test` OK · `npx playwright test e2e/tests/context-menus.spec.ts` 30 passed · `e2e/tests/graph.spec.ts` 35 passed (regression check on the sibling selection paths) · `cargo fmt --check` OK. No Rust touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_