### PR TITLE
Offer SSH keys, not GPG keys, when a repo signs with gpg.format=ssh

### DIFF
--- a/e2e/tests/gpg-dialog.spec.ts
+++ b/e2e/tests/gpg-dialog.spec.ts
@@ -28,6 +28,18 @@ const ED25519 = {
   publicKey: 'ssh-ed25519 AAAA me@example.com',
 };
 
+// get_ssh_keys lists a private key with a known name even when its .pub file
+// is missing, so publicPath names a file that does not exist.
+const ORPHAN = {
+  name: 'id_ecdsa',
+  path: '/home/u/.ssh/id_ecdsa',
+  publicPath: '/home/u/.ssh/id_ecdsa.pub',
+  keyType: 'unknown',
+  fingerprint: null,
+  comment: null,
+  publicKey: null,
+};
+
 const SSH_CONFIG = {
   gpgAvailable: true,
   gpgVersion: 'gpg (GnuPG) 2.2.27',
@@ -86,6 +98,31 @@ test.describe('GPG Dialog - SSH signing', () => {
     await expect(
       page.locator('lv-gpg-dialog .dialog-footer.wizard .btn-secondary')
     ).toHaveText('Refresh');
+  });
+
+  test('a key with no public key file is not offered as a signing choice', async ({ page }) => {
+    // Selecting it would write a nonexistent .pub path into user.signingkey and
+    // report success, while git then fails every signed commit.
+    await startCommandCaptureWithMocks(page, {
+      get_gpg_config: SSH_CONFIG,
+      get_gpg_keys: [],
+      get_ssh_keys: [ED25519, ORPHAN],
+      set_signing_key: null,
+    });
+    await openGpgDialog(page);
+
+    const item = page.locator('lv-gpg-dialog .key-item');
+    await expect(item).toHaveCount(1);
+    await expect(item).toContainText('me@example.com');
+    await expect(page.locator('lv-gpg-dialog .unusable-keys')).toContainText(
+      'id_ecdsa cannot sign'
+    );
+
+    await item.click();
+
+    const calls = await findCommand(page, 'set_signing_key');
+    expect(calls).toHaveLength(1);
+    expect((calls[0].args as { keyId: string }).keyId).toBe('/home/u/.ssh/id_ed25519.pub');
   });
 
   test('a failing SSH key listing surfaces an error', async ({ page }) => {

--- a/e2e/tests/gpg-dialog.spec.ts
+++ b/e2e/tests/gpg-dialog.spec.ts
@@ -1,0 +1,101 @@
+import { test, expect } from '@playwright/test';
+import type { Page } from '@playwright/test';
+import { setupOpenRepository } from '../fixtures/tauri-mock';
+import {
+  startCommandCaptureWithMocks,
+  findCommand,
+  injectCommandError,
+  openViaCommandPalette,
+} from '../fixtures/test-helpers';
+
+/**
+ * E2E tests for the GPG signing dialog (lv-gpg-dialog) when the repository
+ * signs with SSH (gpg.format=ssh).
+ *
+ * Git then signs with a key from ~/.ssh and never consults the GPG keyring,
+ * so the setup wizard must offer the SSH keys — offering GPG keys would write
+ * a GPG key id into user.signingkey and break every signed commit, and
+ * offering "generate a GPG key" is a dead end with no way out.
+ */
+
+const ED25519 = {
+  name: 'id_ed25519',
+  path: '/home/u/.ssh/id_ed25519',
+  publicPath: '/home/u/.ssh/id_ed25519.pub',
+  keyType: 'ssh-ed25519',
+  fingerprint: 'SHA256:abc',
+  comment: 'me@example.com',
+  publicKey: 'ssh-ed25519 AAAA me@example.com',
+};
+
+const SSH_CONFIG = {
+  gpgAvailable: true,
+  gpgVersion: 'gpg (GnuPG) 2.2.27',
+  signingKey: null,
+  signCommits: false,
+  signTags: false,
+  gpgProgram: null,
+  gpgFormat: 'ssh',
+};
+
+async function openGpgDialog(page: Page): Promise<void> {
+  await openViaCommandPalette(page, 'GPG Signing Settings');
+  await page.locator('lv-gpg-dialog .dialog').waitFor({ state: 'visible', timeout: 5000 });
+}
+
+test.describe('GPG Dialog - SSH signing', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+  });
+
+  test('an SSH signer picks a key from ~/.ssh and the choice is persisted', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {
+      get_gpg_config: SSH_CONFIG,
+      get_gpg_keys: [],
+      get_ssh_keys: [ED25519],
+      set_signing_key: null,
+    });
+    await openGpgDialog(page);
+
+    const item = page.locator('lv-gpg-dialog .key-item');
+    await expect(item).toHaveCount(1);
+    await expect(item).toContainText('me@example.com');
+
+    await item.click();
+
+    await expect(page.locator('lv-gpg-dialog .message.success')).toBeVisible();
+    const calls = await findCommand(page, 'set_signing_key');
+    expect(calls).toHaveLength(1);
+    // The public-key path, never a GPG key id: git reads the file at sign time.
+    expect((calls[0].args as { keyId: string }).keyId).toBe('/home/u/.ssh/id_ed25519.pub');
+  });
+
+  test('an SSH signer with no keys is not told to generate a GPG key', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {
+      get_gpg_config: SSH_CONFIG,
+      get_gpg_keys: [],
+      get_ssh_keys: [],
+    });
+    await openGpgDialog(page);
+
+    await expect(page.locator('lv-gpg-dialog .command-block code')).toHaveText(
+      'ssh-keygen -t ed25519 -C "your@email.com"'
+    );
+    await expect(page.locator('lv-gpg-dialog')).not.toContainText('No GPG keys found');
+    // Back would lead into the GPG key-generation guide; Refresh is the way out.
+    await expect(
+      page.locator('lv-gpg-dialog .dialog-footer.wizard .btn-secondary')
+    ).toHaveText('Refresh');
+  });
+
+  test('a failing SSH key listing surfaces an error', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {
+      get_gpg_config: SSH_CONFIG,
+      get_gpg_keys: [],
+    });
+    await injectCommandError(page, 'get_ssh_keys', 'permission denied');
+    await openGpgDialog(page);
+
+    await expect(page.locator('lv-gpg-dialog .message.error')).toContainText('permission denied');
+  });
+});

--- a/src/components/dialogs/__tests__/lv-gpg-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-gpg-dialog.test.ts
@@ -257,6 +257,18 @@ describe('lv-gpg-dialog SSH signing key picker', () => {
     keyType: 'ssh-rsa',
     fingerprint: 'SHA256:def',
     comment: null,
+    publicKey: 'ssh-rsa AAAA',
+  };
+  // get_ssh_keys lists a private key with a known name even when its .pub file
+  // is missing: publicPath then names a file that does not exist, so nothing
+  // can sign with it.
+  const ORPHAN: SshKey = {
+    name: 'id_ecdsa',
+    path: '/home/u/.ssh/id_ecdsa',
+    publicPath: '/home/u/.ssh/id_ecdsa.pub',
+    keyType: 'unknown',
+    fingerprint: null,
+    comment: null,
     publicKey: null,
   };
 
@@ -378,6 +390,48 @@ describe('lv-gpg-dialog SSH signing key picker', () => {
       '.dialog-footer.wizard .btn-primary',
     ) as HTMLButtonElement;
     expect(complete.disabled, 'nothing to complete until a key is picked').to.equal(true);
+  });
+
+  it('does not offer a key whose public key file is missing', async () => {
+    // Writing that nonexistent .pub path into user.signingkey reports success
+    // while ssh_key_is_usable() rejects it and every signed commit then fails
+    // with "failed to read ssh signing key".
+    configByRepo.set(REPO, makeConfig({
+      gpgFormat: 'ssh',
+      gpgAvailable: true,
+      gpgVersion: 'gpg (GnuPG) 2.2.27',
+      signingKey: null,
+    }));
+    sshKeys = [ED25519, ORPHAN];
+
+    const el = await open();
+
+    const items = el.shadowRoot!.querySelectorAll('.key-item');
+    expect(items, 'only the key that can actually sign is offered').to.have.length(1);
+    expect(items[0].textContent).to.contain('me@example.com');
+    const text = el.shadowRoot!.textContent ?? '';
+    expect(text, 'the skipped key is explained, not silently dropped')
+      .to.contain('id_ecdsa cannot sign');
+    expect(text, 'and the way to recover it is offered')
+      .to.contain('ssh-keygen -y -f /home/u/.ssh/id_ecdsa > /home/u/.ssh/id_ecdsa.pub');
+  });
+
+  it('an SSH signer whose only key has no public key file gets ssh-keygen guidance', async () => {
+    configByRepo.set(REPO, makeConfig({ gpgFormat: 'ssh', signingKey: null }));
+    sshKeys = [ORPHAN];
+
+    const el = await open();
+
+    expect(
+      el.shadowRoot!.querySelectorAll('.key-item'),
+      'nothing selectable when no key can sign',
+    ).to.have.length(0);
+    expect(el.shadowRoot!.textContent ?? '').to.contain('No usable SSH keys found');
+    const complete = el.shadowRoot!.querySelector(
+      '.dialog-footer.wizard .btn-primary',
+    ) as HTMLButtonElement;
+    expect(complete.disabled, 'nothing to complete until a usable key exists').to.equal(true);
+    expect(invoked.some((c) => c.command === 'set_signing_key')).to.equal(false);
   });
 
   it('a failing get_ssh_keys is reported, not silently empty', async () => {

--- a/src/components/dialogs/__tests__/lv-gpg-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-gpg-dialog.test.ts
@@ -11,8 +11,15 @@
 let failingCommands: Set<string> = new Set();
 /** Config the backend reports, per repository path. */
 const configByRepo = new Map<string, unknown>();
+/** GPG keyring contents the backend reports. */
+let gpgKeys: unknown[] = [];
+/** ~/.ssh contents the backend reports. */
+let sshKeys: unknown[] = [];
+/** Every command the component issued, in order. */
+let invoked: { command: string; args: unknown }[] = [];
 
 const mockInvoke = (command: string, args?: unknown): Promise<unknown> => {
+  invoked.push({ command, args });
   if (failingCommands.has(command)) {
     return Promise.reject({ code: 'COMMAND_ERROR', message: 'could not lock config file' });
   }
@@ -20,7 +27,8 @@ const mockInvoke = (command: string, args?: unknown): Promise<unknown> => {
     const path = ((args as { path?: string }) ?? {}).path ?? '';
     return Promise.resolve(configByRepo.get(path) ?? null);
   }
-  if (command === 'get_gpg_keys') return Promise.resolve([]);
+  if (command === 'get_gpg_keys') return Promise.resolve(gpgKeys);
+  if (command === 'get_ssh_keys') return Promise.resolve(sshKeys);
   return Promise.resolve(null);
 };
 (globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
@@ -30,7 +38,7 @@ const mockInvoke = (command: string, args?: unknown): Promise<unknown> => {
 import { expect, fixture, html } from '@open-wc/testing';
 import '../lv-gpg-dialog.ts';
 import type { LvGpgDialog } from '../lv-gpg-dialog.ts';
-import type { GpgConfig } from '../../../services/git.service.ts';
+import type { GpgConfig, SshKey } from '../../../services/git.service.ts';
 
 function makeConfig(overrides: Partial<GpgConfig>): GpgConfig {
   return {
@@ -219,5 +227,193 @@ describe('lv-gpg-dialog banner lifecycle', () => {
     await el.updateComplete;
 
     expect(banners(el).success, 'still on screen after a reload').to.contain('Commit signing');
+  });
+});
+
+
+/**
+ * gpg.format=ssh means git signs with an SSH key from ~/.ssh and never touches
+ * the GPG keyring. The setup wizard used to render the OpenPGP key list here:
+ * with a GPG key present, picking one wrote a GPG key id into user.signingkey
+ * and broke every signed commit ("failed to read ssh signing key"); with no
+ * GPG keys — the common case — it was a dead end that told the user to run
+ * `gpg --full-generate-key` and left Complete Setup disabled forever.
+ */
+describe('lv-gpg-dialog SSH signing key picker', () => {
+  const REPO = '/repo/ssh';
+  const ED25519: SshKey = {
+    name: 'id_ed25519',
+    path: '/home/u/.ssh/id_ed25519',
+    publicPath: '/home/u/.ssh/id_ed25519.pub',
+    keyType: 'ssh-ed25519',
+    fingerprint: 'SHA256:abc',
+    comment: 'me@example.com',
+    publicKey: 'ssh-ed25519 AAAA me@example.com',
+  };
+  const RSA: SshKey = {
+    name: 'id_rsa',
+    path: '/home/u/.ssh/id_rsa',
+    publicPath: '/home/u/.ssh/id_rsa.pub',
+    keyType: 'ssh-rsa',
+    fingerprint: 'SHA256:def',
+    comment: null,
+    publicKey: null,
+  };
+
+  beforeEach(() => {
+    failingCommands = new Set();
+    configByRepo.clear();
+    gpgKeys = [];
+    sshKeys = [];
+    invoked = [];
+  });
+
+  /** Wait for any in-flight load to finish and the render to catch up. */
+  async function settle(el: LvGpgDialog): Promise<void> {
+    for (let i = 0; i < 500; i++) {
+      await new Promise((r) => setTimeout(r, 0));
+      if (!(el as unknown as { loading: boolean }).loading) break;
+    }
+    await el.updateComplete;
+  }
+
+  async function open(): Promise<LvGpgDialog> {
+    // The host keeps this dialog mounted and only toggles ?open, and the
+    // repository is pinned on that transition — open it the same way so the
+    // load runs against REPO rather than an unpinned empty path.
+    const el = await fixture<LvGpgDialog>(
+      html`<lv-gpg-dialog .repositoryPath=${REPO}></lv-gpg-dialog>`,
+    );
+    el.open = true;
+    await el.updateComplete;
+    await settle(el);
+    return el;
+  }
+
+  it('offers the ~/.ssh keys, not the GPG keyring, when gpg.format=ssh', async () => {
+    configByRepo.set(REPO, makeConfig({
+      gpgFormat: 'ssh',
+      gpgAvailable: true,
+      gpgVersion: 'gpg (GnuPG) 2.2.27',
+      signingKey: null,
+    }));
+    sshKeys = [ED25519, RSA];
+
+    const el = await open();
+
+    const items = el.shadowRoot!.querySelectorAll('.key-item');
+    expect(items, 'both ~/.ssh keys are offered').to.have.length(2);
+    const text = el.shadowRoot!.textContent ?? '';
+    expect(text).to.contain('me@example.com');
+    expect(text, 'the GPG keyring is irrelevant here').to.not.contain('No GPG keys found');
+  });
+
+  it("writes the chosen key's public-key path to user.signingkey", async () => {
+    configByRepo.set(REPO, makeConfig({
+      gpgFormat: 'ssh',
+      gpgAvailable: true,
+      gpgVersion: 'gpg (GnuPG) 2.2.27',
+      signingKey: null,
+    }));
+    sshKeys = [ED25519, RSA];
+
+    const el = await open();
+    let changed = 0;
+    el.addEventListener('gpg-changed', () => { changed++; });
+
+    const first = el.shadowRoot!.querySelector('.key-item') as HTMLElement | null;
+    expect(first, 'there is a key to pick').to.not.be.null;
+    first!.click();
+    await settle(el);
+
+    const call = invoked.find((c) => c.command === 'set_signing_key');
+    expect(call, 'the key was persisted').to.not.be.undefined;
+    const args = call!.args as { path: string; keyId: string };
+    expect(args.keyId, 'an SSH public-key path, never a GPG key id')
+      .to.equal('/home/u/.ssh/id_ed25519.pub');
+    expect(args.path).to.equal(REPO);
+    expect(
+      el.shadowRoot!.querySelector('.message.success')?.textContent ?? '',
+    ).to.contain('Signing key');
+    expect(changed, 'gpg-changed is dispatched like every sibling handler').to.equal(1);
+  });
+
+  it('marks the configured SSH key as selected in the normal view', async () => {
+    // A configured signing key leaves setupMode false, so this is the view the
+    // wizard hands off into.
+    configByRepo.set(REPO, makeConfig({
+      gpgFormat: 'ssh',
+      gpgAvailable: true,
+      gpgVersion: 'gpg (GnuPG) 2.2.27',
+      signingKey: '~/.ssh/id_ed25519.pub',
+    }));
+    sshKeys = [ED25519, RSA];
+
+    const el = await open();
+
+    const selected = el.shadowRoot!.querySelector('.key-item.selected');
+    expect(selected, 'the configured key is shown as chosen').to.not.be.null;
+    expect(selected!.textContent).to.contain('me@example.com');
+    const text = el.shadowRoot!.textContent ?? '';
+    expect(text, 'no GPG key generation advice for an SSH signer')
+      .to.not.contain('gpg --full-generate-key');
+  });
+
+  it('an SSH signer with no keys gets ssh-keygen guidance, never a GPG key', async () => {
+    configByRepo.set(REPO, makeConfig({ gpgFormat: 'ssh', signingKey: null }));
+    sshKeys = [];
+
+    const el = await open();
+
+    const text = el.shadowRoot!.textContent ?? '';
+    expect(text).to.contain('ssh-keygen');
+    expect(text).to.not.contain('No GPG keys found');
+    const back = el.shadowRoot!.querySelector('.dialog-footer.wizard .btn-secondary');
+    expect(back, 'the wizard footer has a left button').to.not.be.null;
+    expect(
+      back!.textContent!.trim(),
+      'Back would lead to the GPG generate guide; Refresh is the real flow',
+    ).to.equal('Refresh');
+    const complete = el.shadowRoot!.querySelector(
+      '.dialog-footer.wizard .btn-primary',
+    ) as HTMLButtonElement;
+    expect(complete.disabled, 'nothing to complete until a key is picked').to.equal(true);
+  });
+
+  it('a failing get_ssh_keys is reported, not silently empty', async () => {
+    configByRepo.set(REPO, makeConfig({ gpgFormat: 'ssh', signingKey: null }));
+    failingCommands.add('get_ssh_keys');
+
+    const el = await open();
+
+    expect(
+      el.shadowRoot!.querySelector('.message.error')?.textContent ?? '',
+    ).to.contain('could not lock config file');
+  });
+
+  it('openpgp repos still get the GPG keyring and never query ~/.ssh', async () => {
+    // Guard against over-reach — this passes before and after the fix.
+    configByRepo.set(REPO, makeConfig({
+      gpgFormat: null,
+      gpgAvailable: true,
+      gpgVersion: 'gpg (GnuPG) 2.2.27',
+      signingKey: 'LONGKEY1',
+    }));
+    gpgKeys = [{
+      keyId: 'KEY1',
+      keyIdLong: 'LONGKEY1',
+      userId: 'Test User',
+      email: 'test@example.com',
+      keyType: 'rsa',
+      keySize: 4096,
+      trust: 'ultimate',
+      expires: null,
+    }];
+    sshKeys = [ED25519];
+
+    const el = await open();
+
+    expect(el.shadowRoot!.textContent ?? '').to.contain('Test User');
+    expect(invoked.some((c) => c.command === 'get_ssh_keys')).to.equal(false);
   });
 });

--- a/src/components/dialogs/lv-gpg-dialog.ts
+++ b/src/components/dialogs/lv-gpg-dialog.ts
@@ -1278,34 +1278,56 @@ export class LvGpgDialog extends LitElement {
    * The ~/.ssh key picker, shared by the setup wizard and the normal view.
    * Selecting writes the PUBLIC key path into user.signingkey, which is what
    * git (and the backend's usability check) accepts for SSH signing.
+   *
+   * get_ssh_keys also lists a private key whose .pub file is missing (a known
+   * key name is enough), and its publicPath then points at a file that does
+   * not exist. Offering such a key would write that path into user.signingkey
+   * and report success, while ssh_key_is_usable() rejects it and git fails
+   * every signed commit with "failed to read ssh signing key" — so only keys
+   * with readable public-key data are selectable.
    */
   private renderSshKeyList() {
-    if (this.sshKeys.length === 0) {
-      return html`
-        <div class="empty-text">
-          No SSH keys found in ~/.ssh. Generate one, then refresh:
-        </div>
-        ${this.renderCommandBlock('ssh-keygen -t ed25519 -C "your@email.com"')}
-      `;
-    }
+    const usable = this.sshKeys.filter((key) => key.publicKey);
+    const unusable = this.sshKeys.filter((key) => !key.publicKey);
     return html`
-      <div class="key-list">
-        ${this.sshKeys.map(
-          (key) => html`
-            <div
-              class="key-item ${this.isSshKeySelected(key) ? 'selected' : ''}"
-              @click=${() => this.handleSelectKey(key.publicPath)}
-            >
-              <div class="key-radio"></div>
-              <div class="key-info">
-                <div class="key-user">${key.comment || key.name}</div>
-                <div class="key-details">${key.keyType} / ${key.fingerprint || key.publicPath}</div>
-              </div>
-              <span class="key-badge">${key.name}</span>
+      ${usable.length === 0
+        ? html`
+            <div class="empty-text">
+              No usable SSH keys found in ~/.ssh. Generate one, then refresh:
             </div>
+            ${this.renderCommandBlock('ssh-keygen -t ed25519 -C "your@email.com"')}
           `
-        )}
-      </div>
+        : html`
+            <div class="key-list">
+              ${usable.map(
+                (key) => html`
+                  <div
+                    class="key-item ${this.isSshKeySelected(key) ? 'selected' : ''}"
+                    @click=${() => this.handleSelectKey(key.publicPath)}
+                  >
+                    <div class="key-radio"></div>
+                    <div class="key-info">
+                      <div class="key-user">${key.comment || key.name}</div>
+                      <div class="key-details">${key.keyType} / ${key.fingerprint || key.publicPath}</div>
+                    </div>
+                    <span class="key-badge">${key.name}</span>
+                  </div>
+                `
+              )}
+            </div>
+          `}
+      ${unusable.length === 0
+        ? nothing
+        : html`
+            <div class="empty-text unusable-keys">
+              ${unusable.map((key) => key.name).join(', ')} cannot sign: no
+              public key file in ~/.ssh. Recreate it from the private key, then
+              refresh:
+            </div>
+            ${this.renderCommandBlock(
+              `ssh-keygen -y -f ${unusable[0].path} > ${unusable[0].publicPath}`
+            )}
+          `}
     `;
   }
 

--- a/src/components/dialogs/lv-gpg-dialog.ts
+++ b/src/components/dialogs/lv-gpg-dialog.ts
@@ -7,7 +7,7 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
-import type { GpgConfig, GpgKey } from '../../services/git.service.ts';
+import type { GpgConfig, GpgKey, SshKey } from '../../services/git.service.ts';
 import { getPlatform, type Platform } from '../../utils/platform.ts';
 import { openExternalUrl } from '../../utils/external-link.ts';
 import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
@@ -641,6 +641,7 @@ export class LvGpgDialog extends LitElement {
 
   @state() private config: GpgConfig | null = null;
   @state() private keys: GpgKey[] = [];
+  @state() private sshKeys: SshKey[] = [];
   @state() private selectedKey: string | null = null;
   @state() private loading = false;
   @state() private error = '';
@@ -736,10 +737,49 @@ export class LvGpgDialog extends LitElement {
       this.keys = keysResult.data;
     }
 
+    // gpg.format=ssh means git signs with an SSH key and never consults the
+    // GPG keyring, so the list of keys to choose from has to come from ~/.ssh.
+    if (this.config?.gpgFormat === 'ssh') {
+      const sshResult = await gitService.getSshKeys();
+      if (sshResult.success && sshResult.data) {
+        this.sshKeys = sshResult.data;
+      } else {
+        this.sshKeys = [];
+        // Never silent: without a key list this step has nothing to offer.
+        // Keeps an earlier config-load error rather than overwriting it.
+        if (!this.error) {
+          this.error = sshResult.error?.message || 'Failed to load SSH keys';
+        }
+      }
+    } else {
+      this.sshKeys = [];
+    }
+
     // Auto-detect setup state
     this.detectSetupState();
 
     this.loading = false;
+  }
+
+  /** True when this repository signs with SSH (gpg.format=ssh) rather than GPG. */
+  private get isSshFormat(): boolean {
+    return this.config?.gpgFormat === 'ssh';
+  }
+
+  /**
+   * Whether `key` is the key `user.signingkey` currently names. Git accepts
+   * either the public or the private key path there, and the value may still
+   * be the unexpanded "~/" form that the backend expands at sign time.
+   */
+  private isSshKeySelected(key: SshKey): boolean {
+    const configured = (this.selectedKey ?? '').trim();
+    if (!configured) return false;
+    if (configured === key.publicPath || configured === key.path) return true;
+    if (configured.startsWith('~/')) {
+      const tail = configured.slice(1); // "/.ssh/id_ed25519.pub"
+      return key.publicPath.endsWith(tail) || key.path.endsWith(tail);
+    }
+    return false;
   }
 
   private detectSetupState(): void {
@@ -914,7 +954,9 @@ export class LvGpgDialog extends LitElement {
       case 'generate-guide':
         return 'GPG Setup - Generate Key';
       case 'configure':
-        return 'GPG Setup - Select Key';
+        return this.isSshFormat
+          ? 'SSH Signing Setup - Select Key'
+          : 'GPG Setup - Select Key';
       case 'complete':
         return 'GPG Setup - Complete';
     }
@@ -1164,6 +1206,10 @@ export class LvGpgDialog extends LitElement {
   }
 
   private renderConfigureStep() {
+    // An SSH signer must pick an SSH key: writing a GPG key id into
+    // user.signingkey while gpg.format=ssh makes every signed commit fail.
+    if (this.isSshFormat) return this.renderSshConfigureStep();
+
     return html`
       <div class="setup-header">
         <svg class="setup-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
@@ -1207,6 +1253,62 @@ export class LvGpgDialog extends LitElement {
     `;
   }
 
+  private renderSshConfigureStep() {
+    return html`
+      <div class="setup-header">
+        <svg class="setup-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5">
+          <circle cx="12" cy="12" r="3"></circle>
+          <path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06a1.65 1.65 0 0 0 .33-1.82 1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06a1.65 1.65 0 0 0 1.82.33H9a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06a1.65 1.65 0 0 0-.33 1.82V9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"></path>
+        </svg>
+        <div class="setup-title">Select Your SSH Signing Key</div>
+        <div class="setup-description">
+          This repository signs with SSH (gpg.format=ssh), so Git needs an SSH
+          key &mdash; not a GPG key. Choose one of your ~/.ssh keys.
+        </div>
+      </div>
+
+      <div class="section">
+        <div class="section-title">Available SSH Keys</div>
+        ${this.renderSshKeyList()}
+      </div>
+    `;
+  }
+
+  /**
+   * The ~/.ssh key picker, shared by the setup wizard and the normal view.
+   * Selecting writes the PUBLIC key path into user.signingkey, which is what
+   * git (and the backend's usability check) accepts for SSH signing.
+   */
+  private renderSshKeyList() {
+    if (this.sshKeys.length === 0) {
+      return html`
+        <div class="empty-text">
+          No SSH keys found in ~/.ssh. Generate one, then refresh:
+        </div>
+        ${this.renderCommandBlock('ssh-keygen -t ed25519 -C "your@email.com"')}
+      `;
+    }
+    return html`
+      <div class="key-list">
+        ${this.sshKeys.map(
+          (key) => html`
+            <div
+              class="key-item ${this.isSshKeySelected(key) ? 'selected' : ''}"
+              @click=${() => this.handleSelectKey(key.publicPath)}
+            >
+              <div class="key-radio"></div>
+              <div class="key-info">
+                <div class="key-user">${key.comment || key.name}</div>
+                <div class="key-details">${key.keyType} / ${key.fingerprint || key.publicPath}</div>
+              </div>
+              <span class="key-badge">${key.name}</span>
+            </div>
+          `
+        )}
+      </div>
+    `;
+  }
+
   private renderSetupComplete() {
     return html`
       <div class="complete-content">
@@ -1214,10 +1316,12 @@ export class LvGpgDialog extends LitElement {
           <path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"></path>
           <polyline points="22 4 12 14.01 9 11.01"></polyline>
         </svg>
-        <div class="complete-title">GPG is Ready!</div>
+        <div class="complete-title">
+          ${this.isSshFormat ? 'SSH Signing is Ready!' : 'GPG is Ready!'}
+        </div>
         <div class="complete-description">
-          Your GPG signing is now configured. You can enable automatic commit
-          signing in the settings below.
+          Your ${this.isSshFormat ? 'SSH' : 'GPG'} signing is now configured. You
+          can enable automatic commit signing in the settings below.
         </div>
       </div>
     `;
@@ -1228,14 +1332,23 @@ export class LvGpgDialog extends LitElement {
 
     return html`
       <div class="status-section">
-        <div class="status-row">
-          <span class="status-label">GPG Status</span>
-          <span class="status-badge available">Available</span>
-        </div>
-        <div class="status-row" style="margin-top: var(--spacing-xs);">
-          <span class="status-label">Version</span>
-          <span class="status-value">${this.config.gpgVersion || 'Unknown'}</span>
-        </div>
+        ${this.isSshFormat
+          ? html`
+              <div class="status-row">
+                <span class="status-label">Signature Format</span>
+                <span class="status-value">SSH</span>
+              </div>
+            `
+          : html`
+              <div class="status-row">
+                <span class="status-label">GPG Status</span>
+                <span class="status-badge available">Available</span>
+              </div>
+              <div class="status-row" style="margin-top: var(--spacing-xs);">
+                <span class="status-label">Version</span>
+                <span class="status-value">${this.config.gpgVersion || 'Unknown'}</span>
+              </div>
+            `}
       </div>
 
       <div class="scope-toggle">
@@ -1258,7 +1371,10 @@ export class LvGpgDialog extends LitElement {
         <div class="toggle-row">
           <div>
             <div class="toggle-label">Sign commits</div>
-            <div class="toggle-desc">Automatically sign all commits with GPG</div>
+            <div class="toggle-desc">
+              Automatically sign all commits with
+              ${this.isSshFormat ? 'your SSH key' : 'GPG'}
+            </div>
           </div>
           <label class="toggle">
             <input
@@ -1273,7 +1389,10 @@ export class LvGpgDialog extends LitElement {
         <div class="toggle-row">
           <div>
             <div class="toggle-label">Sign tags</div>
-            <div class="toggle-desc">Automatically sign all tags with GPG</div>
+            <div class="toggle-desc">
+              Automatically sign all tags with
+              ${this.isSshFormat ? 'your SSH key' : 'GPG'}
+            </div>
           </div>
           <label class="toggle">
             <input
@@ -1288,8 +1407,12 @@ export class LvGpgDialog extends LitElement {
       </div>
 
       <div class="section">
-        <div class="section-title">Signing Key</div>
-        ${this.keys.length === 0
+        <div class="section-title">
+          ${this.isSshFormat ? 'Signing Key (SSH)' : 'Signing Key'}
+        </div>
+        ${this.isSshFormat
+          ? this.renderSshKeyList()
+          : this.keys.length === 0
           ? html`
               <div class="empty-text">
                 No GPG keys found. Generate a key with:<br>
@@ -1384,9 +1507,22 @@ export class LvGpgDialog extends LitElement {
         return html`
           <div class="dialog-footer wizard">
             <div class="footer-left">
-              <button class="btn btn-secondary" @click=${this.handleSetupBack}>
-                Back
-              </button>
+              ${
+                // Back would lead to the GPG key-generation guide, which an SSH
+                // signer must never be sent to. Refresh is what turns the
+                // zero-key case into a real flow: run ssh-keygen in a terminal,
+                // refresh, pick a key, complete.
+                this.isSshFormat
+                ? html`
+                    <button class="btn btn-secondary" @click=${this.handleRefreshAndCheck}>
+                      Refresh
+                    </button>
+                  `
+                : html`
+                    <button class="btn btn-secondary" @click=${this.handleSetupBack}>
+                      Back
+                    </button>
+                  `}
             </div>
             <div class="footer-right">
               <button
@@ -1430,6 +1566,9 @@ export class LvGpgDialog extends LitElement {
   }
 
   private handleSetupBack(): void {
+    // No Back for an SSH signer: every earlier step is GPG installation and
+    // GPG key generation, neither of which applies when gpg.format=ssh.
+    if (this.isSshFormat) return;
     switch (this.setupStep) {
       case 'generate-guide':
         this.setupStep = 'install-guide';


### PR DESCRIPTION
## What was broken

### The GPG setup wizard offers GPG keys and GPG key generation when `gpg.format=ssh`

`gpg.format=ssh` means Git signs with a key from `~/.ssh` and never consults the GPG keyring. `detectSetupState()` in `src/components/dialogs/lv-gpg-dialog.ts` already had an SSH branch that sends a repo with no `user.signingkey` to the `configure` step — but `renderConfigureStep()` was unconditional and rendered the OpenPGP keyring list. Two user-visible failures followed:

1. **Silent breakage of commit signing.** If a GPG key happened to exist, clicking it called `handleSelectKey(key.keyIdLong)`, writing `user.signingkey <gpg-key-id>` while `gpg.format` stayed `ssh`. `ssh_key_is_usable()` (`src-tauri/src/commands/gpg.rs`) then rejects the value — it is neither an SSH literal nor a path that exists — so `get_signing_status.can_sign` goes false, and Git itself fails every signed commit with `failed to read ssh signing key`.

2. **A hard dead end in the common case.** With no GPG keyring at all — the normal situation for an SSH signer — the step read *"No GPG keys found. Please generate a key first."*, **Back** led to the `gpg --full-generate-key` guide, and **Complete Setup** stayed disabled forever. There was no SSH key picker anywhere in the dialog. The same applied to the normal (non-wizard) view, whose Signing Key section showed the GPG list, a `gpg --full-generate-key` hint, and a hardcoded "GPG Status / Available" block.

The backend was already complete: `get_ssh_keys` is registered and exposed as `gitService.getSshKeys()`, `set_signing_key` writes whatever string it is given, and `ssh_key_is_usable()` accepts a path to an existing key file. Only the UI never reached it.

## The fix

All frontend, no Rust and no CSS changes (every class used already exists in the component's `static styles`).

- `loadData()` fetches `get_ssh_keys` when — and only when — `config.gpgFormat === 'ssh'`. A failure clears the list and surfaces an error banner (without clobbering an earlier config-load error) rather than rendering a silently empty picker.
- New `renderSshKeyList()`, shared by the wizard's new `renderSshConfigureStep()` and the normal view's Signing Key section. It writes the **public-key path** to `user.signingkey` — exactly what `ssh_key_is_usable()` accepts.
- Selection reuses the existing `handleSelectKey()`, so the SSH path inherits the sibling-consistency and feedback rules unchanged: it persists via `set_signing_key`, clears stale banners, shows the success message, reports failures into `this.error`, and dispatches `gpg-changed` (already listened for in `app-shell.ts`).
- `isSshKeySelected()` matches the configured value against both the public and private key path, including the unexpanded `~/` form the backend expands at sign time.
- With zero keys the step shows `ssh-keygen -t ed25519 -C "your@email.com"` and swaps **Back** for **Refresh** — the missing step that turns the dead end into a real flow (run `ssh-keygen` in a terminal → Refresh → pick → Complete). `handleSetupBack()` also guards against ever stranding an SSH repo on the GPG generate guide.
- GPG-only chrome is suppressed for SSH: the dialog title, the status block (a single `Signature Format: SSH` row instead of GPG status + version, which may be absent entirely), the "sign all commits/tags with GPG" toggle wording, and the "GPG is Ready!" completion copy.

## Tests

| Test | Kind | Covers |
| --- | --- | --- |
| offers the `~/.ssh` keys, not the GPG keyring, when `gpg.format=ssh` | unit | happy path — both SSH keys render, no "No GPG keys found" |
| writes the chosen key's public-key path to `user.signingkey` | unit | happy path — `set_signing_key` args are the `.pub` path (never a GPG key id) + repo path, success banner, `gpg-changed` dispatched |
| marks the configured SSH key as selected in the normal view | unit | hand-off after setup — `~/` form matches, no `gpg --full-generate-key` advice |
| an SSH signer with no keys gets `ssh-keygen` guidance, never a GPG key | unit | edge case (the common case) — `ssh-keygen` block, Refresh instead of Back, Complete Setup disabled |
| a failing `get_ssh_keys` is reported, not silently empty | unit | error path — error banner |
| openpgp repos still get the GPG keyring and never query `~/.ssh` | unit | guard against over-reach (passes before and after — declared as a guard, not proof) |
| an SSH signer picks a key from `~/.ssh` and the choice is persisted | e2e | full-stack happy path |
| an SSH signer with no keys is not told to generate a GPG key | e2e | full-stack zero-key flow |
| a failing SSH key listing surfaces an error | e2e | full-stack error path |

### Verified to fail without the fix

Reverting only `lv-gpg-dialog.ts` and re-running:

- Unit: 5 failed / 7 passed. `expected empty NodeList to have 2 children but it had 0 children`; `there is a key to pick: expected null not to be null`; `the configured key is shown as chosen: expected null not to be null`; the no-keys test dumped the actual screen — *"Select Your Signing Key / Choose which GPG key to use… / No GPG keys found. Please generate a key first. / Back"* — and `expected '' to include 'could not lock config file'`. The over-reach guard still passed.
- E2E: all 3 failed — `locator('lv-gpg-dialog .key-item')` resolved to 0 elements, `locator('lv-gpg-dialog .command-block code')` not found, `locator('lv-gpg-dialog .message.error')` not found.

Full gate green: `npm run lint`, `npm run typecheck`, `npm test` (4451 passed), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, plus the snake_case grep (no new matches).


---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_