### PR TITLE
Render the status-bar ahead/behind badge from the repository store

### DIFF
--- a/e2e/tests/remote-operations.spec.ts
+++ b/e2e/tests/remote-operations.spec.ts
@@ -163,6 +163,74 @@ test.describe('Ahead/Behind Badges', () => {
 });
 
 // ============================================================================
+// Status-bar ahead/behind badge
+//
+// The status bar used to render its own copy of the counts, written only by a
+// tab switch, the fetch-on-focus handler and auto-fetch. push/pull/fetch never
+// touched it, so it kept advertising commits that had already been pushed
+// while the dashboard badge a few pixels away had already cleared. It now
+// renders the same store field every other badge does.
+// ============================================================================
+
+test.describe('Status-bar ahead/behind badge', () => {
+  const aheadBadge = (page: import('@playwright/test').Page) =>
+    page.locator('footer.status-bar .status-ahead');
+  const behindBadge = (page: import('@playwright/test').Page) =>
+    page.locator('footer.status-bar .status-behind');
+
+  test('shows the unpushed count for the open repository', async ({ page }) => {
+    await setupOpenRepository(page, withAheadBehind(3, 0));
+
+    await expect(aheadBadge(page)).toHaveText('↑3');
+    await expect(behindBadge(page)).toHaveCount(0);
+  });
+
+  test('clears after a successful push, agreeing with the dashboard badge', async ({ page }) => {
+    await setupOpenRepository(page, withAheadBehind(3, 0));
+    await expect(aheadBadge(page)).toHaveText('↑3');
+
+    await startCommandCapture(page);
+    await page.getByRole('button', { name: /Push/i }).click();
+    await waitForCommand(page, 'push');
+
+    await expect(aheadBadge(page)).toHaveCount(0);
+    await expect(page.locator('.badge.push')).toHaveCount(0);
+    // The status bar is still there — only the badge went away
+    await expect(page.locator('footer.status-bar')).toContainText('/tmp/test-repo');
+  });
+
+  test('clears after a successful pull', async ({ page }) => {
+    await setupOpenRepository(page, withAheadBehind(0, 2));
+    await expect(behindBadge(page)).toHaveText('↓2');
+
+    await startCommandCapture(page);
+    await page.getByRole('button', { name: /Pull/i }).click();
+    await waitForCommand(page, 'pull');
+
+    await expect(behindBadge(page)).toHaveCount(0);
+  });
+
+  test('survives a rejected push, so the commits stay visible', async ({ page }) => {
+    await setupOpenRepository(page, withAheadBehind(3, 0));
+    await expect(aheadBadge(page)).toHaveText('↑3');
+
+    await injectCommandError(page, 'push', 'Push rejected: non-fast-forward');
+    await page.getByRole('button', { name: /Push/i }).click();
+
+    await expect(page.locator('.toast')).toBeVisible({ timeout: 5000 });
+    await expect(aheadBadge(page)).toHaveText('↑3');
+  });
+
+  test('shows no badge when up to date', async ({ page }) => {
+    await setupOpenRepository(page, withAheadBehind(0, 0));
+
+    await expect(page.locator('footer.status-bar')).toContainText('/tmp/test-repo');
+    await expect(aheadBadge(page)).toHaveCount(0);
+    await expect(behindBadge(page)).toHaveCount(0);
+  });
+});
+
+// ============================================================================
 // Branch List Ahead/Behind Indicator Tests
 // ============================================================================
 

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1,6 +1,7 @@
 /**
  * Multi-repo correctness tests for app-shell:
- * - autofetch results from BACKGROUND repos must not drive the toolbar badge
+ * - autofetch results are written per-repo, so a BACKGROUND repo's counts land
+ *   on its own tab badge and never under the active tab
  * - remote-update toasts must name the repo they belong to
  * - watcher events for background repos mark them stale instead of refreshing
  * - closing a repo tears down its watcher and search index
@@ -49,6 +50,40 @@ function mockRepo(path: string, name: string): Repository {
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
+function mockBranch(aheadBehind?: { ahead: number; behind: number }) {
+  return {
+    name: 'main',
+    shorthand: 'main',
+    isHead: true,
+    isRemote: false,
+    upstream: 'origin/main',
+    targetOid: 'abc',
+    isStale: false,
+    ...(aheadBehind ? { aheadBehind } : {}),
+  };
+}
+
+/** Seed an OPEN repo with a current branch so ahead/behind has somewhere to land. */
+function seedRepo(path: string, name: string, aheadBehind?: { ahead: number; behind: number }) {
+  repositoryStore.getState().addRepository(mockRepo(path, name));
+  repositoryStore.getState().updateRepoData(path, { currentBranch: mockBranch(aheadBehind) as any });
+}
+
+/** The status bar's ↑/↓ spans, if rendered. */
+function statusBadges(el: AppShell) {
+  const footer = el.shadowRoot!.querySelector('footer.status-bar');
+  return {
+    ahead: footer?.querySelector('.status-ahead') ?? null,
+    behind: footer?.querySelector('.status-behind') ?? null,
+  };
+}
+
+function aheadBehindOf(path: string) {
+  return repositoryStore
+    .getState()
+    .openRepositories.find((r) => r.repository.path === path)?.currentBranch?.aheadBehind;
+}
+
 /**
  * Make a REAL dialog element in app-shell's shadow root look open and pinned
  * to `pinnedTo`, optionally with work in flight, and report whether the sweep
@@ -92,9 +127,12 @@ describe('app-shell multi-repo behavior', () => {
     searchIndexService.invalidate();
   });
 
+  // Both remote badges (tab bar and status bar) render the store's
+  // currentBranch.aheadBehind, so these assert on that one field.
   describe('autofetch badge scoping', () => {
-    it('updates the badge when the ACTIVE repo fetched', () => {
+    it("updates the ACTIVE repo's counts when it fetched", () => {
       const el = createAppShell();
+      seedRepo('/repo/active', 'active', { ahead: 0, behind: 0 });
       (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
 
       (el as any).handleAutoFetchCompleted({
@@ -104,13 +142,14 @@ describe('app-shell multi-repo behavior', () => {
         behind: 2,
       });
 
-      expect((el as any).remoteStatus).to.deep.equal({ ahead: 1, behind: 2 });
+      expect(aheadBehindOf('/repo/active')).to.deep.equal({ ahead: 1, behind: 2 });
     });
 
-    it('ignores results from BACKGROUND repos', () => {
+    it("a BACKGROUND repo's result never lands on the active repo", () => {
       const el = createAppShell();
+      seedRepo('/repo/active', 'active', { ahead: 0, behind: 0 });
+      seedRepo('/repo/background', 'background', { ahead: 0, behind: 0 });
       (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
-      (el as any).remoteStatus = { ahead: 0, behind: 0 };
 
       (el as any).handleAutoFetchCompleted({
         repoPath: '/repo/background',
@@ -119,13 +158,14 @@ describe('app-shell multi-repo behavior', () => {
         behind: 9,
       });
 
-      expect((el as any).remoteStatus).to.deep.equal({ ahead: 0, behind: 0 });
+      expect(aheadBehindOf('/repo/background')).to.deep.equal({ ahead: 9, behind: 9 });
+      expect(aheadBehindOf('/repo/active')).to.deep.equal({ ahead: 0, behind: 0 });
     });
 
     it('ignores failed fetches', () => {
       const el = createAppShell();
+      seedRepo('/repo/active', 'active', { ahead: 0, behind: 0 });
       (el as any).activeRepository = { repository: mockRepo('/repo/active', 'active') };
-      (el as any).remoteStatus = { ahead: 0, behind: 0 };
 
       (el as any).handleAutoFetchCompleted({
         repoPath: '/repo/active',
@@ -134,7 +174,7 @@ describe('app-shell multi-repo behavior', () => {
         behind: 5,
       });
 
-      expect((el as any).remoteStatus).to.deep.equal({ ahead: 0, behind: 0 });
+      expect(aheadBehindOf('/repo/active')).to.deep.equal({ ahead: 0, behind: 0 });
     });
   });
 
@@ -333,8 +373,6 @@ describe('app-shell multi-repo behavior', () => {
 
       const bg = repositoryStore.getState().openRepositories[0];
       expect(bg.currentBranch?.aheadBehind).to.deep.equal({ ahead: 3, behind: 7 });
-      // The toolbar badge still only follows the ACTIVE repo
-      expect((el as any).remoteStatus).to.be.null;
     });
   });
 
@@ -495,37 +533,30 @@ describe('app-shell multi-repo behavior', () => {
     });
   });
 
-  describe('footer ahead/behind badge on tab switch', () => {
-    it("resets to the newly active repo's last-known counts", async () => {
+  describe('status-bar ahead/behind badge on tab switch', () => {
+    it("follows the newly active repo's counts", async () => {
       const el = createAppShell();
       document.body.appendChild(el);
       try {
         repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'));
         repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
         repositoryStore.getState().updateRepoData('/repo/a', {
-          currentBranch: {
-            name: 'main',
-            shorthand: 'main',
-            isHead: true,
-            isRemote: false,
-            upstream: 'origin/main',
-            targetOid: 'abc',
-            isStale: false,
-            aheadBehind: { ahead: 0, behind: 3 },
-          },
+          currentBranch: mockBranch({ ahead: 0, behind: 3 }) as any,
         });
-        // Simulate a badge left over from the previously active repo
-        (el as any).remoteStatus = { ahead: 9, behind: 9 };
 
         repositoryStore.getState().setActiveIndex(0);
-        await new Promise((r) => setTimeout(r, 0));
-        expect((el as any).remoteStatus).to.deep.equal({ ahead: 0, behind: 3 });
+        await waitUntil(
+          () => statusBadges(el).behind?.textContent?.includes('3') === true,
+          "repo A's counts reach the status bar",
+        );
 
         // Switching to a repo with no known counts clears the badge instead
         // of showing the previous repo's numbers
         repositoryStore.getState().setActiveIndex(1);
-        await new Promise((r) => setTimeout(r, 0));
-        expect((el as any).remoteStatus).to.be.null;
+        await waitUntil(
+          () => !statusBadges(el).behind && !statusBadges(el).ahead,
+          "repo A's counts do not paint under repo B",
+        );
       } finally {
         el.remove();
       }

--- a/src/__tests__/app-shell-remote-feedback.test.ts
+++ b/src/__tests__/app-shell-remote-feedback.test.ts
@@ -31,7 +31,7 @@ let cbId = 0;
 };
 
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
-import { expect } from '@open-wc/testing';
+import { expect, waitUntil } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import '../app-shell.ts';
 import { uiStore, repositoryStore } from '../stores/index.ts';
@@ -619,6 +619,181 @@ describe('app-shell remote-operation feedback', () => {
         expect((el as any).rightPanelVisible).to.equal(true);
         expect(heard).to.equal(1);
       } finally {
+        el.remove();
+      }
+    });
+  });
+
+
+  /**
+   * The status bar's ahead/behind badge used to render a private
+   * `remoteStatus` field that only the tab switch, the fetch-on-focus handler
+   * and auto-fetch ever wrote. push/pull/fetch end at handleRefresh, which
+   * refreshes the repository, the graph and the indexes — never that field —
+   * so a pushed-away "↑3" sat there until the next auto-fetch tick, tab switch
+   * or refocus, contradicting the tab badge a few pixels away. The badge now
+   * renders the store's `currentBranch.aheadBehind`, the same field the tab
+   * badge reads.
+   */
+  describe('the status-bar ahead/behind badge', () => {
+    function branch(aheadBehind?: { ahead: number; behind: number }) {
+      return {
+        name: 'main',
+        shorthand: 'main',
+        isHead: true,
+        isRemote: false,
+        upstream: 'origin/main',
+        targetOid: 'abc',
+        isStale: false,
+        ...(aheadBehind ? { aheadBehind } : {}),
+      };
+    }
+
+    function footerOf(el: AppShell): Element | null {
+      return el.shadowRoot!.querySelector('footer.status-bar');
+    }
+    const aheadOf = (el: AppShell) => footerOf(el)?.querySelector('.status-ahead') ?? null;
+    const behindOf = (el: AppShell) => footerOf(el)?.querySelector('.status-behind') ?? null;
+
+    /** Mount a shell on an open repo whose branch data is already known. */
+    async function mountOnRepo(
+      aheadBehind?: { ahead: number; behind: number } | 'no-branch',
+    ): Promise<AppShell> {
+      // Quiet the sidebar lists that mount with the shell — an unmocked
+      // command resolves to null and each list toasts its own load failure.
+      for (const cmd of ['get_stashes', 'get_tags', 'get_status', 'get_remotes']) {
+        if (!mockResponses[cmd]) mockResponses[cmd] = () => [];
+      }
+      const el = createAppShell();
+      document.body.appendChild(el);
+      await (el as any).updateComplete;
+      repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+      if (aheadBehind !== 'no-branch') {
+        repositoryStore
+          .getState()
+          .updateRepoData('/repo/one', { currentBranch: branch(aheadBehind) as any });
+      }
+      await (el as any).updateComplete;
+      return el;
+    }
+
+    it('shows the unpushed count as soon as the branch is known', async () => {
+      const el = await mountOnRepo({ ahead: 3, behind: 0 });
+      try {
+        await waitUntil(() => aheadOf(el) !== null, 'the ahead badge is rendered');
+        expect(aheadOf(el)!.textContent).to.contain('3');
+        expect(behindOf(el), 'nothing to pull').to.be.null;
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('a successful push clears it', async () => {
+      // The whole reported chain: push → refreshConflictDialogRepo →
+      // handleRefresh → repository-refresh → the branch list re-reads
+      // get_branches → store → this badge.
+      let pushed = false;
+      mockResponses['open_repository'] = () => mockRepo('/repo/one', 'one');
+      mockResponses['get_status'] = () => [];
+      mockResponses['get_remotes'] = () => [];
+      mockResponses['get_cleanup_candidates'] = () => [];
+      mockResponses['get_branches'] = () => [
+        branch(pushed ? { ahead: 0, behind: 0 } : { ahead: 3, behind: 0 }),
+      ];
+      mockResponses['push'] = () => {
+        pushed = true;
+        return null;
+      };
+
+      const el = await mountOnRepo({ ahead: 3, behind: 0 });
+      try {
+        await waitUntil(() => aheadOf(el)?.textContent?.includes('3') === true, 'starts at 3');
+
+        await (el as any).handlePush();
+
+        await waitUntil(() => aheadOf(el) === null, 'the pushed commits stop being advertised');
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('a push that fails leaves the unpushed count on screen', async () => {
+      failures['push'] = { code: 'COMMAND_ERROR', message: 'Updates were rejected' };
+      mockResponses['open_repository'] = () => mockRepo('/repo/one', 'one');
+      mockResponses['get_status'] = () => [];
+      mockResponses['get_remotes'] = () => [];
+      mockResponses['get_cleanup_candidates'] = () => [];
+      mockResponses['get_branches'] = () => [branch({ ahead: 3, behind: 0 })];
+
+      const el = await mountOnRepo({ ahead: 3, behind: 0 });
+      try {
+        await waitUntil(() => aheadOf(el)?.textContent?.includes('3') === true, 'starts at 3');
+        uiStore.setState({ toasts: [] });
+
+        await (el as any).handlePush();
+        await (el as any).updateComplete;
+
+        expect(aheadOf(el), 'the commits are still unpushed, so still shown').to.not.be.null;
+        expect(aheadOf(el)!.textContent).to.contain('3');
+        expect(
+          uiStore
+            .getState()
+            .toasts.some((t) => t.type === 'error' && t.action?.label === 'Pull Now'),
+          'and the rejection is reported, with its recovery',
+        ).to.equal(true);
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('renders a behind-only repo with the down arrow alone', async () => {
+      const el = await mountOnRepo({ ahead: 0, behind: 2 });
+      try {
+        await waitUntil(() => behindOf(el) !== null, 'the behind badge is rendered');
+        expect(aheadOf(el)).to.be.null;
+        expect(behindOf(el)!.textContent).to.contain('2');
+        // No ahead badge before it, so it keeps the full gap from the path
+        expect(behindOf(el)!.getAttribute('style')).to.contain('margin-left: 12px');
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('renders no badge for a branch with no upstream', async () => {
+      const el = await mountOnRepo();
+      try {
+        await (el as any).updateComplete;
+        expect(aheadOf(el), 'never prints an undefined count').to.be.null;
+        expect(behindOf(el)).to.be.null;
+        expect(footerOf(el)!.textContent, 'the path is still shown').to.contain('/repo/one');
+      } finally {
+        el.remove();
+      }
+    });
+
+    it('the fetch-on-focus result reaches both badges, not just this one', async () => {
+      const { settingsStore } = await import('../stores/index.ts');
+      settingsStore.setState({ fetchOnFocus: true });
+      mockResponses['get_remote_status'] = () => ({
+        ahead: 0,
+        behind: 4,
+        hasUpstream: true,
+        upstreamName: 'origin/main',
+      });
+      const el = await mountOnRepo({ ahead: 0, behind: 0 });
+      try {
+        window.dispatchEvent(new Event('focus'));
+
+        await waitUntil(
+          () => behindOf(el)?.textContent?.includes('4') === true,
+          'the status bar picks up the fetched counts',
+        );
+        // The tab badge reads the store — on the old code this stayed stale.
+        expect(
+          repositoryStore.getState().openRepositories[0].currentBranch?.aheadBehind,
+        ).to.deep.equal({ ahead: 0, behind: 4 });
+      } finally {
+        settingsStore.setState({ fetchOnFocus: false });
         el.remove();
       }
     });

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -562,9 +562,6 @@ export class AppShell extends LitElement {
   @state() private blameFile: string | null = null;
   @state() private blameCommitOid: string | null = null;
 
-  // Remote status (for auto-fetch ahead/behind indicators)
-  @state() private remoteStatus: { ahead: number; behind: number } | null = null;
-
   // Progress operations
   @state() private progressOperations: ProgressOperation[] = [];
   private progressUnsubscribe?: () => void;
@@ -1584,16 +1581,6 @@ export class AppShell extends LitElement {
         // Clear search filter
         this.searchFilter = null;
 
-        // The footer ahead/behind badge belongs to the previous repo —
-        // repopulate from the new repo's last-known counts (autofetch keeps
-        // these fresh) instead of showing repo A's counts under repo B
-        this.remoteStatus = newActiveRepo?.currentBranch?.aheadBehind
-          ? {
-              ahead: newActiveRepo.currentBranch.aheadBehind.ahead,
-              behind: newActiveRepo.currentBranch.aheadBehind.behind,
-            }
-          : null;
-
         // Load profile for new repository and check integration
         if (newActiveRepo) {
           gitService.loadProfileForRepository(newActiveRepo.repository.path);
@@ -1679,7 +1666,10 @@ export class AppShell extends LitElement {
       // route, because alt-tabbing back into the app is not a gesture that
       // should raise a native "Allow fetch?" modal.
       // Pinned: the user can switch tabs during the fetch; the result belongs
-      // to the repo it was started for.
+      // to the repo it was started for, so the write below is keyed by that
+      // path rather than gated on whichever tab is active when it lands —
+      // which is also why the focus fetch now refreshes that repo's TAB badge,
+      // which it previously left stale.
       const repoPath = this.activeRepository.repository.path;
       // Alt-tabbing repeatedly used to start a fetch per focus event; on a hung
       // remote they stacked with nothing to cancel them.
@@ -1689,12 +1679,8 @@ export class AppShell extends LitElement {
         try {
         await gitService.fetchInBackground(repoPath);
         const result = await gitService.getRemoteStatus(repoPath);
-        if (
-          result.success &&
-          result.data &&
-          repoPath === this.activeRepository?.repository.path
-        ) {
-          this.remoteStatus = { ahead: result.data.ahead, behind: result.data.behind };
+        if (result.success && result.data) {
+          this.applyAheadBehind(repoPath, result.data.ahead, result.data.behind);
         }
         } finally {
           this.focusFetchInFlight.delete(repoPath);
@@ -4426,10 +4412,27 @@ export class AppShell extends LitElement {
     );
   }
 
-  // Auto-fetch runs for every open repo. Every successful result updates
-  // that repo's ahead/behind in the store (so tab badges stay fresh even for
-  // background tabs), but only the ACTIVE repo's result may drive the
-  // toolbar badge.
+  /**
+   * Mirror freshly computed ahead/behind counts into a repo's store entry.
+   *
+   * Both remote badges — the tab bar's and the status bar's — render this one
+   * field, so a writer that updates only one of them puts them out of step.
+   * Path-keyed: a result belongs to the repo it was computed for, never to
+   * whichever tab happens to be active when it lands.
+   */
+  private applyAheadBehind(repoPath: string, ahead: number, behind: number): void {
+    const store = repositoryStore.getState();
+    const repo = store.openRepositories.find((r) => r.repository.path === repoPath);
+    if (!repo?.currentBranch) return;
+    store.updateRepoData(repoPath, {
+      currentBranch: { ...repo.currentBranch, aheadBehind: { ahead, behind } },
+    });
+  }
+
+  // Auto-fetch runs for every open repo. Every successful result updates that
+  // repo's ahead/behind in the store, which is the single field BOTH badges
+  // (tab bar and status bar) render — so a background repo's result freshens
+  // its own tab badge and can never paint under the active tab.
   private handleAutoFetchCompleted = (event: {
     repoPath: string;
     success: boolean;
@@ -4444,20 +4447,7 @@ export class AppShell extends LitElement {
     // Recovered — let the next failure speak again.
     this.autoFetchFailureReported.delete(event.repoPath);
 
-    const store = repositoryStore.getState();
-    const repo = store.openRepositories.find((r) => r.repository.path === event.repoPath);
-    if (repo?.currentBranch) {
-      store.updateRepoData(event.repoPath, {
-        currentBranch: {
-          ...repo.currentBranch,
-          aheadBehind: { ahead: event.ahead, behind: event.behind },
-        },
-      });
-    }
-
-    if (event.repoPath === this.activeRepository?.repository.path) {
-      this.remoteStatus = { ahead: event.ahead, behind: event.behind };
-    }
+    this.applyAheadBehind(event.repoPath, event.ahead, event.behind);
   };
 
   // With several repos auto-fetching, an unattributed toast is noise — name
@@ -4922,6 +4912,43 @@ export class AppShell extends LitElement {
     keyboardService.setVimMode(e.detail.enabled);
   }
 
+  /**
+   * The status bar's ahead/behind badge.
+   *
+   * Read from the ACTIVE repo's `currentBranch.aheadBehind` — the SAME field
+   * the tab badge renders — not from a private `remoteStatus` field. That
+   * field was written only by the tab switch, the fetch-on-focus handler and
+   * auto-fetch: nothing in push/pull/fetch touched it, and handleRefresh
+   * refreshes the repository, the graph and the indexes but not that. So a
+   * push of three commits left the status bar reading up-3 until the next
+   * auto-fetch tick, tab switch or refocus — forever with auto-fetch off —
+   * which reads as "the push didn't land" and invites a second push, while
+   * the tab badge an inch away already showed nothing. One source of truth is
+   * the only way the two can never disagree.
+   */
+  private renderRemoteBadges() {
+    const ab = this.activeRepository?.currentBranch?.aheadBehind;
+    if (!ab) return nothing;
+    return html`
+      ${ab.ahead > 0
+        ? html`<span
+            class="status-ahead"
+            title="${ab.ahead} commit${ab.ahead !== 1 ? 's' : ''} to push"
+            style="margin-left: 12px; color: var(--color-success, #4caf50);"
+            >&uarr;${ab.ahead}</span
+          >`
+        : nothing}
+      ${ab.behind > 0
+        ? html`<span
+            class="status-behind"
+            title="${ab.behind} commit${ab.behind !== 1 ? 's' : ''} to pull"
+            style="margin-left: ${ab.ahead > 0 ? '4' : '12'}px; color: var(--color-warning, #ff9800);"
+            >&darr;${ab.behind}</span
+          >`
+        : nothing}
+    `;
+  }
+
   render() {
     return html`
       <a class="skip-link" href="#main-content" @click=${(e: Event) => {
@@ -5157,12 +5184,7 @@ export class AppShell extends LitElement {
 
             <footer class="status-bar">
               <span>${this.activeRepository.repository.path}</span>
-              ${this.remoteStatus && this.remoteStatus.ahead > 0
-                ? html`<span style="margin-left: 12px; color: var(--color-success, #4caf50);">&uarr;${this.remoteStatus.ahead}</span>`
-                : ''}
-              ${this.remoteStatus && this.remoteStatus.behind > 0
-                ? html`<span style="margin-left: ${this.remoteStatus.ahead > 0 ? '4' : '12'}px; color: var(--color-warning, #ff9800);">&darr;${this.remoteStatus.behind}</span>`
-                : ''}
+              ${this.renderRemoteBadges()}
             </footer>
           `
         : html`<lv-welcome


### PR DESCRIPTION
## What was broken

### Status-bar ahead/behind badge stale after push/pull/fetch

`src/app-shell.ts` kept a private `@state() private remoteStatus: { ahead; behind } | null`, and the `<footer class="status-bar">` rendered its ↑/↓ badge from it. Exactly three places ever wrote that field:

1. the `repositoryStore` subscription's `repoChanged` block (hydrating it from `newActiveRepo?.currentBranch?.aheadBehind` on a tab switch),
2. the window-focus fetch handler (`fetchInBackground` → `getRemoteStatus`),
3. `handleAutoFetchCompleted`.

`fetchRepository()`, `pullRepository()`, `pushRepository()` and `forcePush()` all end their success path at `refreshConflictDialogRepo(repoPath)` → `handleRefresh()`, which reloads the repository, refreshes the graph and the search indexes and dispatches `repository-refresh` — and never touches `remoteStatus`. The context dashboard's own Push/Pull/Fetch buttons take the same route (`repository-refresh` → `handleRefresh`), so a fix scoped only to the three app-shell handlers would have left that surface broken.

Result: after pushing three commits the status bar kept reading **↑3** until the next auto-fetch tick, tab switch or window refocus — *forever* with auto-fetch disabled. It reads as "the push didn't land" and invites a redundant second push. Meanwhile the tab badge (`lv-toolbar.renderTabBadges` → `repo.currentBranch?.aheadBehind`) and the dashboard badges (`.badge.push` / `.badge.pull`, refreshed by `loadRemoteStatus()` on every `repository-refresh`) *did* update, so the app showed two contradictory ahead/behind readings a few pixels apart.

Two related symptoms, same root cause:

* **First paint.** `addRepository()` fires the subscription with `repoChanged = true` while the store's `currentBranch` is still `null`. The later branch-list write does not re-run the hydration block (`repoChanged` is false by then), so on a freshly opened repo the status-bar badge never appeared at all.
* **Fetch on focus.** The handler discarded its result whenever the user switched tabs mid-fetch, and never wrote the counts to the store — so it left that repo's *tab* badge stale even when it did update the status bar.

## The fix

Delete `remoteStatus` and render the status bar from the same store field every other badge reads: `activeRepository.currentBranch.aheadBehind`, via a new `renderRemoteBadges()` helper (identical inline styles and colours, plus `.status-ahead` / `.status-behind` class hooks and tooltips matching the tab badge's convention).

That field is already refreshed after every operation — for the active repo by `lv-branch-list.loadBranches()` (a window `repository-refresh` listener on the never-unmounted left panel), and for a backgrounded repo by `refreshConflictDialogRepo` → `scheduleBadgeHydration` → `hydrateRepoBadges`. So:

* **`fetchRepository`, `pullRepository`, `pushRepository`, `forcePush` and the dashboard's three buttons are deliberately unchanged** — no new code, no extra IPC. They already refresh the field the badge now renders.
* The two badges can no longer disagree, because there is only one field.
* First paint and post-commit / post-checkout refreshes fix themselves.

The two remaining writers now share a small path-keyed `applyAheadBehind(repoPath, ahead, behind)`, so a result always lands on the repo it was computed for rather than on whichever tab is active when it arrives. The tab-switch hydration block is removed — it was copying the exact field the badge now reads directly.

Accepted behaviour change: with no known current branch (detached HEAD, or the instant before the first branch load) the status bar shows no badge — the same rule the tab badge already follows, and the old code showed nothing there either.

No Rust and no new IPC command; `get_remote_status` is untouched.

## Tests

| Test | File | Kind | Fails without the fix |
| --- | --- | --- | --- |
| shows the unpushed count as soon as the branch is known | `src/__tests__/app-shell-remote-feedback.test.ts` | unit, happy / first paint | ✅ `Timeout: the ahead badge is rendered` |
| a successful push clears it (push → `handleRefresh` → `repository-refresh` → branch list → store → badge) | `src/__tests__/app-shell-remote-feedback.test.ts` | unit, happy | ✅ `Timeout: starts at 3` |
| a push that fails leaves the unpushed count on screen (+ the rejection is reported with its Pull Now recovery) | `src/__tests__/app-shell-remote-feedback.test.ts` | unit, error | ✅ `Timeout: starts at 3` |
| renders a behind-only repo with the down arrow alone, keeping the wider margin | `src/__tests__/app-shell-remote-feedback.test.ts` | unit, edge | ✅ `Timeout: the behind badge is rendered` |
| renders no badge for a branch with no upstream (never prints an undefined count) | `src/__tests__/app-shell-remote-feedback.test.ts` | unit, guard | ❌ passes both ways — deliberate regression guard |
| the fetch-on-focus result reaches both badges, not just this one | `src/__tests__/app-shell-remote-feedback.test.ts` | unit, cross-surface | ✅ `Timeout: the status bar picks up the fetched counts` |
| status-bar badge on tab switch follows the newly active repo's counts, and repo A's counts never paint under repo B | `src/__tests__/app-shell-multi-repo.test.ts` | unit | ✅ `Timeout: repo A's counts reach the status bar` |
| autofetch: active repo's counts updated / background repo's result never lands on the active repo / failed fetches ignored | `src/__tests__/app-shell-multi-repo.test.ts` | unit | ❌ preserved coverage, re-pointed at the store (the old field is gone) |
| shows the unpushed count for the open repository | `e2e/tests/remote-operations.spec.ts` | E2E, happy | ✅ `element(s) not found` for `↑3` |
| clears after a successful push, agreeing with the dashboard badge | `e2e/tests/remote-operations.spec.ts` | E2E, cross-surface | ✅ `element(s) not found` for `↑3` |
| clears after a successful pull | `e2e/tests/remote-operations.spec.ts` | E2E, happy | ✅ `element(s) not found` for `↓2` |
| survives a rejected push, so the commits stay visible | `e2e/tests/remote-operations.spec.ts` | E2E, error | ✅ `element(s) not found` for `↑3` |
| shows no badge when up to date | `e2e/tests/remote-operations.spec.ts` | E2E, edge | ❌ passes both ways — deliberate guard |

Verified by reverting `src/app-shell.ts` alone and re-running: 5/6 new unit tests in `app-shell-remote-feedback`, the rewritten tab-switch test in `app-shell-multi-repo`, and 4/5 new E2E tests fail. The two that pass both ways are labelled above as guards, not fix-proofs.

Gate: `npm run lint`, `npm run typecheck`, `npm test` all green; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` green; the full `e2e/tests/remote-operations.spec.ts` suite passes 41/41.