### PR TITLE
Let the GitLab create-issue form actually pick labels

### DIFF
--- a/e2e/pages/dialogs.page.ts
+++ b/e2e/pages/dialogs.page.ts
@@ -449,6 +449,9 @@ export class GitLabDialogPage extends BaseDialog {
   readonly issuesTab: Locator;
   readonly pipelinesTab: Locator;
 
+  // Create-issue tab
+  readonly labelChips: Locator;
+
   // Connection tab
   readonly instanceUrlInput: Locator;
   readonly tokenInput: Locator;
@@ -473,6 +476,9 @@ export class GitLabDialogPage extends BaseDialog {
     this.mergeRequestsTab = page.locator('lv-gitlab-dialog .tab:has-text("Merge Requests")');
     this.issuesTab = page.locator('lv-gitlab-dialog .tab:has-text("Issues")');
     this.pipelinesTab = page.locator('lv-gitlab-dialog .tab:has-text("Pipelines")');
+
+    // Create-issue label picker
+    this.labelChips = page.locator('lv-gitlab-dialog .label-chip');
 
     // Connection
     this.instanceUrlInput = page.locator('lv-gitlab-dialog input[type="text"]').first();

--- a/e2e/tests/provider-issue-creation.spec.ts
+++ b/e2e/tests/provider-issue-creation.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { setupProfilesAndAccounts } from '../fixtures/tauri-mock';
 import { AppPage } from '../pages/app.page';
 import { DialogsPage } from '../pages/dialogs.page';
@@ -285,5 +285,153 @@ test.describe('Azure DevOps Dialog - Create Work Item', () => {
     await expect(
       page.locator('lv-azure-devops-dialog .error, .toast.error').first()
     ).toBeVisible({ timeout: 5000 });
+  });
+});
+
+
+// ============================================================================
+// GitLab - Create Issue with labels
+// ============================================================================
+
+test.describe('GitLab Dialog - Create Issue with labels', () => {
+  let app: AppPage;
+  let dialogs: DialogsPage;
+
+  test.beforeEach(async ({ page }) => {
+    app = new AppPage(page);
+    dialogs = new DialogsPage(page);
+
+    await setupProfilesAndAccounts(
+      page,
+      {
+        profiles: [
+          {
+            id: 'default',
+            name: 'Default',
+            gitName: 'Test User',
+            gitEmail: 'test@example.com',
+            signingKey: null,
+            urlPatterns: [],
+            isDefault: true,
+            color: '#3b82f6',
+            defaultAccounts: { gitlab: 'gl-1' },
+          },
+        ],
+        accounts: [
+          {
+            id: 'gl-1',
+            name: 'GitLab',
+            integrationType: 'gitlab',
+            config: { type: 'gitlab', instanceUrl: 'https://gitlab.com' },
+            color: null,
+            cachedUser: { username: 'gluser', displayName: 'GL User', avatarUrl: null },
+            urlPatterns: [],
+            isDefault: false,
+          },
+        ],
+        connectedAccounts: ['gl-1'],
+      },
+      {
+        remotes: [
+          { name: 'origin', url: 'https://gitlab.com/test-group/test-project.git', pushUrl: null },
+        ],
+      },
+    );
+
+    await startCommandCapture(page);
+
+    await injectCommandMock(page, {
+      detect_gitlab_repo: {
+        instanceUrl: 'https://gitlab.com',
+        projectPath: 'test-group/test-project',
+        remoteName: 'origin',
+      },
+      check_gitlab_connection: {
+        connected: true,
+        user: { id: 1, username: 'gluser', name: 'GL User', avatarUrl: '', webUrl: '' },
+        instanceUrl: 'https://gitlab.com',
+      },
+      check_gitlab_connection_with_token: {
+        connected: true,
+        user: { id: 1, username: 'gluser', name: 'GL User', avatarUrl: '', webUrl: '' },
+        instanceUrl: 'https://gitlab.com',
+      },
+      list_gitlab_merge_requests: [],
+      list_gitlab_issues: [],
+      list_gitlab_pipelines: [],
+      get_gitlab_labels: ['bug', 'enhancement'],
+    });
+  });
+
+  async function openCreateIssueForm(page: Page): Promise<void> {
+    await app.executeCommand('GitLab');
+    await expect(dialogs.gitlab.dialog).toBeVisible();
+
+    await dialogs.gitlab.issuesTab.click();
+    await expect(dialogs.gitlab.issuesTab).toHaveClass(/active/);
+
+    await page.locator('lv-gitlab-dialog .btn', { hasText: 'New Issue' }).click();
+  }
+
+  test('attaches the picked label to the created issue', async ({ page }) => {
+    await injectCommandMock(page, {
+      create_gitlab_issue: {
+        iid: 77,
+        title: 'E2E labelled issue',
+        description: null,
+        state: 'opened',
+        author: { id: 1, username: 'gluser', name: 'GL User', avatarUrl: '', webUrl: '' },
+        assignees: [],
+        labels: ['bug'],
+        createdAt: new Date().toISOString(),
+        webUrl: 'https://gitlab.com/test-group/test-project/-/issues/77',
+      },
+    });
+
+    await openCreateIssueForm(page);
+
+    await page.locator('lv-gitlab-dialog .token-form input[type="text"]').fill('E2E labelled issue');
+
+    await expect(dialogs.gitlab.labelChips).toHaveCount(2);
+    const bugChip = dialogs.gitlab.labelChips.filter({ hasText: 'bug' });
+    await bugChip.click();
+    await expect(bugChip).toHaveClass(/selected/);
+
+    await page.locator('lv-gitlab-dialog .btn-primary', { hasText: 'Create Issue' }).click();
+
+    await waitForCommand(page, 'create_gitlab_issue');
+    const cmds = await findCommand(page, 'create_gitlab_issue');
+    expect(cmds.length).toBeGreaterThan(0);
+    const args = cmds[0].args as Record<string, unknown>;
+    const input = args.input as Record<string, unknown>;
+    expect(input.title).toBe('E2E labelled issue');
+    expect(input.labels).toEqual(['bug']);
+
+    // Returns to the issues list and reports success.
+    await expect(dialogs.gitlab.issuesTab).toHaveClass(/active/);
+    await expect(page.locator('lv-toast-container .toast.success').first()).toBeVisible({ timeout: 5000 });
+  });
+
+  test('shows an error and keeps the picked label when creation fails', async ({ page }) => {
+    await openCreateIssueForm(page);
+
+    await page.locator('lv-gitlab-dialog .token-form input[type="text"]').fill('Will fail');
+
+    await expect(dialogs.gitlab.labelChips).toHaveCount(2);
+    const bugChip = dialogs.gitlab.labelChips.filter({ hasText: 'bug' });
+    await bugChip.click();
+    await expect(bugChip).toHaveClass(/selected/);
+
+    await injectCommandError(page, 'create_gitlab_issue', 'Labels not allowed');
+
+    await page.locator('lv-gitlab-dialog .btn-primary', { hasText: 'Create Issue' }).click();
+
+    await expect(dialogs.gitlab.dialog).toBeVisible();
+    await expect(
+      page.locator('lv-gitlab-dialog .error, .toast.error').first()
+    ).toBeVisible({ timeout: 5000 });
+
+    // The form (and the picked label) survives so the user can retry.
+    await expect(bugChip).toHaveClass(/selected/);
   });
 });

--- a/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
@@ -871,4 +871,174 @@ describe('lv-gitlab-dialog', () => {
       expect((el as unknown as { error: string | null }).error).to.equal(null);
     });
   });
+
+  describe('Create issue labels', () => {
+    async function openCreateIssueTab(): Promise<LvGitLabDialog> {
+      unifiedProfileStore.getState().setAccounts([mockAccount]);
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      (el as unknown as { activeTab: string }).activeTab = 'create-issue';
+      await el.updateComplete;
+      return el;
+    }
+
+    function chips(el: LvGitLabDialog): HTMLElement[] {
+      return Array.from(el.shadowRoot!.querySelectorAll<HTMLElement>('.label-chip'));
+    }
+
+    function lastCreateIssueInput(): { labels?: string[]; title?: string } | undefined {
+      const entries = invokeHistory.filter((e) => e.command === 'create_gitlab_issue');
+      if (entries.length === 0) return undefined;
+      const args = entries[entries.length - 1].args as Record<string, unknown>;
+      return args.input as { labels?: string[]; title?: string };
+    }
+
+    it('loads the project labels when the New Issue button is clicked', async () => {
+      unifiedProfileStore.getState().setAccounts([mockAccount]);
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+
+      (el as unknown as { activeTab: string }).activeTab = 'issues';
+      await el.updateComplete;
+
+      // Only the click must be credited — the create-issue tab has no other
+      // loader, so opening the form is what has to fetch the labels.
+      const before = invokeHistory.length;
+
+      const newIssueBtn = Array.from(
+        el.shadowRoot!.querySelectorAll<HTMLElement>('.btn')
+      ).find((b) => b.textContent?.trim() === '+ New Issue')!;
+      expect(newIssueBtn, 'New Issue button').to.not.be.undefined;
+      newIssueBtn.click();
+      await waitForLoad(el);
+
+      expect(
+        invokeHistory.slice(before).some((e) => e.command === 'get_gitlab_labels')
+      ).to.be.true;
+      expect(chips(el).length).to.equal(3);
+    });
+
+    it('renders a chip for every project label on the create-issue form', async () => {
+      const el = await openCreateIssueTab();
+
+      const rendered = chips(el);
+      expect(rendered.length).to.equal(3);
+      expect(rendered.map((c) => c.textContent?.trim())).to.deep.equal([
+        'bug',
+        'enhancement',
+        'performance',
+      ]);
+    });
+
+    it('sends the selected labels to create_gitlab_issue', async () => {
+      const el = await openCreateIssueTab();
+
+      (el as unknown as { createIssueTitle: string }).createIssueTitle = 'Labelled issue';
+      await el.updateComplete;
+
+      const bug = chips(el).find((c) => c.textContent?.trim() === 'bug')!;
+      bug.click();
+      await el.updateComplete;
+
+      expect(
+        chips(el).find((c) => c.textContent?.trim() === 'bug')!.classList.contains('selected')
+      ).to.be.true;
+
+      await (el as unknown as { handleCreateIssue: () => Promise<void> }).handleCreateIssue();
+      await el.updateComplete;
+
+      expect(lastCreateIssueInput()?.labels).to.deep.equal(['bug']);
+      // Successful create resets the picker for the next issue.
+      expect((el as unknown as { createIssueLabels: string[] }).createIssueLabels).to.deep.equal([]);
+    });
+
+    it('deselects a label when its chip is clicked again', async () => {
+      const el = await openCreateIssueTab();
+
+      (el as unknown as { createIssueTitle: string }).createIssueTitle = 'No labels after all';
+      await el.updateComplete;
+
+      chips(el).find((c) => c.textContent?.trim() === 'bug')!.click();
+      await el.updateComplete;
+      chips(el).find((c) => c.textContent?.trim() === 'bug')!.click();
+      await el.updateComplete;
+
+      const bug = chips(el).find((c) => c.textContent?.trim() === 'bug')!;
+      expect(bug.classList.contains('selected')).to.be.false;
+      expect(bug.getAttribute('aria-pressed')).to.equal('false');
+
+      await (el as unknown as { handleCreateIssue: () => Promise<void> }).handleCreateIssue();
+      await el.updateComplete;
+
+      // Empty selection is omitted, not sent as an empty array.
+      expect(lastCreateIssueInput()?.labels).to.equal(undefined);
+    });
+
+    it('drops selections for labels the new project does not have', async () => {
+      const el = await openCreateIssueTab();
+
+      chips(el).find((c) => c.textContent?.trim() === 'bug')!.click();
+      await el.updateComplete;
+      expect((el as unknown as { createIssueLabels: string[] }).createIssueLabels).to.deep.equal([
+        'bug',
+      ]);
+
+      const previous = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_gitlab_labels') return ['enhancement'];
+        return previous(command, args);
+      };
+
+      await (el as unknown as { loadLabels: () => Promise<void> }).loadLabels();
+      await el.updateComplete;
+
+      expect((el as unknown as { labels: string[] }).labels).to.deep.equal(['enhancement']);
+      expect((el as unknown as { createIssueLabels: string[] }).createIssueLabels).to.deep.equal([]);
+    });
+
+    it('keeps the picker and reports the failure when the labels request fails', async () => {
+      const el = await openCreateIssueTab();
+      expect(chips(el).length).to.equal(3);
+
+      const previous = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_gitlab_labels') throw new Error('GitLab API error 500');
+        return previous(command, args);
+      };
+
+      await (el as unknown as { loadLabels: () => Promise<void> }).loadLabels();
+      await el.updateComplete;
+
+      expect((el as unknown as { error: string | null }).error).to.equal('GitLab API error 500');
+      // A failed refresh must not wipe the already-rendered picker.
+      expect(chips(el).length).to.equal(3);
+    });
+
+    it('clears labels and selections on disconnect', async () => {
+      const el = await openCreateIssueTab();
+      (el as unknown as { selectedAccountId: string | null }).selectedAccountId = 'gl-acc-1';
+
+      chips(el).find((c) => c.textContent?.trim() === 'bug')!.click();
+      await el.updateComplete;
+
+      await (el as unknown as { handleDisconnect: () => Promise<void> }).handleDisconnect();
+      (el as unknown as { activeTab: string }).activeTab = 'create-issue';
+      await el.updateComplete;
+
+      expect((el as unknown as { labels: string[] }).labels).to.deep.equal([]);
+      expect((el as unknown as { createIssueLabels: string[] }).createIssueLabels).to.deep.equal([]);
+      expect(chips(el).length).to.equal(0);
+    });
+  });
 });

--- a/src/components/dialogs/lv-gitlab-dialog.ts
+++ b/src/components/dialogs/lv-gitlab-dialog.ts
@@ -347,6 +347,34 @@ export class LvGitLabDialog extends LitElement {
         color: var(--color-text-secondary);
       }
 
+      /* Label picker on the create-issue form */
+      .label-picker {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 4px;
+      }
+
+      .label-chip {
+        padding: 2px 8px;
+        border-radius: var(--radius-sm);
+        font-size: var(--font-size-xs);
+        background: var(--color-bg-hover);
+        color: var(--color-text-secondary);
+        border: 1px solid var(--color-border);
+        cursor: pointer;
+        transition: background var(--transition-fast);
+      }
+
+      .label-chip:hover {
+        background: var(--color-bg-tertiary);
+      }
+
+      .label-chip.selected {
+        background: var(--color-primary);
+        border-color: var(--color-primary);
+        color: white;
+      }
+
       .pipeline-item {
         display: flex;
         align-items: center;
@@ -997,6 +1025,9 @@ export class LvGitLabDialog extends LitElement {
 
       if (result.success && result.data) {
         this.labels = result.data;
+        // A different project (account/repo switch) has a different label set —
+        // drop selections that no longer exist so they can't be submitted invisibly.
+        this.createIssueLabels = this.createIssueLabels.filter(l => this.labels.includes(l));
       } else if (!result.success) {
         this.error = result.error?.message ?? 'Failed to load labels';
       }
@@ -1097,6 +1128,8 @@ export class LvGitLabDialog extends LitElement {
       this.mergeRequests = [];
       this.issues = [];
       this.pipelines = [];
+      this.labels = [];
+      this.createIssueLabels = [];
     } catch (err) {
       this.error = err instanceof Error ? err.message : 'Failed to disconnect';
       showToast(this.error, 'error');
@@ -1441,6 +1474,12 @@ export class LvGitLabDialog extends LitElement {
     }
   }
 
+  private toggleCreateIssueLabel(label: string): void {
+    this.createIssueLabels = this.createIssueLabels.includes(label)
+      ? this.createIssueLabels.filter(l => l !== label)
+      : [...this.createIssueLabels, label];
+  }
+
   private handleClose(): void {
     this.dispatchEvent(new CustomEvent('close'));
   }
@@ -1665,7 +1704,7 @@ export class LvGitLabDialog extends LitElement {
           <option value="closed" ?selected=${this.issueFilter === 'closed'}>Closed</option>
           <option value="all" ?selected=${this.issueFilter === 'all'}>All</option>
         </select>
-        <button class="btn" @click=${() => this.activeTab = 'create-issue'}>
+        <button class="btn" @click=${() => { this.activeTab = 'create-issue'; this.loadLabels(); }}>
           + New Issue
         </button>
       </div>
@@ -1842,6 +1881,23 @@ export class LvGitLabDialog extends LitElement {
             @input=${(e: Event) => this.createIssueDescription = (e.target as HTMLTextAreaElement).value}
           ></textarea>
         </div>
+        ${this.labels.length > 0 ? html`
+          <div class="form-group">
+            <label>Labels</label>
+            <div class="label-picker">
+              ${this.labels.map(label => html`
+                <button
+                  type="button"
+                  class="label-chip ${this.createIssueLabels.includes(label) ? 'selected' : ''}"
+                  aria-pressed=${this.createIssueLabels.includes(label) ? 'true' : 'false'}
+                  @click=${() => this.toggleCreateIssueLabel(label)}
+                >
+                  ${label}
+                </button>
+              `)}
+            </div>
+          </div>
+        ` : ''}
         <div class="btn-row">
           <button class="btn" @click=${() => this.activeTab = 'issues'}>
             Cancel


### PR DESCRIPTION
## What was broken

### GitLab issue labels were loaded but no label picker existed (dead-end feature)

`src/components/dialogs/lv-gitlab-dialog.ts` wired issue labels end-to-end **except for the one piece the user touches**:

- `@state() private labels: string[]` was filled by `loadLabels()` (`get_gitlab_labels`),
- `@state() private createIssueLabels: string[]` existed,
- `handleCreateIssue()` already sent `labels: this.createIssueLabels.length > 0 ? this.createIssueLabels : undefined` in `CreateGitLabIssueInput`, and `src-tauri/src/commands/gitlab.rs::create_gitlab_issue` already joins that into the API call.

But `renderCreateIssueTab()` rendered only Title, Description and the button row. **Nothing in the file ever wrote to `createIssueLabels`**, so it was permanently `[]` and no issue created from Leviathan could carry a label. The omission was conspicuous because `renderIssuesTab()` already renders `issue.labels` as chips, and the sibling GitHub dialog has exactly this picker.

### Follow-on discovery: the labels were never actually fetched on a normal open

While writing the E2E test I found the labels request does not fire at all in the common case. `loadAllData()` (the only caller of `loadLabels()`) runs from `detectRepo()` **only when `connectionStatus?.connected` is already true** — but `loadInitialData()` calls `detectRepo()` *before* `checkConnection()`. So opening the dialog with a saved token detects the repo (status still `null`, no `loadAllData()`), then establishes the connection, and never goes back for the labels. Without correcting this the new picker would have rendered empty forever, so the fix is included.

The other tabs are unaffected by that ordering because each tab button loads its own data (`this.activeTab = 'issues'; this.loadIssues();`). The create-issue tab was the only one with no loader of its own.

## The fix

All product changes are in `src/components/dialogs/lv-gitlab-dialog.ts`:

| Change | Why |
| --- | --- |
| Chip picker in `renderCreateIssueTab()`, fed from `this.labels`, plus `.label-picker` / `.label-chip` styles | The missing UI. Chips are real `<button type="button">`s with `aria-pressed` so they are keyboard-reachable, and the group is hidden when the project exposes no labels (matching the GitHub dialog's `repoLabels.length > 0` guard). |
| `toggleCreateIssueLabel()` | Toggles a label in/out of `createIssueLabels`, reassigning the array immutably so Lit re-renders. |
| "+ New Issue" button also calls `loadLabels()` | Makes the picker reachable at all (see above), and matches the per-tab loading pattern the rest of the dialog uses. It also means no labels request is spent when the user never opens the create form. |
| `loadLabels()` prunes selections missing from the new label set | An account/project switch brings a different label set; a stale selection would otherwise be submitted invisibly to a project that has no such label. |
| `handleDisconnect()` clears `labels` and `createIssueLabels` | It already cleared `mergeRequests`/`issues`/`pipelines`; without this the picker keeps showing the disconnected account's labels. Mirrors the GitHub dialog, which clears `repoLabels` on disconnect. |

No Rust, no type, and no Tauri-contract changes — `CreateGitLabIssueInput.labels?: string[]`, `getGitLabLabels()` and the `create_gitlab_issue` command already existed. No snake_case introduced.

## Tests

`src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts` — new `describe('Create issue labels')`; `e2e/tests/provider-issue-creation.spec.ts` — new `GitLab Dialog - Create Issue with labels` block; `e2e/pages/dialogs.page.ts` — `labelChips` locator on `GitLabDialogPage`.

| # | Test | Covers | Fails without the fix with |
| --- | --- | --- | --- |
| 1 | unit — loads the project labels when the New Issue button is clicked | on-demand load | `expected false to be true` (no `get_gitlab_labels` after the click) |
| 2 | unit — renders a chip for every project label on the create-issue form | happy path / rendering | `expected 0 to equal 3` |
| 3 | unit — sends the selected labels to `create_gitlab_issue` | happy path / contract | `TypeError: Cannot read properties of undefined (reading 'click')` — no chip exists |
| 4 | unit — deselects a label when its chip is clicked again | toggle path; also asserts an empty selection is omitted, not sent as `[]` | same `TypeError` |
| 5 | unit — drops selections for labels the new project does not have | edge case (prune) | `expected [ 'bug' ] to deeply equal []` |
| 6 | unit — keeps the picker and reports the failure when the labels request fails | error path (failed refresh must not wipe an in-progress selection) | `expected 0 to equal 3` |
| 7 | unit — clears labels and selections on disconnect | disconnect consistency | `expected [ 'bug', 'enhancement', 'performance' ] to deeply equal []` |
| 8 | e2e — attaches the picked label to the created issue | full-stack happy path: asserts `input.labels === ['bug']` **and** the UI outcome (returns to Issues tab, success toast) | `toHaveCount(2)` on `.label-chip` times out, `Received: 0` |
| 9 | e2e — shows an error and keeps the picked label when creation fails | full-stack error path: error surfaced, dialog stays open, chip still `selected` so the user can retry | same `toHaveCount` timeout |

**Verified the tests bite.** Each production hunk was reverted in isolation and the suite re-run:

- revert only the `renderCreateIssueTab()` picker markup → unit tests 2–7 fail (6 failures, messages above); e2e 8–9 fail.
- revert only the `loadLabels()` prune line → **only** test 5 fails (`expected [ 'bug' ] to deeply equal []`).
- revert only the two `handleDisconnect()` lines → **only** test 7 fails (`expected [ 'bug', 'enhancement', 'performance' ] to deeply equal []`).
- revert only the `loadLabels()` call on the "+ New Issue" button → test 1 fails, and both e2e tests fail on `toHaveCount`.

## Gate

`npm run lint` OK · `npm run typecheck` OK · `npm test` OK · `cargo fmt --check` OK · `cargo clippy --all-targets -- -D warnings` OK.
`npx playwright test e2e/tests/provider-issue-creation.spec.ts e2e/tests/gitlab-dialog.spec.ts` → 17 passed (no regressions in the existing GitLab dialog suite). CLAUDE.md snake_case grep clean.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_