### PR TITLE
Re-apply an edited profile's identity to the repositories using it

### DIFF
--- a/e2e/tests/profiles-integrations-flows.spec.ts
+++ b/e2e/tests/profiles-integrations-flows.spec.ts
@@ -513,7 +513,7 @@ test.describe('Cross-component propagation - toolbar reflects dialog state', () 
         repositoryAssignments: {},
       },
       get_migration_backup_info: { hasBackup: false },
-      save_unified_profile: renamed,
+      save_unified_profile: { profile: renamed, failedRepositories: [] },
     });
 
     await expect(dashboardProfileName(page)).toHaveText('Work');
@@ -531,6 +531,42 @@ test.describe('Cross-component propagation - toolbar reflects dialog state', () 
     await expect(dashboardProfileName(page)).toHaveText('Client A', { timeout: 5000 });
   });
 
+  // Saving an edited profile re-writes the git identity of every repository
+  // assigned to it. The ones the backend could not rewrite must be named, not
+  // hidden behind a generic "Profile saved".
+  test('editing a profile warns about repositories that kept the old identity', async ({ page }) => {
+    const dialogs = new DialogsPage(page);
+
+    await setupProfilesAndAccounts(page, {
+      profiles: [workProfile],
+      accounts: [githubWork],
+    });
+
+    await injectCommandMock(page, {
+      get_unified_profiles_config: {
+        version: 3,
+        profiles: [workProfile],
+        accounts: [githubWork],
+        repositoryAssignments: { '/repo/personal': workProfile.id },
+      },
+      get_migration_backup_info: { hasBackup: false },
+      save_unified_profile: {
+        profile: { ...workProfile, gitEmail: 'new@company.com' },
+        failedRepositories: ['/repo/personal'],
+      },
+    });
+
+    await openProfileManager(page, dialogs);
+    await page.locator('.profile-item').first().click();
+
+    await page.getByPlaceholder(/john@example.com/i).fill('new@company.com');
+    await page.getByRole('button', { name: 'Save Profile' }).click();
+
+    const warning = page.locator('lv-toast-container .toast.warning .toast-message');
+    await expect(warning).toBeVisible({ timeout: 5000 });
+    await expect(warning).toContainText('personal');
+  });
+
   test('creating the first profile marked default makes it the active profile', async ({ page }) => {
     const dialogs = new DialogsPage(page);
 
@@ -546,7 +582,7 @@ test.describe('Cross-component propagation - toolbar reflects dialog state', () 
         repositoryAssignments: {},
       },
       get_migration_backup_info: { hasBackup: false },
-      save_unified_profile: newProfile,
+      save_unified_profile: { profile: newProfile, failedRepositories: [] },
       get_unified_profile: newProfile,
       apply_unified_profile: null,
     });
@@ -1144,7 +1180,10 @@ test.describe('Workflow - Profile Manager ↔ Integration dialogs', () => {
     // Save the profile and verify the backend received the auto-attached
     // account as the profile's github default — not just UI-only state.
     await startCommandCaptureWithMocks(page, {
-      save_unified_profile: { ...personalProfile, defaultAccounts: { github: newAccount.id } },
+      save_unified_profile: {
+        profile: { ...personalProfile, defaultAccounts: { github: newAccount.id } },
+        failedRepositories: [],
+      },
     });
     await page.getByRole('button', { name: 'Save Profile' }).click();
     await waitForCommand(page, 'save_unified_profile');
@@ -1338,7 +1377,7 @@ test.describe('Remaining flows - Profile Manager', () => {
         repositoryAssignments: {},
       },
       get_migration_backup_info: { hasBackup: false },
-      save_unified_profile: { ...profile, isDefault: true },
+      save_unified_profile: { profile: { ...profile, isDefault: true }, failedRepositories: [] },
     });
 
     await openProfileManager(page, dialogs);
@@ -1352,7 +1391,7 @@ test.describe('Remaining flows - Profile Manager', () => {
     }
 
     await startCommandCaptureWithMocks(page, {
-      save_unified_profile: { ...profile, isDefault: true },
+      save_unified_profile: { profile: { ...profile, isDefault: true }, failedRepositories: [] },
     });
     await page.getByRole('button', { name: 'Save Profile' }).click();
     await waitForCommand(page, 'save_unified_profile');
@@ -1387,15 +1426,18 @@ test.describe('Remaining flows - Profile Manager', () => {
 
     await startCommandCaptureWithMocks(page, {
       save_unified_profile: {
-        id: 'profile-multi',
-        name: 'Multi-Pattern',
-        gitName: 'Multi User',
-        gitEmail: 'multi@example.com',
-        signingKey: null,
-        urlPatterns: ['github.com/acme/*', 'gitlab.acme.com/*', 'bitbucket.org/team/*'],
-        isDefault: false,
-        color: '#3b82f6',
-        defaultAccounts: {},
+        profile: {
+          id: 'profile-multi',
+          name: 'Multi-Pattern',
+          gitName: 'Multi User',
+          gitEmail: 'multi@example.com',
+          signingKey: null,
+          urlPatterns: ['github.com/acme/*', 'gitlab.acme.com/*', 'bitbucket.org/team/*'],
+          isDefault: false,
+          color: '#3b82f6',
+          defaultAccounts: {},
+        },
+        failedRepositories: [],
       },
     });
     await page.getByRole('button', { name: 'Save Profile' }).click();

--- a/e2e/tests/profiles-integrations.spec.ts
+++ b/e2e/tests/profiles-integrations.spec.ts
@@ -303,8 +303,8 @@ test.describe('Profile Manager Dialog - Integration Accounts', () => {
 
     await startCommandCaptureWithMocks(page, {
       save_unified_profile: {
-        ...testProfiles.personal,
-        defaultAccounts: { github: 'account-github-personal' },
+        profile: { ...testProfiles.personal, defaultAccounts: { github: 'account-github-personal' } },
+        failedRepositories: [],
       },
     });
 
@@ -327,7 +327,10 @@ test.describe('Profile Manager Dialog - Integration Accounts', () => {
     await expect(dialogs.profileManager.attachedAccountItems).toHaveCount(1);
 
     await startCommandCaptureWithMocks(page, {
-      save_unified_profile: { ...testProfiles.work, defaultAccounts: {} },
+      save_unified_profile: {
+        profile: { ...testProfiles.work, defaultAccounts: {} },
+        failedRepositories: [],
+      },
     });
 
     // Click the detach (X) button on the attached account
@@ -558,8 +561,8 @@ test.describe('Profile Manager Dialog - Attach with no accounts', () => {
     // And saving persists it to the profile
     await startCommandCaptureWithMocks(page, {
       save_unified_profile: {
-        ...testProfiles.personal,
-        defaultAccounts: { github: 'account-new-gh' },
+        profile: { ...testProfiles.personal, defaultAccounts: { github: 'account-new-gh' } },
+        failedRepositories: [],
       },
     });
     await page.getByRole('button', { name: 'Save Profile' }).click();
@@ -1128,7 +1131,7 @@ test.describe('Profile CRUD Operations', () => {
     // Start capturing commands before clicking save
     // The actual Tauri command is save_unified_profile (not save_profile)
     await startCommandCaptureWithMocks(page, {
-      save_unified_profile: { id: 'profile-cicd', name: 'CI/CD', gitName: 'CI Bot', gitEmail: 'ci@company.com', signingKey: null, urlPatterns: [], isDefault: false, color: '#3b82f6', defaultAccounts: {} },
+      save_unified_profile: { profile: { id: 'profile-cicd', name: 'CI/CD', gitName: 'CI Bot', gitEmail: 'ci@company.com', signingKey: null, urlPatterns: [], isDefault: false, color: '#3b82f6', defaultAccounts: {} }, failedRepositories: [] },
     });
 
     // Click the save button
@@ -1244,7 +1247,7 @@ test.describe('Profile CRUD Operations', () => {
 
     // The actual Tauri command is save_unified_profile
     await startCommandCaptureWithMocks(page, {
-      save_unified_profile: { id: 'profile-test', name: 'Test Profile', gitName: 'Test Author', gitEmail: 'author@test.com', signingKey: null, urlPatterns: [], isDefault: false, color: '#3b82f6', defaultAccounts: {} },
+      save_unified_profile: { profile: { id: 'profile-test', name: 'Test Profile', gitName: 'Test Author', gitEmail: 'author@test.com', signingKey: null, urlPatterns: [], isDefault: false, color: '#3b82f6', defaultAccounts: {} }, failedRepositories: [] },
     });
 
     const saveButton = page.getByRole('button', { name: 'Save Profile' });
@@ -1384,7 +1387,7 @@ test.describe('Profiles - UI Outcome Verification', () => {
     };
 
     await startCommandCaptureWithMocks(page, {
-      save_unified_profile: newProfile,
+      save_unified_profile: { profile: newProfile, failedRepositories: [] },
       get_unified_profiles_config: {
         version: 3,
         profiles: [newProfile],

--- a/src-tauri/src/commands/unified_profiles.rs
+++ b/src-tauri/src/commands/unified_profiles.rs
@@ -233,13 +233,29 @@ pub async fn get_unified_profile(profile_id: String) -> Result<Option<UnifiedPro
     Ok(config.profiles.into_iter().find(|p| p.id == profile_id))
 }
 
-/// Save a unified profile (create or update)
+/// Outcome of saving a profile: the stored profile plus the repositories whose
+/// local git config could not be rewritten with the edited identity.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SaveProfileResult {
+    pub profile: UnifiedProfile,
+    pub failed_repositories: Vec<String>,
+}
+
+/// Save a unified profile (create or update) and push the (possibly edited)
+/// identity back into every repository already assigned to it.
+///
+/// Repositories whose local git config could not be rewritten come back in
+/// `failed_repositories` instead of failing the save.
 #[command]
-pub async fn save_unified_profile(profile: UnifiedProfile) -> Result<UnifiedProfile> {
+pub async fn save_unified_profile(profile: UnifiedProfile) -> Result<SaveProfileResult> {
     let mut config = load_unified_profiles_config()?;
-    config.save_profile(profile.clone());
+    let failed_repositories = save_and_reapply(&mut config, &profile);
     save_unified_profiles_config(&config)?;
-    Ok(profile)
+    Ok(SaveProfileResult {
+        profile,
+        failed_repositories,
+    })
 }
 
 /// Delete a unified profile
@@ -688,6 +704,39 @@ fn apply_profile_git_config(repo_path: &Path, profile: &UnifiedProfile) -> Resul
     }
 
     Ok(())
+}
+
+/// Store an edited profile AND push its identity back into every repository
+/// already assigned to it.
+///
+/// These must happen together, for the same reason assignment writes git config:
+/// the dashboard and the profile list render the profile's identity as the
+/// repository's commit identity, so persisting only the JSON left every assigned
+/// repository committing — and signing — as the profile was BEFORE the edit.
+/// Fixing a typo in a work email or rotating a signing key changed nothing but
+/// what the UI displayed.
+///
+/// Best effort per repository: one that has been moved or deleted must not block
+/// the edit, so its path is returned instead of failing the save.
+///
+/// Takes the config by reference so the pairing is testable without the global
+/// on-disk profile store.
+fn save_and_reapply(config: &mut UnifiedProfilesConfig, profile: &UnifiedProfile) -> Vec<String> {
+    config.save_profile(profile.clone());
+
+    let mut failed: Vec<String> = config
+        .repository_assignments
+        .iter()
+        .filter(|(_, assigned_id)| assigned_id.as_str() == profile.id)
+        .filter(|(repo_path, _)| {
+            apply_profile_git_config(Path::new(repo_path.as_str()), profile).is_err()
+        })
+        .map(|(repo_path, _)| repo_path.clone())
+        .collect();
+    // HashMap iteration order is arbitrary; sort so the paths the UI names come
+    // out in a stable order.
+    failed.sort();
+    failed
 }
 
 /// Apply a profile to a repository (set git config)
@@ -1449,6 +1498,146 @@ mod tests {
                 key
             );
         }
+    }
+
+    /// Editing a profile must rewrite the identity of the repositories that
+    /// already use it.
+    ///
+    /// Saving used to persist only the JSON, so fixing a typo in an email or
+    /// rotating a signing key changed what the dashboard displayed while every
+    /// assigned repository kept committing — and signing — as the profile was
+    /// before the edit.
+    #[test]
+    fn test_editing_a_profile_rewrites_assigned_repositories() {
+        let repo = TestRepo::with_initial_commit();
+
+        let profile = UnifiedProfile::new(
+            "Work".to_string(),
+            "Alice Work".to_string(),
+            "alice@work.example".to_string(),
+        );
+        let profile_id = profile.id.clone();
+
+        let mut config = UnifiedProfilesConfig::default();
+        config.save_profile(profile.clone());
+        assign_and_apply(&mut config, repo.path_str(), profile_id.clone())
+            .expect("assignment should succeed");
+
+        let mut edited = profile;
+        edited.git_email = "alice@newwork.example".to_string();
+        edited.signing_key = Some("ssh-ed25519 AAAAC3Nz".to_string());
+
+        let failed = save_and_reapply(&mut config, &edited);
+
+        assert!(failed.is_empty(), "no repository should have failed");
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "user.email"]
+            )
+            .unwrap(),
+            "alice@newwork.example"
+        );
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "user.signingkey"]
+            )
+            .unwrap(),
+            "ssh-ed25519 AAAAC3Nz"
+        );
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "gpg.format"]
+            )
+            .unwrap(),
+            "ssh"
+        );
+    }
+
+    /// A repository that has been moved or deleted must not block the edit — it
+    /// is reported so the UI can name it.
+    #[test]
+    fn test_editing_a_profile_reports_repositories_it_could_not_update() {
+        let repo = TestRepo::with_initial_commit();
+        let missing = repo.path.join("gone-repo").to_string_lossy().to_string();
+
+        let profile = UnifiedProfile::new(
+            "Work".to_string(),
+            "Alice Work".to_string(),
+            "alice@work.example".to_string(),
+        );
+        let profile_id = profile.id.clone();
+
+        let mut config = UnifiedProfilesConfig::default();
+        config.save_profile(profile.clone());
+        assign_and_apply(&mut config, repo.path_str(), profile_id.clone())
+            .expect("assignment should succeed");
+        // A path that was assigned once and has since disappeared.
+        config.assign_profile(missing.clone(), profile_id.clone());
+
+        let mut edited = profile;
+        edited.git_email = "alice@newwork.example".to_string();
+
+        let failed = save_and_reapply(&mut config, &edited);
+
+        assert_eq!(failed, vec![missing]);
+        // The live repository was still updated...
+        assert_eq!(
+            run_git_config(
+                Some(repo.path.as_path()),
+                &["--local", "--get", "user.email"]
+            )
+            .unwrap(),
+            "alice@newwork.example"
+        );
+        // ...and the edit itself was still stored.
+        assert_eq!(
+            config.get_profile(&profile_id).unwrap().git_email,
+            "alice@newwork.example"
+        );
+    }
+
+    /// Only the edited profile's own repositories may be rewritten.
+    #[test]
+    fn test_editing_a_profile_leaves_other_profiles_repositories_alone() {
+        let repo_a = TestRepo::with_initial_commit();
+        let repo_b = TestRepo::with_initial_commit();
+
+        let profile_a = UnifiedProfile::new(
+            "Work".to_string(),
+            "Alice Work".to_string(),
+            "alice@work.example".to_string(),
+        );
+        let profile_b = UnifiedProfile::new(
+            "Personal".to_string(),
+            "Alice Home".to_string(),
+            "alice@home.example".to_string(),
+        );
+        let id_a = profile_a.id.clone();
+        let id_b = profile_b.id.clone();
+
+        let mut config = UnifiedProfilesConfig::default();
+        config.save_profile(profile_a.clone());
+        config.save_profile(profile_b);
+        assign_and_apply(&mut config, repo_a.path_str(), id_a).expect("assign a");
+        assign_and_apply(&mut config, repo_b.path_str(), id_b).expect("assign b");
+
+        let mut edited = profile_a;
+        edited.git_email = "alice@newwork.example".to_string();
+
+        let failed = save_and_reapply(&mut config, &edited);
+
+        assert!(failed.is_empty());
+        assert_eq!(
+            run_git_config(
+                Some(repo_b.path.as_path()),
+                &["--local", "--get", "user.email"]
+            )
+            .unwrap(),
+            "alice@home.example"
+        );
     }
 
     /// An unknown profile must not be recorded as an assignment.

--- a/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts
@@ -110,7 +110,7 @@ function setupDefaultMocks(): void {
       case 'get_migration_backup_info':
         return { hasBackup: false, backupDate: null, profilesCount: null, accountsCount: null };
       case 'save_unified_profile':
-        return testProfiles[0];
+        return { profile: testProfiles[0], failedRepositories: [] };
       case 'delete_unified_profile':
         return null;
       case 'save_global_account':
@@ -156,7 +156,10 @@ function useConfig(profiles: UnifiedProfile[], accounts: IntegrationAccount[]): 
         return { hasBackup: false, backupDate: null, profilesCount: null, accountsCount: null };
       case 'save_unified_profile':
         // Echo back the submitted profile so the store reflects what was saved.
-        return (args as { profile?: UnifiedProfile } | undefined)?.profile ?? profiles[0] ?? null;
+        return {
+          profile: (args as { profile?: UnifiedProfile } | undefined)?.profile ?? profiles[0] ?? null,
+          failedRepositories: [],
+        };
       case 'delete_global_account':
         return null;
       case 'plugin:dialog|message':
@@ -358,7 +361,7 @@ describe('lv-profile-manager-dialog', () => {
             return { hasBackup: false, backupDate: null, profilesCount: null, accountsCount: null };
           case 'save_unified_profile': {
             const typedArgs = args as { profile: UnifiedProfile };
-            return typedArgs.profile;
+            return { profile: typedArgs.profile, failedRepositories: [] };
           }
           default:
             return null;
@@ -464,7 +467,7 @@ describe('lv-profile-manager-dialog', () => {
             return { hasBackup: false, backupDate: null, profilesCount: null, accountsCount: null };
           case 'save_unified_profile': {
             const typedArgs = args as { profile: UnifiedProfile };
-            return typedArgs.profile;
+            return { profile: typedArgs.profile, failedRepositories: [] };
           }
           default:
             return null;
@@ -671,7 +674,7 @@ describe('lv-profile-manager-dialog', () => {
             return { hasBackup: false, backupDate: null, profilesCount: null, accountsCount: null };
           case 'save_unified_profile': {
             const typedArgs = args as { profile: UnifiedProfile };
-            return typedArgs.profile;
+            return { profile: typedArgs.profile, failedRepositories: [] };
           }
           default:
             return null;
@@ -732,7 +735,7 @@ describe('lv-profile-manager-dialog', () => {
             return { hasBackup: false, backupDate: null, profilesCount: null, accountsCount: null };
           case 'save_unified_profile': {
             const typedArgs = args as { profile: UnifiedProfile };
-            return typedArgs.profile;
+            return { profile: typedArgs.profile, failedRepositories: [] };
           }
           default:
             return null;
@@ -2209,6 +2212,120 @@ describe('lv-profile-manager-dialog', () => {
       expect(shell.viewMode).to.equal('edit');
       const toasts = uiStore.getState().toasts;
       expect(toasts.some((t) => t.type === 'success')).to.be.true;
+    });
+  });
+
+  // Saving a profile re-applies its identity to every repository assigned to it
+  // (the backend rewrites their .git/config). The dialog must report the ones
+  // that kept the old identity, and refresh the open repo when it was rewritten.
+  describe('save re-applies the identity to assigned repositories', () => {
+    function mocksWithSaveResult(
+      failedRepositories: string[],
+      repositoryAssignments: Record<string, string>
+    ): void {
+      mockInvoke = async (command: string, args?: unknown) => {
+        switch (command) {
+          case 'get_unified_profiles_config':
+            return { version: 3, profiles: testProfiles, accounts: testAccounts, repositoryAssignments };
+          case 'get_migration_backup_info':
+            return { hasBackup: false, backupDate: null, profilesCount: null, accountsCount: null };
+          case 'save_unified_profile':
+            return {
+              profile: (args as { profile: UnifiedProfile }).profile,
+              failedRepositories,
+            };
+          default:
+            return null;
+        }
+      };
+    }
+
+    it('names the repositories that kept the old identity', async () => {
+      mocksWithSaveResult(['/repo/personal'], { '/repo/personal': 'profile-1' });
+
+      const el = await renderDialog();
+      uiStore.getState().toasts.length = 0;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const shell = el as any;
+      shell.editingProfile = makeProfile({ id: 'profile-1', gitEmail: 'new@work.com' });
+      shell.viewMode = 'edit';
+      await shell.handleSave();
+      await el.updateComplete;
+
+      const toasts = uiStore.getState().toasts;
+      const warn = toasts.find((t) => t.type === 'warning');
+      expect(warn, 'a warning toast was shown').to.not.be.undefined;
+      expect(warn!.message).to.match(/personal/);
+      expect(toasts.some((t) => t.type === 'success')).to.be.false;
+    });
+
+    it('refreshes the open repository when the saved profile is the one assigned to it', async () => {
+      mocksWithSaveResult([], { '/repo/work': 'profile-1' });
+
+      const el = await renderDialog({ repoPath: '/repo/work' });
+      let refreshed = false;
+      const onRefresh = (): void => {
+        refreshed = true;
+      };
+      window.addEventListener('repository-refresh', onRefresh);
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const shell = el as any;
+        shell.editingProfile = makeProfile({ id: 'profile-1', gitEmail: 'new@work.com' });
+        shell.viewMode = 'edit';
+        await shell.handleSave();
+        await el.updateComplete;
+      } finally {
+        window.removeEventListener('repository-refresh', onRefresh);
+      }
+
+      expect(refreshed, 'repository-refresh was dispatched').to.be.true;
+    });
+
+    it('does not refresh when the open repository is assigned to a different profile', async () => {
+      mocksWithSaveResult([], { '/repo/work': 'profile-2' });
+
+      const el = await renderDialog({ repoPath: '/repo/work' });
+      uiStore.getState().toasts.length = 0;
+      let refreshed = false;
+      const onRefresh = (): void => {
+        refreshed = true;
+      };
+      window.addEventListener('repository-refresh', onRefresh);
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const shell = el as any;
+        shell.editingProfile = makeProfile({ id: 'profile-1', gitEmail: 'new@work.com' });
+        shell.viewMode = 'edit';
+        await shell.handleSave();
+        await el.updateComplete;
+      } finally {
+        window.removeEventListener('repository-refresh', onRefresh);
+      }
+
+      expect(refreshed, 'no refresh for an unrelated profile').to.be.false;
+      expect(uiStore.getState().toasts.some((t) => t.type === 'success')).to.be.true;
+    });
+
+    it('shows the plain success toast when every assigned repository was updated', async () => {
+      mocksWithSaveResult([], { '/repo/personal': 'profile-1' });
+
+      const el = await renderDialog();
+      uiStore.getState().toasts.length = 0;
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const shell = el as any;
+      shell.editingProfile = makeProfile({ id: 'profile-1', gitEmail: 'new@work.com' });
+      shell.viewMode = 'edit';
+      await shell.handleSave();
+      await el.updateComplete;
+
+      const toasts = uiStore.getState().toasts;
+      expect(toasts.filter((t) => t.type === 'success').map((t) => t.message)).to.deep.equal([
+        'Profile saved',
+      ]);
+      expect(toasts.some((t) => t.type === 'warning')).to.be.false;
     });
   });
 

--- a/src/components/dialogs/lv-profile-manager-dialog.ts
+++ b/src/components/dialogs/lv-profile-manager-dialog.ts
@@ -1096,12 +1096,15 @@ export class LvProfileManagerDialog extends LitElement {
   }
 
   // D5: This and its sibling mutators (handleSaveAccount, handleDelete,
-  // handleDeleteGlobalAccount) intentionally dispatch NO change event. The
-  // Zustand unified-profile store subscription is the single source of truth for
-  // UI sync — these handlers call unifiedProfileService.* which updates the store,
-  // and subscribed components re-render. Do NOT add a CustomEvent here: there is
-  // no parent listener for it, so it would be an orphan event (CLAUDE.md
-  // "Event Dispatch Consistency").
+  // handleDeleteGlobalAccount) intentionally dispatch NO profile-change event.
+  // The Zustand unified-profile store subscription is the single source of truth
+  // for UI sync — these handlers call unifiedProfileService.* which updates the
+  // store, and subscribed components re-render. Do NOT add a profile-change
+  // CustomEvent here: there is no parent listener for it, so it would be an
+  // orphan event (CLAUDE.md "Event Dispatch Consistency"). The window-level
+  // `repository-refresh` below is a different thing: saving rewrites the open
+  // repository's .git/config, and app-shell listens for that event (same as
+  // handleApply).
   private async handleSave(): Promise<void> {
     if (!this.editingProfile) return;
 
@@ -1135,13 +1138,31 @@ export class LvProfileManagerDialog extends LitElement {
 
     try {
       const wasCreate = this.viewMode === 'create';
-      await unifiedProfileService.saveUnifiedProfile(profile);
-      showToast(wasCreate ? 'Profile created' : 'Profile saved', 'success');
+      const { failedRepositories } = await unifiedProfileService.saveUnifiedProfile(profile);
+      if (failedRepositories.length > 0) {
+        // Saving rewrites the git identity of every repository assigned to this
+        // profile. Name the ones that kept the old identity instead of showing a
+        // bare "saved" — they are still committing and signing as the profile
+        // was before this edit.
+        const names = failedRepositories.map((p) => this.formatRepoPath(p)).join(', ');
+        showToast(
+          `Profile saved, but ${failedRepositories.length} ${failedRepositories.length === 1 ? 'repository' : 'repositories'} kept the old identity: ${names}`,
+          'warning'
+        );
+      } else {
+        showToast(wasCreate ? 'Profile created' : 'Profile saved', 'success');
+      }
       // After creating a new profile, re-evaluate which profile applies to the
       // current repo. Without this, a freshly-created default profile sits in
       // the list but never becomes active until the user manually applies it.
       if (this.repoPath) {
         await unifiedProfileService.loadUnifiedProfileForRepository(this.repoPath);
+        // If the open repo is assigned to the profile just saved, its
+        // .git/config was rewritten by the save — refresh so listeners re-read
+        // the identity now (same reason handleApply refreshes).
+        if (this.repositoryAssignments[this.repoPath] === profile.id) {
+          window.dispatchEvent(new CustomEvent('repository-refresh'));
+        }
       }
       // Changes are persisted — clear the dirty flag so navigating back doesn't
       // prompt to discard.

--- a/src/services/__tests__/unified-profile.service.test.ts
+++ b/src/services/__tests__/unified-profile.service.test.ts
@@ -265,7 +265,7 @@ describe('unified-profile.service - saveUnifiedProfile default-badge sync', () =
     mockInvoke = async (command: string, args?: unknown) => {
       const params = args as Record<string, unknown> | undefined;
       if (command === 'save_unified_profile') {
-        return params?.profile;
+        return { profile: params?.profile, failedRepositories: [] };
       }
       return null;
     };
@@ -302,6 +302,31 @@ describe('unified-profile.service - saveUnifiedProfile default-badge sync', () =
 
     const profiles = unifiedProfileStore.getState().profiles;
     expect(profiles.find((p) => p.id === 'p-a')!.isDefault).to.be.true;
+  });
+
+  // Saving re-applies the profile's identity to every repository assigned to it.
+  // The caller needs the repositories the backend could not rewrite so it can
+  // tell the user which ones kept the pre-edit identity.
+  it('returns the repositories the backend could not update and stores the saved profile', async () => {
+    const pA = makeTestProfile('p-a', { name: 'A', isDefault: true });
+    const pB = makeTestProfile('p-b', { name: 'B', isDefault: false });
+    unifiedProfileStore.getState().setConfig({
+      version: 3,
+      profiles: [pA, pB],
+      accounts: [],
+      repositoryAssignments: {},
+    });
+    mockInvoke = async () => ({
+      profile: { ...pB, name: 'B renamed' },
+      failedRepositories: ['/repo/gone'],
+    });
+
+    const result = await saveUnifiedProfile({ ...pB, name: 'B renamed' });
+
+    expect(result.failedRepositories).to.deep.equal(['/repo/gone']);
+    expect(result.profile.name).to.equal('B renamed');
+    const profiles = unifiedProfileStore.getState().profiles;
+    expect(profiles.find((p) => p.id === 'p-b')!.name).to.equal('B renamed');
   });
 });
 

--- a/src/services/unified-profile.service.ts
+++ b/src/services/unified-profile.service.ts
@@ -19,6 +19,7 @@ import type {
   UnifiedProfilesConfig,
   IntegrationAccount,
   CurrentGitIdentity,
+  SaveProfileResult,
   MigrationPreview,
   MigrationBackupInfo,
   UnifiedMigrationResult,
@@ -67,15 +68,18 @@ export async function getUnifiedProfile(profileId: string): Promise<UnifiedProfi
 
 /**
  * Save a unified profile (create or update)
+ *
+ * The backend also re-applies the identity to every repository assigned to this
+ * profile; repositories it could not rewrite come back in `failedRepositories`.
  */
-export async function saveUnifiedProfile(profile: UnifiedProfile): Promise<UnifiedProfile> {
-  const result = await invokeCommand<UnifiedProfile>('save_unified_profile', { profile });
+export async function saveUnifiedProfile(profile: UnifiedProfile): Promise<SaveProfileResult> {
+  const result = await invokeCommand<SaveProfileResult>('save_unified_profile', { profile });
   if (!result.success) {
     throw new Error(result.error?.message || 'Failed to save unified profile');
   }
 
   // Update store
-  const saved = result.data!;
+  const { profile: saved, failedRepositories } = result.data!;
   const store = unifiedProfileStore.getState();
   const existingProfile = store.profiles.find((p) => p.id === saved.id);
   if (existingProfile) {
@@ -96,7 +100,7 @@ export async function saveUnifiedProfile(profile: UnifiedProfile): Promise<Unifi
     }
   }
 
-  return saved;
+  return { profile: saved, failedRepositories };
 }
 
 /**

--- a/src/types/unified-profile.types.ts
+++ b/src/types/unified-profile.types.ts
@@ -159,6 +159,15 @@ export interface UnifiedProfilesConfigV2 {
 }
 
 /**
+ * Result of saving a profile: the stored profile, plus the repositories assigned
+ * to it whose local git config could not be rewritten with the edited identity.
+ */
+export interface SaveProfileResult {
+  profile: UnifiedProfile;
+  failedRepositories: string[];
+}
+
+/**
  * Current git identity for a repository
  */
 export interface CurrentGitIdentity {


### PR DESCRIPTION
## What was broken

### Editing a profile's identity or signing key left every assigned repository on the old git config

`save_unified_profile` (`src-tauri/src/commands/unified_profiles.rs`) did three things: load the config, `config.save_profile(...)`, save the config. It never touched git config.

Assignment and unassignment in the same file deliberately pair the mapping with a `.git/config` write — `assign_and_apply` calls `apply_profile_git_config` before recording the mapping, and `unassign_unified_profile_from_repository` calls `clear_profile_git_config` after removing it, both with comments explaining that the two must happen together. The save path had no such pairing.

The result: fix a typo in a work email, or rotate a signing key, and the profile card and context dashboard immediately render the new values while every repository in `repositoryAssignments` pointing at that profile keeps committing — and signing — with the pre-edit `user.name` / `user.email` / `user.signingkey` / `gpg.format`. The divergence is silent and survives restarts, because `.git/config` is what git actually reads.

On the frontend, `handleSave` in `src/components/dialogs/lv-profile-manager-dialog.ts` called `saveUnifiedProfile(profile)` and then only `loadUnifiedProfileForRepository(this.repoPath)` — a store-level active-profile refresh, no git-config write and no `repository-refresh`, unlike its sibling `handleApply`.

## The fix

**Backend** (`unified_profiles.rs`): a new `save_and_reapply` helper stores the profile and then re-applies its identity to every repository whose assignment points at that profile id. It is best effort per repository — one that has been moved or deleted returns its path instead of failing the whole save — and the paths are sorted so the UI names them in a stable order (`HashMap` iteration order is arbitrary). Like `assign_and_apply`, it takes the config by reference so the pairing is testable without the on-disk store. `save_unified_profile` now returns `SaveProfileResult { profile, failedRepositories }`. Creating a profile has no assignments, so the loop is a no-op there.

**Service** (`unified-profile.service.ts`): `saveUnifiedProfile` returns `SaveProfileResult`; the store update and the `isDefault` mirroring keep operating on the saved profile exactly as before.

**Dialog** (`lv-profile-manager-dialog.ts`): when the backend reports repositories it could not rewrite, the toast names them (`warning`) instead of a bare "Profile saved" — they are still on the old identity and the user needs to know which. When the open repository is one of the ones the save rewrote, `repository-refresh` is dispatched so listeners re-read the identity now (the same reason `handleApply` refreshes; `app-shell.ts` listens for it). The `D5` comment above `handleSave` is amended to distinguish this window-level event from the profile-change events that stay intentionally undispatched.

Existing `save_unified_profile` mocks across the unit and E2E suites were wrapped in the new result shape; the `save_unified_profile: null` arms in the validation tests (which assert the command is never called) are untouched.

## Tests

| Test | File | Covers |
| --- | --- | --- |
| `test_editing_a_profile_rewrites_assigned_repositories` | `src-tauri/src/commands/unified_profiles.rs` | Happy path: edited email + signing key land in the assigned repo's `.git/config` (`user.email`, `user.signingkey`, `gpg.format=ssh`) |
| `test_editing_a_profile_reports_repositories_it_could_not_update` | same | Error path: a deleted repo path is reported, the live repo is still updated, the profile edit is still stored |
| `test_editing_a_profile_leaves_other_profiles_repositories_alone` | same | Edge case: editing profile A must not rewrite a repo assigned to profile B |
| `names the repositories that kept the old identity` | `src/components/dialogs/__tests__/lv-profile-manager-dialog.test.ts` | Warning toast names the failed repo; no success toast |
| `refreshes the open repository when the saved profile is the one assigned to it` | same | `repository-refresh` dispatched |
| `does not refresh when the open repository is assigned to a different profile` | same | Edge case: no refresh for an unrelated profile, success toast still shown |
| `shows the plain success toast when every assigned repository was updated` | same | Happy path regression guard for the new branch |
| `returns the repositories the backend could not update and stores the saved profile` | `src/services/__tests__/unified-profile.service.test.ts` | Service returns `failedRepositories` and hands the store the profile, not the wrapper |
| `editing a profile warns about repositories that kept the old identity` | `e2e/tests/profiles-integrations-flows.spec.ts` | Full flow: edit email, save, warning toast naming the repo is visible |

### Verified to fail without the fix

Each production hunk was reverted in turn and the tests re-run:

- `save_and_reapply` body reduced to `config.save_profile(...); Vec::new()`:
  - `test_editing_a_profile_rewrites_assigned_repositories` — `assertion left == right failed / left: "alice@work.example" / right: "alice@newwork.example"`
  - `test_editing_a_profile_reports_repositories_it_could_not_update` — `left: [] / right: ["/tmp/.tmpoVjX1z/gone-repo"]`
- Dialog warning branch disabled: `names the repositories that kept the old identity` — `AssertionError: a warning toast was shown: expected undefined not to be undefined`; E2E `editing a profile warns...` — `expect(locator).toBeVisible() failed / element(s) not found`
- `repository-refresh` dispatch disabled: `refreshes the open repository...` — `AssertionError: repository-refresh was dispatched: expected false to be true`
- Service destructure reverted to the pre-fix `const saved = result.data!` / `return saved`: `returns the repositories the backend could not update...` — `AssertionError: expected 'B' to equal 'B renamed'`

### Gate

`npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --lib` all pass, plus both profile E2E specs (117 passed / 3 skipped) and the CLAUDE.md snake_case grep (the new field is `failedRepositories` on the TS side). The Rust tests were additionally re-run against git 2.55 to match CI.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_