### PR TITLE
Detect LFS from attributes anywhere in the repo, not just the root

### DIFF
--- a/src-tauri/src/commands/lfs.rs
+++ b/src-tauri/src/commands/lfs.rs
@@ -80,6 +80,68 @@ fn is_lfs_installed() -> bool {
         .unwrap_or(false)
 }
 
+/// Whether an attributes file's contents turn the LFS filter on for some
+/// pattern. Comment lines do not count: a commented-out rule is not config.
+fn enables_lfs(content: &str) -> bool {
+    content.lines().any(|line| {
+        let line = line.trim();
+        !line.starts_with('#') && line.contains("filter=lfs")
+    })
+}
+
+/// Whether the attributes file at `path` enables LFS. A missing or unreadable
+/// file simply does not.
+fn file_enables_lfs(path: &Path) -> bool {
+    std::fs::read_to_string(path)
+        .map(|c| enables_lfs(&c))
+        .unwrap_or(false)
+}
+
+/// Whether LFS is configured for this repository.
+///
+/// Git reads attributes from a `.gitattributes` in every directory of the
+/// tree, not just the root, plus `.git/info/attributes`. A monorepo that keeps
+/// its rules in e.g. `assets/.gitattributes` is an LFS repo just the same;
+/// looking only at the root file reported those repos as "not configured",
+/// which hid the file list and the pull/prune actions in the UI.
+fn is_lfs_enabled(repo_path: &Path) -> bool {
+    // The root file is read straight from disk: `git lfs track` writes it long
+    // before it is ever committed.
+    if file_enables_lfs(&repo_path.join(".gitattributes")) {
+        return true;
+    }
+
+    let Ok(repo) = git2::Repository::open(repo_path) else {
+        return false;
+    };
+
+    // Not part of the tree; repo.path() resolves the git dir for linked
+    // worktrees too.
+    if file_enables_lfs(&repo.path().join("info").join("attributes")) {
+        return true;
+    }
+
+    // Nested attributes files, taken from the index rather than a directory
+    // walk: it costs no directory IO and still sees files that are not checked
+    // out. Prefer the working-tree copy when there is one so uncommitted edits
+    // count, and fall back to the committed blob.
+    let Ok(index) = repo.index() else {
+        return false;
+    };
+    index.iter().any(|entry| {
+        let rel = String::from_utf8_lossy(&entry.path).to_string();
+        let rel = Path::new(&rel);
+        if rel.file_name() != Some(std::ffi::OsStr::new(".gitattributes")) {
+            return false;
+        }
+        file_enables_lfs(&repo_path.join(rel))
+            || repo
+                .find_blob(entry.id)
+                .map(|b| enables_lfs(&String::from_utf8_lossy(b.content())))
+                .unwrap_or(false)
+    })
+}
+
 /// Get LFS version
 fn get_lfs_version() -> Option<String> {
     create_command("git")
@@ -116,12 +178,8 @@ pub async fn get_lfs_status(path: String) -> Result<LfsStatus> {
         });
     }
 
-    // Check if LFS is enabled (has .gitattributes with lfs filter)
-    let gitattributes = repo_path.join(".gitattributes");
-    let enabled = gitattributes.exists()
-        && std::fs::read_to_string(&gitattributes)
-            .map(|c| c.contains("filter=lfs"))
-            .unwrap_or(false);
+    // Check if LFS is enabled (attributes anywhere in the repo, not just root)
+    let enabled = is_lfs_enabled(repo_path);
 
     // Get tracked patterns
     let patterns = if enabled {
@@ -419,6 +477,101 @@ mod tests {
         if status.installed {
             assert!(status.enabled);
         }
+    }
+
+    #[test]
+    fn test_lfs_enabled_from_nested_gitattributes() {
+        let repo = TestRepo::with_initial_commit();
+
+        // Monorepo layout: the LFS rules live in a subdirectory, with no
+        // .gitattributes at the repo root at all.
+        repo.create_commit(
+            "Track assets",
+            &[(
+                "assets/.gitattributes",
+                "*.psd filter=lfs diff=lfs merge=lfs -text\n",
+            )],
+        );
+        assert!(!repo.path.join(".gitattributes").exists());
+
+        assert!(is_lfs_enabled(&repo.path));
+    }
+
+    #[test]
+    fn test_lfs_enabled_from_nested_gitattributes_not_checked_out() {
+        let repo = TestRepo::with_initial_commit();
+
+        repo.create_commit(
+            "Track assets",
+            &[(
+                "assets/.gitattributes",
+                "*.psd filter=lfs diff=lfs merge=lfs -text\n",
+            )],
+        );
+
+        // Sparse/partial checkout: the entry is in the index and the committed
+        // tree, but there is no file on disk to read.
+        std::fs::remove_file(repo.path.join("assets/.gitattributes")).unwrap();
+
+        assert!(is_lfs_enabled(&repo.path));
+    }
+
+    #[test]
+    fn test_lfs_enabled_from_info_attributes() {
+        let repo = TestRepo::with_initial_commit();
+
+        // Repo-local attributes, deliberately not part of the tree.
+        std::fs::create_dir_all(repo.path.join(".git/info")).unwrap();
+        std::fs::write(
+            repo.path.join(".git/info/attributes"),
+            "*.bin filter=lfs diff=lfs merge=lfs -text\n",
+        )
+        .unwrap();
+        assert!(!repo.path.join(".gitattributes").exists());
+
+        assert!(is_lfs_enabled(&repo.path));
+    }
+
+    #[test]
+    fn test_lfs_enabled_from_root_gitattributes() {
+        let repo = TestRepo::with_initial_commit();
+
+        // Uncommitted, as `git lfs track` leaves it.
+        repo.create_file(
+            ".gitattributes",
+            "*.bin filter=lfs diff=lfs merge=lfs -text\n",
+        );
+
+        assert!(is_lfs_enabled(&repo.path));
+    }
+
+    #[test]
+    fn test_lfs_not_enabled_without_lfs_filter() {
+        let repo = TestRepo::with_initial_commit();
+
+        // Attributes files exist at the root and nested, but none of them
+        // mention the LFS filter.
+        repo.create_file(".gitattributes", "*.txt text\n");
+        repo.create_commit("Docs attributes", &[("docs/.gitattributes", "*.md text\n")]);
+
+        assert!(!is_lfs_enabled(&repo.path));
+    }
+
+    #[test]
+    fn test_lfs_not_enabled_for_commented_out_filter() {
+        let repo = TestRepo::with_initial_commit();
+
+        repo.create_file(
+            ".gitattributes",
+            "# *.psd filter=lfs diff=lfs merge=lfs -text\n",
+        );
+
+        assert!(!is_lfs_enabled(&repo.path));
+    }
+
+    #[test]
+    fn test_lfs_enabled_false_for_missing_repo() {
+        assert!(!is_lfs_enabled(std::path::Path::new("/nonexistent/path")));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/lfs.rs
+++ b/src-tauri/src/commands/lfs.rs
@@ -123,8 +123,11 @@ fn is_lfs_enabled(repo_path: &Path) -> bool {
 
     // Nested attributes files, taken from the index rather than a directory
     // walk: it costs no directory IO and still sees files that are not checked
-    // out. Prefer the working-tree copy when there is one so uncommitted edits
-    // count, and fall back to the committed blob.
+    // out. The working-tree copy is what git actually applies, so when the file
+    // is there it is the only thing consulted -- `git lfs untrack` empties a
+    // rule long before that removal is committed, and falling through to the
+    // old blob would keep reporting the repo as configured. The committed blob
+    // is only for entries with no file on disk at all (sparse/partial clones).
     let Ok(index) = repo.index() else {
         return false;
     };
@@ -134,12 +137,75 @@ fn is_lfs_enabled(repo_path: &Path) -> bool {
         if rel.file_name() != Some(std::ffi::OsStr::new(".gitattributes")) {
             return false;
         }
-        file_enables_lfs(&repo_path.join(rel))
-            || repo
-                .find_blob(entry.id)
-                .map(|b| enables_lfs(&String::from_utf8_lossy(b.content())))
-                .unwrap_or(false)
+        let checked_out = repo_path.join(rel);
+        if checked_out.exists() {
+            return file_enables_lfs(&checked_out);
+        }
+        repo.find_blob(entry.id)
+            .map(|b| enables_lfs(&String::from_utf8_lossy(b.content())))
+            .unwrap_or(false)
     })
+}
+
+/// The pattern a `git lfs track` listing line reports, and the attributes file
+/// that defines it. Lines look like `    assets/*.psd (assets/.gitattributes)`,
+/// optionally with a ` [lockable]` marker before the source.
+fn parse_track_line(line: &str) -> Option<(&str, &str)> {
+    let line = line.trim();
+    let (left, source) = line.rsplit_once('(')?;
+    let source = source.strip_suffix(')')?.trim();
+    let pattern = left.split_whitespace().next()?;
+    Some((pattern, source))
+}
+
+/// Whether a `git lfs track` listing still reports `pattern`.
+fn lists_pattern(track_output: &str, pattern: &str) -> bool {
+    track_output
+        .lines()
+        .any(|line| parse_track_line(line).is_some_and(|(listed, _)| listed == pattern))
+}
+
+/// Where `git lfs untrack` has to run to remove `pattern`, and the pattern as
+/// written in the attributes file it lives in.
+///
+/// `git lfs track` reports patterns relative to the repository root and names
+/// the file that defines each one, so a rule written as `*.psd` in
+/// `assets/.gitattributes` is listed as `assets/*.psd`. `git lfs untrack` only
+/// rewrites the `.gitattributes` in its own working directory, and matches
+/// lines by the pattern exactly as written there. Run from the root with the
+/// listed name it therefore rewrites the root file, leaves the nested rule
+/// alone and still exits 0 -- which is what made Remove report success and
+/// change nothing.
+///
+/// Returns the directory relative to the repository root ("" for the root
+/// itself) and the pattern to pass. `None` when the listing does not mention
+/// the pattern, or when it comes from inside the git directory
+/// (`.git/info/attributes`), which `git lfs untrack` cannot rewrite at all --
+/// the caller falls back to the root and the check afterwards reports the
+/// pattern is still tracked.
+fn resolve_untrack_target(track_output: &str, pattern: &str) -> Option<(String, String)> {
+    let source = track_output.lines().find_map(|line| {
+        parse_track_line(line).and_then(|(listed, source)| (listed == pattern).then_some(source))
+    })?;
+
+    let dir = Path::new(source)
+        .parent()
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_default();
+
+    if dir.is_empty() || dir == "." {
+        return Some((String::new(), pattern.to_string()));
+    }
+
+    if dir == ".git" || dir.starts_with(".git/") {
+        return None;
+    }
+
+    let raw = pattern
+        .strip_prefix(&format!("{}/", dir))
+        .unwrap_or(pattern)
+        .to_string();
+    Some((dir, raw))
 }
 
 /// Get LFS version
@@ -289,7 +355,37 @@ pub async fn lfs_track(path: String, pattern: String) -> Result<()> {
 #[command]
 pub async fn lfs_untrack(path: String, pattern: String) -> Result<()> {
     let repo_path = Path::new(&path);
-    run_lfs_command(repo_path, &["untrack", &pattern])?;
+
+    // A rule defined in a nested `.gitattributes` has to be removed from the
+    // directory that defines it -- see `resolve_untrack_target`. When the
+    // listing is unavailable, or does not name the pattern, fall back to the
+    // repository root, which is where every pattern used to be removed from.
+    let (dir, raw) = run_lfs_command(repo_path, &["track"])
+        .ok()
+        .and_then(|output| resolve_untrack_target(&output, &pattern))
+        .unwrap_or_else(|| (String::new(), pattern.clone()));
+
+    let work_dir = if dir.is_empty() {
+        repo_path.to_path_buf()
+    } else {
+        repo_path.join(&dir)
+    };
+
+    run_lfs_command(&work_dir, &["untrack", &raw])?;
+
+    // `git lfs untrack` rewrites the attributes file in its working directory
+    // and exits 0 even when it matched nothing, so a success here is not proof
+    // the rule is gone. Confirm it, rather than letting the dialog report
+    // "No longer tracking ..." over a pattern that is still there.
+    if let Ok(output) = run_lfs_command(repo_path, &["track"]) {
+        if lists_pattern(&output, &pattern) {
+            return Err(LeviathanError::OperationFailed(format!(
+                "{} is still tracked. Remove it from the .gitattributes that defines it.",
+                pattern
+            )));
+        }
+    }
+
     Ok(())
 }
 
@@ -567,6 +663,130 @@ mod tests {
         );
 
         assert!(!is_lfs_enabled(&repo.path));
+    }
+
+    #[test]
+    fn test_lfs_not_enabled_when_nested_attributes_emptied_in_working_tree() {
+        let repo = TestRepo::with_initial_commit();
+
+        repo.create_commit(
+            "Track assets",
+            &[(
+                "assets/.gitattributes",
+                "*.psd filter=lfs diff=lfs merge=lfs -text\n",
+            )],
+        );
+
+        // What `git lfs untrack` leaves behind: the file is still checked out,
+        // the rule is gone, and the removal is not committed yet. The stale
+        // blob must not keep the repo reading as configured.
+        repo.create_file("assets/.gitattributes", "\n");
+
+        assert!(!is_lfs_enabled(&repo.path));
+    }
+
+    #[test]
+    fn test_lfs_not_enabled_when_root_attributes_emptied_in_working_tree() {
+        let repo = TestRepo::with_initial_commit();
+
+        repo.create_commit(
+            "Track binaries",
+            &[(
+                ".gitattributes",
+                "*.bin filter=lfs diff=lfs merge=lfs -text\n",
+            )],
+        );
+
+        repo.create_file(".gitattributes", "*.txt text\n");
+
+        assert!(!is_lfs_enabled(&repo.path));
+    }
+
+    #[test]
+    fn test_parse_track_line_root_and_nested() {
+        assert_eq!(
+            parse_track_line("    *.psd (.gitattributes)"),
+            Some(("*.psd", ".gitattributes"))
+        );
+        assert_eq!(
+            parse_track_line("    assets/*.psd (assets/.gitattributes)"),
+            Some(("assets/*.psd", "assets/.gitattributes"))
+        );
+        assert_eq!(
+            parse_track_line("    assets/*.psd [lockable] (assets/.gitattributes)"),
+            Some(("assets/*.psd", "assets/.gitattributes"))
+        );
+        assert_eq!(parse_track_line("Listing tracked patterns"), None);
+        assert_eq!(parse_track_line(""), None);
+    }
+
+    #[test]
+    fn test_resolve_untrack_target_nested_runs_from_defining_directory() {
+        let output = "Listing tracked patterns\n    *.bin (.gitattributes)\n    assets/*.psd (assets/.gitattributes)\n";
+
+        // The listed name is repo-relative; the file itself says "*.psd".
+        assert_eq!(
+            resolve_untrack_target(output, "assets/*.psd"),
+            Some(("assets".to_string(), "*.psd".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_untrack_target_deeply_nested() {
+        let output = "    a/b/c/*.psd (a/b/c/.gitattributes)\n";
+
+        assert_eq!(
+            resolve_untrack_target(output, "a/b/c/*.psd"),
+            Some(("a/b/c".to_string(), "*.psd".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_untrack_target_root_stays_at_root() {
+        let output = "Listing tracked patterns\n    *.bin (.gitattributes)\n";
+
+        assert_eq!(
+            resolve_untrack_target(output, "*.bin"),
+            Some((String::new(), "*.bin".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_untrack_target_lockable_pattern() {
+        let output = "    assets/*.psd [lockable] (assets/.gitattributes)\n";
+
+        assert_eq!(
+            resolve_untrack_target(output, "assets/*.psd"),
+            Some(("assets".to_string(), "*.psd".to_string()))
+        );
+    }
+
+    #[test]
+    fn test_resolve_untrack_target_unknown_pattern() {
+        let output = "Listing tracked patterns\n    *.bin (.gitattributes)\n";
+
+        // Nothing to redirect to; the caller falls back to the repository root.
+        assert_eq!(resolve_untrack_target(output, "*.psd"), None);
+    }
+
+    #[test]
+    fn test_resolve_untrack_target_ignores_git_dir_source() {
+        // `.git/info/attributes` is not a file `git lfs untrack` can rewrite,
+        // and its directory is not a place to run from.
+        let output = "    .git/info/*.psd (.git/info/attributes)\n";
+
+        assert_eq!(resolve_untrack_target(output, ".git/info/*.psd"), None);
+    }
+
+    #[test]
+    fn test_lists_pattern() {
+        let output = "Listing tracked patterns\n    *.bin (.gitattributes)\n    assets/*.psd (assets/.gitattributes)\n";
+
+        assert!(lists_pattern(output, "*.bin"));
+        assert!(lists_pattern(output, "assets/*.psd"));
+        assert!(!lists_pattern(output, "*.psd"));
+        assert!(!lists_pattern(output, ""));
+        assert!(!lists_pattern("", "*.bin"));
     }
 
     #[test]

--- a/src/components/dialogs/lv-lfs-dialog.ts
+++ b/src/components/dialogs/lv-lfs-dialog.ts
@@ -870,9 +870,9 @@ export class LvLfsDialog extends LitElement {
       </div>
 
       <!-- Tracked Patterns is gated on INSTALLED, not enabled.
-           "enabled" means .gitattributes exists and contains filter=lfs, and
-           the only thing that writes that file is git lfs track — which lived
-           in here. git lfs install (the Initialize button) sets config and
+           "enabled" means some .gitattributes in the repo enables the LFS
+           filter, and the only thing that writes that file is git lfs track —
+           which lived in here. git lfs install (the Initialize button) sets config and
            hooks but never touches .gitattributes, so Initialize reported
            success, the badge stayed "Not configured", and the one control that
            could have changed it was unreachable. The dialog was a dead end on


### PR DESCRIPTION
## What was broken

### LFS `enabled` only looked at the root `.gitattributes`

`get_lfs_status` in `src-tauri/src/commands/lfs.rs` decided `enabled` solely from `<repo>/.gitattributes`:

```rust
// Check if LFS is enabled (has .gitattributes with lfs filter)
let gitattributes = repo_path.join(".gitattributes");
let enabled = gitattributes.exists()
    && std::fs::read_to_string(&gitattributes)
        .map(|c| c.contains("filter=lfs"))
        .unwrap_or(false);
```

Git applies attributes from a `.gitattributes` in **every directory** of the tree, plus `.git/info/attributes`. A monorepo that keeps its LFS rules in e.g. `assets/.gitattributes` — a common layout — reported `enabled = false`.

Both downstream blocks are gated on that flag (`let patterns = if enabled {...}` running `git lfs track`, and `let (file_count, total_size) = if enabled {...}` running `git lfs ls-files -s`), so they never ran and patterns/counts came back empty as well.

User-visible consequence in `src/components/dialogs/lv-lfs-dialog.ts`: the status badge renders **"Not configured"** and offers *Initialize LFS*; Tracked Patterns shows **"No patterns configured"** because the backend never queried `git lfs track`; and the `${this.status.enabled ? ...}` block holding the **LFS Files** list plus the **Pull Files** and **Prune Old Files** buttons renders nothing. An actively-LFS repo had no way to pull its LFS content from the UI.

Secondary defect in the same expression: the whole-file substring match meant a commented-out `# *.psd filter=lfs` line counted as configured.

## The fix

Detection now reads the attribute files themselves, in three places, short-circuiting on the first hit:

1. **Root `.gitattributes` on disk** — `git lfs track` writes it long before it is ever committed, so this case must not regress.
2. **`.git/info/attributes`** — repo-local, deliberately not part of the tree. Resolved through `repo.path()`, so linked worktrees work too.
3. **Nested `.gitattributes`, enumerated from the git2 index** — no directory walk, so no directory IO cost on large repos, and entries that are not checked out (sparse/partial clones) still count. The working-tree copy is preferred so uncommitted edits count, falling back to the committed blob.

Comment lines are skipped, so a disabled rule no longer reads as configuration.

Two notes on why it is done this way rather than by shelling out to `git lfs track` as originally suggested:

- **Testability.** git-lfs is not installed in CI (no `lfs` reference in any workflow) and `get_lfs_status` early-returns when the binary is absent. Every existing LFS test that shells out is a silent no-op skip. A subprocess-based fix could not be covered by a test that fails without it; this one is pure and fully testable with `TestRepo`.
- **Fidelity.** Reading `.git/info/attributes` and every `.gitattributes` in the tree is exactly what git-lfs does internally.

`git lfs track` already reports nested patterns (it walks the same files), so a correct `enabled` is all that was needed — patterns, counts, Files, Pull and Prune all light up with no further change. No extra subprocesses were added, and the `patterns` / `(file_count, total_size)` blocks are untouched.

The only `src/` change is a one-sentence comment correction in the dialog; its render logic is unchanged, since it already rendered correctly for `enabled === true` and was simply being handed the wrong value.

## Tests

All in the existing `#[cfg(test)] mod tests` of `src-tauri/src/commands/lfs.rs`, using `TestRepo` with real git2. **None require the git-lfs binary**, so unlike the existing LFS tests they actually run here and in CI.

| Test | Covers | Fails without the fix |
| --- | --- | --- |
| `test_lfs_enabled_from_nested_gitattributes` | Happy path — the reported defect: `assets/.gitattributes`, no root file | **Yes** |
| `test_lfs_enabled_from_nested_gitattributes_not_checked_out` | Edge — sparse/partial checkout; entry only in index + tree, file removed from disk. Pins the index/blob fallback | **Yes** |
| `test_lfs_enabled_from_info_attributes` | Edge — repo-local `.git/info/attributes`, outside the tree | **Yes** |
| `test_lfs_not_enabled_for_commented_out_filter` | Edge — `# *.psd filter=lfs` is not configuration | **Yes** |
| `test_lfs_enabled_from_root_gitattributes` | Regression guard — uncommitted root file, as fresh `git lfs track` leaves it | No (by design) |
| `test_lfs_not_enabled_without_lfs_filter` | Negative path — root and nested attributes files that never mention the LFS filter | No (guards against "any `.gitattributes` means enabled") |
| `test_lfs_enabled_false_for_missing_repo` | Error path — the new git2 open/index path degrades to `false` instead of panicking | No (guards the new failure mode) |

Existing `test_get_lfs_status_with_gitattributes` and `test_get_lfs_status_invalid_path` pass unchanged.

### Verified the tests bite

The body of `is_lfs_enabled` was temporarily replaced with the old root-only expression and `cargo test --lib commands::lfs` re-run. Result: `20 passed; 4 failed`, exactly the four marked above:

```
assertion failed: is_lfs_enabled(&repo.path)    -- test_lfs_enabled_from_nested_gitattributes
assertion failed: is_lfs_enabled(&repo.path)    -- test_lfs_enabled_from_nested_gitattributes_not_checked_out
assertion failed: is_lfs_enabled(&repo.path)    -- test_lfs_enabled_from_info_attributes
assertion failed: !is_lfs_enabled(&repo.path)   -- test_lfs_not_enabled_for_commented_out_filter
```

The real body was then restored and all 24 tests in the module pass.

## Gate

`npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` — all green.

Because the change reads on-disk git attribute text, the module was also run against git 2.55 (this box has 2.43) to rule out version skew: 24 passed. The change parses no git CLI output.

No frontend or e2e test added: the only `src/` change is a comment.