### PR TITLE
Show only the selected GitHub auth method's connect form

### DIFF
--- a/e2e/pages/dialogs.page.ts
+++ b/e2e/pages/dialogs.page.ts
@@ -337,6 +337,10 @@ export class GitHubDialogPage extends BaseDialog {
   readonly authMethodToggle: Locator;
   readonly oauthButton: Locator;
   readonly patButton: Locator;
+  readonly appButton: Locator;
+  readonly appIdInput: Locator;
+  readonly appPrivateKeyInput: Locator;
+  readonly connectViaAppButton: Locator;
   readonly oauthSignInButton: Locator;
   readonly oauthSpinner: Locator;
   readonly oauthStatus: Locator;
@@ -371,6 +375,10 @@ export class GitHubDialogPage extends BaseDialog {
     this.authMethodToggle = page.locator('lv-github-dialog .auth-method-toggle');
     this.oauthButton = page.locator('lv-github-dialog .auth-method-toggle button:has-text("Sign in with GitHub")');
     this.patButton = page.locator('lv-github-dialog .auth-method-toggle button:has-text("Personal Access Token")');
+    this.appButton = page.locator('lv-github-dialog .auth-method-toggle button:has-text("GitHub App")');
+    this.appIdInput = page.locator('lv-github-dialog input[placeholder="123456"]');
+    this.appPrivateKeyInput = page.locator('lv-github-dialog textarea');
+    this.connectViaAppButton = page.locator('lv-github-dialog button:has-text("Connect via GitHub App")');
     this.oauthSignInButton = page.locator('lv-github-dialog .btn-oauth');
     this.oauthSpinner = page.locator('lv-github-dialog .oauth-spinner');
     this.oauthStatus = page.locator('lv-github-dialog .oauth-status');
@@ -420,6 +428,10 @@ export class GitHubDialogPage extends BaseDialog {
 
   async selectPATMethod(): Promise<void> {
     await this.patButton.click();
+  }
+
+  async selectAppMethod(): Promise<void> {
+    await this.appButton.click();
   }
 
   async isOAuthConfigured(): Promise<boolean> {

--- a/e2e/tests/github-dialog.spec.ts
+++ b/e2e/tests/github-dialog.spec.ts
@@ -166,6 +166,28 @@ test.describe('GitHub Dialog - Connection Flow', () => {
     // The error is caught and displayed, so just verify the dialog remains open
     await expect(dialogs.github.dialog).toBeVisible();
   });
+
+  test('should replace the token form when the GitHub App method is selected', async () => {
+    await app.executeCommand('GitHub');
+    await expect(dialogs.github.dialog).toBeVisible();
+
+    // GitHub App and Personal Access Token are alternative flows: selecting one
+    // must replace the other's form, never stack both connect buttons.
+    await dialogs.github.selectAppMethod();
+
+    await expect(dialogs.github.appIdInput).toBeVisible();
+    await expect(dialogs.github.connectViaAppButton).toBeVisible();
+    await expect(dialogs.github.tokenInput).toHaveCount(0);
+    await expect(dialogs.github.connectButton).toHaveCount(0);
+
+    // ...and the swap is symmetric.
+    await dialogs.github.selectPATMethod();
+
+    await expect(dialogs.github.tokenInput).toBeVisible();
+    await expect(dialogs.github.connectButton).toBeVisible();
+    await expect(dialogs.github.appIdInput).toHaveCount(0);
+    await expect(dialogs.github.connectViaAppButton).toHaveCount(0);
+  });
 });
 
 test.describe('GitHub Dialog - Close', () => {

--- a/src/components/dialogs/__tests__/lv-github-dialog-auth-method.test.ts
+++ b/src/components/dialogs/__tests__/lv-github-dialog-auth-method.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Picking an auth method must swap the connect form, not stack two of them.
+ *
+ * The connection tab rendered the Personal Access Token form in the *else*
+ * branch of `authMethod === 'oauth' ? ... : ...`, and the GitHub App form in a
+ * separate `authMethod === 'app'` block. Because the else branch was
+ * unconditional, choosing "GitHub App" (which is simply not 'oauth') painted
+ * the PAT password box, its "Delete Integration" button and its primary
+ * "Connect to GitHub" button directly above the App ID / private key form.
+ *
+ * The user was shown two competing connect flows with two primary buttons, and
+ * could press "Connect to GitHub" — saving an empty token — while filling in
+ * App credentials. Each method must render exactly one form.
+ *
+ * Assertions below compare counts and text rather than element references:
+ * a failed assertion holding a live DOM node cannot be serialised back to the
+ * test runner, which turns a plain failure into a hung run.
+ */
+
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as unknown as { __TAURI_INTERNALS__: { invoke: MockInvoke } }).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+};
+
+import { expect, fixture, html } from '@open-wc/testing';
+import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
+import '../lv-github-dialog.ts';
+import type { LvGitHubDialog } from '../lv-github-dialog.ts';
+
+interface DialogInternals {
+  authMethod: 'oauth' | 'pat' | 'app';
+  selectedAccountId: string | null;
+}
+
+async function openDisconnectedDialog(): Promise<LvGitHubDialog> {
+  const el = await fixture<LvGitHubDialog>(html`<lv-github-dialog .open=${true}></lv-github-dialog>`);
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 50));
+  await el.updateComplete;
+  return el;
+}
+
+/** How many buttons in the dialog carry this label. */
+function buttonCount(el: LvGitHubDialog, text: string): number {
+  return Array.from(el.shadowRoot!.querySelectorAll('button')).filter((b) =>
+    b.textContent?.includes(text),
+  ).length;
+}
+
+function count(el: LvGitHubDialog, selector: string): number {
+  return el.shadowRoot!.querySelectorAll(selector).length;
+}
+
+function primaryButtonLabels(el: LvGitHubDialog): string[] {
+  return Array.from(el.shadowRoot!.querySelectorAll('.btn-primary')).map((b) =>
+    (b.textContent ?? '').trim(),
+  );
+}
+
+function clickAuthMethod(el: LvGitHubDialog, text: string): void {
+  const buttons = Array.from(el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.auth-method-btn'));
+  const match = buttons.find((b) => b.textContent?.trim() === text);
+  expect(
+    match === undefined,
+    `auth method button "${text}" must exist, saw: ${buttons.map((b) => (b.textContent ?? '').trim()).join(' | ')}`,
+  ).to.be.false;
+  match!.click();
+}
+
+const PAT_INPUT = 'input[type="password"]';
+const APP_KEY_INPUT = 'textarea';
+
+describe('lv-github-dialog auth method switching', () => {
+  beforeEach(() => {
+    mockInvoke = (command: string) => {
+      if (command === 'check_github_connection') {
+        return Promise.resolve({ connected: false, user: null, scopes: [] });
+      }
+      return Promise.resolve(null);
+    };
+    unifiedProfileStore.getState().setAccounts([]);
+  });
+
+  it('hides the Personal Access Token form when the GitHub App method is selected', async () => {
+    const el = await openDisconnectedDialog();
+    const internals = el as unknown as DialogInternals;
+
+    internals.authMethod = 'app';
+    await el.updateComplete;
+
+    expect(count(el, PAT_INPUT), 'the PAT token box must not render in App mode').to.equal(0);
+    expect(
+      buttonCount(el, 'Connect to GitHub'),
+      'the PAT connect button must not render in App mode',
+    ).to.equal(0);
+    expect(
+      count(el, APP_KEY_INPUT),
+      'the App private key field must render in App mode',
+    ).to.equal(1);
+  });
+
+  it('shows a single primary action and no PAT delete button in GitHub App mode', async () => {
+    const el = await openDisconnectedDialog();
+    const internals = el as unknown as DialogInternals;
+
+    internals.selectedAccountId = 'gh-acc-1';
+    internals.authMethod = 'app';
+    await el.updateComplete;
+
+    expect(
+      count(el, '.btn-row'),
+      'App mode must show one button row, not two stacked flows',
+    ).to.equal(1);
+    expect(
+      primaryButtonLabels(el),
+      'App mode must offer exactly one primary action',
+    ).to.deep.equal(['Connect via GitHub App']);
+    expect(
+      buttonCount(el, 'Delete Integration'),
+      'the PAT delete button belongs to the PAT form only',
+    ).to.equal(0);
+  });
+
+  it('renders only the PAT form for the Personal Access Token method', async () => {
+    const el = await openDisconnectedDialog();
+    const internals = el as unknown as DialogInternals;
+
+    internals.authMethod = 'pat';
+    await el.updateComplete;
+
+    expect(count(el, PAT_INPUT), 'the PAT token box must render in PAT mode').to.equal(1);
+    expect(buttonCount(el, 'Connect to GitHub'), 'the PAT connect button must render').to.equal(1);
+    expect(count(el, APP_KEY_INPUT), 'the App form must not render in PAT mode').to.equal(0);
+    expect(buttonCount(el, 'Connect via GitHub App')).to.equal(0);
+  });
+
+  it('switching App -> PAT -> App swaps the forms instead of stacking them', async () => {
+    const el = await openDisconnectedDialog();
+
+    clickAuthMethod(el, 'GitHub App');
+    await el.updateComplete;
+    expect(count(el, PAT_INPUT), 'App mode must not stack the PAT form').to.equal(0);
+    expect(count(el, APP_KEY_INPUT), 'App mode must show the App form').to.equal(1);
+
+    clickAuthMethod(el, 'Personal Access Token');
+    await el.updateComplete;
+    expect(count(el, PAT_INPUT), 'PAT mode must show the token box').to.equal(1);
+    expect(count(el, APP_KEY_INPUT), 'PAT mode must not show the App form').to.equal(0);
+
+    clickAuthMethod(el, 'GitHub App');
+    await el.updateComplete;
+    expect(count(el, APP_KEY_INPUT), 'switching back must show the App form').to.equal(1);
+    expect(count(el, PAT_INPUT), 'switching back must not bring the PAT form along').to.equal(0);
+  });
+
+  it('OAuth method shows neither the PAT nor the App form', async () => {
+    const el = await openDisconnectedDialog();
+    const internals = el as unknown as DialogInternals;
+
+    internals.authMethod = 'oauth';
+    await el.updateComplete;
+
+    expect(count(el, '.oauth-section'), 'OAuth mode must show the sign-in section').to.equal(1);
+    expect(count(el, PAT_INPUT), 'OAuth mode must not show the PAT form').to.equal(0);
+    expect(count(el, APP_KEY_INPUT), 'OAuth mode must not show the App form').to.equal(0);
+  });
+});

--- a/src/components/dialogs/lv-github-dialog.ts
+++ b/src/components/dialogs/lv-github-dialog.ts
@@ -1932,7 +1932,7 @@ export class LvGitHubDialog extends LitElement {
               `}
             `}
           </div>
-        ` : html`
+        ` : this.authMethod === 'pat' ? html`
           <!-- PAT Form -->
           <div class="form-group">
             <label>Personal Access Token</label>
@@ -1975,7 +1975,7 @@ export class LvGitHubDialog extends LitElement {
               Connect to GitHub
             </button>
           </div>
-        `}
+        ` : nothing}
 
         ${this.authMethod === 'app' ? html`
           <!-- GitHub App Form -->


### PR DESCRIPTION
## What was broken

### Personal Access Token form renders above the GitHub App form

`renderConnectionTab()` in `src/components/dialogs/lv-github-dialog.ts` rendered the auth-method body as two independent expressions:

```ts
${this.authMethod === 'oauth' ? html`<oauth section>` : html`<PAT form>`}

${this.authMethod === 'app' ? html`<App form>` : nothing}
```

The first ternary's **else branch was unconditional**. Selecting "GitHub App" sets `authMethod = 'app'`, which is simply *not* `'oauth'`, so the PAT branch rendered too — the password box, its "Delete Integration" button and its primary "Connect to GitHub" button all painted directly above the App ID / private key form.

The user was shown two competing connect flows stacked in one panel: two `.btn-row`s and two `.btn-primary` buttons. Pressing the first primary button ("Connect to GitHub") calls `handleSaveToken()` with an empty/irrelevant token while the user is filling in App credentials.

## The fix

Two lines. Chain the ternary into `nothing` so the PAT form is gated on its own method:

```ts
${this.authMethod === 'oauth' ? html`<oauth section>`
  : this.authMethod === 'pat' ? html`<PAT form>`
  : nothing}
```

`nothing` was already imported from `lit`, and this chained-ternary shape matches the style already used in `lv-settings-dialog.ts`, `lv-azure-devops-dialog.ts` and `lv-interactive-rebase-dialog.ts`. The separate App block is untouched. Each method now renders exactly one form and exactly one primary action.

No handlers, dispatched events or feedback paths are added or removed, so the CLAUDE.md UI event/feedback consistency rules are unaffected.

**Deliberately out of scope:** the "Delete Integration" button lives inside the PAT branch, so after this change it is hidden in App mode exactly as it already was in OAuth mode — behaviour becomes consistent across the two non-PAT methods rather than regressing. Giving that button a home outside the PAT form is separate work and is not done here.

## Tests

New unit spec: `src/components/dialogs/__tests__/lv-github-dialog-auth-method.test.ts`
E2E: one test added to `GitHub Dialog - Connection Flow` in `e2e/tests/github-dialog.spec.ts`, plus App-mode locators (`appButton`, `appIdInput`, `appPrivateKeyInput`, `connectViaAppButton`) and `selectAppMethod()` on the GitHub page object.

| # | Test | Kind | Covers | Fails without the fix |
|---|------|------|--------|-----------------------|
| 1 | hides the Personal Access Token form when the GitHub App method is selected | unit | the defect: no PAT box, no "Connect to GitHub", App key field present | ✅ `the PAT token box must not render in App mode: expected 1 to equal 0` |
| 2 | shows a single primary action and no PAT delete button in GitHub App mode | unit | edge case with `selectedAccountId` set — one `.btn-row`, one `.btn-primary` ("Connect via GitHub App"), no "Delete Integration" | ✅ `App mode must show one button row, not two stacked flows: expected 2 to equal 1` |
| 3 | renders only the PAT form for the Personal Access Token method | unit | happy path / anti-over-hiding guard: the fix must not hide the PAT form from the PAT method | ❌ by design (passes both ways) |
| 4 | switching App → PAT → App swaps the forms instead of stacking them | unit | interaction round trip driven through the real `.auth-method-btn` toggles | ✅ `App mode must not stack the PAT form: expected 1 to equal 0` |
| 5 | OAuth method shows neither the PAT nor the App form | unit | locks the third arm of the chain so a future edit cannot leak the PAT form into the OAuth branch | ❌ by design (passes both ways) |
| 6 | should replace the token form when the GitHub App method is selected | e2e | full-stack user flow, and that the PAT ↔ App swap is symmetric in both directions | ✅ `expect(locator).toHaveCount(expected) failed / Locator: locator('lv-github-dialog input[type="password"]') / Expected: 0 / Received: 1` |

**Bite verified:** the production change was reverted and the suites re-run. Unit tests 1, 2 and 4 failed with the messages above while 3 and 5 still passed; the E2E test failed on `tokenInput` count 1 instead of 0. The fix was then restored and everything passes.

Assertions compare counts and text rather than element references — a failed assertion holding a live DOM node cannot be serialised back to web-test-runner, which turns a plain failure into a 120s hung run (observed during the revert check).

## Gate

`npm run lint` ✅ · `npm run typecheck` ✅ · `npm test` ✅ · `cargo fmt --check` ✅ · `cargo clippy --all-targets -- -D warnings` ✅ (no Rust change; run per CLAUDE.md).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_