### PR TITLE
Make the Word Wrap setting the one word-wrap preference the diff view uses

### DIFF
--- a/e2e/tests/diff.spec.ts
+++ b/e2e/tests/diff.spec.ts
@@ -822,3 +822,67 @@ test.describe('Diff - UI Outcome Verification', () => {
     await expect(onionSkinBtn).not.toHaveClass(/active/);
   });
 });
+
+test.describe('Word Wrap setting', () => {
+  let rightPanel: RightPanelPage;
+  let graph: GraphPanelPage;
+
+  // The diff view has its own `.diff-content` inside the app-shell wrapper of the
+  // same name, so scope the assertion to the component.
+  const DIFF_CONTENT = 'lv-diff-view .diff-content';
+  const WORD_WRAP_TOGGLE =
+    'lv-settings-dialog .setting-row:has(.setting-name:text-is("Word Wrap")) .toggle-switch';
+
+  test.beforeEach(async ({ page }) => {
+    rightPanel = new RightPanelPage(page);
+    graph = new GraphPanelPage(page);
+    await setupOpenRepository(
+      page,
+      withModifiedFiles([
+        { path: 'src/main.ts', status: 'modified', isStaged: false, isConflicted: false },
+      ])
+    );
+  });
+
+  test('Settings > Word Wrap wraps the open diff', async ({ page }) => {
+    await rightPanel.openFileDiff('src/main.ts');
+    await expect(graph.diffOverlay).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(DIFF_CONTENT)).not.toHaveClass(/word-wrap/);
+
+    await page.keyboard.press('Meta+,');
+    await expect(page.locator('lv-settings-dialog')).toBeVisible();
+    await page.locator(`${WORD_WRAP_TOGGLE} .toggle-slider`).click();
+    await page.locator('lv-settings-dialog button:has-text("Done")').click();
+
+    await expect(page.locator(DIFF_CONTENT)).toHaveClass(/word-wrap/);
+  });
+
+  test('the toolbar button is the same preference as the setting', async ({ page }) => {
+    await rightPanel.openFileDiff('src/main.ts');
+    await expect(graph.diffOverlay).toBeVisible({ timeout: 5000 });
+
+    await page.keyboard.press('Meta+,');
+    await expect(page.locator(`${WORD_WRAP_TOGGLE} input`)).not.toBeChecked();
+    await page.locator('lv-settings-dialog button:has-text("Done")').click();
+
+    await page.locator('lv-diff-view [title="Toggle word wrap"]').click();
+    await expect(page.locator(DIFF_CONTENT)).toHaveClass(/word-wrap/);
+
+    await page.keyboard.press('Meta+,');
+    await expect(page.locator(`${WORD_WRAP_TOGGLE} input`)).toBeChecked();
+  });
+
+  test('wrapping survives closing and reopening the diff', async ({ page }) => {
+    await rightPanel.openFileDiff('src/main.ts');
+    await expect(graph.diffOverlay).toBeVisible({ timeout: 5000 });
+    await page.locator('lv-diff-view [title="Toggle word wrap"]').click();
+    await expect(page.locator(DIFF_CONTENT)).toHaveClass(/word-wrap/);
+
+    await graph.closeDiff();
+    await expect(graph.diffOverlay).not.toBeVisible();
+
+    await rightPanel.openFileDiff('src/main.ts');
+    await expect(graph.diffOverlay).toBeVisible({ timeout: 5000 });
+    await expect(page.locator(DIFF_CONTENT)).toHaveClass(/word-wrap/);
+  });
+});

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -28,6 +28,7 @@ import type { LvDiffView } from '../lv-diff-view.ts';
 // Import the actual component — registers <lv-diff-view> custom element
 import '../lv-diff-view.ts';
 import { uiStore } from '../../../stores/ui.store.ts';
+import { settingsStore } from '../../../stores/settings.store.ts';
 
 // ── Test data ──────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
@@ -169,12 +170,30 @@ async function renderDiffView(props: {
   return el;
 }
 
+function findWordWrapButton(el: LvDiffView): HTMLElement | null {
+  const viewBtns = el.shadowRoot!.querySelectorAll('.view-btn');
+  return (
+    (Array.from(viewBtns).find((btn) => btn.getAttribute('title') === 'Toggle word wrap') as
+      | HTMLElement
+      | undefined) ?? null
+  );
+}
+
+function clickWordWrapButton(el: LvDiffView): void {
+  const btn = findWordWrapButton(el);
+  expect(btn, 'the word wrap toolbar button exists').to.not.be.null;
+  btn!.click();
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────
 describe('lv-diff-view', () => {
   beforeEach(() => {
     clearHistory();
     setupDefaultMocks();
     confirmAnswer = 'Ok';
+    // Word wrap is a shared setting now — start every test from a known off.
+    settingsStore.getState().setWordWrap(false);
+    localStorage.removeItem('leviathan-diff-word-wrap');
   });
 
   // ── Rendering ──────────────────────────────────────────────────────────
@@ -813,6 +832,61 @@ describe('lv-diff-view', () => {
       diffContent = el.shadowRoot!.querySelector('.diff-content');
       expect(diffContent).to.not.be.null;
       expect(diffContent!.classList.contains('word-wrap')).to.be.true;
+    });
+
+    it('toolbar button writes the shared Word Wrap setting', async () => {
+      const el = await renderDiffView();
+
+      clickWordWrapButton(el);
+      await el.updateComplete;
+
+      expect(settingsStore.getState().wordWrap, 'the app setting is the source of truth').to.be
+        .true;
+      const diffContent = el.shadowRoot!.querySelector('.diff-content');
+      expect(diffContent!.classList.contains('word-wrap')).to.be.true;
+    });
+
+    it('renders wrapped when the setting is already on', async () => {
+      settingsStore.getState().setWordWrap(true);
+
+      const el = await renderDiffView();
+
+      const diffContent = el.shadowRoot!.querySelector('.diff-content');
+      expect(diffContent!.classList.contains('word-wrap')).to.be.true;
+      const wordWrapBtn = findWordWrapButton(el);
+      expect(wordWrapBtn!.classList.contains('active'), 'the toolbar button reflects it').to.be
+        .true;
+    });
+
+    it('follows the Settings dialog changing the setting while the diff is open', async () => {
+      const el = await renderDiffView();
+      let diffContent = el.shadowRoot!.querySelector('.diff-content');
+      expect(diffContent!.classList.contains('word-wrap')).to.be.false;
+
+      settingsStore.getState().setWordWrap(true);
+      await el.updateComplete;
+
+      diffContent = el.shadowRoot!.querySelector('.diff-content');
+      expect(diffContent!.classList.contains('word-wrap')).to.be.true;
+    });
+
+    it('no longer writes its own word-wrap storage key', async () => {
+      const el = await renderDiffView();
+
+      clickWordWrapButton(el);
+      await el.updateComplete;
+
+      expect(localStorage.getItem('leviathan-diff-word-wrap')).to.be.null;
+    });
+
+    it('stops following the setting once removed', async () => {
+      const el = await renderDiffView();
+
+      el.remove();
+      settingsStore.getState().setWordWrap(true);
+
+      expect((el as unknown as { wordWrap: boolean }).wordWrap, 'the subscription is torn down').to
+        .be.false;
     });
   });
 

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -5,6 +5,7 @@ import { codeStyles } from '../../styles/code-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import { showConfirm } from '../../services/dialog.service.ts';
+import { settingsStore } from '../../stores/settings.store.ts';
 import { CodeRenderMixin } from '../../mixins/code-render-mixin.ts';
 import type { DiffFile, DiffHunk, DiffLine, StatusEntry } from '../../types/git.types.ts';
 import {
@@ -926,7 +927,9 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   @state() private loading = false;
   @state() private error: string | null = null;
   @state() private viewMode: DiffViewMode = 'unified';
-  @state() private wordWrap: boolean = false;
+  // Word wrap is an app setting (Settings > Editor); the toolbar button below is
+  // the same preference, not a second one.
+  @state() private wordWrap: boolean = settingsStore.getState().wordWrap;
   @state() private editMode = false;
   @state() private editContent = '';
   @state() private originalContent = '';
@@ -946,6 +949,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   // When true, load the diff without a line cap (set by "Load full diff").
   @state() private showFullDiff = false;
 
+  private settingsUnsubscribe: (() => void) | null = null;
   private virtualScrollManager = new DiffVirtualScrollManager();
   private flatLines: FlatDiffItem[] = [];
   private diffScrollTop = 0;
@@ -979,11 +983,12 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   connectedCallback(): void {
     super.connectedCallback();
     document.addEventListener('click', this.handleDocumentClick);
-    // Restore word wrap preference from localStorage
-    const savedWordWrap = localStorage.getItem('leviathan-diff-word-wrap');
-    if (savedWordWrap !== null) {
-      this.wordWrap = savedWordWrap === 'true';
-    }
+    // Word wrap comes from the shared setting, so the Settings dialog toggle and
+    // the toolbar button below stay in step.
+    this.wordWrap = settingsStore.getState().wordWrap;
+    this.settingsUnsubscribe = settingsStore.subscribe((state) => {
+      this.wordWrap = state.wordWrap;
+    });
     this.addEventListener('keydown', this.handleKeydown);
     // Make host focusable for keyboard shortcuts
     if (!this.hasAttribute('tabindex')) {
@@ -995,6 +1000,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     super.disconnectedCallback();
     document.removeEventListener('click', this.handleDocumentClick);
     this.removeEventListener('keydown', this.handleKeydown);
+    this.settingsUnsubscribe?.();
+    this.settingsUnsubscribe = null;
   }
 
   willUpdate(changedProperties: Map<string, unknown>): void {
@@ -1136,8 +1143,9 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   }
 
   private toggleWordWrap(): void {
-    this.wordWrap = !this.wordWrap;
-    localStorage.setItem('leviathan-diff-word-wrap', String(this.wordWrap));
+    // Writing the shared setting keeps the Settings dialog toggle and this button
+    // in step; the store subscription updates `this.wordWrap`.
+    settingsStore.getState().setWordWrap(!this.wordWrap);
   }
 
   /**

--- a/src/stores/__tests__/settings.store.test.ts
+++ b/src/stores/__tests__/settings.store.test.ts
@@ -43,8 +43,10 @@ describe('settings.store', () => {
       expect(settingsStore.getState().diffContextLines).to.equal(3);
     });
 
-    it('should have word wrap enabled by default', () => {
-      expect(settingsStore.getState().wordWrap).to.be.true;
+    it('should have word wrap disabled by default', () => {
+      // The diff view's own copy — the only word wrap that ever did anything —
+      // defaulted to off, so this default must match it.
+      expect(settingsStore.getState().wordWrap).to.be.false;
     });
 
     it('should not show whitespace by default', () => {
@@ -376,6 +378,10 @@ describe('settings.store', () => {
 
       expect(migrated.autoStashOnCheckout).to.equal(true);
       expect(migrated.theme, 'other settings survive').to.equal('dark');
+      expect(
+        (migrated as unknown as { wordWrap: boolean }).wordWrap,
+        'the never-read value is dropped'
+      ).to.equal(false);
     });
 
     it('leaves a v2 state alone', () => {
@@ -391,6 +397,76 @@ describe('settings.store', () => {
       };
 
       expect(migrated.autoStashOnCheckout, 'a v2 false is a real user choice').to.equal(false);
+    });
+
+    it('a v2 wordWrap is dropped — nothing read it', () => {
+      const persist = (
+        settingsStore as unknown as {
+          persist: { getOptions: () => { migrate?: (s: unknown, v: number) => unknown } };
+        }
+      ).persist;
+      const migrate = persist.getOptions().migrate!;
+
+      const migrated = migrate({ wordWrap: true, autoStashOnCheckout: false }, 2) as {
+        wordWrap: boolean;
+        autoStashOnCheckout: boolean;
+      };
+
+      expect(migrated.wordWrap, 'a persisted wordWrap was never a user choice').to.equal(false);
+      expect(migrated.autoStashOnCheckout, 'a v2 false is a real user choice').to.equal(false);
+    });
+
+    it('leaves a v3 wordWrap alone', () => {
+      const persist = (
+        settingsStore as unknown as {
+          persist: { getOptions: () => { migrate?: (s: unknown, v: number) => unknown } };
+        }
+      ).persist;
+      const migrate = persist.getOptions().migrate!;
+
+      const migrated = migrate({ wordWrap: true }, 3) as { wordWrap: boolean };
+
+      expect(migrated.wordWrap, 'a v3 value is a real user choice').to.equal(true);
+    });
+  });
+
+  describe('legacy diff word-wrap key', () => {
+    const LEGACY_KEY = 'leviathan-diff-word-wrap';
+
+    const rehydrate = (): void => {
+      (settingsStore as unknown as { persist: { rehydrate: () => void } }).persist.rehydrate();
+    };
+
+    afterEach(() => {
+      localStorage.removeItem(LEGACY_KEY);
+    });
+
+    it('adopts the diff view word-wrap preference and removes the old key', () => {
+      localStorage.setItem(LEGACY_KEY, 'true');
+
+      rehydrate();
+
+      expect(settingsStore.getState().wordWrap, 'the only real choice is carried over').to.be.true;
+      expect(localStorage.getItem(LEGACY_KEY), 'the old key is adopted once, then dropped').to.be
+        .null;
+    });
+
+    it('treats any non-"true" stored value as off and still drops the key', () => {
+      localStorage.setItem(LEGACY_KEY, 'yes');
+
+      rehydrate();
+
+      expect(settingsStore.getState().wordWrap).to.be.false;
+      expect(localStorage.getItem(LEGACY_KEY)).to.be.null;
+    });
+
+    it('leaves the setting alone when there is no old key to adopt', () => {
+      localStorage.removeItem(LEGACY_KEY);
+      settingsStore.getState().setWordWrap(true);
+
+      rehydrate();
+
+      expect(settingsStore.getState().wordWrap, 'a real setting is not clobbered').to.be.true;
     });
   });
 });

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -99,7 +99,9 @@ const defaultSettings = {
   graphRowHeight: 40,
   graphColorScheme: 'default' as GraphColorScheme,
   diffContextLines: 3,
-  wordWrap: true,
+  // Defaults OFF: until it was wired up nothing read this, and the diff view's
+  // own copy — the only word wrap anyone has ever seen — defaulted to off.
+  wordWrap: false,
   showWhitespace: false,
   autoFetchInterval: 0,
   fetchOnFocus: false,
@@ -117,6 +119,26 @@ const defaultSettings = {
   minimizeToTray: false,
   showNativeNotifications: true,
 };
+
+const LEGACY_DIFF_WORD_WRAP_KEY = 'leviathan-diff-word-wrap';
+
+/**
+ * The diff view used to keep word wrap in its own localStorage key, and its
+ * toolbar button was the only control that did anything — `wordWrap` here was
+ * read by nothing. That key holds the user's only real choice on the matter,
+ * so adopt it once, then drop it.
+ */
+function adoptLegacyDiffWordWrap(state: SettingsState): void {
+  let legacy: string | null;
+  try {
+    legacy = localStorage.getItem(LEGACY_DIFF_WORD_WRAP_KEY);
+    if (legacy === null) return;
+    localStorage.removeItem(LEGACY_DIFF_WORD_WRAP_KEY);
+  } catch {
+    return; // Storage unavailable — nothing to carry over.
+  }
+  state.setWordWrap(legacy === 'true');
+}
 
 export const settingsStore = createStore<SettingsState>()(
   persist(
@@ -195,7 +217,7 @@ export const settingsStore = createStore<SettingsState>()(
     }),
     {
       name: 'leviathan-settings',
-      version: 2,
+      version: 3,
       // Changing a default only affects installs with no persisted state.
       // zustand's default merge is a shallow `{...defaults, ...persisted}`, and
       // the whole settings object is persisted the moment the user changes
@@ -203,11 +225,16 @@ export const settingsStore = createStore<SettingsState>()(
       // `autoStashOnCheckout: false` over the new default and still got a
       // refused checkout. That `false` was never a user choice: the setting was
       // not read by anything until it was wired up, so every one of those users
-      // has only ever experienced auto-stashing.
+      // has only ever experienced auto-stashing. `wordWrap` has exactly the same
+      // story: it was persisted but never read, so a persisted value is not a
+      // user choice either and is dropped in favour of the diff view's own key.
       migrate: (persisted: unknown, fromVersion: number) => {
-        const state = (persisted ?? {}) as Partial<SettingsState>;
+        const state = { ...((persisted ?? {}) as Partial<SettingsState>) };
         if (fromVersion < 2) {
-          return { ...state, autoStashOnCheckout: true } as SettingsState;
+          state.autoStashOnCheckout = true;
+        }
+        if (fromVersion < 3) {
+          state.wordWrap = false;
         }
         return state as SettingsState;
       },
@@ -217,6 +244,7 @@ export const settingsStore = createStore<SettingsState>()(
           applyFontSize(state.fontSize);
           applyDensity(state.density);
           applyGraphColorScheme(state.graphColorScheme);
+          adoptLegacyDiffWordWrap(state);
         }
       },
     }


### PR DESCRIPTION
## What was broken

### Settings > Editor > "Word Wrap" was inert, and the diff view kept a second, conflicting preference

`settingsStore.wordWrap` is exposed as the "Word Wrap / Wrap long lines in diff view" row in the Settings dialog (`lv-settings-dialog.ts`: `renderToggle(this.wordWrap, 'wordWrap')` -> `handleToggle` case `'wordWrap'` -> `settingsStore.setWordWrap`), but **no component ever read it**. A repo-wide search for `wordWrap` found only the store, its own unit test, the dialog, and an unrelated unused `AppSettings` interface.

The word wrap that actually did something lived in `lv-diff-view.ts` as `@state() private wordWrap = false`, restored in `connectedCallback` from its own localStorage key `'leviathan-diff-word-wrap'` and written back in `toggleWordWrap()` — a key read and written nowhere else.

Consequences for a user:

- Flipping **Word Wrap** in Settings changed nothing anywhere. Dead control.
- The diff toolbar button was the only working control, and its state was invisible to Settings.
- The two defaults were opposite (store `true`, diff view `false`), so the Settings toggle showed "on" while every diff rendered unwrapped, and the two values then diverged silently.

## The fix

`settingsStore.wordWrap` becomes the single source of truth.

- `lv-diff-view` seeds `wordWrap` from the store, subscribes to it, and tears the subscription down in `disconnectedCallback` — the same `settingsUnsubscribe` pattern `lv-graph-canvas` already uses for `showAvatars`. Its toolbar button now calls `setWordWrap`, so the toggle and the button are two controls over one preference, in both directions. The class bindings (`.diff-content` / `.split-container` / the `active` button) are unchanged.
- The private `'leviathan-diff-word-wrap'` key is gone from the component; no reference to it remains outside the one-time adoption below.
- The store default flips to `false`, because off is the only word wrap users have ever experienced (the diff view's own copy defaulted to off).
- Persist `version` goes 2 -> 3 and the migration drops any persisted `wordWrap`. Nothing read that value, so it was never a user choice — exactly the reasoning already recorded in this file for `autoStashOnCheckout`, and the migration is restructured so branches accumulate rather than return early, leaving v1 behaviour untouched. The choice users *did* make lives in the old diff-view key, so `onRehydrateStorage` adopts it once (`localStorage` failures swallowed) and then removes it — nobody loses their preference, including users with no persisted settings at all.

Out of scope (separate finding): `diffContextLines` and `showWhitespace` are also consumer-less, but neither is exposed in any UI, so there is no dead user-visible control for them. `AppSettings.wordWrap` in `src/types/api.types.ts` is untouched.

## Tests

| Level | Test | Covers | Fails without the fix |
| --- | --- | --- | --- |
| Unit — store | `should have word wrap disabled by default` | default matches the only behaviour ever shipped | yes — `expected true to be false` |
| Unit — store | `v1 state carries autoStashOnCheckout forward as true` (extended) | v1 migration unchanged + `wordWrap` dropped | yes — `the never-read value is dropped: expected undefined to equal false` |
| Unit — store | `a v2 wordWrap is dropped — nothing read it` | v2 -> v3 drops the never-read value, keeps a real `autoStashOnCheckout` choice | yes — `expected true to equal false` |
| Unit — store | `leaves a v3 wordWrap alone` | edge: guards against an over-eager migration | no (paired guard) |
| Unit — store | `adopts the diff view word-wrap preference and removes the old key` | happy path: legacy key adopted once, then dropped | yes — `expected 'true' to be null` |
| Unit — store | `treats any non-"true" stored value as off and still drops the key` | error/garbage path | yes — `expected true to be false` |
| Unit — store | `leaves the setting alone when there is no old key to adopt` | edge: adoption must not clobber a real setting | no (regression guard) |
| Unit — diff view | `toolbar button writes the shared Word Wrap setting` | happy path: button -> store -> class | yes — `the app setting is the source of truth: expected false to be true` |
| Unit — diff view | `renders wrapped when the setting is already on` | store -> initial render + active button | yes — `expected false to be true` |
| Unit — diff view | `follows the Settings dialog changing the setting while the diff is open` | live subscription | yes — `expected false to be true` |
| Unit — diff view | `no longer writes its own word-wrap storage key` | private key is gone | yes — `expected 'true' to be null` |
| Unit — diff view | `stops following the setting once removed` | edge: unsubscribe on disconnect, no leak | no (leak guard) |
| E2E | `Settings > Word Wrap wraps the open diff` | the dead control now works, end to end | yes — `Expected pattern: /word-wrap/ … Received string: "diff-content  "` |
| E2E | `the toolbar button is the same preference as the setting` | both directions agree; default is off | yes — `expect(locator).not.toBeChecked() … Received: checked` |
| E2E | `wrapping survives closing and reopening the diff` | edge: leaving the private key did not lose persistence | no (regression guard) |

Verified by reverting only the two production files and re-running: 9 unit assertions and 2 E2E tests fail; restored, all green.

Gate: `npm run lint`, `npm run typecheck`, `npm test` (all unit suites), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, plus the full `e2e/tests/diff.spec.ts` (35 passed). No Rust changes and no Tauri invoke payloads touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_