### PR TITLE
Refresh and confirm the dashboard profile switch

### DIFF
--- a/e2e/tests/profiles-integrations-flows.spec.ts
+++ b/e2e/tests/profiles-integrations-flows.spec.ts
@@ -607,6 +607,58 @@ test.describe('Cross-component propagation - toolbar reflects dialog state', () 
     expect(applyArgs.profileId).toBe('profile-personal');
   });
 
+  test('switching profile from the dashboard confirms it and refreshes the identity listeners', async ({ page }) => {
+    await setupProfilesAndAccounts(page, {
+      profiles: [workProfile, personalProfile],
+      accounts: [githubWork],
+    });
+    await injectCommandMock(page, {
+      get_unified_profiles_config: {
+        version: 3,
+        profiles: [workProfile, personalProfile],
+        accounts: [githubWork],
+        repositoryAssignments: {},
+      },
+      apply_unified_profile: null,
+      get_unified_profile: personalProfile,
+    });
+
+    await expect(dashboardProfileName(page)).toHaveText('Work');
+
+    // Clears the capture buffer, so any get_user_identity seen below is a
+    // consequence of the switch, not of the initial repository load.
+    await startCommandCaptureWithMocks(page, {
+      apply_unified_profile: null,
+      get_unified_profile: personalProfile,
+      get_user_identity: {
+        name: 'John Personal',
+        email: 'johnd@personal.com',
+        nameIsGlobal: false,
+        emailIsGlobal: false,
+      },
+    });
+
+    await page.locator('lv-context-dashboard .profile-selector-btn').click();
+    await page.locator('lv-context-dashboard .profile-dropdown .dropdown-item', {
+      hasText: 'Personal',
+    }).click();
+
+    // The chip reflects the new profile...
+    await expect(dashboardProfileName(page)).toHaveText('Personal', { timeout: 5000 });
+
+    // ...the switch confirms itself instead of completing silently...
+    await expect(
+      page.locator('lv-toast-container .toast.success .toast-message')
+    ).toContainText('Personal', { timeout: 5000 });
+
+    // ...and the repository-refresh reaches the commit panel, which re-reads
+    // the git identity behind its commit-template author placeholder. Without
+    // it the rest of the app keeps the old identity until an unrelated refresh.
+    await expect
+      .poll(async () => (await findCommand(page, 'get_user_identity')).length, { timeout: 5000 })
+      .toBeGreaterThan(0);
+  });
+
   test('saving a PAT in the GitHub dialog flips the toolbar dot from Reconnect to connected', async ({ page }) => {
     // Real production path: toolbar starts in Reconnect → user opens GitHub
     // dialog (no stored token → shows PAT form) → enters PAT → handleSaveToken

--- a/src/components/dashboard/__tests__/lv-context-dashboard.test.ts
+++ b/src/components/dashboard/__tests__/lv-context-dashboard.test.ts
@@ -644,6 +644,115 @@ describe('lv-context-dashboard', () => {
     });
   });
 
+  // ── Profile-switch refresh + confirmation ──────────────────────────────────
+  // Applying a profile rewrites the repo's local git identity/signing config,
+  // so the switch must refresh listeners (the commit panel re-reads the author
+  // behind its commit-template placeholder) and confirm itself, exactly like
+  // the profile manager dialog's Apply and this component's fetch/pull/push.
+  describe('profile switch refresh + confirmation', () => {
+    const personalProfile = makeProfile({ id: 'profile-2', name: 'Personal' });
+
+    function captureRefresh(el: HTMLElement): { event: CustomEvent | null } {
+      const captured: { event: CustomEvent | null } = { event: null };
+      el.addEventListener('repository-refresh', (e: Event) => {
+        captured.event = e as CustomEvent;
+      });
+      return captured;
+    }
+
+    it('dispatches repository-refresh naming the repo the switch ran on', async () => {
+      setupStores({ profiles: [defaultProfile, personalProfile] });
+      mockInvoke = async () => null;
+
+      const el = await renderDashboard();
+      const captured = captureRefresh(el);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleSelectProfile(personalProfile);
+      await el.updateComplete;
+
+      expect(captured.event, 'a repository-refresh is dispatched').to.not.be.null;
+      // bubbles + composed so it escapes the shadow root and reaches both
+      // app-shell's @repository-refresh binding and its window listener.
+      expect(captured.event!.bubbles, 'event bubbles').to.be.true;
+      expect(captured.event!.composed, 'event is composed').to.be.true;
+      expect(captured.event!.detail.repoPath).to.equal('/test/repo');
+    });
+
+    it('confirms the switch with a success toast naming the profile', async () => {
+      setupStores({ profiles: [defaultProfile, personalProfile] });
+      mockInvoke = async () => null;
+
+      const el = await renderDashboard();
+      uiStore.setState({ toasts: [] });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleSelectProfile(personalProfile);
+      await el.updateComplete;
+
+      const successToasts = uiStore.getState().toasts.filter((t) => t.type === 'success');
+      expect(successToasts, 'a success toast is shown').to.have.lengthOf(1);
+      expect(successToasts[0].message).to.include('Personal');
+    });
+
+    it('names the repo the switch started in even if the user switches tabs mid-apply', async () => {
+      setupStores({ profiles: [defaultProfile, personalProfile] });
+      mockInvoke = async (command: string) => {
+        if (command === 'apply_unified_profile') {
+          // The user opens another repo while the IPC round-trip is in flight;
+          // addRepository activates it, so this.activeRepository changes before
+          // the await resolves.
+          repositoryStore
+            .getState()
+            .addRepository(makeRepository({ path: '/test/other', name: 'other' }));
+        }
+        return null;
+      };
+
+      const el = await renderDashboard();
+      const captured = captureRefresh(el);
+      clearHistory();
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleSelectProfile(personalProfile);
+      await el.updateComplete;
+
+      const applyCall = invokeHistory.find((c) => c.command === 'apply_unified_profile');
+      expect(applyCall, 'the profile was applied').to.not.be.undefined;
+      expect((applyCall!.args as { path: string }).path).to.equal('/test/repo');
+
+      expect(captured.event, 'a repository-refresh is dispatched').to.not.be.null;
+      expect(captured.event!.detail.repoPath).to.equal('/test/repo');
+    });
+
+    it('emits no refresh and no success toast when the switch fails', async () => {
+      setupStores({ profiles: [defaultProfile, personalProfile] });
+      mockInvoke = async (command: string) => {
+        if (command === 'apply_unified_profile') {
+          throw new Error('git config is locked');
+        }
+        return null;
+      };
+
+      const el = await renderDashboard();
+      uiStore.setState({ toasts: [] });
+      const captured = captureRefresh(el);
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleSelectProfile(personalProfile);
+      await el.updateComplete;
+
+      expect(captured.event, 'no refresh for a failed apply').to.be.null;
+      expect(
+        uiStore.getState().toasts.filter((t) => t.type === 'success'),
+        'no success toast for a failed apply'
+      ).to.have.lengthOf(0);
+      const errorToasts = uiStore.getState().toasts.filter((t) => t.type === 'error');
+      expect(errorToasts.length, 'the failure is still surfaced').to.be.greaterThan(0);
+      expect(errorToasts[0].message).to.include('Failed to switch profile');
+    });
+  });
+
   // ── Default-account precedence (Wave 1, item 6) ────────────────────────────
   describe('default account precedence badge', () => {
     it('marks the active account as Global default when it is account.isDefault but not a profile preference', async () => {

--- a/src/components/dashboard/lv-context-dashboard.ts
+++ b/src/components/dashboard/lv-context-dashboard.ts
@@ -876,13 +876,26 @@ export class LvContextDashboard extends LitElement {
     if (!this.activeRepository || this.isApplyingProfile) return;
 
     this.isProfileDropdownOpen = false;
+    // Captured before the await: applying is an IPC round-trip, and the
+    // refresh must name the repo the switch ran ON, not whichever tab is
+    // active when it returns.
+    const repoPath = this.activeRepository.repository.path;
     this.isApplyingProfile = true;
 
     try {
-      await unifiedProfileService.applyUnifiedProfile(
-        this.activeRepository.repository.path,
-        profile.id
-      );
+      await unifiedProfileService.applyUnifiedProfile(repoPath, profile.id);
+      showToast(`Applied profile "${profile.name}"`, 'success');
+      // Applying a profile rewrites the repo's local git identity/signing
+      // config. Refresh so listeners re-read it now (the commit panel reloads
+      // the author behind its ${author} commit-template placeholder) instead
+      // of only after the tab is re-switched — the same reason the profile
+      // manager's Apply refreshes. Inside the try, so a failed apply never
+      // announces success or refreshes.
+      this.dispatchEvent(new CustomEvent('repository-refresh', {
+        bubbles: true,
+        composed: true,
+        detail: { repoPath },
+      }));
     } catch (err) {
       // Surface the failure via a visible toast — the repository store's error
       // field has no render sink, so setError alone would be silent (CLAUDE.md


### PR DESCRIPTION
## What was broken

### Dashboard profile switch does not refresh listeners or confirm itself

`handleSelectProfile` in `src/components/dashboard/lv-context-dashboard.ts` awaited `unifiedProfileService.applyUnifiedProfile(...)` and, on success, did nothing at all — no success toast, no `repository-refresh`. Only the `catch` produced any user-visible feedback.

Two consequences:

1. **Stale identity everywhere but the chip.** Applying a profile rewrites the repository's *local git identity/signing config*. `applyUnifiedProfile` itself only calls `unifiedProfileStore.setActiveProfile(...)`, so the dashboard chip updated while the rest of the app kept the old identity. `src/components/sidebar/lv-commit-panel.ts` registers `window.addEventListener('repository-refresh', this.boundHandleRepositoryRefresh)` where the handler is `() => this.loadAuthorName()` — that call re-reads `get_user_identity` into `cachedAuthor`, the value substituted for the `${author}` commit-template placeholder. With no dispatch, the commit panel kept offering the previous author until some unrelated refresh happened.
2. **Silent success.** The user got no confirmation the switch had landed.

This is a cross-surface inconsistency, not just a missing nicety. The same operation reached from the profile manager (`handleApply` in `src/components/dialogs/lv-profile-manager-dialog.ts`) already shows `Applied profile "..."` and dispatches `repository-refresh`, with a comment giving exactly this reason. And within this component it was the only state-modifying handler without a dispatch — `handleFetch`/`handlePull`/`handlePush` each dispatch `repository-refresh` with `{ bubbles: true, composed: true, detail: { repoPath } }` (CLAUDE.md *Event Dispatch Consistency* + *User Feedback Consistency*).

## The fix

Scoped entirely to `handleSelectProfile`; guard, dropdown close, `isApplyingProfile` flag, `catch` and `finally` are untouched.

- Capture `repoPath` **before** the await, matching the sibling remote handlers, so the refresh names the repo the switch ran *in* rather than whichever tab is active when the IPC round-trip returns.
- After a successful apply, inside the `try`: `showToast(\`Applied profile "${profile.name}"\`, 'success')` — deliberately the same string the profile manager uses, so both surfaces of one operation say the same thing.
- Then dispatch `repository-refresh` with `{ bubbles: true, composed: true, detail: { repoPath } }`, matching the fetch/pull/push siblings. It has listeners: app-shell binds `@repository-refresh=${() => this.handleRefresh()}` on `<lv-context-dashboard>`, and being composed it also reaches app-shell's window-level `handleWindowRefresh`, which can pin the refresh to the originating repo via `detail.repoPath`.

Both additions live inside the `try`, so a failed apply still produces only the existing error toast — it never announces success and never refreshes. No new state, no new imports (`showToast` was already imported), no invoke args added.

## Tests

| Test | File | Covers |
| --- | --- | --- |
| dispatches repository-refresh naming the repo the switch ran on | `src/components/dashboard/__tests__/lv-context-dashboard.test.ts` | Happy path — event fires, is `bubbles`+`composed`, `detail.repoPath === '/test/repo'` |
| confirms the switch with a success toast naming the profile | same | Happy path — exactly one success toast, mentions the profile |
| names the repo the switch started in even if the user switches tabs mid-apply | same | Edge case — a second repo is activated *during* the in-flight apply; asserts the invoke and the refresh both carry the originating path |
| emits no refresh and no success toast when the switch fails | same | Error path — no refresh, no success toast, existing error toast intact |
| switching profile from the dashboard confirms it and refreshes the identity listeners | `e2e/tests/profiles-integrations-flows.spec.ts` | Full stack — chip updates, success toast visible, and `get_user_identity` is re-invoked (proving the refresh actually reached the commit panel's listener) |

### Verified to fail without the fix

Production change reverted, tests re-run:

- *dispatches repository-refresh naming the repo the switch ran on* → `AssertionError: a repository-refresh is dispatched: expected null not to be null`
- *confirms the switch with a success toast naming the profile* → `AssertionError: a success toast is shown: expected [] to have a length of 1 but got 0`
- *names the repo the switch started in even if the user switches tabs mid-apply* → `AssertionError: a repository-refresh is dispatched: expected null not to be null`; and against a naive variant that re-reads `this.activeRepository` *after* the await it fails with `expected '/test/other' to equal '/test/repo'`, pinning the pre-await capture
- *E2E* → toast assertion fails with `expect(locator).toContainText(expected) failed / element(s) not found`; with the toast kept but only the dispatch removed, the second assertion fails with `expect(received).toBeGreaterThan(expected) / Expected: > 0 / Received: 0`, proving the refresh reaching the commit panel is what that assertion measures

The error-path test passes both with and without the fix by design — it is a regression guard that locks the toast and dispatch *inside* the `try` (a `finally`-block implementation would announce success for a failed apply), not a bisect test. The two pre-existing error-feedback tests stay green.

## Gate

`npm run lint`, `npm run typecheck`, `npm test` all pass; `npx playwright test --config=e2e/playwright.config.ts e2e/tests/profiles-integrations-flows.spec.ts` passes in full. `cargo fmt --check` clean (no Rust touched). The snake_case grep returns only pre-existing, unrelated matches — this change adds no invoke args.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_