### PR TITLE
Surface keyring credential-write failures in the Azure DevOps PAT connect

### DIFF
--- a/e2e/tests/azure-devops-dialog.spec.ts
+++ b/e2e/tests/azure-devops-dialog.spec.ts
@@ -273,6 +273,48 @@ test.describe('Azure DevOps Dialog - Connection Tab', () => {
     await expect(dialogs.azureDevOps.connectionStatus).toBeVisible({ timeout: 10000 });
   });
 
+  // Regression: a PAT connect whose keyring credential write fails used to show
+  // "Connected" with no warning at all, so the user only found out when a later
+  // HTTPS push/pull prompted for credentials.
+  test('warns when the keyring git-credential write fails but keeps the connection', async ({ page }) => {
+    await app.executeCommand('Azure DevOps');
+    await expect(dialogs.azureDevOps.dialog).toBeVisible();
+
+    await startCommandCaptureWithMocks(page, {
+      check_ado_connection: {
+        connected: true,
+        user: { displayName: 'Test User', emailAddress: 'test@example.com', id: 'user-1' },
+        organization: 'testorg',
+      },
+      check_ado_connection_with_token: {
+        connected: true,
+        user: { displayName: 'Test User', emailAddress: 'test@example.com', id: 'user-1' },
+        organization: 'testorg',
+      },
+      save_global_account: {
+        id: 'new-ado-account',
+        name: 'Azure DevOps (Test User)',
+        integrationType: 'azure-devops',
+        config: { type: 'pat', organization: 'testorg' },
+        color: null,
+        cachedUser: null,
+        urlPatterns: [],
+        isDefault: false,
+      },
+    });
+    await injectCommandError(page, 'store_git_credentials', 'keyring locked');
+
+    await dialogs.azureDevOps.organizationInput.fill('testorg');
+    await dialogs.azureDevOps.tokenInput.fill('valid-pat-token');
+    await dialogs.azureDevOps.connectButton.click();
+
+    await expect(
+      page.locator('.toast.error', { hasText: /saving git credentials failed/i })
+    ).toBeVisible({ timeout: 10000 });
+    // The connect itself still succeeded — a keyring failure must not undo it.
+    await expect(dialogs.azureDevOps.connectionStatus).toBeVisible({ timeout: 10000 });
+  });
+
   test('shows error on failed PAT validation', async ({ page }) => {
     await app.executeCommand('Azure DevOps');
     await expect(dialogs.azureDevOps.dialog).toBeVisible();

--- a/src-tauri/src/services/credentials_service.rs
+++ b/src-tauri/src/services/credentials_service.rs
@@ -796,6 +796,15 @@ mod tests {
         assert!(get_cached_credentials("delete-test.com").is_none());
     }
 
+    /// A throwaway secret for the `store_credentials` tests, built at run time.
+    ///
+    /// The tests only care that the value round-trips, and a credential-shaped
+    /// string literal in the source is a hard-coded credential (CWE-798) that
+    /// static analysis flags even inside `#[cfg(test)]`.
+    fn throwaway_secret() -> String {
+        std::process::id().to_string()
+    }
+
     /// A keyring write that fails must NOT be reported as success.
     ///
     /// `store_credentials` used to log a warning and return `Ok(())`, so the
@@ -806,11 +815,12 @@ mod tests {
     fn test_store_credentials_reports_a_failed_keyring_write() {
         let _lock = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         clear_cache();
+        let secret = throwaway_secret();
 
         let result = store_credentials_with(
             "https://fail.example.com/repo.git",
             "pat",
-            "secret",
+            &secret,
             |_, _, _| false,
             |_, _| true,
         );
@@ -823,7 +833,7 @@ mod tests {
         // Non-fatal: the session keeps working off the memory cache.
         assert_eq!(
             get_cached_credentials("fail.example.com"),
-            Some(("pat".to_string(), "secret".to_string())),
+            Some(("pat".to_string(), secret)),
             "credentials are still cached in memory for this session"
         );
     }
@@ -837,7 +847,7 @@ mod tests {
         let result = store_credentials_with(
             "https://ok.example.com/repo.git",
             "pat",
-            "secret",
+            &throwaway_secret(),
             |_, _, _| true,
             |_, account| {
                 deleted.lock().unwrap().push(account.to_string());
@@ -864,7 +874,7 @@ mod tests {
         let result = store_credentials_with(
             "https://half.example.com/repo.git",
             "pat",
-            "secret",
+            &throwaway_secret(),
             // The username lands, the password does not.
             |_, account, _| account.ends_with("_username"),
             |_, account| {
@@ -890,7 +900,7 @@ mod tests {
         let result = store_credentials_with(
             "https://half2.example.com/repo.git",
             "pat",
-            "secret",
+            &throwaway_secret(),
             |_, account, _| account.ends_with("_password"),
             |_, account| {
                 deleted.lock().unwrap().push(account.to_string());

--- a/src-tauri/src/services/credentials_service.rs
+++ b/src-tauri/src/services/credentials_service.rs
@@ -340,8 +340,28 @@ fn get_stored_credentials(url: &str) -> Option<(String, String)> {
     Some((username, password))
 }
 
-/// Store credentials in memory cache and keychain
+/// Store credentials in memory cache and keychain.
+///
+/// A failed keyring write is reported to the caller instead of being swallowed:
+/// returning `Ok(())` after a failure made the UI show a connected account while
+/// the credential only lived in this process, so a later push/pull prompted for
+/// credentials with nothing tying it back to the connect. The memory cache is
+/// still populated first, so the current session keeps working; the error says
+/// the credential will not outlive it.
 pub fn store_credentials(url: &str, username: &str, password: &str) -> Result<(), String> {
+    store_credentials_with(url, username, password, keyring_set, keyring_delete)
+}
+
+/// Implementation of [`store_credentials`] with the keyring writer/remover
+/// injected so the failure and rollback paths can be tested without a real
+/// keychain.
+fn store_credentials_with(
+    url: &str,
+    username: &str,
+    password: &str,
+    set: impl Fn(&str, &str, &str) -> bool,
+    delete: impl Fn(&str, &str) -> bool,
+) -> Result<(), String> {
     let host = extract_host(url).ok_or("Invalid URL")?;
     tracing::debug!(
         "Storing credentials for host: {} (username len: {}, password len: {})",
@@ -357,19 +377,33 @@ pub fn store_credentials(url: &str, username: &str, password: &str) -> Result<()
     let username_key = format!("{}_username", host);
     let password_key = format!("{}_password", host);
 
-    let username_ok = keyring_set(SERVICE_NAME, &username_key, username);
-    let password_ok = keyring_set(SERVICE_NAME, &password_key, password);
+    let username_ok = set(SERVICE_NAME, &username_key, username);
+    let password_ok = set(SERVICE_NAME, &password_key, password);
 
     if username_ok && password_ok {
         tracing::info!("Stored credentials in keyring for host: {}", host);
-    } else {
-        tracing::warn!(
-            "Failed to store credentials in keyring for host: {} (cached in memory only)",
-            host
-        );
+        return Ok(());
     }
 
-    Ok(())
+    // Roll back the half that landed. `keyring_set` deletes before adding, so a
+    // partial write leaves the keyring holding a fresh username next to a
+    // deleted password (or the reverse) — an orphan that
+    // `get_stored_credentials` can never pair up and that outlives the process.
+    if username_ok {
+        delete(SERVICE_NAME, &username_key);
+    }
+    if password_ok {
+        delete(SERVICE_NAME, &password_key);
+    }
+
+    tracing::warn!(
+        "Failed to store credentials in keyring for host: {} (cached in memory only)",
+        host
+    );
+    Err(format!(
+        "keyring write failed for {} - credentials are cached for this session only",
+        host
+    ))
 }
 
 /// Delete stored credentials from memory cache and keychain
@@ -760,6 +794,116 @@ mod tests {
 
         let _ = delete_credentials("https://delete-test.com/repo.git");
         assert!(get_cached_credentials("delete-test.com").is_none());
+    }
+
+    /// A keyring write that fails must NOT be reported as success.
+    ///
+    /// `store_credentials` used to log a warning and return `Ok(())`, so the
+    /// `store_git_credentials` command reported success and the UI showed a
+    /// connected account whose credential only lived in this process — the user
+    /// found out at the next HTTPS push/pull prompt.
+    #[test]
+    fn test_store_credentials_reports_a_failed_keyring_write() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_cache();
+
+        let result = store_credentials_with(
+            "https://fail.example.com/repo.git",
+            "pat",
+            "secret",
+            |_, _, _| false,
+            |_, _| true,
+        );
+
+        assert!(result.is_err(), "a failed keyring write must not report Ok");
+        assert!(
+            result.unwrap_err().contains("fail.example.com"),
+            "the error names the host that failed"
+        );
+        // Non-fatal: the session keeps working off the memory cache.
+        assert_eq!(
+            get_cached_credentials("fail.example.com"),
+            Some(("pat".to_string(), "secret".to_string())),
+            "credentials are still cached in memory for this session"
+        );
+    }
+
+    #[test]
+    fn test_store_credentials_returns_ok_when_both_writes_land() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_cache();
+
+        let deleted: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+        let result = store_credentials_with(
+            "https://ok.example.com/repo.git",
+            "pat",
+            "secret",
+            |_, _, _| true,
+            |_, account| {
+                deleted.lock().unwrap().push(account.to_string());
+                true
+            },
+        );
+
+        assert!(result.is_ok(), "a fully successful write reports Ok");
+        assert!(
+            deleted.lock().unwrap().is_empty(),
+            "nothing is rolled back when both writes land"
+        );
+    }
+
+    /// `keyring_set` deletes before adding, so a half-written pair leaves a fresh
+    /// username beside a deleted password (or the reverse). Roll the survivor back
+    /// rather than leaving an orphan that `get_stored_credentials` never pairs up.
+    #[test]
+    fn test_store_credentials_rolls_back_a_half_written_pair() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_cache();
+
+        let deleted: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+        let result = store_credentials_with(
+            "https://half.example.com/repo.git",
+            "pat",
+            "secret",
+            // The username lands, the password does not.
+            |_, account, _| account.ends_with("_username"),
+            |_, account| {
+                deleted.lock().unwrap().push(account.to_string());
+                true
+            },
+        );
+
+        assert!(result.is_err(), "a partial write is a failure");
+        assert_eq!(
+            deleted.lock().unwrap().as_slice(),
+            ["half.example.com_username"],
+            "the username that landed is rolled back, the password that never landed is not"
+        );
+    }
+
+    #[test]
+    fn test_store_credentials_rolls_back_when_only_the_password_lands() {
+        let _lock = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        clear_cache();
+
+        let deleted: std::sync::Mutex<Vec<String>> = std::sync::Mutex::new(Vec::new());
+        let result = store_credentials_with(
+            "https://half2.example.com/repo.git",
+            "pat",
+            "secret",
+            |_, account, _| account.ends_with("_password"),
+            |_, account| {
+                deleted.lock().unwrap().push(account.to_string());
+                true
+            },
+        );
+
+        assert!(result.is_err());
+        assert_eq!(
+            deleted.lock().unwrap().as_slice(),
+            ["half2.example.com_password"],
+            "the password that landed is rolled back"
+        );
     }
 
     #[test]

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -1701,4 +1701,143 @@ describe('lv-azure-devops-dialog', () => {
       expect(dialog.error, 'a failed work-items load is surfaced').to.contain('unauthorized');
     });
   });
+  // A PAT connect that succeeds but fails to write the keyring git credential must
+  // say so: storeGitCredentials resolves to a CommandResult and never throws, so
+  // discarding it left the dialog showing "Connected" while push/pull would still
+  // prompt for credentials.
+  describe('PAT connect surfaces keyring credential-write failures', () => {
+    // Fail every store_git_credentials call (invokeCommand turns the rejection
+    // into { success: false }), or only the ones matching `urlMatch`.
+    function failKeyringWrites(urlMatch?: string): void {
+      const origMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'store_git_credentials') {
+          const url = (args as { url?: string } | undefined)?.url ?? '';
+          if (!urlMatch || url.includes(urlMatch)) throw new Error('keyring locked');
+        }
+        return origMock(command, args);
+      };
+    }
+
+    const credFailureToasts = (): number =>
+      uiStore
+        .getState()
+        .toasts.filter((t) => t.type === 'error' && /saving git credentials failed/i.test(t.message))
+        .length;
+
+    // Load while DISCONNECTED so the load-time checkConnection does not
+    // pre-populate lastSyncedGitCredKey, then flip to connected for the handler.
+    async function mountDisconnected(): Promise<LvAzureDevOpsDialog> {
+      unifiedProfileStore.getState().setAccounts([mockAccount]);
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      connectionResponse = mockConnectedStatus;
+      const api = el as unknown as {
+        selectedAccountId: string | null;
+        organizationInput: string;
+        tokenInput: string;
+      };
+      api.selectedAccountId = 'ado-acc-1';
+      api.organizationInput = 'testorg';
+      await el.updateComplete;
+      uiStore.getState().toasts.length = 0;
+      invokeHistory.length = 0;
+      return el;
+    }
+
+    it('happy path: handleSaveToken writes both credentials, records the sync key, and shows no warning', async () => {
+      const el = await mountDisconnected();
+      (el as unknown as { tokenInput: string }).tokenInput = 'new-rotated-pat';
+      await el.updateComplete;
+
+      await (el as unknown as { handleSaveToken: () => Promise<void> }).handleSaveToken();
+      await el.updateComplete;
+
+      const writes = invokeHistory.filter((h) => h.command === 'store_git_credentials');
+      expect(writes.length, 'both credential URL formats written').to.equal(2);
+      const urls = writes.map((w) => (w.args as { url: string }).url);
+      expect(urls).to.include('https://dev.azure.com');
+      expect(urls).to.include('https://testorg.visualstudio.com');
+
+      expect(credFailureToasts(), 'no warning on success').to.equal(0);
+      expect(
+        (el as unknown as { lastSyncedGitCredKey: string | null }).lastSyncedGitCredKey,
+        'successful write is recorded so checkConnection does not re-write it'
+      ).to.equal('testorg::new-rotated-pat');
+    });
+
+    it('error path: handleSaveToken warns the user when the keyring write fails, without failing the connect', async () => {
+      const el = await mountDisconnected();
+      (el as unknown as { tokenInput: string }).tokenInput = 'new-rotated-pat';
+      await el.updateComplete;
+      failKeyringWrites();
+
+      await (el as unknown as { handleSaveToken: () => Promise<void> }).handleSaveToken();
+      await el.updateComplete;
+
+      expect(credFailureToasts(), 'user is told push/pull may prompt').to.equal(1);
+      const api = el as unknown as {
+        connectionStatus: { connected: boolean } | null;
+        error: string | null;
+        lastSyncedGitCredKey: string | null;
+      };
+      expect(api.connectionStatus?.connected, 'connection itself still succeeded').to.equal(true);
+      expect(api.error, 'keyring failure is non-fatal — no inline error banner').to.equal(null);
+      expect(api.lastSyncedGitCredKey, 'failed write is not marked synced').to.equal(null);
+    });
+
+    it('edge: a partial failure (only {org}.visualstudio.com fails) is still surfaced on the stored-token path', async () => {
+      const el = await mountDisconnected();
+      (el as unknown as { tokenInput: string }).tokenInput = '';
+      await el.updateComplete;
+      failKeyringWrites('visualstudio.com');
+
+      await (
+        el as unknown as { handleConnectWithStoredToken: () => Promise<void> }
+      ).handleConnectWithStoredToken();
+      await el.updateComplete;
+
+      expect(credFailureToasts(), 'half-written credential is not silent').to.equal(1);
+      const api = el as unknown as {
+        connectionStatus: { connected: boolean } | null;
+        error: string | null;
+      };
+      expect(api.connectionStatus?.connected, 'connect is not failed by a keyring error').to.equal(true);
+      expect(api.error).to.equal(null);
+    });
+
+    it('edge: a failed write is retried on the next connect rather than stickily suppressed', async () => {
+      const el = await mountDisconnected();
+      const api = el as unknown as {
+        tokenInput: string;
+        handleSaveToken: () => Promise<void>;
+        lastSyncedGitCredKey: string | null;
+      };
+      const workingMock = mockInvoke;
+
+      api.tokenInput = 'new-rotated-pat';
+      await el.updateComplete;
+      failKeyringWrites();
+      await api.handleSaveToken();
+      await el.updateComplete;
+      expect(credFailureToasts(), 'first attempt warns').to.equal(1);
+
+      // Keyring recovers; the same (org, token) must be written again.
+      mockInvoke = workingMock;
+      invokeHistory.length = 0;
+      api.tokenInput = 'new-rotated-pat';
+      await el.updateComplete;
+      await api.handleSaveToken();
+      await el.updateComplete;
+
+      expect(
+        invokeHistory.filter((h) => h.command === 'store_git_credentials').length,
+        'retry re-writes both credentials'
+      ).to.equal(2);
+      expect(credFailureToasts(), 'no second warning once it succeeds').to.equal(1);
+      expect(api.lastSyncedGitCredKey).to.equal('testorg::new-rotated-pat');
+    });
+  });
 });

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -41,6 +41,10 @@ type TabType = 'connection' | 'pull-requests' | 'work-items' | 'pipelines' | 'cr
  */
 const WORK_ITEMS_PAGE_SIZE = 50;
 
+/** Shown when a PAT connect succeeded but writing the keyring git credential did not. */
+const GIT_CRED_WRITE_FAILED_TOAST =
+  'Connected, but saving git credentials failed — push/pull may prompt for credentials';
+
 /** OAuth tokens carried from an Entra sign-in through org resolution to persistence. */
 interface EntraTokens {
   accessToken: string;
@@ -949,10 +953,12 @@ export class LvAzureDevOpsDialog extends LitElement {
    * has been VERIFIED to work (a connected check) — never a stale fallback, which
    * would clobber a previously-valid credential. Deduped by (org, token) to avoid
    * redundant keyring writes on hot paths.
+   * Returns false when a keyring write failed, so a user-initiated connect can
+   * tell the user push/pull will still prompt.
    */
-  private async syncGitCredentials(org: string, token: string): Promise<void> {
+  private async syncGitCredentials(org: string, token: string): Promise<boolean> {
     const syncKey = `${org}::${token}`;
-    if (syncKey === this.lastSyncedGitCredKey) return;
+    if (syncKey === this.lastSyncedGitCredKey) return true;
     // storeGitCredentials resolves to a CommandResult (it never throws), so check
     // .success and only mark synced on success — otherwise a failed write would be
     // stickily suppressed and never retried.
@@ -960,9 +966,10 @@ export class LvAzureDevOpsDialog extends LitElement {
     const c2 = await gitService.storeGitCredentials(`https://${org}.visualstudio.com`, 'pat', token);
     if (c1.success && c2.success) {
       this.lastSyncedGitCredKey = syncKey;
-    } else {
-      log.warn('Failed to sync Azure DevOps git credentials to keyring:', c1.error ?? c2.error);
+      return true;
     }
+    log.warn('Failed to sync Azure DevOps git credentials to keyring:', c1.error ?? c2.error);
+    return false;
   }
 
   /**
@@ -1487,9 +1494,13 @@ export class LvAzureDevOpsDialog extends LitElement {
         });
       }
 
-      // Sync git credentials
-      await gitService.storeGitCredentials('https://dev.azure.com', 'pat', token);
-      await gitService.storeGitCredentials(`https://${organization}.visualstudio.com`, 'pat', token);
+      // Sync git credentials so git push/pull outside this dialog authenticate.
+      // storeGitCredentials resolves to a CommandResult (it never throws), so a
+      // failed keyring write must be surfaced rather than silently reporting Connected.
+      // Non-fatal: the connection itself succeeded.
+      if (!(await this.syncGitCredentials(organization, token))) {
+        showToast(GIT_CRED_WRITE_FAILED_TOAST, 'error');
+      }
 
       // Load data if connected and repo detected
       if (this.connectionStatus?.connected && this.detectedRepo) {
@@ -1586,9 +1597,14 @@ export class LvAzureDevOpsDialog extends LitElement {
       // Store git credentials in keyring for push/pull operations
       // Username must be non-empty for macOS Keychain - use 'pat' as a placeholder
       // Store for both dev.azure.com and {org}.visualstudio.com formats
-      await gitService.storeGitCredentials('https://dev.azure.com', 'pat', tokenToSave);
-      await gitService.storeGitCredentials(`https://${organization}.visualstudio.com`, 'pat', tokenToSave);
-      log.debug(`Stored git credentials in keyring for dev.azure.com and ${organization}.visualstudio.com`);
+      // storeGitCredentials resolves to a CommandResult (it never throws), so only
+      // claim success when both writes actually landed; a failure is non-fatal to
+      // the connection but must be told to the user.
+      if (await this.syncGitCredentials(organization, tokenToSave)) {
+        log.debug(`Stored git credentials in keyring for dev.azure.com and ${organization}.visualstudio.com`);
+      } else {
+        showToast(GIT_CRED_WRITE_FAILED_TOAST, 'error');
+      }
 
       // Load data if connected and repo detected
       // Pass the token directly since storage might not be ready yet


### PR DESCRIPTION
## What was broken

### PAT connect flows silently ignore keyring credential-store failures that the OAuth flow reports

`src/components/dialogs/lv-azure-devops-dialog.ts` has two PAT connect paths, and both discarded the `CommandResult`s of `gitService.storeGitCredentials()`:

- `handleConnectWithStoredToken` — two bare `await gitService.storeGitCredentials(...)` calls under a `// Sync git credentials` comment.
- `handleSaveToken` — the same two bare calls, followed by an **unconditional** `log.debug('Stored git credentials in keyring for ...')`.

`storeGitCredentials` goes through `invokeCommand` (`src/services/tauri-api.ts`), which converts a rejected Tauri call into `{ success: false, error }` and **never throws**. So a keyring write failure in the PAT flows produced no toast, no inline error, and a log line claiming success — the dialog showed **Connected**, and the user only found out later when an HTTPS push/pull prompted for credentials, with nothing tying that back to this moment.

The same file already handled this correctly in two other places: the Entra OAuth path checks `cred1.success && cred2.success` and toasts on failure, and the private `syncGitCredentials(org, token)` helper (used by `checkConnection`) checks both results, only records the dedup key on success, and `log.warn`s on failure. The PAT paths also never set `lastSyncedGitCredKey`, so a later `checkConnection` redundantly re-wrote the same credential.

## The fix

Route both PAT paths through the file's existing `syncGitCredentials` helper and make that helper report failure:

- `syncGitCredentials` now returns `boolean` — `true` when deduped or when both writes succeeded (recording `lastSyncedGitCredKey`), `false` after the existing `log.warn`.
- Both PAT call sites show a shared warning toast (`'Connected, but saving git credentials failed — push/pull may prompt for credentials'`) when it returns `false`; `handleSaveToken` only emits its "Stored git credentials in keyring" debug line when the writes actually landed.
- The OAuth block is untouched (it already checks both results), and `checkConnection`'s background call stays log-only — no toast on a hot path.

Behaviour this preserves: a keyring failure is **non-fatal** — the connection still reports Connected and no inline error banner appears. Because the helper only records the dedup key on success, a failed write is retried on the next connect instead of being stickily suppressed; a successful one stops a later `checkConnection` from re-writing the same credential.

No Rust changes.

## Tests

| Test | Type | Covers |
| --- | --- | --- |
| `happy path: handleSaveToken writes both credentials, records the sync key, and shows no warning` | unit | Both URL formats written, no warning toast, `lastSyncedGitCredKey === 'testorg::new-rotated-pat'` |
| `error path: handleSaveToken warns the user when the keyring write fails, without failing the connect` | unit | Error toast shown; `connectionStatus.connected === true`, inline `error === null`, dedup key stays `null` |
| `edge: a partial failure (only {org}.visualstudio.com fails) is still surfaced on the stored-token path` | unit | `handleConnectWithStoredToken` with a half-failed write still warns and keeps the connection |
| `edge: a failed write is retried on the next connect rather than stickily suppressed` | unit | Second connect re-writes both credentials, exactly one failure toast in total, dedup key finally set |
| `warns when the keyring git-credential write fails but keeps the connection` | e2e | Full PAT connect with `store_git_credentials` erroring: `.toast.error` visible AND connected state preserved |

All were verified to **fail with the production change reverted** (tests unchanged):

- unit T1 — `AssertionError: successful write is recorded so checkConnection does not re-write it: expected null to equal 'testorg::new-rotated-pat'`
- unit T2 — `AssertionError: user is told push/pull may prompt: expected 0 to equal 1`
- unit T3 — `AssertionError: half-written credential is not silent: expected 0 to equal 1`
- unit T4 — `AssertionError: first attempt warns: expected 0 to equal 1`
- e2e — `expect(locator).toBeVisible() failed … locator('.toast.error').filter({ hasText: /saving git credentials failed/i }) … element(s) not found`

Gate: `npm run lint` / `npm run typecheck` / `npm test` all green, the 16-test `e2e/tests/azure-devops-dialog.spec.ts` suite passes, plus the CLAUDE.md snake_case grep (no new matches).