### PR TITLE
Report command palette "open file in editor" failures instead of swallowing them

### DIFF
--- a/e2e/tests/dialogs.spec.ts
+++ b/e2e/tests/dialogs.spec.ts
@@ -2,7 +2,7 @@ import { test, expect } from '@playwright/test';
 import { setupOpenRepository, setupTauriMocks } from '../fixtures/tauri-mock';
 import { AppPage } from '../pages/app.page';
 import { DialogsPage } from '../pages/dialogs.page';
-import { injectCommandError } from '../fixtures/test-helpers';
+import { injectCommandError, injectCommandMock } from '../fixtures/test-helpers';
 
 test.describe('Settings Dialog', () => {
   let app: AppPage;
@@ -532,5 +532,44 @@ test.describe('Dialogs - Error Scenarios', () => {
 
     // Dialog should still be visible (no crash)
     await expect(dialogs.settings.dialog).toBeVisible();
+  });
+});
+
+test.describe('Command Palette - open file in editor', () => {
+  let dialogs: DialogsPage;
+
+  test.beforeEach(async ({ page }) => {
+    dialogs = new DialogsPage(page);
+    await setupOpenRepository(page);
+  });
+
+  test('selecting a file whose editor fails shows an error toast', async ({ page }) => {
+    await injectCommandMock(page, { list_tracked_files: ['src/main.rs'] });
+    await injectCommandError(page, 'open_in_configured_editor', 'Invalid path: src/main.rs');
+
+    await dialogs.commandPalette.open();
+    // File entries only join the results once the query is at least 2 chars.
+    await dialogs.commandPalette.search('main.rs');
+    await dialogs.commandPalette.selectResultByText('src/main.rs');
+
+    // executeSelected closes the palette, so the toast is unobstructed.
+    await expect(dialogs.commandPalette.palette).not.toBeVisible();
+    await expect(
+      page.locator('lv-toast-container .toast.error .toast-message').first()
+    ).toContainText('src/main.rs');
+  });
+
+  test('selecting a file that opens successfully shows no error toast', async ({ page }) => {
+    await injectCommandMock(page, {
+      list_tracked_files: ['src/main.rs'],
+      open_in_configured_editor: { success: true, message: 'Opened in code' },
+    });
+
+    await dialogs.commandPalette.open();
+    await dialogs.commandPalette.search('main.rs');
+    await dialogs.commandPalette.selectResultByText('src/main.rs');
+
+    await expect(dialogs.commandPalette.palette).not.toBeVisible();
+    await expect(page.locator('lv-toast-container .toast.error')).toHaveCount(0);
   });
 });

--- a/src/__tests__/app-shell-palette-open-file.test.ts
+++ b/src/__tests__/app-shell-palette-open-file.test.ts
@@ -1,0 +1,150 @@
+/**
+ * Feedback for the command palette's "open file in editor" action.
+ *
+ * The handler wrapped gitService.openInConfiguredEditor in a try/catch, but
+ * invokeCommand never throws — it resolves to {success:false} — so the catch
+ * was dead code and neither result.success nor the payload's own OpenResult
+ * success flag was inspected. A file deleted since the palette listed it, an
+ * editor command that cannot be spawned, or no editor at all closed the
+ * palette and produced no feedback whatsoever.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
+const mockResponses: Record<string, (args: Record<string, unknown>) => unknown> = {};
+/** Commands that should reject, and with what. */
+const failures: Record<string, { code?: string; message: string }> = {};
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCallArgs.push({ command, args: args || {} });
+    if (failures[command]) return Promise.reject(failures[command]);
+    const handler = mockResponses[command];
+    return Promise.resolve(handler ? handler(args || {}) : null);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect } from '@open-wc/testing';
+import type { AppShell } from '../app-shell.ts';
+import '../app-shell.ts';
+import { uiStore, repositoryStore } from '../stores/index.ts';
+import type { Repository } from '../types/git.types.ts';
+
+function mockRepo(path: string, name: string): Repository {
+  return {
+    path,
+    name,
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+describe('app-shell command palette: open file in editor', () => {
+  beforeEach(() => {
+    invokeCallArgs.length = 0;
+    for (const k of Object.keys(mockResponses)) delete mockResponses[k];
+    for (const k of Object.keys(failures)) delete failures[k];
+    uiStore.setState({ toasts: [] });
+    repositoryStore.getState().reset();
+  });
+
+  afterEach(() => {
+    repositoryStore.getState().reset();
+  });
+
+  function shellOnRepo(): AppShell {
+    const el = document.createElement('lv-app-shell') as AppShell;
+    (el as any).activeRepository = { repository: mockRepo('/repo/one', 'one') };
+    return el;
+  }
+
+  async function openFile(el: AppShell, path: string): Promise<void> {
+    await (el as any).handleOpenFileFromPalette(
+      new CustomEvent('open-file', { detail: { path } }),
+    );
+  }
+
+  function errorToasts(): Array<{ message: string; type: string }> {
+    return uiStore
+      .getState()
+      .toasts.filter((t) => t.type === 'error') as Array<{ message: string; type: string }>;
+  }
+
+  it('a successful open in the configured editor produces no error toast', async () => {
+    mockResponses['open_in_configured_editor'] = () => ({
+      success: true,
+      message: 'Opened in code',
+    });
+
+    const el = shellOnRepo();
+    await openFile(el, 'src/main.rs');
+
+    const call = invokeCallArgs.find((c) => c.command === 'open_in_configured_editor');
+    expect(call, 'the editor command should be invoked').to.exist;
+    expect(call!.args.path).to.equal('/repo/one');
+    expect(call!.args.filePath).to.equal('src/main.rs');
+    expect(errorToasts()).to.have.lengthOf(0);
+  });
+
+  it('a rejected open_in_configured_editor surfaces the backend reason', async () => {
+    failures['open_in_configured_editor'] = {
+      code: 'INVALID_PATH',
+      message: 'Invalid path: src/gone.rs',
+    };
+
+    const el = shellOnRepo();
+    await openFile(el, 'src/gone.rs');
+
+    const errors = errorToasts();
+    expect(errors, 'a missing file must not fail silently').to.have.lengthOf(1);
+    expect(errors[0].message).to.contain('src/gone.rs');
+  });
+
+  it('an editor that fails to spawn is reported, not swallowed', async () => {
+    failures['open_in_configured_editor'] = {
+      code: 'COMMAND_ERROR',
+      message: "Failed to open editor 'nope': No such file or directory",
+    };
+
+    const el = shellOnRepo();
+    await openFile(el, 'src/main.rs');
+
+    const errors = errorToasts();
+    expect(errors, 'an unlaunchable editor must not fail silently').to.have.lengthOf(1);
+    expect(errors[0].message).to.contain("Failed to open editor 'nope'");
+  });
+
+  it('a payload that reports failure is reported even though the command resolved', async () => {
+    mockResponses['open_in_configured_editor'] = () => ({
+      success: false,
+      message: 'No editor configured',
+    });
+
+    const el = shellOnRepo();
+    await openFile(el, 'src/main.rs');
+
+    const errors = errorToasts();
+    expect(errors, 'OpenResult.success === false must be reported').to.have.lengthOf(1);
+    expect(errors[0].message).to.contain('No editor configured');
+  });
+
+  it('with no repository open nothing is invoked and nothing is toasted', async () => {
+    const el = shellOnRepo();
+    (el as any).activeRepository = null;
+
+    await openFile(el, 'src/main.rs');
+
+    expect(invokeCallArgs).to.have.lengthOf(0);
+    expect(uiStore.getState().toasts).to.have.lengthOf(0);
+  });
+});

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -4834,10 +4834,19 @@ export class AppShell extends LitElement {
 
   private async handleOpenFileFromPalette(e: CustomEvent<{ path: string }>): Promise<void> {
     if (!this.activeRepository) return;
-    try {
-      await gitService.openInConfiguredEditor(this.activeRepository.repository.path, e.detail.path);
-    } catch {
-      showToast('Failed to open file in editor', 'error');
+    // gitService.openInConfiguredEditor returns a CommandResult (invokeCommand
+    // never throws), so we must inspect result.success — the catch-only path
+    // could never fire, so a file deleted since the palette listed it, or an
+    // editor that fails to launch, closed the palette and did nothing at all.
+    const result = await gitService.openInConfiguredEditor(
+      this.activeRepository.repository.path,
+      e.detail.path,
+    );
+    if (!result.success || !result.data?.success) {
+      const message =
+        result.data?.message || result.error?.message || 'Failed to open file in editor';
+      log.error('Failed to open file in editor:', message);
+      showToast(message, 'error');
     }
   }
 


### PR DESCRIPTION
## What was broken

### Palette "open file in editor" failures are completely silent

`handleOpenFileFromPalette` in `src/app-shell.ts` wrapped `gitService.openInConfiguredEditor` in a `try`/`catch`:

```ts
try {
  await gitService.openInConfiguredEditor(this.activeRepository.repository.path, e.detail.path);
} catch {
  showToast('Failed to open file in editor', 'error');
}
```

`invokeCommand` (`src/services/tauri-api.ts`) never throws — it catches everything and resolves to `{ success: false, error: { code, message } }`. That contract is already spelled out in this very file by the sibling `fetchRepository` / `pullRepository` / `pushRepository` handlers ("gitService.\<op\> returns a CommandResult (invokeCommand never throws), so we must inspect result.success"). So the `catch` was dead code, and the handler inspected neither `result.success` nor the payload's own `OpenResult.success` flag.

The backend genuinely fails on this path. `open_in_configured_editor` (`src-tauri/src/commands/file.rs`) returns:

- `InvalidPath(...)` when the target file no longer exists — e.g. a palette entry for a file deleted since `list_tracked_files` ran;
- `OperationFailed("Failed to open editor '<cmd>': ...")` when the configured `core.editor` cannot be spawned;
- and with no editor configured it falls through to the default-app launcher, which errors when `xdg-open`/`open` cannot spawn.

In every one of those cases the palette closed and *nothing happened* — no toast, no log, no indication the file did not open. That is exactly the silent error path `CLAUDE.md` forbids ("Error paths must never be silent"). This is the only call site of `openInConfiguredEditor` in the app, and it had no unit or E2E coverage.

## The fix

One method in `src/app-shell.ts`. Inspect the `CommandResult` the way the sibling network handlers and `checkoutBranchFromPalette` already do, and surface the backend's own reason:

```ts
const result = await gitService.openInConfiguredEditor(
  this.activeRepository.repository.path,
  e.detail.path,
);
if (!result.success || !result.data?.success) {
  const message =
    result.data?.message || result.error?.message || 'Failed to open file in editor';
  log.error('Failed to open file in editor:', message);
  showToast(message, 'error');
}
```

- `result.data?.success` is checked too because `OpenResult` carries its own `success`/`message` pair; the backend sets it `true` on `Ok` today, but the flag is part of the payload contract — the same belt-and-braces check `checkoutBranchFromPalette` applies to `checkoutWithAutoStash`.
- The message falls back `data.message` → `error.message` → generic, so the user sees "Invalid path: …" or "Failed to open editor 'nope': …" rather than a blank failure.
- A plain error toast (matching `handleWorkspaceOpenRepoFile` right below) rather than `showErrorWithSuggestion`, which only maps libgit2 push/pull/checkout strings and has nothing to say about editors.
- Success stays silent — the editor window appearing is the feedback, and no sibling toasts on a successful open.

No Rust changes, no new imports (`log` and `showToast` were already in scope), no new object literals passed to `gitService` (snake_case grep stays clean).

## Tests

New unit file `src/__tests__/app-shell-palette-open-file.test.ts` (harness copied from `app-shell-remote-feedback.test.ts`) plus a new `Command Palette - open file in editor` describe block in `e2e/tests/dialogs.spec.ts`.

| # | Layer | Test | Covers | Fails without the fix |
|---|-------|------|--------|-----------------------|
| 1 | unit | a successful open in the configured editor produces no error toast | happy path; also pins the camelCase `filePath` Tauri arg | no (guard) |
| 2 | unit | a rejected `open_in_configured_editor` surfaces the backend reason | error path — missing file | **yes** |
| 3 | unit | an editor that fails to spawn is reported, not swallowed | error path — unlaunchable `core.editor` | **yes** |
| 4 | unit | a payload that reports failure is reported even though the command resolved | edge case — `OpenResult.success === false` | **yes** |
| 5 | unit | with no repository open nothing is invoked and nothing is toasted | edge case — early return | no (guard) |
| 6 | e2e | selecting a file whose editor fails shows an error toast | full palette → handler → toast flow | **yes** |
| 7 | e2e | selecting a file that opens successfully shows no error toast | companion happy path | no (guard) |

### Verified failing without the fix

The production change was reverted (tests untouched) and the suites re-run:

- Unit tests 2, 3, 4 all failed identically — `expected [] to have a length of 1 but got 0` (e.g. `AssertionError: a missing file must not fail silently`) — because today zero toasts are produced on every failure path. Tests 1 and 5 stayed green as intended.
- E2E test 6 failed with `Expect "toContainText" with timeout 5000ms — waiting for locator('lv-toast-container .toast.error .toast-message').first() … element(s) not found`: the palette closes and no toast is ever rendered.

Restoring the fix turns all of them green.

### Gate

`npm run lint` OK · `npm run typecheck` OK · `npm test` OK · `cargo fmt --check` OK (no Rust changes) · `npx playwright test e2e/tests/dialogs.spec.ts` — 37 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_