### PR TITLE
Release the OAuth loopback port when a sign-in is cancelled

### DIFF
--- a/e2e/pages/dialogs.page.ts
+++ b/e2e/pages/dialogs.page.ts
@@ -594,6 +594,7 @@ export class BitbucketDialogPage extends BaseDialog {
   readonly oauthButton: Locator;
   readonly appPasswordButton: Locator;
   readonly oauthSignInButton: Locator;
+  readonly oauthCancelButton: Locator;
   readonly oauthSpinner: Locator;
   readonly oauthStatus: Locator;
 
@@ -619,6 +620,7 @@ export class BitbucketDialogPage extends BaseDialog {
     this.oauthButton = page.locator('lv-bitbucket-dialog .auth-method-toggle button:has-text("Sign in with Bitbucket")');
     this.appPasswordButton = page.locator('lv-bitbucket-dialog .auth-method-toggle button:has-text("App Password")');
     this.oauthSignInButton = page.locator('lv-bitbucket-dialog .btn-oauth');
+    this.oauthCancelButton = page.locator('lv-bitbucket-dialog .oauth-cancel');
     this.oauthSpinner = page.locator('lv-bitbucket-dialog .oauth-spinner');
     this.oauthStatus = page.locator('lv-bitbucket-dialog .oauth-status');
   }

--- a/e2e/tests/bitbucket-dialog.spec.ts
+++ b/e2e/tests/bitbucket-dialog.spec.ts
@@ -6,6 +6,7 @@ import {
   startCommandCapture,
   findCommand,
   injectCommandError,
+  injectCommandHang,
   injectCommandMock,
   startCommandCaptureWithMocks,
   waitForCommand,
@@ -223,5 +224,51 @@ test.describe('Bitbucket Dialog - Extended Scenarios', () => {
 
     // Verify the error is shown within the dialog
     await expect(page.locator('lv-bitbucket-dialog .error, lv-bitbucket-dialog .error-message, .toast.error').first()).toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe('Bitbucket Dialog - Cancelling a pending OAuth sign-in', () => {
+  let app: AppPage;
+  let dialogs: DialogsPage;
+
+  test.beforeEach(async ({ page }) => {
+    app = new AppPage(page);
+    dialogs = new DialogsPage(page);
+    await setupOpenRepository(page);
+  });
+
+  test('releases the loopback port and re-enables Sign in', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {
+      oauth_get_authorize_url: {
+        authorizeUrl: 'https://bitbucket.org/site/oauth2/authorize',
+        state: 'st-1',
+        // Bitbucket's registered redirect pins the callback to this port.
+        loopbackPort: 8085,
+      },
+      // Don't actually open a browser window.
+      'plugin:shell|open': null,
+      oauth_cancel_flow: null,
+    });
+    // The callback never arrives — the user abandons the browser tab.
+    await injectCommandHang(page, 'oauth_wait_for_callback');
+
+    await app.executeCommand('Bitbucket');
+    await expect(dialogs.bitbucket.dialog).toBeVisible();
+    await dialogs.bitbucket.waitUntilReady();
+
+    await dialogs.bitbucket.oauthSignInButton.click();
+    await expect(dialogs.bitbucket.oauthCancelButton).toBeVisible();
+
+    await dialogs.bitbucket.oauthCancelButton.click();
+
+    // The backend loopback server is released, so the fixed port is free for a
+    // retry instead of staying bound until the flow times out.
+    await waitForCommand(page, 'oauth_cancel_flow');
+    const cancelCalls = await findCommand(page, 'oauth_cancel_flow');
+    expect(cancelCalls[0].args).toMatchObject({ port: 8085 });
+
+    // And the form is usable again.
+    await expect(dialogs.bitbucket.oauthCancelButton).toHaveCount(0);
+    await expect(dialogs.bitbucket.oauthSignInButton).toBeEnabled();
   });
 });

--- a/src-tauri/src/commands/oauth.rs
+++ b/src-tauri/src/commands/oauth.rs
@@ -4,11 +4,12 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 use std::time::Duration;
 
 use crate::error::{LeviathanError, Result};
-use crate::services::loopback_server::LoopbackServer;
+use crate::services::loopback_server::{CancelHandle, LoopbackServer};
 use crate::services::oauth::{
     generate_state, OAuthConfig, OAuthProvider, OAuthTokenResponse, PKCEChallenge,
 };
@@ -28,6 +29,74 @@ struct PendingServer {
 /// Global storage for pending loopback servers (GitHub OAuth)
 static PENDING_SERVERS: Lazy<Mutex<HashMap<u16, PendingServer>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// A loopback wait already in flight, with the handle that can abort it.
+///
+/// `oauth_wait_for_callback` REMOVES the server from `PENDING_SERVERS` and moves
+/// it into a blocking wait, so that map can no longer release the port. This
+/// registry keeps the detached cancel handle so an abandoned sign-in can free
+/// its socket instead of holding it until the callback timeout.
+struct ActiveWait {
+    /// Identifies this specific wait, so a finishing wait cannot deregister the
+    /// handle belonging to a newer wait that reused the same port.
+    id: u64,
+    cancel: CancelHandle,
+}
+
+/// In-flight loopback waits, keyed by port.
+static ACTIVE_WAITS: Lazy<Mutex<HashMap<u16, ActiveWait>>> =
+    Lazy::new(|| Mutex::new(HashMap::new()));
+
+/// Monotonic id source for `ActiveWait`.
+static NEXT_WAIT_ID: AtomicU64 = AtomicU64::new(1);
+
+/// Deregister a finished wait, but ONLY if the registered entry is still the
+/// same wait. A cancelled wait can return AFTER the user's retry registered a
+/// new wait on the same port; removing blindly would strip the new flow's
+/// ability to cancel.
+fn unregister_wait(port: u16, id: u64) {
+    if let Ok(mut waits) = ACTIVE_WAITS.lock() {
+        if waits.get(&port).is_some_and(|w| w.id == id) {
+            waits.remove(&port);
+        }
+    }
+}
+
+/// Release the loopback server bound to `port`, whether it is still parked in
+/// `PENDING_SERVERS` or already moved into a blocking wait. Returns `true` if
+/// something of ours was released, `false` if we hold nothing on that port.
+///
+/// The teardown blocks until the accept loop confirms its listeners are closed
+/// (~100 ms worst case), so it runs on a blocking task and the port is
+/// re-bindable as soon as this returns.
+async fn release_loopback_port(port: u16) -> Result<bool> {
+    let parked = PENDING_SERVERS
+        .lock()
+        .map_err(|e| LeviathanError::OAuth(format!("Failed to access server storage: {}", e)))?
+        .remove(&port);
+    let in_flight = ACTIVE_WAITS
+        .lock()
+        .map_err(|e| LeviathanError::OAuth(format!("Failed to access OAuth waits: {}", e)))?
+        .remove(&port);
+
+    if parked.is_none() && in_flight.is_none() {
+        return Ok(false);
+    }
+
+    tokio::task::spawn_blocking(move || {
+        if let Some(pending) = parked {
+            pending.server.shutdown();
+        }
+        if let Some(wait) = in_flight {
+            wait.cancel.cancel();
+        }
+    })
+    .await
+    .map_err(|e| LeviathanError::OAuth(format!("Task join error: {}", e)))?;
+
+    tracing::debug!("Released OAuth loopback server on port {}", port);
+    Ok(true)
+}
 
 /// Remove expired entries from the pending servers map.
 fn cleanup_expired_pending_servers(map: &mut HashMap<u16, PendingServer>) {
@@ -236,7 +305,23 @@ pub async fn oauth_get_authorize_url(
             // Bitbucket requires http/https redirect URIs and only allows ONE callback URL
             // We use a dedicated port (8085) to avoid conflicts with GitHub/GitLab
             const BITBUCKET_PORT: u16 = 8085;
-            let server = LoopbackServer::new_with_port(BITBUCKET_PORT)?;
+            // The port is pinned by Bitbucket's registered redirect, so a flow
+            // abandoned without a cancel (or a retry that races one) would leave
+            // OUR OWN listener holding 8085 and the user would be told to close
+            // whatever application is using the port. A new sign-in supersedes
+            // the old one — the frontend already drops a superseded flow's late
+            // callback silently — so release ours and re-bind. A genuine
+            // third-party occupant still yields the original error.
+            let server = match LoopbackServer::new_with_port(BITBUCKET_PORT) {
+                Ok(server) => server,
+                Err(bind_error) => {
+                    if release_loopback_port(BITBUCKET_PORT).await? {
+                        LoopbackServer::new_with_port(BITBUCKET_PORT)?
+                    } else {
+                        return Err(bind_error);
+                    }
+                }
+            };
             let port = server.port();
             let config = OAuthConfig::bitbucket(&client_id, port);
 
@@ -562,19 +647,42 @@ pub struct CallbackResponse {
 #[tauri::command]
 pub async fn oauth_wait_for_callback(port: u16) -> Result<CallbackResponse> {
     // Retrieve the stored server for this port
-    let pending = PENDING_SERVERS
+    let mut pending = PENDING_SERVERS
         .lock()
         .map_err(|e| LeviathanError::OAuth(format!("Failed to access server storage: {}", e)))?
         .remove(&port)
         .ok_or_else(|| LeviathanError::OAuth(format!("No server found for port {}", port)))?;
 
+    // Detach a cancel handle BEFORE the server is consumed by the wait, and
+    // register it so `oauth_cancel_flow` can free the port if the user abandons
+    // the sign-in instead of waiting out the timeout.
+    let wait_id = NEXT_WAIT_ID.fetch_add(1, Ordering::Relaxed);
+    if let Some(cancel) = pending.server.take_cancel_handle() {
+        ACTIVE_WAITS
+            .lock()
+            .map_err(|e| LeviathanError::OAuth(format!("Failed to access OAuth waits: {}", e)))?
+            .insert(
+                port,
+                ActiveWait {
+                    id: wait_id,
+                    cancel,
+                },
+            );
+    }
+
     // Use the server's wait_for_callback method
     // This runs in a blocking thread to avoid blocking the async runtime
     let timeout = Duration::from_secs(300); // 5 minutes
 
-    let callback = tokio::task::spawn_blocking(move || pending.server.wait_for_callback(timeout))
-        .await
-        .map_err(|e| LeviathanError::OAuth(format!("Task join error: {}", e)))??;
+    let joined =
+        tokio::task::spawn_blocking(move || pending.server.wait_for_callback(timeout)).await;
+
+    // Deregister before propagating, so an errored/cancelled/aborted wait still
+    // clears its registry entry.
+    unregister_wait(port, wait_id);
+
+    let callback =
+        joined.map_err(|e| LeviathanError::OAuth(format!("Task join error: {}", e)))??;
 
     // Validate the returned `state` against an in-flight flow. We only PEEK here
     // (the flow is consumed later by `oauth_exchange_code`), so confirm a match
@@ -611,6 +719,19 @@ fn validate_callback_state(state: &str) -> Result<()> {
 #[tauri::command]
 pub async fn oauth_wait_for_github_callback(port: u16) -> Result<CallbackResponse> {
     oauth_wait_for_callback(port).await
+}
+
+/// Cancel an in-flight OAuth flow and release its loopback server.
+///
+/// `oauth_wait_for_callback` consumes the pending server, so without this the
+/// listener stays bound until the 5-minute callback timeout. That blocks a
+/// retry for providers pinned to a fixed port (Bitbucket's registered redirect
+/// is `127.0.0.1:8085`) with a "port is not available" error that points the
+/// user at the wrong application. Cancelling a port with nothing in flight is a
+/// no-op, so cancelling twice — or after the flow already completed — is safe.
+#[tauri::command]
+pub async fn oauth_cancel_flow(port: u16) -> Result<()> {
+    release_loopback_port(port).await.map(|_| ())
 }
 
 #[cfg(test)]
@@ -839,8 +960,14 @@ mod tests {
         );
     }
 
+    /// Bitbucket's redirect is pinned to the fixed port 8085, so the tests that
+    /// exercise it must not run concurrently with each other.
+    /// An async mutex: the guard is held across `.await` points.
+    static BITBUCKET_PORT_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
     #[tokio::test]
     async fn test_oauth_get_authorize_url_bitbucket() {
+        let _guard = BITBUCKET_PORT_TEST_LOCK.lock().await;
         let result =
             oauth_get_authorize_url("bitbucket".to_string(), None, "test-client-id".to_string())
                 .await;
@@ -1249,6 +1376,147 @@ mod tests {
             deserialized.instance_url,
             Some("https://auth.example.com".to_string())
         );
+    }
+
+    // ==========================================================================
+    // Cancelling an in-flight OAuth flow (loopback port release)
+    // ==========================================================================
+
+    /// Park a server the way `oauth_get_authorize_url` does.
+    fn park_server(server: LoopbackServer) -> u16 {
+        let port = server.port();
+        PENDING_SERVERS.lock().unwrap().insert(
+            port,
+            PendingServer {
+                server,
+                created_at: std::time::Instant::now(),
+            },
+        );
+        port
+    }
+
+    /// Register an in-flight wait exactly the way `oauth_wait_for_callback`
+    /// does — detach the cancel handle, record it under the port, and move the
+    /// server into a blocking wait that keeps the socket bound.
+    fn register_wait(
+        mut server: LoopbackServer,
+    ) -> (
+        u16,
+        u64,
+        std::thread::JoinHandle<Result<crate::services::loopback_server::CallbackResult>>,
+    ) {
+        let port = server.port();
+        let id = NEXT_WAIT_ID.fetch_add(1, Ordering::Relaxed);
+        let cancel = server
+            .take_cancel_handle()
+            .expect("cancel handle available");
+        ACTIVE_WAITS
+            .lock()
+            .unwrap()
+            .insert(port, ActiveWait { id, cancel });
+        let handle = std::thread::spawn(move || server.wait_for_callback(Duration::from_secs(300)));
+        (port, id, handle)
+    }
+
+    fn port_is_free(port: u16) -> bool {
+        std::net::TcpListener::bind(("127.0.0.1", port)).is_ok()
+    }
+
+    /// The core bug: `oauth_wait_for_callback` consumes the pending server, so a
+    /// cancelled sign-in used to hold its port until the 5-minute timeout.
+    #[tokio::test]
+    async fn test_oauth_cancel_flow_releases_a_port_held_by_an_in_flight_wait() {
+        let port = park_server(LoopbackServer::new_with_port(0).unwrap());
+
+        let waiting = tokio::spawn(oauth_wait_for_callback(port));
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        assert!(
+            !port_is_free(port),
+            "the in-flight wait should own the port before the cancel"
+        );
+
+        oauth_cancel_flow(port).await.unwrap();
+
+        assert!(
+            port_is_free(port),
+            "cancelling must free the port for an immediate retry"
+        );
+        assert!(
+            waiting.await.unwrap().is_err(),
+            "the cancelled wait must not report a callback"
+        );
+    }
+
+    /// A flow abandoned before the frontend started waiting is still parked in
+    /// `PENDING_SERVERS`; cancelling must evict it and free the port too.
+    #[tokio::test]
+    async fn test_oauth_cancel_flow_releases_a_server_that_never_started_waiting() {
+        let port = park_server(LoopbackServer::new_with_port(0).unwrap());
+
+        oauth_cancel_flow(port).await.unwrap();
+
+        assert!(
+            !PENDING_SERVERS.lock().unwrap().contains_key(&port),
+            "the parked server must be evicted"
+        );
+        assert!(port_is_free(port), "the parked server's port must be freed");
+
+        // Cancelling again (or after the flow already finished) is a no-op.
+        assert!(oauth_cancel_flow(port).await.is_ok());
+    }
+
+    /// Cancelling a port we hold nothing on must succeed quietly — the frontend
+    /// fires this on every cancel, including for already-completed flows.
+    #[tokio::test]
+    async fn test_oauth_cancel_flow_is_a_noop_for_an_unknown_port() {
+        assert!(oauth_cancel_flow(59998).await.is_ok());
+    }
+
+    /// A cancelled wait returns AFTER the user's retry has registered a new wait
+    /// on the same (fixed) port. Its deregistration must not strip the retry's
+    /// cancel handle, or the retry becomes uncancellable and its port leaks.
+    #[tokio::test]
+    async fn test_a_finished_wait_does_not_strip_a_retrys_cancel_handle() {
+        // Wait A takes the port, then the user cancels it.
+        let (port, id_a, handle_a) = register_wait(LoopbackServer::new_with_port(0).unwrap());
+        oauth_cancel_flow(port).await.unwrap();
+        assert!(handle_a.join().unwrap().is_err());
+
+        // The retry (wait B) reuses the same port.
+        let (_, id_b, handle_b) = register_wait(LoopbackServer::new_with_port(port).unwrap());
+        assert_ne!(id_a, id_b);
+
+        // Wait A's task only now gets around to deregistering itself.
+        unregister_wait(port, id_a);
+
+        // B is still cancellable, so its port is released on the next cancel.
+        oauth_cancel_flow(port).await.unwrap();
+        assert!(
+            port_is_free(port),
+            "the retry must still be cancellable after the older wait finishes"
+        );
+        assert!(handle_b.join().unwrap().is_err());
+    }
+
+    /// End-to-end: a Bitbucket sign-in abandoned without a cancel must not make
+    /// the next attempt fail with "Port 8085 is not available".
+    #[tokio::test]
+    async fn test_bitbucket_flow_can_restart_after_an_abandoned_sign_in() {
+        let _guard = BITBUCKET_PORT_TEST_LOCK.lock().await;
+        let first = oauth_get_authorize_url("bitbucket".to_string(), None, "cid".to_string()).await;
+        // Self-skip when another process on this host owns 8085 (same pattern as
+        // the IPv6 loopback test) — there is nothing of ours to release then.
+        let Ok(first) = first else {
+            return;
+        };
+        assert_eq!(first.loopback_port, Some(8085));
+
+        let second = oauth_get_authorize_url("bitbucket".to_string(), None, "cid".to_string())
+            .await
+            .expect("a second Bitbucket sign-in must be able to re-bind port 8085");
+        assert_eq!(second.loopback_port, Some(8085));
+
+        oauth_cancel_flow(8085).await.unwrap();
     }
 }
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -667,6 +667,7 @@ pub fn run() {
             commands::oauth::oauth_refresh_token,
             commands::oauth::oauth_wait_for_callback,
             commands::oauth::oauth_wait_for_github_callback,
+            commands::oauth::oauth_cancel_flow,
             commands::oauth::discover_oidc_provider,
             commands::oauth::decode_oidc_id_token,
             // Git Flow

--- a/src-tauri/src/services/loopback_server.rs
+++ b/src-tauri/src/services/loopback_server.rs
@@ -8,7 +8,7 @@ use std::io::{Read, Write};
 use std::net::{TcpListener, TcpStream};
 use std::sync::mpsc;
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::error::LeviathanError;
 
@@ -39,9 +39,32 @@ pub struct LoopbackServer {
 }
 
 /// How long a cancel waits for the accept loop to confirm it closed its
-/// listeners. The loop polls on a 100 ms tick, so this is generous; on timeout
-/// we give up waiting rather than block a command indefinitely.
+/// listeners. Both the accept poll and the per-connection request read run on
+/// [`ACCEPT_POLL_INTERVAL`], so this is generous; on timeout we give up waiting
+/// rather than block a command indefinitely.
 const SHUTDOWN_ACK_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// The tick the accept loop polls on, and the slice each request read blocks
+/// for before re-checking the shutdown signal. Every blocking step in the
+/// server thread MUST be bounded by this, so a cancel is always observed well
+/// inside [`SHUTDOWN_ACK_TIMEOUT`].
+const ACCEPT_POLL_INTERVAL: Duration = Duration::from_millis(100);
+
+/// Overall budget for reading one request off an accepted connection. Spread
+/// across [`ACCEPT_POLL_INTERVAL`] slices rather than spent in a single
+/// blocking read, so cancellation stays observable throughout.
+const CONNECTION_READ_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// What the accept loop should do after servicing one connection.
+enum ConnectionOutcome {
+    /// A callback (or a failed parse of one): deliver it and stop.
+    Delivered(Result<CallbackResult, String>),
+    /// An incidental request (`/favicon.ico`, a bare `/`): keep listening.
+    Ignored,
+    /// Shutdown was signalled while the request was being read: stop WITHOUT a
+    /// result, so both listeners are released immediately.
+    Cancelled,
+}
 
 /// A detachable handle that can shut a [`LoopbackServer`] down AFTER the server
 /// itself has been moved into [`LoopbackServer::wait_for_callback`] (which
@@ -308,8 +331,10 @@ impl LoopbackServer {
             match listener_v4.accept() {
                 Ok((stream, _)) => {
                     serviced = true;
-                    if let Some(result) = Self::handle_connection(stream) {
-                        return Some(result);
+                    match Self::handle_connection(stream, shutdown_rx) {
+                        ConnectionOutcome::Delivered(result) => return Some(result),
+                        ConnectionOutcome::Cancelled => return None,
+                        ConnectionOutcome::Ignored => {}
                     }
                 }
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
@@ -325,8 +350,10 @@ impl LoopbackServer {
                 match v6.accept() {
                     Ok((stream, _)) => {
                         serviced = true;
-                        if let Some(result) = Self::handle_connection(stream) {
-                            return Some(result);
+                        match Self::handle_connection(stream, shutdown_rx) {
+                            ConnectionOutcome::Delivered(result) => return Some(result),
+                            ConnectionOutcome::Cancelled => return None,
+                            ConnectionOutcome::Ignored => {}
                         }
                     }
                     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
@@ -339,22 +366,53 @@ impl LoopbackServer {
 
             if !serviced {
                 // No connection on either listener, sleep briefly.
-                thread::sleep(Duration::from_millis(100));
+                thread::sleep(ACCEPT_POLL_INTERVAL);
             }
         }
     }
 
-    /// Handle an incoming HTTP connection
-    fn handle_connection(mut stream: TcpStream) -> Option<Result<CallbackResult, String>> {
+    /// Handle an incoming HTTP connection.
+    ///
+    /// The request is read in [`ACCEPT_POLL_INTERVAL`] slices, re-checking the
+    /// shutdown signal between them, up to an overall
+    /// [`CONNECTION_READ_TIMEOUT`] budget. A single blocking read for the whole
+    /// budget would pin BOTH listeners here — a peer that connects and sends
+    /// nothing (a browser preconnect, a port scan) is enough — for longer than
+    /// [`SHUTDOWN_ACK_TIMEOUT`], so `cancel()` would give up waiting and report
+    /// the port released while it was in fact still bound, and the retry that
+    /// followed would fail to bind.
+    fn handle_connection(
+        mut stream: TcpStream,
+        shutdown_rx: &mpsc::Receiver<()>,
+    ) -> ConnectionOutcome {
         let mut buffer = [0; 4096];
 
-        // Set read timeout
-        let _ = stream.set_read_timeout(Some(Duration::from_secs(5)));
+        // `accept()` hands back a stream that inherits the listener's
+        // non-blocking mode on some platforms (Windows), where a read timeout is
+        // then ignored; force blocking mode so the slice below is honoured
+        // everywhere.
+        let _ = stream.set_nonblocking(false);
+        let _ = stream.set_read_timeout(Some(ACCEPT_POLL_INTERVAL));
 
-        // Read the request
-        let n = match stream.read(&mut buffer) {
-            Ok(n) => n,
-            Err(_) => return Some(Err("Failed to read request".to_string())),
+        // Read the request, staying cancellable throughout.
+        let deadline = Instant::now() + CONNECTION_READ_TIMEOUT;
+        let n = loop {
+            if shutdown_rx.try_recv().is_ok() {
+                return ConnectionOutcome::Cancelled;
+            }
+            match stream.read(&mut buffer) {
+                Ok(n) => break n,
+                // This slice expired with nothing to read: keep polling until
+                // the overall budget is spent.
+                Err(ref e)
+                    if matches!(
+                        e.kind(),
+                        std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                    ) && Instant::now() < deadline => {}
+                Err(_) => {
+                    return ConnectionOutcome::Delivered(Err("Failed to read request".to_string()))
+                }
+            }
         };
 
         let request = String::from_utf8_lossy(&buffer[..n]);
@@ -366,7 +424,7 @@ impl LoopbackServer {
         let parts: Vec<&str> = first_line.split_whitespace().collect();
         if parts.len() < 2 {
             Self::send_error_response(&mut stream, "Invalid request");
-            return Some(Err("Invalid request".to_string()));
+            return ConnectionOutcome::Delivered(Err("Invalid request".to_string()));
         }
 
         let path = parts[1];
@@ -383,7 +441,7 @@ impl LoopbackServer {
         // ignored.
         if !query_is_callback(query) {
             Self::send_error_response(&mut stream, "Not found");
-            return None; // Continue listening
+            return ConnectionOutcome::Ignored; // Continue listening
         }
 
         // Parse + validate the callback query. State binding is enforced here
@@ -393,11 +451,11 @@ impl LoopbackServer {
         match parse_callback_query(query) {
             Ok(result) => {
                 Self::send_success_response(&mut stream);
-                Some(Ok(result))
+                ConnectionOutcome::Delivered(Ok(result))
             }
             Err(msg) => {
                 Self::send_error_response(&mut stream, &msg);
-                Some(Err(msg))
+                ConnectionOutcome::Delivered(Err(msg))
             }
         }
     }
@@ -714,6 +772,89 @@ mod tests {
         assert!(
             handle.join().unwrap().is_err(),
             "the aborted wait must not report a successful callback"
+        );
+    }
+
+    /// A peer can connect and then send nothing at all — a browser preconnect,
+    /// a port scan, a half-open socket. The accept loop is inside the request
+    /// read at that moment, and that read must stay cancellable: a single
+    /// blocking read for the whole request budget outlasts
+    /// `SHUTDOWN_ACK_TIMEOUT`, so `cancel()` would return claiming the port was
+    /// released while both listeners were still bound, and the user's retry
+    /// would fail with EADDRINUSE.
+    #[test]
+    fn test_cancel_releases_the_port_while_a_silent_connection_is_being_read() {
+        let mut server = LoopbackServer::new_with_port(0).unwrap();
+        let port = server.port();
+        let cancel = server
+            .take_cancel_handle()
+            .expect("cancel handle available");
+
+        let handle = thread::spawn(move || server.wait_for_callback(Duration::from_secs(300)));
+        thread::sleep(Duration::from_millis(150));
+
+        // Connect and send nothing: the accept loop is now in the request read.
+        let _silent = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        thread::sleep(Duration::from_millis(150));
+
+        cancel.cancel();
+
+        assert!(
+            TcpListener::bind(("127.0.0.1", port)).is_ok(),
+            "cancelling must release the port even while a connection is being read"
+        );
+        assert!(
+            handle.join().unwrap().is_err(),
+            "the aborted wait must not report a successful callback"
+        );
+    }
+
+    /// The slice-and-poll read must not shorten the request budget: a browser
+    /// that opens the connection before it writes the callback (or writes it a
+    /// few ticks later) must still be served.
+    #[test]
+    fn test_callback_is_received_when_the_request_arrives_several_ticks_late() {
+        let server = LoopbackServer::new_with_port(0).unwrap();
+        let port = server.port();
+        let handle = thread::spawn(move || server.wait_for_callback(Duration::from_secs(10)));
+
+        thread::sleep(Duration::from_millis(150));
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+
+        // Several read slices pass with nothing on the socket.
+        thread::sleep(ACCEPT_POLL_INTERVAL * 5);
+        stream
+            .write_all(
+                b"GET /callback?code=late&state=latestate HTTP/1.1\r\nHost: localhost\r\n\r\n",
+            )
+            .unwrap();
+
+        let result = handle.join().unwrap().unwrap();
+        assert_eq!(result.code, "late");
+        assert_eq!(result.state, "latestate");
+    }
+
+    /// Error path: a connection that never delivers a request must still give up
+    /// at the read deadline rather than pin the listener for the whole callback
+    /// timeout.
+    #[test]
+    fn test_a_silent_connection_gives_up_at_the_read_deadline() {
+        let server = LoopbackServer::new_with_port(0).unwrap();
+        let port = server.port();
+        let handle = thread::spawn(move || server.wait_for_callback(Duration::from_secs(300)));
+        thread::sleep(Duration::from_millis(150));
+
+        let _silent = TcpStream::connect(("127.0.0.1", port)).unwrap();
+
+        let started = Instant::now();
+        let result = handle.join().unwrap();
+        assert!(
+            result.is_err(),
+            "a request that never arrives is not a callback"
+        );
+        assert!(
+            started.elapsed() < CONNECTION_READ_TIMEOUT * 3,
+            "the read must give up at its deadline, not hold the listener for the callback timeout"
         );
     }
 

--- a/src-tauri/src/services/loopback_server.rs
+++ b/src-tauri/src/services/loopback_server.rs
@@ -32,6 +32,39 @@ pub struct LoopbackServer {
     shutdown_tx: Option<mpsc::Sender<()>>,
     /// Receiver for the authorization code + state
     code_rx: Option<mpsc::Receiver<Result<CallbackResult, String>>>,
+    /// Receiver acknowledging that the accept loop has released BOTH listeners.
+    /// Used by [`CancelHandle::cancel`] / [`LoopbackServer::shutdown`] to wait
+    /// until the port is actually free again.
+    closed_rx: Option<mpsc::Receiver<()>>,
+}
+
+/// How long a cancel waits for the accept loop to confirm it closed its
+/// listeners. The loop polls on a 100 ms tick, so this is generous; on timeout
+/// we give up waiting rather than block a command indefinitely.
+const SHUTDOWN_ACK_TIMEOUT: Duration = Duration::from_secs(2);
+
+/// A detachable handle that can shut a [`LoopbackServer`] down AFTER the server
+/// itself has been moved into [`LoopbackServer::wait_for_callback`] (which
+/// consumes it).
+///
+/// Without this, an abandoned sign-in keeps its socket bound until the callback
+/// timeout fires — for a provider pinned to a fixed port (Bitbucket's registered
+/// redirect is `127.0.0.1:8085`) that makes an immediate retry impossible.
+pub struct CancelHandle {
+    shutdown_tx: mpsc::Sender<()>,
+    closed_rx: mpsc::Receiver<()>,
+}
+
+impl CancelHandle {
+    /// Signal the accept loop and BLOCK until it confirms both listeners are
+    /// closed, so the caller can re-bind the port as soon as this returns.
+    ///
+    /// A `Disconnected` result means the server thread is already gone, which
+    /// likewise means its sockets have been released.
+    pub fn cancel(self) {
+        let _ = self.shutdown_tx.send(());
+        let _ = self.closed_rx.recv_timeout(SHUTDOWN_ACK_TIMEOUT);
+    }
 }
 
 /// Preferred ports for OAuth callbacks (should match redirect URIs registered with providers)
@@ -90,9 +123,10 @@ impl LoopbackServer {
 
         let listener_v6 = Self::try_bind_ipv6_loopback(port);
 
-        // Set up channels for shutdown and code reception
+        // Set up channels for shutdown, close acknowledgement, and code reception
         let (shutdown_tx, shutdown_rx) = mpsc::channel::<()>();
         let (code_tx, code_rx) = mpsc::channel::<Result<CallbackResult, String>>();
+        let (closed_tx, closed_rx) = mpsc::channel::<()>();
 
         // Set non-blocking mode so the accept loop can poll both listeners.
         listener
@@ -105,13 +139,14 @@ impl LoopbackServer {
 
         // Spawn server thread
         thread::spawn(move || {
-            Self::run_server(listener, listener_v6, shutdown_rx, code_tx);
+            Self::run_server(listener, listener_v6, shutdown_rx, code_tx, closed_tx);
         });
 
         Ok(Self {
             port,
             shutdown_tx: Some(shutdown_tx),
             code_rx: Some(code_rx),
+            closed_rx: Some(closed_rx),
         })
     }
 
@@ -185,19 +220,83 @@ impl LoopbackServer {
         }
     }
 
-    /// Run the server loop, polling the IPv4 listener and (when present) the IPv6
-    /// loopback listener so the callback is received on whichever family the
-    /// browser used to reach `localhost`.
+    /// Take a handle that can cancel this server later.
+    ///
+    /// MUST be taken BEFORE the server is moved into [`Self::wait_for_callback`],
+    /// which consumes it — after that there is no other way to stop the accept
+    /// loop before its timeout. The shutdown sender is cloned (not moved) so
+    /// `Drop` still signals shutdown for a server that is simply dropped.
+    /// Returns `None` if a handle was already taken.
+    pub fn take_cancel_handle(&mut self) -> Option<CancelHandle> {
+        let shutdown_tx = self.shutdown_tx.as_ref()?.clone();
+        let closed_rx = self.closed_rx.take()?;
+        Some(CancelHandle {
+            shutdown_tx,
+            closed_rx,
+        })
+    }
+
+    /// Shut the server down and wait until its listeners are actually closed,
+    /// so the caller can re-bind the port immediately afterwards.
+    ///
+    /// Plain `drop` only *signals* shutdown; the accept loop can take up to a
+    /// poll tick to notice, during which the port is still bound.
+    pub fn shutdown(mut self) {
+        match (self.shutdown_tx.take(), self.closed_rx.take()) {
+            (Some(shutdown_tx), Some(closed_rx)) => CancelHandle {
+                shutdown_tx,
+                closed_rx,
+            }
+            .cancel(),
+            // The close acknowledgement was already handed to a `CancelHandle`
+            // (or consumed): fall back to signalling shutdown without waiting,
+            // which is what `Drop` does.
+            (Some(shutdown_tx), None) => {
+                let _ = shutdown_tx.send(());
+            }
+            _ => {}
+        }
+    }
+
+    /// Run the server thread: accept until a callback arrives or shutdown is
+    /// signalled, then release BOTH listeners, announce the close, and only then
+    /// deliver any result.
+    ///
+    /// The order matters: a caller unblocked by the close acknowledgement (or by
+    /// the callback result) must be able to re-bind the port straight away, so
+    /// the sockets are dropped before either is sent.
     fn run_server(
         listener_v4: TcpListener,
-        mut listener_v6: Option<TcpListener>,
+        listener_v6: Option<TcpListener>,
         shutdown_rx: mpsc::Receiver<()>,
         code_tx: mpsc::Sender<Result<CallbackResult, String>>,
+        closed_tx: mpsc::Sender<()>,
     ) {
+        let result = Self::accept_loop(&listener_v4, listener_v6, &shutdown_rx);
+
+        drop(listener_v4);
+        let _ = closed_tx.send(());
+
+        if let Some(result) = result {
+            let _ = code_tx.send(result);
+        }
+    }
+
+    /// Poll the IPv4 listener and (when present) the IPv6 loopback listener so
+    /// the callback is received on whichever family the browser used to reach
+    /// `localhost`. Returns `None` when stopped by the shutdown signal.
+    ///
+    /// The IPv6 listener is owned here so it is dropped (releasing the port on
+    /// that family too) as soon as the loop ends.
+    fn accept_loop(
+        listener_v4: &TcpListener,
+        mut listener_v6: Option<TcpListener>,
+        shutdown_rx: &mpsc::Receiver<()>,
+    ) -> Option<Result<CallbackResult, String>> {
         loop {
             // Check for shutdown signal
             if shutdown_rx.try_recv().is_ok() {
-                break;
+                return None;
             }
 
             // Poll both loopback listeners (both non-blocking). `serviced` tracks
@@ -210,14 +309,12 @@ impl LoopbackServer {
                 Ok((stream, _)) => {
                     serviced = true;
                     if let Some(result) = Self::handle_connection(stream) {
-                        let _ = code_tx.send(result);
-                        return;
+                        return Some(result);
                     }
                 }
                 Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
                 Err(e) => {
-                    let _ = code_tx.send(Err(format!("Accept error: {}", e)));
-                    return;
+                    return Some(Err(format!("Accept error: {}", e)));
                 }
             }
 
@@ -229,8 +326,7 @@ impl LoopbackServer {
                     Ok((stream, _)) => {
                         serviced = true;
                         if let Some(result) = Self::handle_connection(stream) {
-                            let _ = code_tx.send(result);
-                            return;
+                            return Some(result);
                         }
                     }
                     Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {}
@@ -571,6 +667,78 @@ mod tests {
         let result = handle.join().unwrap().unwrap();
         assert_eq!(result.code, "v6code");
         assert_eq!(result.state, "v6state");
+    }
+
+    /// `shutdown` must not return until the socket is actually closed: an
+    /// abandoned OAuth sign-in has to free its port for an immediate retry.
+    /// Plain `drop` only signals the accept loop, which can take a poll tick
+    /// (100 ms) to notice — long enough for the retry's bind to fail.
+    #[test]
+    fn test_shutdown_releases_the_port_before_returning() {
+        let server = LoopbackServer::new_with_port(0).unwrap();
+        let port = server.port();
+
+        server.shutdown();
+
+        assert!(
+            TcpListener::bind(("127.0.0.1", port)).is_ok(),
+            "shutdown must confirm the socket is closed before returning"
+        );
+    }
+
+    /// A cancel handle taken before the server is consumed by `wait_for_callback`
+    /// must be able to abort that wait and free the port — otherwise the listener
+    /// is held for the full callback timeout.
+    #[test]
+    fn test_cancel_handle_aborts_an_in_flight_wait_and_frees_the_port() {
+        let mut server = LoopbackServer::new_with_port(0).unwrap();
+        let port = server.port();
+        let cancel = server
+            .take_cancel_handle()
+            .expect("cancel handle available");
+
+        let handle = thread::spawn(move || server.wait_for_callback(Duration::from_secs(300)));
+        thread::sleep(Duration::from_millis(150));
+
+        assert!(
+            TcpListener::bind(("127.0.0.1", port)).is_err(),
+            "the in-flight wait should still own the port"
+        );
+
+        cancel.cancel();
+
+        assert!(
+            TcpListener::bind(("127.0.0.1", port)).is_ok(),
+            "cancelling must release the port immediately"
+        );
+        assert!(
+            handle.join().unwrap().is_err(),
+            "the aborted wait must not report a successful callback"
+        );
+    }
+
+    /// Taking a cancel handle (and never using it) must not disturb normal
+    /// callback delivery — guards the run_server/accept_loop split and the
+    /// close-ack-before-result ordering.
+    #[test]
+    fn test_taking_a_cancel_handle_does_not_break_callback_delivery() {
+        let mut server = LoopbackServer::new_with_port(0).unwrap();
+        let port = server.port();
+        let _cancel = server
+            .take_cancel_handle()
+            .expect("cancel handle available");
+
+        let handle = thread::spawn(move || server.wait_for_callback(Duration::from_secs(5)));
+        thread::sleep(Duration::from_millis(150));
+
+        let mut stream = TcpStream::connect(("127.0.0.1", port)).unwrap();
+        stream
+            .write_all(b"GET /callback?code=abc&state=xyz HTTP/1.1\r\nHost: localhost\r\n\r\n")
+            .unwrap();
+
+        let result = handle.join().unwrap().unwrap();
+        assert_eq!(result.code, "abc");
+        assert_eq!(result.state, "xyz");
     }
 
     #[test]

--- a/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
@@ -1082,6 +1082,81 @@ describe('lv-bitbucket-dialog', () => {
     });
   });
 
+  describe('Cancelling a pending OAuth sign-in', () => {
+    /** Starts a Bitbucket sign-in that hangs waiting for the browser callback. */
+    async function startPendingSignIn(options: { cancelFails?: boolean } = {}) {
+      const previousMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'oauth_get_authorize_url') {
+          return {
+            authorizeUrl: 'https://bitbucket.org/site/oauth2/authorize',
+            state: 'bb-state-1',
+            loopbackPort: 8085,
+          };
+        }
+        // Never resolves: the flow stays pending, as it does while the user is
+        // in the browser.
+        if (command === 'oauth_wait_for_callback') return new Promise(() => {});
+        if (command === 'oauth_cancel_flow' && options.cancelFails) {
+          throw new Error('No server found for port 8085');
+        }
+        return previousMock(command, args);
+      };
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true}></lv-bitbucket-dialog>
+      `);
+      await el.updateComplete;
+
+      await oauthService.startOAuth('bitbucket', 'test-client-id');
+      await el.updateComplete;
+      return el;
+    }
+
+    afterEach(() => {
+      oauthService.cancelOAuth();
+    });
+
+    it('offers a Cancel button while pending and returns the form to idle', async () => {
+      const el = await startPendingSignIn();
+
+      const signInButton = el.shadowRoot!.querySelector('.btn-oauth') as HTMLButtonElement;
+      expect(signInButton.disabled, 'sign in is disabled while pending').to.be.true;
+      const cancelButton = el.shadowRoot!.querySelector('.oauth-cancel') as HTMLButtonElement;
+      expect(cancelButton, 'a pending sign-in must offer a way out').to.exist;
+
+      invokeHistory.length = 0;
+      cancelButton.click();
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect((el as unknown as { oauthState: { status: string } }).oauthState.status).to.equal('idle');
+      expect((el.shadowRoot!.querySelector('.btn-oauth') as HTMLButtonElement).disabled).to.be.false;
+      expect(el.shadowRoot!.querySelector('.oauth-cancel'), 'cancel disappears once idle').to.not.exist;
+      expect(el.shadowRoot!.querySelector('.oauth-spinner'), 'spinner is gone').to.not.exist;
+
+      const release = invokeHistory.find((h) => h.command === 'oauth_cancel_flow');
+      expect(release, 'the backend loopback server is released').to.exist;
+      expect(release!.args).to.deep.equal({ port: 8085 });
+    });
+
+    it('returns the dialog to idle even when the backend release fails', async () => {
+      const el = await startPendingSignIn({ cancelFails: true });
+
+      const cancelButton = el.shadowRoot!.querySelector('.oauth-cancel') as HTMLButtonElement;
+      expect(cancelButton).to.exist;
+
+      cancelButton.click();
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 10));
+
+      expect((el.shadowRoot!.querySelector('.btn-oauth') as HTMLButtonElement).disabled).to.be.false;
+      expect(el.shadowRoot!.querySelector('.oauth-spinner'), 'no spinner remains').to.not.exist;
+      expect(el.shadowRoot!.querySelector('.oauth-status.error'), 'a failed release is not user-facing').to.not.exist;
+      expect((el as unknown as { error: string | null }).error).to.be.null;
+    });
+  });
+
   describe('OAuth completes after dialog closed', () => {
     it('persists the account and surfaces a toast instead of failing silently', async () => {
       connectionResponse = mockConnectedStatus;

--- a/src/components/dialogs/lv-bitbucket-dialog.ts
+++ b/src/components/dialogs/lv-bitbucket-dialog.ts
@@ -529,6 +529,12 @@ export class LvBitbucketDialog extends LitElement {
         height: 20px;
       }
 
+      .oauth-cancel {
+        width: 100%;
+        justify-content: center;
+        margin-top: var(--spacing-sm);
+      }
+
       .oauth-spinner {
         width: 20px;
         height: 20px;
@@ -1221,6 +1227,19 @@ export class LvBitbucketDialog extends LitElement {
   }
 
   /**
+   * Abandon a sign-in that is waiting on the browser. This also releases the
+   * backend loopback server, so a retry can re-bind Bitbucket's fixed callback
+   * port instead of failing until the flow times out. The local state is set
+   * explicitly rather than relying on the service's notification, so the form
+   * can never stay stuck if there is no pending entry to cancel.
+   */
+  private handleCancelOAuth(): void {
+    oauthService.cancelOAuth('bitbucket');
+    this.oauthState = { status: 'idle' };
+    this.error = null;
+  }
+
+  /**
    * Handle OAuth completion
    */
   private async handleOAuthComplete(tokens: OAuthTokenResponse): Promise<void> {
@@ -1531,6 +1550,10 @@ export class LvBitbucketDialog extends LitElement {
               <span>Sign in with Bitbucket</span>
             `}
           </button>
+
+          ${isOAuthPending ? html`
+            <button class="btn oauth-cancel" @click=${this.handleCancelOAuth}>Cancel</button>
+          ` : ''}
 
           ${this.oauthState.status === 'error' ? html`
             <div class="oauth-status error">${this.oauthState.error}</div>

--- a/src/services/__tests__/oauth.service.test.ts
+++ b/src/services/__tests__/oauth.service.test.ts
@@ -371,3 +371,109 @@ describe('oauth.service - loopback cancel/restart guard', () => {
     unsub();
   });
 });
+
+describe('oauth.service - cancel releases the backend loopback server', () => {
+  const defaultMock = mockInvoke;
+  let invoked: Array<{ command: string; args: unknown }> = [];
+
+  /** Installs a mock that logs every invoke, hands out `loopbackPort` per start,
+   *  and holds `oauth_wait_for_callback` open so the flow stays pending. */
+  function installMock(options: { ports?: (number | undefined)[]; cancelFails?: boolean } = {}) {
+    const ports = options.ports ?? [8085];
+    let n = 0;
+    mockInvoke = (command, args) => {
+      invoked.push({ command, args });
+      if (command === 'oauth_get_authorize_url') {
+        const port = ports[Math.min(n, ports.length - 1)];
+        n += 1;
+        return Promise.resolve({
+          authorizeUrl: 'https://bitbucket.org/site/oauth2/authorize',
+          state: `state-${n}`,
+          loopbackPort: port,
+        });
+      }
+      if (command === 'oauth_wait_for_callback') {
+        return new Promise(() => {});
+      }
+      if (command === 'oauth_cancel_flow' && options.cancelFails) {
+        return Promise.reject(new Error('no server found for port'));
+      }
+      return Promise.resolve(null);
+    };
+  }
+
+  const cancelCalls = () => invoked.filter((c) => c.command === 'oauth_cancel_flow');
+
+  beforeEach(() => {
+    invoked = [];
+  });
+
+  afterEach(() => {
+    cancelOAuth();
+    mockInvoke = defaultMock;
+  });
+
+  it("releases the cancelled flow's loopback server", async () => {
+    const { startOAuth } = await import('../oauth.service.ts');
+    installMock({ ports: [8085] });
+
+    await startOAuth('bitbucket', 'cid');
+    cancelOAuth('bitbucket');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(cancelCalls(), 'the backend wait is aborted').to.have.length(1);
+    expect(cancelCalls()[0].args).to.deep.equal({ port: 8085 });
+    expect(isPendingOAuth()).to.be.false;
+  });
+
+  it("cancelOAuth() with no provider releases every pending flow's port", async () => {
+    const { startOAuth } = await import('../oauth.service.ts');
+    installMock({ ports: [8080, 8085] });
+
+    await startOAuth('github', 'cid');
+    await startOAuth('bitbucket', 'cid');
+    cancelOAuth();
+    await new Promise((r) => setTimeout(r, 10));
+
+    const ports = cancelCalls().map((c) => (c.args as { port: number }).port).sort();
+    expect(ports).to.deep.equal([8080, 8085]);
+    expect(isPendingOAuth()).to.be.false;
+  });
+
+  it('does not call oauth_cancel_flow when there is nothing to release', async () => {
+    const { startOAuth } = await import('../oauth.service.ts');
+    installMock({ ports: [undefined] });
+
+    // (a) No pending flow at all.
+    cancelOAuth('bitbucket');
+    cancelOAuth();
+    await new Promise((r) => setTimeout(r, 10));
+    expect(cancelCalls(), 'nothing pending, nothing to release').to.have.length(0);
+
+    // (b) A pending flow with no loopback port (deep-link providers).
+    await startOAuth('bitbucket', 'cid');
+    cancelOAuth('bitbucket');
+    await new Promise((r) => setTimeout(r, 10));
+    expect(cancelCalls(), 'no loopback port to release').to.have.length(0);
+  });
+
+  it('still cancels locally, and surfaces no error, when the release fails', async () => {
+    const { startOAuth } = await import('../oauth.service.ts');
+    installMock({ ports: [8085], cancelFails: true });
+
+    const errors: string[] = [];
+    const unsub = onOAuthStateChange((s) => {
+      if (s.provider === 'bitbucket' && s.status === 'error') errors.push(s.error ?? '');
+    });
+
+    await startOAuth('bitbucket', 'cid');
+    cancelOAuth('bitbucket');
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(cancelCalls(), 'the release was attempted').to.have.length(1);
+    expect(isPendingOAuth(), 'the flow is cancelled locally regardless').to.be.false;
+    expect(errors, 'a failed release is not a user-facing failure').to.have.length(0);
+
+    unsub();
+  });
+});

--- a/src/services/oauth.service.ts
+++ b/src/services/oauth.service.ts
@@ -364,11 +364,12 @@ async function pollLoopbackCallback(
   } catch (e) {
     log.error(`${provider} OAuth error:`, e);
     // Same guard as the success path: only surface/clean up if the flow THIS poll
-    // served is still the current one. A superseded flow's late error/timeout
-    // (the user cancelled and restarted — cancelOAuth can't abort the backend
-    // wait, which runs to its timeout) must NOT fire a spurious error for the new
-    // flow or delete the new flow's pending entry (which would silently drop the
-    // user's real, in-progress sign-in).
+    // served is still the current one. `cancelOAuth` aborts the backend wait via
+    // `oauth_cancel_flow`, so the abandoned wait rejects promptly — often while
+    // the user's restarted flow is already pending. That superseded flow's late
+    // error must NOT fire a spurious error for the new flow or delete the new
+    // flow's pending entry (which would silently drop the user's real,
+    // in-progress sign-in).
     const current = pendingAuthByProvider.get(provider);
     if (!current || current.state !== expectedState) {
       return;
@@ -463,6 +464,30 @@ export async function refreshToken(
 }
 
 /**
+ * Release the backend loopback server for an abandoned flow.
+ *
+ * The backend's callback wait owns the socket until it times out (5 minutes),
+ * which blocks a retry for providers pinned to a fixed port (Bitbucket's
+ * registered redirect is 127.0.0.1:8085). Fire-and-forget: the local pending
+ * state is already cleared, and a failure here only means the socket lingers
+ * until that timeout, so it is not surfaced to the user.
+ */
+function releaseLoopbackServer(pending: PendingOAuth): void {
+  const port = pending.loopbackPort;
+  if (port === undefined) return;
+  void invokeCommand('oauth_cancel_flow', { port }).then(
+    (result) => {
+      if (!result.success) {
+        log.debug(`Failed to release OAuth loopback server on port ${port}:`, result.error?.message);
+      }
+    },
+    (e) => {
+      log.debug(`Failed to release OAuth loopback server on port ${port}:`, e);
+    }
+  );
+}
+
+/**
  * Cancel pending OAuth flow
  */
 export function cancelOAuth(provider?: OAuthProvider): void {
@@ -471,12 +496,15 @@ export function cancelOAuth(provider?: OAuthProvider): void {
     if (pending) {
       notifyStateChange({ status: 'idle', provider });
       pendingAuthByProvider.delete(provider);
+      releaseLoopbackServer(pending);
     }
   } else {
+    const cancelled = [...pendingAuthByProvider.values()];
     for (const [p] of pendingAuthByProvider) {
       notifyStateChange({ status: 'idle', provider: p });
     }
     pendingAuthByProvider.clear();
+    cancelled.forEach(releaseLoopbackServer);
   }
 }
 


### PR DESCRIPTION
## What was broken

### A cancelled Bitbucket sign-in blocked the retry for 5 minutes

`oauth_wait_for_callback` (`src-tauri/src/commands/oauth.rs`) **removes** the pending server from `PENDING_SERVERS` and moves it into `spawn_blocking(move || pending.server.wait_for_callback(timeout))` with a 300 s timeout. The accept-loop thread owns both listeners for that entire window, and the `PENDING_SERVER_TTL` cleanup cannot help — the entry is already out of the map.

There was no way to stop that wait. No `oauth_cancel_flow` command existed, and `cancelOAuth()` in `src/services/oauth.service.ts` only notified `idle` and deleted from `pendingAuthByProvider` — no backend call at all (its own comment conceded "cancelOAuth can't abort the backend wait, which runs to its timeout").

Bitbucket's registered redirect pins the callback to `127.0.0.1:8085`, so the next attempt hit `TcpListener::bind("127.0.0.1:8085")` → `EADDRINUSE` → *"Port 8085 is not available for OAuth callback. Please close any application using this port and try again."* The application using the port was Leviathan.

### The Bitbucket dialog had no cancel affordance at all

Unlike the GitHub, OIDC and Azure DevOps dialogs, `lv-bitbucket-dialog.ts` offered no way out of the pending state: while `oauthState.status === 'pending'`, the `.btn-oauth` button and both auth-method toggles are `?disabled`. An abandoned sign-in was a hard dead end on "Waiting for browser..." for the full five minutes — and re-entering the flow produced the misleading port error above.

## The fix

**Shutdown is now observable** (`src-tauri/src/services/loopback_server.rs`). `run_server` is split into an `accept_loop` plus a single teardown point: the loop ends, **both** listeners are dropped, the close is acknowledged on a new channel, and only then is any result delivered. A caller unblocked by that ack (or by the callback result) can re-bind the port straight away. Plain `drop` only *signalled* shutdown, and the loop sleeps up to 100 ms before noticing — long enough for a retry's bind to fail.

**Shutdown is now reachable.** `CancelHandle` (shutdown sender + close-ack receiver) is detachable via `take_cancel_handle()` *before* the server is moved into `wait_for_callback`, which consumes it. `cancel()` signals and blocks until the listeners are confirmed closed. `LoopbackServer::shutdown()` does the same for a server that never started waiting.

**A cancel command** (`oauth_cancel_flow(port)`, registered in `lib.rs`). `oauth_wait_for_callback` registers its detached handle in a new `ACTIVE_WAITS` map keyed by port, and deregisters after the join — deregistration is **id-guarded**, because a cancelled wait can return *after* the user's retry registered a new wait on the same fixed port; removing blindly would strip the new flow's ability to cancel. `release_loopback_port` handles both cases (parked in `PENDING_SERVERS`, or already in flight) and is a no-op for a port we hold nothing on, so cancelling twice or after completion is safe.

**Belt and braces on Bitbucket's fixed port.** If `new_with_port(8085)` fails, we release anything of *ours* on that port and bind once more; if we held nothing, the original error is returned unchanged so a genuine third-party occupant still gets the existing message. This covers a flow abandoned without a cancel, or a retry that races one.

**Frontend.** `cancelOAuth` now calls `oauth_cancel_flow` for every flow it drops (fire-and-forget — the local state is already cleared, and a failed release only means the socket lingers until its timeout). The Bitbucket dialog gets a `Cancel` button while pending which returns the form to idle, matching the other providers; it sets the local state explicitly so the button can never leave the form stuck.

## Tests

| # | Test | File | Covers |
|---|---|---|---|
| R1 | `test_shutdown_releases_the_port_before_returning` | `loopback_server.rs` | Happy path — shutdown confirms the socket is closed |
| R2 | `test_cancel_handle_aborts_an_in_flight_wait_and_frees_the_port` | `loopback_server.rs` | Aborting a wait that already owns the port |
| R3 | `test_taking_a_cancel_handle_does_not_break_callback_delivery` | `loopback_server.rs` | Edge — the `run_server`/`accept_loop` split and ack-before-result ordering |
| R4 | existing IPv4 / root-path / IPv6 callback tests | `loopback_server.rs` | Regression, unchanged |
| R5 | `test_oauth_cancel_flow_releases_a_port_held_by_an_in_flight_wait` | `commands/oauth.rs` | Happy path — the core bug, end to end through the command |
| R6 | `test_oauth_cancel_flow_releases_a_server_that_never_started_waiting` | `commands/oauth.rs` | Happy path — a flow abandoned before the wait began |
| R7 | `test_oauth_cancel_flow_is_a_noop_for_an_unknown_port` | `commands/oauth.rs` | Error/edge — cancelling twice, or a port we don't hold |
| R8 | `test_a_finished_wait_does_not_strip_a_retrys_cancel_handle` | `commands/oauth.rs` | Race edge — the id guard in `unregister_wait` |
| R9 | `test_bitbucket_flow_can_restart_after_an_abandoned_sign_in` | `commands/oauth.rs` | End to end — two `oauth_get_authorize_url("bitbucket")` calls both get 8085 (self-skips if another process owns the port) |
| T1 | `releases the cancelled flow's loopback server` | `oauth.service.test.ts` | Happy path — `oauth_cancel_flow` invoked with `{ port: 8085 }` |
| T2 | `cancelOAuth() with no provider releases every pending flow's port` | `oauth.service.test.ts` | Happy path — all pending flows released |
| T3 | `does not call oauth_cancel_flow when there is nothing to release` | `oauth.service.test.ts` | Edge — no pending flow, and a flow with no loopback port |
| T4 | `still cancels locally, and surfaces no error, when the release fails` | `oauth.service.test.ts` | Error path — a rejecting release is not user-facing |
| T5 | `offers a Cancel button while pending and returns the form to idle` | `lv-bitbucket-dialog.test.ts` | Happy path — button exists, form returns to idle, port released |
| T6 | `returns the dialog to idle even when the backend release fails` | `lv-bitbucket-dialog.test.ts` | Error path — no stuck spinner, no spurious error banner |
| T7 | `releases the loopback port and re-enables Sign in` | `e2e/tests/bitbucket-dialog.spec.ts` | Full-stack user flow with a hung `oauth_wait_for_callback` |

### Verified to fail without the fix

Each production mechanism was reverted individually and the tests re-run:

- **Close acknowledgement removed** (`cancel()` signals without waiting) → R1 `shutdown must confirm the socket is closed before returning`; R2 `cancelling must release the port immediately`; R5 `cancelling must free the port for an immediate retry`; R6 and R8 fail likewise (5 failures).
- **Id guard removed from `unregister_wait`** → R8 `the retry must still be cancellable after the older wait finishes`.
- **Bitbucket rebind retry removed** → R9 `a second Bitbucket sign-in must be able to re-bind port 8085: OAuth("Port 8085 is not available for OAuth callback. Please close any application using this port and try again. Error: Address already in use (os error 98)")` — the exact error the user saw.
- **`ACTIVE_WAITS` registration removed** → R5 no longer completes at all: the wait cannot be aborted and the test hangs for the full 300 s callback timeout, which is precisely the dead end being fixed.
- **`releaseLoopbackServer` call removed from `cancelOAuth`** → T1 `expected [] to have a length of 1 but got 0`, T2 `expected [] to deeply equal [ 8080, 8085 ]`, T4 `the release was attempted: expected [] to have a length of 1 but got 0`.
- **Cancel button removed from the dialog** → T5 `a pending sign-in must offer a way out: expected null to exist`, T6 likewise, and T7 fails on `expect(locator).toBeVisible()` — `element(s) not found`.

The two tests that touch the fixed port 8085 (the pre-existing `test_oauth_get_authorize_url_bitbucket` and the new R9) now share a test-only async mutex, since they cannot run concurrently.

Gate: `npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib`, plus `npx playwright test e2e/tests/bitbucket-dialog.spec.ts` (12 passed) and the CLAUDE.md snake_case grep — all green.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_