### PR TITLE
Keep the recents remove button inside its row on the welcome screen

### DIFF
--- a/e2e/tests/welcome.spec.ts
+++ b/e2e/tests/welcome.spec.ts
@@ -578,3 +578,88 @@ test.describe('Welcome - Extended Tests', () => {
     await expect(app.welcomeScreen).not.toBeVisible({ timeout: 10000 });
   });
 });
+
+test.describe('Welcome Screen - recent repository rows', () => {
+  let app: AppPage;
+
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMocks(page, emptyRepository());
+    app = new AppPage(page);
+    await app.goto();
+
+    await page.waitForFunction(
+      () => typeof (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ !== 'undefined',
+      { timeout: 10000 }
+    );
+
+    // Seed recents through the store: most recent first ⇒ rows are repo1, repo2.
+    await page.evaluate(() => {
+      const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as {
+        repositoryStore: {
+          getState: () => {
+            clearRecentRepositories: () => void;
+            addRecentRepository: (path: string, name: string) => void;
+          };
+        };
+      };
+      const state = stores.repositoryStore.getState();
+      state.clearRecentRepositories();
+      state.addRecentRepository('/path/to/repo2', 'repo2');
+      state.addRecentRepository('/path/to/repo1', 'repo1');
+    });
+
+    await expect(app.recentItems).toHaveCount(2);
+  });
+
+  test('reveals the per-row remove control on hover', async () => {
+    const remove = app.recentItems.first().locator('.recent-remove');
+    await expect(remove).toHaveCount(1);
+
+    await expect
+      .poll(() => remove.evaluate((el) => getComputedStyle(el).opacity))
+      .toBe('0');
+
+    await app.recentItems.first().hover();
+
+    await expect
+      .poll(() => remove.evaluate((el) => getComputedStyle(el).opacity))
+      .toBe('1');
+  });
+
+  test('has no stray remove buttons sitting between rows', async () => {
+    await expect(app.welcomeScreen.locator('.recent-list > button.recent-remove')).toHaveCount(0);
+  });
+
+  test('removes only the clicked entry and does not open it', async ({ page }) => {
+    await startCommandCapture(page);
+
+    await app.recentItems.first().hover();
+    await app.recentItems.first().locator('.recent-remove').click();
+
+    await expect(app.recentItems).toHaveCount(1);
+    await expect(app.recentItems.first()).toContainText('repo2');
+    expect(await findCommand(page, 'open_repository')).toHaveLength(0);
+  });
+
+  test('opens a recent repository with the keyboard', async ({ page }) => {
+    await startCommandCapture(page);
+
+    await app.recentItems.first().press('Enter');
+
+    await waitForCommand(page, 'open_repository');
+    const openCmds = await findCommand(page, 'open_repository');
+    expect(openCmds.length).toBeGreaterThan(0);
+    expect((openCmds[0].args as { path: string }).path).toBe('/path/to/repo1');
+  });
+
+  test('Enter on the remove button removes the entry without opening it', async ({ page }) => {
+    await startCommandCapture(page);
+
+    await app.recentItems.first().hover();
+    await app.recentItems.first().locator('.recent-remove').press('Enter');
+
+    await expect(app.recentItems).toHaveCount(1);
+    await expect(app.recentItems.first()).toContainText('repo2');
+    expect(await findCommand(page, 'open_repository')).toHaveLength(0);
+  });
+});

--- a/src/components/welcome/__tests__/lv-welcome-recents.test.ts
+++ b/src/components/welcome/__tests__/lv-welcome-recents.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for the welcome screen's recent-repository rows: the per-row remove
+ * control must be a real descendant of its row (a nested <button> inside a
+ * <button> is hoisted out by the HTML parser), and the row must stay
+ * activatable by mouse and keyboard.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
+const mockResponses: Record<string, (args: Record<string, unknown>) => unknown> = {};
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCallArgs.push({ command, args: args || {} });
+    const handler = mockResponses[command];
+    try {
+      return Promise.resolve(handler ? handler(args || {}) : null);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-welcome.ts';
+import type { LvWelcome } from '../lv-welcome.ts';
+import { repositoryStore } from '../../../stores/index.ts';
+
+function mockRepoPayload(path: string) {
+  return {
+    path,
+    name: path.split('/').pop(),
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+/** Let the click handler's promise chain settle. */
+async function flush(el: LvWelcome): Promise<void> {
+  await el.updateComplete;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await el.updateComplete;
+}
+
+function openCalls() {
+  return invokeCallArgs.filter((c) => c.command === 'open_repository');
+}
+
+describe('lv-welcome recent repository rows', () => {
+  let el: LvWelcome;
+
+  beforeEach(async () => {
+    invokeCallArgs.length = 0;
+    for (const key of Object.keys(mockResponses)) {
+      delete mockResponses[key];
+    }
+    repositoryStore.getState().reset();
+    // Most recent first ⇒ rendered order is alpha, beta.
+    repositoryStore.getState().addRecentRepository('/repos/beta', 'beta');
+    repositoryStore.getState().addRecentRepository('/repos/alpha', 'alpha');
+    mockResponses['open_repository'] = (args) => mockRepoPayload(args.path as string);
+
+    el = await fixture<LvWelcome>(html`<lv-welcome></lv-welcome>`);
+    await el.updateComplete;
+  });
+
+  afterEach(() => {
+    repositoryStore.getState().reset();
+  });
+
+  it('nests each remove control inside its own recent row', () => {
+    const root = el.shadowRoot!;
+    expect(root.querySelectorAll('.recent-item').length).to.equal(2);
+    expect(root.querySelectorAll('.recent-item .recent-remove').length).to.equal(2);
+    // A nested <button> would be hoisted out and become a stray sibling row.
+    expect(root.querySelectorAll('.recent-list > .recent-remove').length).to.equal(0);
+
+    const row = root.querySelector('.recent-item') as HTMLElement;
+    expect(row.tagName).to.equal('DIV');
+    expect(row.getAttribute('role')).to.equal('button');
+    expect(row.getAttribute('tabindex')).to.equal('0');
+  });
+
+  it('opens the repository when a recent row is clicked', async () => {
+    const row = el.shadowRoot!.querySelector('.recent-item') as HTMLElement;
+    row.click();
+    await flush(el);
+
+    expect(openCalls().length).to.equal(1);
+    expect(openCalls()[0].args.path).to.equal('/repos/alpha');
+    const state = repositoryStore.getState();
+    expect(state.openRepositories.length).to.equal(1);
+    expect(state.openRepositories[0].repository.path).to.equal('/repos/alpha');
+  });
+
+  it('opens the repository when Enter is pressed on a focused recent row', async () => {
+    const row = el.shadowRoot!.querySelector('.recent-item') as HTMLElement;
+    row.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true }));
+    await flush(el);
+
+    expect(openCalls().length).to.equal(1);
+    expect(openCalls()[0].args.path).to.equal('/repos/alpha');
+  });
+
+  it('removes only that entry when its remove button is clicked, without opening the repository', async () => {
+    const remove = el.shadowRoot!.querySelector('.recent-item .recent-remove') as HTMLButtonElement;
+    expect(remove, 'remove button must be a descendant of its row').to.exist;
+    remove.click();
+    await flush(el);
+
+    expect(repositoryStore.getState().recentRepositories.map((r) => r.path)).to.deep.equal([
+      '/repos/beta',
+    ]);
+    expect(el.shadowRoot!.querySelectorAll('.recent-item').length).to.equal(1);
+    expect(openCalls().length).to.equal(0);
+  });
+
+  it('removes the entry — and does not open it — when Enter is pressed on the remove button', async () => {
+    const remove = el.shadowRoot!.querySelector('.recent-item .recent-remove') as HTMLButtonElement;
+    expect(remove, 'remove button must be a descendant of its row').to.exist;
+    remove.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter', bubbles: true, composed: true })
+    );
+    await flush(el);
+
+    expect(repositoryStore.getState().recentRepositories.map((r) => r.path)).to.deep.equal([
+      '/repos/beta',
+    ]);
+    expect(openCalls().length).to.equal(0);
+  });
+
+  it('ignores unrelated keys on a recent row and on its remove button', async () => {
+    const row = el.shadowRoot!.querySelector('.recent-item') as HTMLElement;
+    const remove = el.shadowRoot!.querySelector('.recent-item .recent-remove') as HTMLButtonElement;
+    row.dispatchEvent(new KeyboardEvent('keydown', { key: 'a', bubbles: true, composed: true }));
+    remove.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', bubbles: true, composed: true }));
+    await flush(el);
+
+    expect(openCalls().length).to.equal(0);
+    expect(repositoryStore.getState().recentRepositories.length).to.equal(2);
+  });
+
+  it('surfaces an error and opens nothing when a recent repository can no longer be opened', async () => {
+    mockResponses['open_repository'] = () => {
+      throw new Error('repository not found');
+    };
+    const row = el.shadowRoot!.querySelector('.recent-item') as HTMLElement;
+    row.click();
+    await flush(el);
+
+    const state = repositoryStore.getState();
+    expect(state.openRepositories.length).to.equal(0);
+    expect(state.error ?? '').to.contain('repository not found');
+  });
+});

--- a/src/components/welcome/lv-welcome.ts
+++ b/src/components/welcome/lv-welcome.ts
@@ -217,7 +217,8 @@ export class LvWelcome extends LitElement {
         transition: opacity var(--transition-fast);
       }
 
-      .recent-item:hover .recent-remove {
+      .recent-item:hover .recent-remove,
+      .recent-remove:focus-visible {
         opacity: 1;
       }
 
@@ -402,7 +403,29 @@ export class LvWelcome extends LitElement {
     this.openRepoByPath(path);
   }
 
+  private handleRecentKeydown(e: KeyboardEvent, path: string): void {
+    // The nested remove button's keydown bubbles up to the row, so activating
+    // on it unconditionally would open the repository the user just removed.
+    // Only the row itself activates.
+    if (e.target !== e.currentTarget) return;
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    e.preventDefault();
+    e.stopPropagation();
+    this.handleRecentClick(path);
+  }
+
   private handleRecentRemove(e: Event, path: string): void {
+    e.stopPropagation();
+    repositoryStore.getState().removeRecentRepository(path);
+  }
+
+  private handleRecentRemoveKeydown(e: KeyboardEvent, path: string): void {
+    if (e.key !== 'Enter' && e.key !== ' ') return;
+    // The global keyboard service claims Enter/Space and cancels them before
+    // the browser turns them into a click, so the button needs to activate
+    // itself. preventDefault also suppresses any native activation, keeping
+    // the removal to exactly one call.
+    e.preventDefault();
     e.stopPropagation();
     repositoryStore.getState().removeRecentRepository(path);
   }
@@ -569,9 +592,13 @@ export class LvWelcome extends LitElement {
                 <div class="recent-list">
                   ${this.recentRepositories.map(
                     (repo) => html`
-                      <button
+                      <div
                         class="recent-item"
+                        role="button"
+                        tabindex="0"
+                        aria-label="Open ${repo.name}"
                         @click=${() => this.handleRecentClick(repo.path)}
+                        @keydown=${(e: KeyboardEvent) => this.handleRecentKeydown(e, repo.path)}
                       >
                         <svg class="recent-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                           <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
@@ -582,14 +609,17 @@ export class LvWelcome extends LitElement {
                         </div>
                         <button
                           class="recent-remove"
+                          title="Remove from recent repositories"
+                          aria-label="Remove ${repo.name} from recent repositories"
                           @click=${(e: Event) => this.handleRecentRemove(e, repo.path)}
+                          @keydown=${(e: KeyboardEvent) => this.handleRecentRemoveKeydown(e, repo.path)}
                         >
                           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <line x1="18" y1="6" x2="6" y2="18"></line>
                             <line x1="6" y1="6" x2="18" y2="18"></line>
                           </svg>
                         </button>
-                      </button>
+                      </div>
                     `
                   )}
                 </div>


### PR DESCRIPTION
## What was broken

### Nested `<button>` hoisted the per-item recents remove control out of its row

`src/components/welcome/lv-welcome.ts` rendered every recent repository as a `<button class="recent-item">` (click = open the repo) with a second `<button class="recent-remove">` nested inside it. Per the HTML parsing spec, a `<button>` start tag while a button is in button scope generates implied end tags and pops the open button — so the template parser closed the row and hoisted `.recent-remove` out as a **sibling** inside `.recent-list`. Two user-visible consequences:

1. **Per-item removal was invisible.** The reveal rule `.recent-item:hover .recent-remove { opacity: 1 }` is a descendant selector that could never match after the hoist, so the X stayed pinned at `opacity: 0`. Users had no way to discover or see per-item removal and could only "Clear" everything.
2. **Invisible click targets deleted entries.** `.recent-list` is `display: flex; flex-direction: column; gap`, so each hoisted 20×20 control became its own flex row *between* entries — invisible but fully clickable, with `handleRecentRemove` still bound. A click that landed between rows silently deleted a recent repository.

While testing this, a third defect fell out: the row was a native `<button>`, but the global keyboard service (`src/services/keyboard.service.ts`) claims `Enter` (`preventDefault` + `stopPropagation`) before the browser turns it into a click, so **recent rows could not be activated from the keyboard at all** — the e2e keyboard test fails against the unpatched row.

## The fix

- The row is now a `<div class="recent-item" role="button" tabindex="0" aria-label="Open …">` with `@click` and `@keydown` activation — the pattern already used by `.group-header` in `lv-tag-list.ts` — so `.recent-remove` can stay a real nested `<button>` and the hover-reveal rule matches again.
- `handleRecentKeydown` activates only when `e.target === e.currentTarget`; otherwise the remove button's bubbling `Enter` would open the repository the user just removed.
- `handleRecentRemoveKeydown` activates the remove button on `Enter`/`Space` itself (with `preventDefault`, which also suppresses any native activation so removal happens exactly once), because the global keyboard service cancels those keys before a click is generated.
- CSS: the reveal rule now also matches `.recent-remove:focus-visible`, since the control is genuinely tab-reachable and would otherwise be focused while invisible. `sharedStyles`' global `:focus-visible` outline gives the `tabindex="0"` row its focus ring.

No store, service, or Rust change; no new events, so no listener work in `app-shell.ts`.

## Tests

New unit file `src/components/welcome/__tests__/lv-welcome-recents.test.ts` and a new `Welcome Screen - recent repository rows` describe block in `e2e/tests/welcome.spec.ts`.

| Test | Kind | Covers | Fails without the fix |
| --- | --- | --- | --- |
| nests each remove control inside its own recent row | unit | structure — the core defect | yes: `.recent-item .recent-remove` → 0, expected 2 |
| opens the repository when a recent row is clicked | unit | happy path / guards the div conversion | no (regression guard) |
| opens the repository when Enter is pressed on a focused recent row | unit | keyboard happy path | yes: `expected 0 to equal 1` open calls |
| removes only that entry when its remove button is clicked, without opening the repository | unit | removal + `stopPropagation` | yes: `expected null to exist` (button is a sibling) |
| removes the entry — and does not open it — when Enter is pressed on the remove button | unit | edge case: target guard + local key activation | yes: `expected null to exist` |
| ignores unrelated keys on a recent row and on its remove button | unit | edge case: non-activation keys | no (guard) |
| surfaces an error and opens nothing when a recent repository can no longer be opened | unit | error path | no (error-path guard) |
| reveals the per-row remove control on hover | e2e | the invisible-X symptom | yes: `toHaveCount` 1 → received 0 |
| has no stray remove buttons sitting between rows | e2e | the invisible click targets | yes: `toHaveCount` 0 → received 2 |
| removes only the clicked entry and does not open it | e2e | user-visible removal | yes: `locator.click` times out |
| opens a recent repository with the keyboard | e2e | keyboard activation | yes: `waitForFunction` timeout — `open_repository` never invoked |
| Enter on the remove button removes the entry without opening it | e2e | edge case | yes: `locator.press` times out |

**Verified by reverting only `lv-welcome.ts` and re-running:** 4 of 7 unit tests fail (structure, keyboard-open, click-remove, Enter-remove) and **all 5** e2e tests fail; with the fix restored, 7/7 unit and 39/39 e2e in `welcome.spec.ts` pass.

Gate: `npm run lint`, `npm run typecheck`, `npm test` all green; `cargo fmt --check` green (no Rust touched).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_