### PR TITLE
Pin the post-commit refresh to the repository the commit ran in

### DIFF
--- a/e2e/tests/staging.spec.ts
+++ b/e2e/tests/staging.spec.ts
@@ -474,7 +474,9 @@ test.describe('Staging to Commit Flow', () => {
     await expect(rightPanel.commitMessage).toHaveValue('');
   });
 
-  test('successful commit should dispatch repository-refresh event', async ({ page }) => {
+  test('successful commit should dispatch repository-refresh pinned to the committing repository', async ({
+    page,
+  }) => {
     rightPanel = new RightPanelPage(page);
     await setupOpenRepository(
       page,
@@ -487,20 +489,37 @@ test.describe('Staging to Commit Flow', () => {
       create_commit: { oid: 'abc123', shortId: 'abc123d', summary: 'test' },
     });
 
-    // Listen for repository-refresh event (what the commit panel dispatches)
-    // Do NOT await evaluate immediately -- it returns a promise that resolves when the inner promise does
-    const eventPromise = page.evaluate(() => {
-      return new Promise<boolean>((resolve) => {
-        window.addEventListener('repository-refresh', () => resolve(true), { once: true });
-        setTimeout(() => resolve(false), 5000);
+    // Collect every repository-refresh the commit flow emits (the commit panel's
+    // own and the right panel's re-broadcast), skipping app-shell's tagged
+    // self-broadcast. Each must name the repo the commit ran in — an untagged
+    // refresh falls back to whichever tab is active.
+    await page.evaluate(() => {
+      const w = window as unknown as { __refreshDetails?: Array<{ repoPath?: string }> };
+      w.__refreshDetails = [];
+      window.addEventListener('repository-refresh', (e) => {
+        const detail = (e as CustomEvent).detail as
+          | { repoPath?: string; source?: string }
+          | undefined;
+        if (detail?.source === 'app-shell') return;
+        w.__refreshDetails?.push({ repoPath: detail?.repoPath });
       });
     });
 
     await rightPanel.commitMessage.fill('feat: trigger refresh');
     await rightPanel.commitButton.click();
 
-    const result = await eventPromise;
-    expect(result).toBe(true);
+    await page.waitForFunction(() => {
+      const w = window as unknown as { __refreshDetails?: unknown[] };
+      return (w.__refreshDetails?.length ?? 0) > 0;
+    });
+
+    const details = await page.evaluate(
+      () => (window as unknown as { __refreshDetails: Array<{ repoPath?: string }> }).__refreshDetails
+    );
+    expect(details.length).toBeGreaterThan(0);
+    for (const detail of details) {
+      expect(detail.repoPath).toBe('/tmp/test-repo');
+    }
   });
 
   test('successful commit should dispatch commit-created event with commit data', async ({ page }) => {

--- a/src/components/sidebar/__tests__/lv-commit-panel-refresh-pin.test.ts
+++ b/src/components/sidebar/__tests__/lv-commit-panel-refresh-pin.test.ts
@@ -1,0 +1,194 @@
+/**
+ * A commit must refresh the repo it ran IN, not whichever tab is active when
+ * it lands.
+ *
+ * `handleCommit` already captures the repo path before the create_commit await
+ * (for the ref lock), but the follow-up window `repository-refresh` went out
+ * bare. The host falls back to refreshing the ACTIVE repository when the event
+ * names no repo, so a user who switched tabs during the IPC round-trip left the
+ * committed repo stale — graph, branch list and badges all unchanged until the
+ * file watcher happened to notice — while an unrelated repo got a pointless
+ * full refresh. The same hole existed one hop out: the panel's `commit-created`
+ * detail carried no repo, so the right panel's re-broadcast could not pin either.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+const invoked: string[] = [];
+
+interface Deferred {
+  promise: Promise<unknown>;
+  resolve: (value: unknown) => void;
+}
+
+/** When set, create_commit blocks on this until the test resolves it. */
+let pendingCommit: Deferred | null = null;
+/** When set, create_commit rejects with this (the Rust error shape). */
+let commitFailure: { code: string; message: string } | null = null;
+
+const COMMIT = { oid: 'abc0000000', shortId: 'abc123d', summary: 's' };
+
+const mockInvoke: MockInvoke = async (command: string) => {
+  invoked.push(command);
+  if (command === 'plugin:notification|is_permission_granted') return false;
+  if (command === 'get_status') return { staged: [], unstaged: [], untracked: [] };
+  if (command === 'create_commit') {
+    if (commitFailure) throw commitFailure;
+    if (pendingCommit) await pendingCommit.promise;
+    return COMMIT;
+  }
+  return null;
+};
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: mockInvoke,
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-commit-panel.ts';
+import type { LvRightPanel } from '../lv-right-panel.ts';
+import '../lv-right-panel.ts';
+import { resetRefOpLocks } from '../../../utils/ref-lock.ts';
+
+const REPO_A = '/test/repo-a';
+const REPO_B = '/test/repo-b';
+
+interface Panel extends HTMLElement {
+  repositoryPath: string;
+  updateComplete: Promise<unknown>;
+}
+
+type RefreshDetail = { repoPath?: string; source?: string } | undefined;
+
+let refreshes: RefreshDetail[] = [];
+const collectRefresh = (e: Event): void => {
+  refreshes.push((e as CustomEvent).detail as RefreshDetail);
+};
+
+async function renderPanel(): Promise<Panel> {
+  const el = await fixture<Panel>(html`
+    <lv-commit-panel .repositoryPath=${REPO_A} .stagedCount=${2}></lv-commit-panel>
+  `);
+  await el.updateComplete;
+  (el as unknown as { summary: string }).summary = 'feat: a commit message';
+  await el.updateComplete;
+  return el;
+}
+
+function commitOf(el: Panel): Promise<void> {
+  return (el as unknown as { handleCommit: () => Promise<void> }).handleCommit();
+}
+
+function makeDeferred(): Deferred {
+  let resolve!: (value: unknown) => void;
+  const promise = new Promise<unknown>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+describe('lv-commit-panel pins its post-commit refresh to the committed repo', () => {
+  beforeEach(() => {
+    resetRefOpLocks();
+    invoked.length = 0;
+    refreshes = [];
+    pendingCommit = null;
+    commitFailure = null;
+    window.addEventListener('repository-refresh', collectRefresh);
+  });
+
+  afterEach(() => {
+    window.removeEventListener('repository-refresh', collectRefresh);
+    resetRefOpLocks();
+    pendingCommit = null;
+    commitFailure = null;
+  });
+
+  it('names the repo the commit ran in', async () => {
+    const el = await renderPanel();
+
+    await commitOf(el);
+
+    const pinned = refreshes.filter((d) => d?.source !== 'app-shell');
+    expect(pinned, 'the commit must ask for a refresh').to.have.length.greaterThan(0);
+    for (const detail of pinned) {
+      expect(detail?.repoPath, 'an unpinned refresh lands on whichever tab is active').to.equal(
+        REPO_A
+      );
+    }
+  });
+
+  it('keeps the pin when the user switches tabs mid-commit', async () => {
+    const el = await renderPanel();
+    pendingCommit = makeDeferred();
+
+    const inFlight = commitOf(el);
+
+    // The user Ctrl+Tabs to another repository while create_commit is still out.
+    el.repositoryPath = REPO_B;
+    await el.updateComplete;
+
+    pendingCommit.resolve(null);
+    await inFlight;
+
+    const pinned = refreshes.filter((d) => d?.source !== 'app-shell');
+    expect(pinned).to.have.length.greaterThan(0);
+    for (const detail of pinned) {
+      expect(detail?.repoPath, 'the refresh must follow the commit, not the active tab').to.equal(
+        REPO_A
+      );
+      expect(detail?.repoPath).to.not.equal(REPO_B);
+    }
+  });
+
+  it('carries the originating repo on commit-created so forwarders stay pinned', async () => {
+    const el = await renderPanel();
+    const details: Array<{ repositoryPath?: string }> = [];
+    el.addEventListener('commit-created', (e) => {
+      details.push((e as CustomEvent).detail as { repositoryPath?: string });
+    });
+
+    await commitOf(el);
+
+    expect(details, 'a successful commit must announce itself').to.have.length(1);
+    expect(details[0]?.repositoryPath).to.equal(REPO_A);
+  });
+
+  it('forwards that pin through the right panel re-broadcast', async () => {
+    const el = await fixture<LvRightPanel>(html`<lv-right-panel></lv-right-panel>`);
+    await el.updateComplete;
+    refreshes = [];
+
+    (
+      el as unknown as { handleCommitCreated: (e?: Event) => void }
+    ).handleCommitCreated(
+      new CustomEvent('commit-created', {
+        detail: { commit: COMMIT, repositoryPath: REPO_A },
+      })
+    );
+
+    const pinned = refreshes.filter((d) => d?.source !== 'app-shell');
+    expect(pinned, 'the right panel re-broadcasts a refresh of its own').to.have.length(1);
+    expect(pinned[0]?.repoPath).to.equal(REPO_A);
+  });
+
+  // Guard, not proof: this passes before and after the fix. It exists so the
+  // pin cannot be implemented as an unconditional dispatch outside the
+  // success branch.
+  it('dispatches neither commit-created nor a refresh when the commit fails', async () => {
+    const el = await renderPanel();
+    commitFailure = { code: 'COMMAND_ERROR', message: 'pre-commit hook rejected' };
+    const created: Event[] = [];
+    el.addEventListener('commit-created', (e) => created.push(e));
+
+    await commitOf(el);
+
+    expect(created, 'a failed commit created nothing to announce').to.have.length(0);
+    expect(refreshes.filter((d) => d?.source !== 'app-shell')).to.have.length(0);
+    expect((el as unknown as { error: string | null }).error).to.equal('pre-commit hook rejected');
+  });
+});

--- a/src/components/sidebar/__tests__/lv-commit-panel-refresh-pin.test.ts
+++ b/src/components/sidebar/__tests__/lv-commit-panel-refresh-pin.test.ts
@@ -35,8 +35,8 @@ const mockInvoke: MockInvoke = async (command: string) => {
   if (command === 'plugin:notification|is_permission_granted') return false;
   if (command === 'get_status') return { staged: [], unstaged: [], untracked: [] };
   if (command === 'create_commit') {
-    if (commitFailure) throw commitFailure;
     if (pendingCommit) await pendingCommit.promise;
+    if (commitFailure) throw commitFailure;
     return COMMIT;
   }
   return null;
@@ -53,6 +53,7 @@ import '../lv-commit-panel.ts';
 import type { LvRightPanel } from '../lv-right-panel.ts';
 import '../lv-right-panel.ts';
 import { resetRefOpLocks } from '../../../utils/ref-lock.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
 
 const REPO_A = '/test/repo-a';
 const REPO_B = '/test/repo-b';
@@ -60,6 +61,23 @@ const REPO_B = '/test/repo-b';
 interface Panel extends HTMLElement {
   repositoryPath: string;
   updateComplete: Promise<unknown>;
+}
+
+/** The panel's own live state, which a mid-commit tab switch rebinds. */
+interface PanelState {
+  summary: string;
+  description: string;
+  amend: boolean;
+  success: string | null;
+  error: string | null;
+}
+
+function stateOf(el: Panel): PanelState {
+  return el as unknown as PanelState;
+}
+
+function toasts(): string[] {
+  return uiStore.getState().toasts.map((t) => `${t.type}:${t.message}`);
 }
 
 type RefreshDetail = { repoPath?: string; source?: string } | undefined;
@@ -190,5 +208,110 @@ describe('lv-commit-panel pins its post-commit refresh to the committed repo', (
     expect(created, 'a failed commit created nothing to announce').to.have.length(0);
     expect(refreshes.filter((d) => d?.source !== 'app-shell')).to.have.length(0);
     expect((el as unknown as { error: string | null }).error).to.equal('pre-commit hook rejected');
+  });
+});
+
+/**
+ * Pinning the refresh EVENT was only half of it. The commit panel outlives a
+ * repository tab switch — `willUpdate` stashes the outgoing repo's draft in
+ * `draftCache` and swaps the incoming repo's draft into the live fields — so
+ * the completion path running against whatever repo happens to be on screen
+ * wiped an uncommitted draft belonging to a repo that never committed, hung
+ * the success banner off it, and left the committed repo's cached draft
+ * holding the message it had just committed.
+ */
+describe('lv-commit-panel pins its post-commit state to the committed repo', () => {
+  beforeEach(() => {
+    resetRefOpLocks();
+    invoked.length = 0;
+    refreshes = [];
+    pendingCommit = null;
+    commitFailure = null;
+    uiStore.setState({ toasts: [] });
+  });
+
+  afterEach(() => {
+    resetRefOpLocks();
+    pendingCommit = null;
+    commitFailure = null;
+    uiStore.setState({ toasts: [] });
+  });
+
+  /** Commit in A, switch to B mid-flight and type a draft there, then land. */
+  async function commitInAWhileViewingB(el: Panel, bDraft: string): Promise<void> {
+    pendingCommit = makeDeferred();
+    const inFlight = commitOf(el);
+
+    el.repositoryPath = REPO_B;
+    await el.updateComplete;
+    stateOf(el).summary = bDraft;
+    await el.updateComplete;
+
+    pendingCommit.resolve(null);
+    await inFlight;
+    await el.updateComplete;
+  }
+
+  it("leaves the repo now on screen holding its own draft", async () => {
+    const el = await renderPanel();
+
+    await commitInAWhileViewingB(el, 'wip: half-written repo-b message');
+
+    expect(stateOf(el).summary, "repo B's draft was never committed").to.equal(
+      'wip: half-written repo-b message'
+    );
+    expect(stateOf(el).success, 'no banner may claim repo B committed').to.equal(null);
+    expect(
+      toasts().some((t) => t.startsWith('success:') && t.includes('repo-a')),
+      `the result must name the repo it landed in: ${toasts().join(' | ')}`
+    ).to.equal(true);
+  });
+
+  it('does not hand the committed message back as a draft on return', async () => {
+    const el = await renderPanel();
+
+    await commitInAWhileViewingB(el, 'wip: half-written repo-b message');
+
+    el.repositoryPath = REPO_A;
+    await el.updateComplete;
+
+    expect(stateOf(el).summary, 'the committed message must not come back').to.equal('');
+  });
+
+  it('still clears its own fields when the committed repo is the one on screen', async () => {
+    const el = await renderPanel();
+
+    await commitOf(el);
+    await el.updateComplete;
+
+    expect(stateOf(el).summary, 'the committed draft is spent').to.equal('');
+    expect(stateOf(el).amend).to.equal(false);
+    expect(stateOf(el).success).to.contain('abc123d');
+    expect(
+      toasts().filter((t) => t.startsWith('success:')),
+      'the banner already says it — a toast would double-report'
+    ).to.have.length(0);
+  });
+
+  it('blames the repo that failed, not the tab now on screen', async () => {
+    const el = await renderPanel();
+    commitFailure = { code: 'COMMAND_ERROR', message: 'pre-commit hook rejected' };
+    pendingCommit = makeDeferred();
+
+    const inFlight = commitOf(el);
+    el.repositoryPath = REPO_B;
+    await el.updateComplete;
+    pendingCommit.resolve(null);
+    await inFlight;
+    await el.updateComplete;
+
+    expect(stateOf(el).error, "repo B's panel must not show repo A's failure").to.equal(null);
+    expect(
+      toasts().some(
+        (t) =>
+          t.startsWith('error:') && t.includes('repo-a') && t.includes('pre-commit hook rejected')
+      ),
+      `the failure must name the repo it happened in: ${toasts().join(' | ')}`
+    ).to.equal(true);
   });
 });

--- a/src/components/sidebar/lv-commit-panel.ts
+++ b/src/components/sidebar/lv-commit-panel.ts
@@ -1272,7 +1272,7 @@ export class LvCommitPanel extends LitElement {
     try {
       const message = this.buildCommitMessage();
 
-      const result = await gitService.createCommit(this.repositoryPath, {
+      const result = await gitService.createCommit(repoPath, {
         message,
         amend: this.amend,
       });
@@ -1287,9 +1287,10 @@ export class LvCommitPanel extends LitElement {
         this.originalSummary = '';
         this.originalDescription = '';
 
-        // Notify parent to refresh
+        // Notify parent to refresh. The originating repo rides along so
+        // forwarders can keep their own refresh pinned to it.
         this.dispatchEvent(new CustomEvent('commit-created', {
-          detail: { commit: result.data },
+          detail: { commit: result.data, repositoryPath: repoPath },
           bubbles: true,
           composed: true,
         }));
@@ -1297,8 +1298,11 @@ export class LvCommitPanel extends LitElement {
         // Trigger file status refresh immediately
         window.dispatchEvent(new CustomEvent('status-refresh'));
 
-        // Trigger graph refresh and badge update
-        window.dispatchEvent(new CustomEvent('repository-refresh'));
+        // Trigger graph refresh and badge update. Names the repo the commit
+        // ran IN — captured before the await. Without it the host falls back to
+        // refreshing whichever tab is active, so a commit the user tabbed away
+        // from would leave its own repo stale until the file watcher noticed.
+        window.dispatchEvent(new CustomEvent('repository-refresh', { detail: { repoPath } }));
 
         // Clear success message after a delay
         setTimeout(() => {

--- a/src/components/sidebar/lv-commit-panel.ts
+++ b/src/components/sidebar/lv-commit-panel.ts
@@ -1257,6 +1257,25 @@ export class LvCommitPanel extends LitElement {
     }
   }
 
+  /** Basename of a repo path, for naming an off-screen repo to the user. */
+  private repoLabel(path: string): string {
+    return path.split(/[\\/]/).filter(Boolean).pop() ?? path;
+  }
+
+  /**
+   * Report a failed commit where the user will actually see it: the panel's
+   * own banner while it still shows the repo that failed, a repo-named toast
+   * once the user has tabbed away (the banner would otherwise blame the repo
+   * now on screen for a failure in a different one).
+   */
+  private reportCommitFailure(repoPath: string, message: string): void {
+    if (this.repositoryPath === repoPath) {
+      this.error = message;
+    } else {
+      showToast(`${this.repoLabel(repoPath)}: ${message}`, 'error');
+    }
+  }
+
   private async handleCommit(): Promise<void> {
     if (!this.canCommit) return;
 
@@ -1279,13 +1298,35 @@ export class LvCommitPanel extends LitElement {
 
       if (result.success) {
         this.saveToHistory(message);
-        this.success = `Created commit ${result.data?.shortId}`;
-        this.summary = '';
-        this.description = '';
-        this.amend = false;
-        this.lastCommit = null;
-        this.originalSummary = '';
-        this.originalDescription = '';
+
+        if (this.repositoryPath === repoPath) {
+          this.success = `Created commit ${result.data?.shortId}`;
+          this.summary = '';
+          this.description = '';
+          this.amend = false;
+          this.lastCommit = null;
+          this.originalSummary = '';
+          this.originalDescription = '';
+
+          // Clear success message after a delay
+          setTimeout(() => {
+            this.success = null;
+          }, 3000);
+        } else {
+          // The user switched tabs while create_commit was out, so this
+          // long-lived panel is bound to ANOTHER repo and willUpdate has
+          // already swapped that repo's draft into the fields. Clearing them
+          // here would wipe a draft that was never committed and hang our
+          // success banner off the wrong repo. Retire the committed repo's
+          // CACHED draft instead — willUpdate stashed the message we just
+          // committed there — and name the repo in a toast, since the panel
+          // is no longer showing it.
+          this.draftCache.delete(repoPath);
+          showToast(
+            `Created commit ${result.data?.shortId} in ${this.repoLabel(repoPath)}`,
+            'success'
+          );
+        }
 
         // Notify parent to refresh. The originating repo rides along so
         // forwarders can keep their own refresh pinned to it.
@@ -1303,19 +1344,14 @@ export class LvCommitPanel extends LitElement {
         // refreshing whichever tab is active, so a commit the user tabbed away
         // from would leave its own repo stale until the file watcher noticed.
         window.dispatchEvent(new CustomEvent('repository-refresh', { detail: { repoPath } }));
-
-        // Clear success message after a delay
-        setTimeout(() => {
-          this.success = null;
-        }, 3000);
       } else if (!gitService.isNetworkGateRefusal(result.error)) {
         // A declined confirm — the pushed-amend warning, or the network gate —
         // is the user's own decision, already accounted for. Showing it in the
         // red error banner reports their click back to them as a failure.
-        this.error = result.error?.message ?? 'Failed to create commit';
+        this.reportCommitFailure(repoPath, result.error?.message ?? 'Failed to create commit');
       }
     } catch (err) {
-      this.error = err instanceof Error ? err.message : 'Unknown error';
+      this.reportCommitFailure(repoPath, err instanceof Error ? err.message : 'Unknown error');
     } finally {
       this.isCommitting = false;
       releaseRefOp(repoPath);

--- a/src/components/sidebar/lv-right-panel.ts
+++ b/src/components/sidebar/lv-right-panel.ts
@@ -389,9 +389,14 @@ export class LvRightPanel extends LitElement {
     }
   }
 
-  private handleCommitCreated(): void {
+  /** Forward the repo the commit ran in (captured pre-await by the commit
+   * panel) so the host pins the refresh to it, not whichever tab is active if
+   * the user switched mid-commit. */
+  private handleCommitCreated(e?: Event): void {
+    const repoPath = (e as CustomEvent<{ repositoryPath?: string }> | undefined)?.detail
+      ?.repositoryPath;
     this.dispatchEvent(new CustomEvent('repository-changed', { bubbles: true, composed: true }));
-    window.dispatchEvent(new CustomEvent('repository-refresh'));
+    window.dispatchEvent(new CustomEvent('repository-refresh', { detail: { repoPath } }));
   }
 }
 


### PR DESCRIPTION
## What was broken

### The commit flow's refresh was not pinned to the repository it committed in

`handleCommit()` in `src/components/sidebar/lv-commit-panel.ts` already captured the repository path before the `create_commit` await (it needs it to release the right ref lock), but the post-success refresh went out bare:

```ts
window.dispatchEvent(new CustomEvent('repository-refresh'));
```

`app-shell.ts`'s `handleWindowRefresh` reads `detail.repoPath` and, when it is absent, falls back to `this.handleRefresh()` — which refreshes whichever repository tab is **active**. So a user who Ctrl+Tabbed to another repository during the commit IPC round-trip left the repository they actually committed in stale: graph, branch list and badges all unchanged until the file watcher happened to notice, while an unrelated repository got a pointless full refresh.

The hole ran one hop further out. The panel dispatched `commit-created` with `detail: { commit }` only, and `lv-right-panel.handleCommitCreated()` re-broadcast a **second** bare `repository-refresh`. Pinning only the panel's own dispatch would have left that one unpinned, so both had to change for the fix to be real.

Every sibling mutating flow already pins this way — `lv-left-panel.forwardRefresh` dispatches `{ detail: { repoPath } }` from the incoming `detail.repositoryPath`, `lv-branch-list.dispatchBranchesChanged` emits `{ repositoryPath: repoPath }`, and `lv-context-dashboard`'s fetch/pull/push dispatches carry a comment documenting exactly this stale-repo bug. The commit flow — the most common mutation in a git client — was the one flow missing it.

## The fix

- `lv-commit-panel.handleCommit()` now dispatches `repository-refresh` with `{ detail: { repoPath } }`, using the path captured before the await, and includes `repositoryPath: repoPath` in the `commit-created` detail so forwarders can stay pinned.
- `lv-right-panel.handleCommitCreated(e?)` reads that `repositoryPath` off the incoming event and forwards it as the pin, mirroring `lv-left-panel.forwardRefresh` exactly (incoming key `repositoryPath`, outgoing key `repoPath`). The template binding already passed the event; only the handler signature changed.
- The `gitService.createCommit` call now passes the same captured `repoPath` rather than re-reading `this.repositoryPath`, so the IPC and the refresh that reports it can never name different repositories.

No app-shell change is needed: `handleWindowRefresh` already routes `detail.repoPath` through `refreshConflictDialogRepo`, which no-ops for a closed tab and marks a backgrounded one stale while hydrating its badge. The sibling `repository-changed` dispatch stays unpinned, matching `lv-left-panel` — app-shell's `@repository-changed` handler is the active-tab refresh both panels already rely on. When the committed repository is still active, behaviour is unchanged.

No Rust, no API-surface change, no snake_case introduced.

## Tests

New unit file `src/components/sidebar/__tests__/lv-commit-panel-refresh-pin.test.ts`, plus a tightened E2E in `e2e/tests/staging.spec.ts`.

| Test | Covers | Fails without the fix |
| --- | --- | --- |
| `names the repo the commit ran in` | Happy path — every non-`app-shell` `repository-refresh` carries `detail.repoPath === REPO_A` | Yes — `AssertionError: an unpinned refresh lands on whichever tab is active: expected undefined to equal '/test/repo-a'` |
| `keeps the pin when the user switches tabs mid-commit` | Edge case — `create_commit` held open, `repositoryPath` flipped to REPO_B mid-flight, then resolved | Yes — `AssertionError: the refresh must follow the commit, not the active tab: expected undefined to equal '/test/repo-a'`. Also catches a naive fix that reads `this.repositoryPath` at dispatch time (that would yield REPO_B) |
| `carries the originating repo on commit-created so forwarders stay pinned` | The hand-off key the right panel reads | Yes — `AssertionError: expected undefined to equal '/test/repo-a'` |
| `forwards that pin through the right panel re-broadcast` | `lv-right-panel.handleCommitCreated` emits a pinned refresh | Yes — `AssertionError: expected undefined to equal '/test/repo-a'` (the old handler ignores its argument) |
| `dispatches neither commit-created nor a refresh when the commit fails` | Error path — `create_commit` rejects; zero events, `el.error` set | No — **guard, not proof**. It exists so the pin cannot be written as an unconditional dispatch outside the `result.success` branch |
| E2E `successful commit should dispatch repository-refresh pinned to the committing repository` | Full stack — collects every `repository-refresh` detail (filtering app-shell's tagged self-broadcast) and asserts each names `/tmp/test-repo` | Yes — `expect(received).toBe(expected) / Expected: "/tmp/test-repo" / Received: undefined` |

The E2E replaces the old `successful commit should dispatch repository-refresh event`, which only asserted that an event fired at all. It uses `page.waitForFunction`, no `waitForTimeout`, per the E2E conventions. The existing `injectCommandError(page, 'create_commit', ...)` test already covers the commit-failure path end to end, so no duplicate was added.

Every failure message above was recorded by checking out the pre-fix version of **only** the two production files (`lv-commit-panel.ts` and `lv-right-panel.ts`), leaving the tests untouched, and re-running: 4 of the 5 unit tests failed and the E2E failed. Restoring the two files turned them all green again.

## Gate

`npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` all pass, plus the full `e2e/tests/staging.spec.ts` suite (47 passed) and the CLAUDE.md snake_case grep (only pre-existing, unrelated matches — a comment and two underscore-prefixed unused parameters).