### PR TITLE
Count workspace ahead/behind against the branch's real upstream

### DIFF
--- a/e2e/tests/workspace-manager.spec.ts
+++ b/e2e/tests/workspace-manager.spec.ts
@@ -109,3 +109,66 @@ test.describe('Workspace Manager - open-repo-file handler', () => {
     await expect(page.locator('lv-toast-container .toast.error, lv-toast-container .toast-error')).toBeVisible({ timeout: 5000 });
   });
 });
+
+
+test.describe('Workspace Manager - repo status chips', () => {
+  test('renders the tracked branch with its ahead/behind counts and labels a detached repo', async ({ page }) => {
+    await setupOpenRepository(page);
+
+    await startCommandCaptureWithMocks(page, {
+      get_workspaces: [
+        {
+          id: 'ws-1',
+          name: 'Alpha Workspace',
+          description: '',
+          color: '#4fc3f7',
+          repositories: [
+            { path: '/repos/alpha', name: 'alpha' },
+            { path: '/repos/beta', name: 'beta' },
+          ],
+          createdAt: '2024-01-01T00:00:00Z',
+          lastOpened: null,
+        },
+      ],
+      search_workspace: [],
+      validate_workspace_repositories: [
+        {
+          path: '/repos/alpha',
+          name: 'alpha',
+          exists: true,
+          isValidRepo: true,
+          changedFilesCount: 0,
+          currentBranch: 'main',
+          isDetached: false,
+          ahead: 2,
+          behind: 1,
+        },
+        {
+          path: '/repos/beta',
+          name: 'beta',
+          exists: true,
+          isValidRepo: true,
+          changedFilesCount: 0,
+          currentBranch: null,
+          isDetached: true,
+          ahead: 0,
+          behind: 0,
+        },
+      ],
+    });
+
+    // The dialog auto-selects the first workspace on open.
+    await openWorkspaceManager(page);
+
+    const dialog = page.locator('lv-workspace-manager-dialog');
+
+    // The tracked branch keeps its name and its counts...
+    await expect(dialog.locator('.repo-branch').first()).toHaveText('main');
+    await expect(dialog.locator('.repo-ahead-behind').first()).toHaveText('↑2 ↓1');
+
+    // ...and the detached repo says so instead of showing a branch named HEAD,
+    // with no ahead/behind, which is what git reports for it.
+    await expect(dialog.locator('.repo-branch.detached')).toHaveText('detached HEAD');
+    await expect(dialog.locator('.repo-ahead-behind')).toHaveCount(1);
+  });
+});

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -213,6 +213,7 @@ pub async fn validate_workspace_repositories(
                 is_valid_repo: false,
                 changed_files_count: 0,
                 current_branch: None,
+                is_detached: false,
                 ahead: 0,
                 behind: 0,
             });
@@ -221,10 +222,7 @@ pub async fn validate_workspace_repositories(
 
         match Repository::open(repo_path) {
             Ok(repo) => {
-                let current_branch = repo
-                    .head()
-                    .ok()
-                    .and_then(|head| head.shorthand().ok().map(String::from));
+                let (current_branch, is_detached) = head_branch(&repo);
 
                 let changed_files_count = repo
                     .statuses(Some(
@@ -245,6 +243,7 @@ pub async fn validate_workspace_repositories(
                     is_valid_repo: true,
                     changed_files_count,
                     current_branch,
+                    is_detached,
                     ahead,
                     behind,
                 });
@@ -257,6 +256,7 @@ pub async fn validate_workspace_repositories(
                     is_valid_repo: false,
                     changed_files_count: 0,
                     current_branch: None,
+                    is_detached: false,
                     ahead: 0,
                     behind: 0,
                 });
@@ -399,30 +399,66 @@ pub async fn import_workspace(json_data: String) -> Result<Workspace> {
     Ok(workspace)
 }
 
-/// Compute ahead/behind counts for HEAD relative to its upstream tracking branch
+/// The checked-out branch name, plus whether HEAD is detached.
+///
+/// `shorthand()` returns the literal "HEAD" on a detached HEAD, which the
+/// workspace dialog then rendered as if it were a branch called "HEAD". An
+/// unborn HEAD has no branch yet and is not detached either.
+fn head_branch(repo: &Repository) -> (Option<String>, bool) {
+    let head = match repo.head() {
+        Ok(h) => h,
+        Err(_) => return (None, false),
+    };
+
+    if !head.is_branch() {
+        return (None, true);
+    }
+
+    (head.shorthand().ok().map(String::from), false)
+}
+
+/// Compute ahead/behind counts for HEAD relative to its configured upstream
+/// tracking branch
 fn compute_ahead_behind(repo: &Repository) -> (usize, usize) {
     let head = match repo.head() {
         Ok(h) => h,
         Err(_) => return (0, 0),
     };
 
+    // A detached HEAD is not a branch, so it has no upstream to compare
+    // against. shorthand() is the literal "HEAD" when detached, which used to
+    // resolve refs/remotes/origin/HEAD — the remote's default-branch pointer —
+    // and count the checked-out commit against it.
+    if !head.is_branch() {
+        return (0, 0);
+    }
+
     let local_oid = match head.target() {
         Some(oid) => oid,
         None => return (0, 0),
     };
 
-    let branch_name = match head.shorthand().ok() {
-        Some(name) => name.to_string(),
-        None => return (0, 0),
-    };
-
-    let upstream_name = format!("refs/remotes/origin/{}", branch_name);
-    let upstream_ref = match repo.find_reference(&upstream_name) {
-        Ok(r) => r,
+    let branch_name = match head.shorthand() {
+        Ok(name) => name,
         Err(_) => return (0, 0),
     };
 
-    let upstream_oid = match upstream_ref.target() {
+    // Follow the branch's own upstream (branch.<name>.remote/merge) rather than
+    // assuming origin/<branch>. A fork tracking upstream/main, a clone whose
+    // remote is not called "origin", and a branch tracking a differently named
+    // remote branch each counted against the wrong ref or reported nothing —
+    // and disagreed with the branches panel for the same repository, which has
+    // always used the configured upstream. A branch with no upstream has
+    // nothing to report, which is not a failure.
+    let upstream = match repo
+        .find_branch(branch_name, git2::BranchType::Local)
+        .and_then(|b| b.upstream())
+    {
+        Ok(u) => u,
+        Err(_) => return (0, 0),
+    };
+
+    let upstream_oid = match upstream.get().target() {
         Some(oid) => oid,
         None => return (0, 0),
     };
@@ -434,6 +470,151 @@ fn compute_ahead_behind(repo: &Repository) -> (usize, usize) {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_utils::TestRepo;
+
+    /// Commit on top of `parent` without moving any ref — stands in for
+    /// commits that only exist on the remote-tracking side.
+    fn dangling_commit(repo: &Repository, parent: git2::Oid, message: &str) -> git2::Oid {
+        let parent_commit = repo.find_commit(parent).expect("parent commit");
+        let tree = parent_commit.tree().expect("parent tree");
+        let sig = repo.signature().expect("signature");
+        repo.commit(None, &sig, &sig, message, &tree, &[&parent_commit])
+            .expect("commit")
+    }
+
+    fn set_remote_ref(repo: &Repository, refname: &str, oid: git2::Oid) {
+        repo.reference(refname, oid, true, "test").expect("ref");
+    }
+
+    /// Fork workflow: `origin` is your stale fork, the branch tracks
+    /// `upstream/main`. Counting against origin/<branch> reported "in sync"
+    /// for a branch that is two commits ahead of what it actually tracks.
+    #[test]
+    fn test_ahead_behind_follows_the_configured_upstream_not_origin() {
+        let test_repo = TestRepo::with_initial_commit();
+        let base = test_repo.head_oid();
+        test_repo.create_commit("Local 1", &[("a.txt", "a")]);
+        test_repo.create_commit("Local 2", &[("b.txt", "b")]);
+        let local_tip = test_repo.head_oid();
+
+        let repo = test_repo.repo();
+        let branch = test_repo.current_branch();
+        repo.remote("origin", "https://example.com/fork.git")
+            .unwrap();
+        repo.remote("upstream", "https://example.com/canonical.git")
+            .unwrap();
+
+        // The fork is up to date with the local branch; the real upstream is not.
+        set_remote_ref(&repo, &format!("refs/remotes/origin/{}", branch), local_tip);
+        set_remote_ref(&repo, &format!("refs/remotes/upstream/{}", branch), base);
+
+        repo.find_branch(&branch, git2::BranchType::Local)
+            .unwrap()
+            .set_upstream(Some(&format!("upstream/{}", branch)))
+            .unwrap();
+
+        assert_eq!(compute_ahead_behind(&repo), (2, 0));
+    }
+
+    /// `git clone -o github` (or a renamed remote): there is no
+    /// refs/remotes/origin/* at all, so a hard-coded origin lookup reported
+    /// 0/0 while git reported divergence in both directions.
+    #[test]
+    fn test_ahead_behind_reports_divergence_when_the_remote_is_not_named_origin() {
+        let test_repo = TestRepo::with_initial_commit();
+        let base = test_repo.head_oid();
+        test_repo.create_commit("Local 1", &[("a.txt", "a")]);
+
+        let repo = test_repo.repo();
+        let branch = test_repo.current_branch();
+        repo.remote("github", "https://example.com/repo.git")
+            .unwrap();
+        assert!(repo.find_remote("origin").is_err(), "origin must not exist");
+
+        let remote_1 = dangling_commit(&repo, base, "Remote 1");
+        let remote_2 = dangling_commit(&repo, remote_1, "Remote 2");
+        set_remote_ref(&repo, &format!("refs/remotes/github/{}", branch), remote_2);
+
+        repo.find_branch(&branch, git2::BranchType::Local)
+            .unwrap()
+            .set_upstream(Some(&format!("github/{}", branch)))
+            .unwrap();
+
+        assert_eq!(compute_ahead_behind(&repo), (1, 2));
+    }
+
+    /// A branch with no upstream has nothing to report, even when a
+    /// same-named remote-tracking ref happens to exist — git prints no
+    /// ahead/behind for it, so neither should the workspace dialog.
+    #[test]
+    fn test_ahead_behind_is_zero_for_a_branch_with_no_upstream() {
+        let test_repo = TestRepo::with_initial_commit();
+        let base = test_repo.head_oid();
+        // Creates refs/remotes/origin/<branch> only — no branch.<name>.merge.
+        test_repo.create_remote_branch(&test_repo.current_branch(), base);
+        test_repo.create_commit("Local 1", &[("a.txt", "a")]);
+        test_repo.create_commit("Local 2", &[("b.txt", "b")]);
+
+        let repo = test_repo.repo();
+        let branch = test_repo.current_branch();
+        assert!(
+            repo.find_branch(&branch, git2::BranchType::Local)
+                .unwrap()
+                .upstream()
+                .is_err(),
+            "branch must have no configured upstream"
+        );
+
+        assert_eq!(compute_ahead_behind(&repo), (0, 0));
+    }
+
+    /// Detached HEAD: shorthand() is the literal "HEAD", which used to resolve
+    /// refs/remotes/origin/HEAD. In a mirror-style clone that ref is a DIRECT
+    /// ref to the remote's default branch, so the checked-out commit was
+    /// counted against it.
+    #[test]
+    fn test_ahead_behind_on_a_detached_head_ignores_the_remote_head_pointer() {
+        let test_repo = TestRepo::with_initial_commit();
+        let base = test_repo.head_oid();
+        test_repo.create_commit("Local 1", &[("a.txt", "a")]);
+        test_repo.create_commit("Local 2", &[("b.txt", "b")]);
+        let local_tip = test_repo.head_oid();
+
+        let repo = test_repo.repo();
+        set_remote_ref(&repo, "refs/remotes/origin/HEAD", base);
+        repo.set_head_detached(local_tip).unwrap();
+        assert!(
+            !repo.head().unwrap().is_branch(),
+            "HEAD must be detached for this test"
+        );
+
+        assert_eq!(compute_ahead_behind(&repo), (0, 0));
+    }
+
+    /// A detached HEAD is not a branch called "HEAD" — the dialog must not
+    /// print one.
+    #[test]
+    fn test_head_branch_reports_a_detached_head_as_no_branch() {
+        let test_repo = TestRepo::with_initial_commit();
+        let repo = test_repo.repo();
+        repo.set_head_detached(test_repo.head_oid()).unwrap();
+
+        assert_eq!(head_branch(&repo), (None, true));
+    }
+
+    /// Guard against over-correcting: a checked-out branch still reports its
+    /// name, and a fresh repository with an unborn HEAD is not "detached".
+    #[test]
+    fn test_head_branch_reports_the_checked_out_branch() {
+        let test_repo = TestRepo::with_initial_commit();
+        assert_eq!(
+            head_branch(&test_repo.repo()),
+            (Some(test_repo.current_branch()), false)
+        );
+
+        let empty = TestRepo::new();
+        assert_eq!(head_branch(&empty.repo()), (None, false));
+    }
 
     #[test]
     fn test_load_default_config() {

--- a/src-tauri/src/models/workspace.rs
+++ b/src-tauri/src/models/workspace.rs
@@ -47,6 +47,9 @@ pub struct WorkspaceRepoStatus {
     pub is_valid_repo: bool,
     pub changed_files_count: usize,
     pub current_branch: Option<String>,
+    /// True when HEAD is detached — the dialog renders that state rather than
+    /// a branch name, since `shorthand()` reports the literal "HEAD" there
+    pub is_detached: bool,
     pub ahead: usize,
     pub behind: usize,
 }
@@ -116,6 +119,7 @@ mod tests {
             is_valid_repo: true,
             changed_files_count: 5,
             current_branch: Some("main".to_string()),
+            is_detached: false,
             ahead: 2,
             behind: 1,
         };
@@ -130,6 +134,31 @@ mod tests {
         assert_eq!(deserialized.current_branch, Some("main".to_string()));
         assert_eq!(deserialized.ahead, 2);
         assert_eq!(deserialized.behind, 1);
+    }
+
+    /// A detached HEAD ships as `isDetached` with no branch name, so the
+    /// dialog can render the state instead of a branch called "HEAD".
+    #[test]
+    fn test_workspace_repo_status_detached_head_serialization() {
+        let status = WorkspaceRepoStatus {
+            path: "/test".to_string(),
+            name: "test".to_string(),
+            exists: true,
+            is_valid_repo: true,
+            changed_files_count: 0,
+            current_branch: None,
+            is_detached: true,
+            ahead: 0,
+            behind: 0,
+        };
+
+        let json = serde_json::to_string(&status).unwrap();
+        assert!(json.contains("isDetached"));
+        assert!(!json.contains("is_detached"));
+
+        let deserialized: WorkspaceRepoStatus = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.is_detached);
+        assert_eq!(deserialized.current_branch, None);
     }
 
     #[test]

--- a/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
@@ -52,6 +52,7 @@ function makeRepoStatus(overrides: Partial<WorkspaceRepoStatus> = {}): Workspace
     isValidRepo: true,
     changedFilesCount: 0,
     currentBranch: 'main',
+    isDetached: false,
     ahead: 0,
     behind: 0,
     ...overrides,
@@ -693,6 +694,52 @@ describe('lv-workspace-manager-dialog', () => {
 
       const validateCalls = findCommands('validate_workspace_repositories');
       expect(validateCalls.length).to.be.greaterThan(0);
+    });
+
+    it('shows the branch name for an attached repo and "detached HEAD" for a detached one', async () => {
+      setupDefaultMocks({
+        statuses: [
+          makeRepoStatus({ path: '/repos/alpha', name: 'alpha', currentBranch: 'main' }),
+          makeRepoStatus({
+            path: '/repos/beta',
+            name: 'beta',
+            currentBranch: null,
+            isDetached: true,
+          }),
+        ],
+      });
+
+      const el = await renderDialog();
+      await tick(el, 100);
+
+      const branches = el.shadowRoot!.querySelectorAll('.repo-branch');
+      expect(branches.length).to.equal(2);
+      expect(branches[0].textContent?.trim()).to.equal('main');
+      expect(branches[0].classList.contains('detached')).to.be.false;
+
+      const detached = el.shadowRoot!.querySelector('.repo-branch.detached');
+      expect(detached).to.not.be.null;
+      expect(detached!.textContent?.trim()).to.equal('detached HEAD');
+    });
+
+    it('shows no branch chip when a repo has no branch and is not detached', async () => {
+      setupDefaultMocks({
+        statuses: [
+          makeRepoStatus({
+            path: '/repos/alpha',
+            name: 'alpha',
+            exists: false,
+            isValidRepo: false,
+            currentBranch: null,
+            isDetached: false,
+          }),
+        ],
+      });
+
+      const el = await renderDialog();
+      await tick(el, 100);
+
+      expect(el.shadowRoot!.querySelectorAll('.repo-branch').length).to.equal(0);
     });
 
     it('renders repo status badges from validation result', async () => {

--- a/src/components/dialogs/lv-workspace-manager-dialog.ts
+++ b/src/components/dialogs/lv-workspace-manager-dialog.ts
@@ -372,6 +372,10 @@ export class LvWorkspaceManagerDialog extends LitElement {
         font-family: var(--font-mono);
       }
 
+      .repo-branch.detached {
+        font-style: italic;
+      }
+
       .repo-status {
         font-size: var(--font-size-xs);
         padding: 1px 6px;
@@ -1425,7 +1429,9 @@ export class LvWorkspaceManagerDialog extends LitElement {
                                   <span class="repo-name" title="${repo.path}">${repo.name}</span>
                                   ${status?.currentBranch
                                     ? html`<span class="repo-branch">${status.currentBranch}</span>`
-                                    : nothing}
+                                    : status?.isDetached
+                                      ? html`<span class="repo-branch detached">detached HEAD</span>`
+                                      : nothing}
                                   ${this.renderRepoStatus(status)}
                                   ${this.renderAheadBehind(status)}
                                 </div>

--- a/src/services/__tests__/workspace.service.test.ts
+++ b/src/services/__tests__/workspace.service.test.ts
@@ -160,6 +160,7 @@ describe('workspace.service', () => {
           isValidRepo: true,
           changedFilesCount: 3,
           currentBranch: 'main',
+          isDetached: false,
           ahead: 1,
           behind: 0,
         },
@@ -170,6 +171,18 @@ describe('workspace.service', () => {
           isValidRepo: false,
           changedFilesCount: 0,
           currentBranch: null,
+          isDetached: false,
+          ahead: 0,
+          behind: 0,
+        },
+        {
+          path: '/repo/three',
+          name: 'three',
+          exists: true,
+          isValidRepo: true,
+          changedFilesCount: 0,
+          currentBranch: null,
+          isDetached: true,
           ahead: 0,
           behind: 0,
         },
@@ -180,9 +193,13 @@ describe('workspace.service', () => {
       expect(lastInvokedCommand).to.equal('validate_workspace_repositories');
       expect((lastInvokedArgs as Record<string, unknown>).workspaceId).to.equal('ws-1');
       expect(result.success).to.be.true;
-      expect(result.data?.length).to.equal(2);
+      expect(result.data?.length).to.equal(3);
       expect(result.data?.[0].changedFilesCount).to.equal(3);
       expect(result.data?.[1].exists).to.be.false;
+      // isDetached crosses the IPC boundary in camelCase, as Tauri renames it
+      expect(result.data?.[0].isDetached).to.be.false;
+      expect(result.data?.[2].isDetached).to.be.true;
+      expect(result.data?.[2].currentBranch).to.be.null;
     });
   });
 });

--- a/src/types/git.types.ts
+++ b/src/types/git.types.ts
@@ -634,6 +634,7 @@ export interface WorkspaceRepoStatus {
   isValidRepo: boolean;
   changedFilesCount: number;
   currentBranch: string | null;
+  isDetached: boolean;
   ahead: number;
   behind: number;
 }


### PR DESCRIPTION
## What was broken

### Ahead/behind was measured against a guessed upstream

`compute_ahead_behind()` in `src-tauri/src/commands/workspace.rs` built the upstream by hand as `refs/remotes/origin/<branch>`, never reading `branch.<name>.remote` / `branch.<name>.merge`. The ↑/↓ chips in the workspace manager therefore misreported git state in every setup where the branch does not track a same-named branch on a remote called `origin`:

| Setup | What git says | What the dialog said |
| --- | --- | --- |
| Fork workflow — branch tracks `upstream/main`, `origin` is your stale fork | ahead 2 | in sync (counted against `origin/main`) |
| `git clone -o github`, or a renamed remote | ahead 1, behind 2 | nothing — the `origin/...` lookup missed |
| Local `feature` tracking `origin/main` | divergence | nothing |
| Branch with **no** upstream but a stale `origin/<name>` ref present | nothing | invented counts |

It also disagreed with the branches panel for the same repository: `src-tauri/src/commands/branch.rs` `get_branches()` has always resolved the configured upstream via `branch.upstream()`.

### Detached HEAD was reported as a branch named "HEAD"

`Reference::shorthand()` is the literal `"HEAD"` on a detached HEAD.

- `compute_ahead_behind` resolved `refs/remotes/origin/HEAD` from it. In a normal clone that ref is a symref so it happened to fall through to `(0, 0)`; in a mirror-style clone it is a **direct** ref, and the checked-out commit was counted against the remote's default branch.
- `validate_workspace_repositories` did `head.shorthand().ok().map(String::from)`, returning `Some("HEAD")`, which `lv-workspace-manager-dialog.ts` rendered verbatim in the `.repo-branch` chip as if it were a branch.

## The fix

`compute_ahead_behind` now mirrors what `autofetch_service.rs::get_remote_status_internal` and `commit.rs::is_head_published` already do: guard on `!head.is_branch()`, then follow `find_branch(..).upstream()`. A branch with no upstream returns zeros — nothing to report is not a failure.

A new sibling helper `head_branch()` returns `(Option<String>, bool)` so the detached case is fixed at the source and is unit-testable. `WorkspaceRepoStatus` gains `is_detached` (ships as `isDetached`; the struct already carries `#[serde(rename_all = "camelCase")]`), and the dialog renders `detached HEAD` — the same wording already used for detached worktree rows in `lv-worktree-dialog.ts` — so a detached repo shows its state rather than a blank row. An unborn HEAD stays `(None, false)`: not detached.

`renderAheadBehind` already hides the chip at 0/0, so a detached or untracked repo simply shows no ↑/↓, which is what git reports. No new events and no new service calls, so the UI event/feedback rules are unaffected.

## Tests

| Test | File | Covers | Fails without the fix |
| --- | --- | --- | --- |
| `test_ahead_behind_follows_the_configured_upstream_not_origin` | `src-tauri/src/commands/workspace.rs` | Happy path — fork workflow, branch tracks `upstream/main` while `origin/main` is up to date | Yes — `left: (0, 0), right: (2, 0)` |
| `test_ahead_behind_reports_divergence_when_the_remote_is_not_named_origin` | same | Remote named `github`, no `origin` anywhere, divergence both ways | Yes — `left: (0, 0), right: (1, 2)` |
| `test_ahead_behind_is_zero_for_a_branch_with_no_upstream` | same | Untracked branch that happens to have an `origin/<name>` ref | Yes — `left: (2, 0), right: (0, 0)` |
| `test_ahead_behind_on_a_detached_head_ignores_the_remote_head_pointer` | same | Detached HEAD with a **direct** `refs/remotes/origin/HEAD` | Yes — `left: (2, 0), right: (0, 0)` |
| `test_head_branch_reports_a_detached_head_as_no_branch` | same | `current_branch` half of the detached case | Yes — `left: (Some("HEAD"), false), right: (None, true)` |
| `test_head_branch_reports_the_checked_out_branch` | same | Guard: attached branch keeps its name; unborn HEAD is not "detached" | No, by design — it exists to catch the over-correction |
| `test_workspace_repo_status_detached_head_serialization` | `src-tauri/src/models/workspace.rs` | `isDetached` crosses the IPC boundary in camelCase and round-trips | Yes — the field does not exist |
| `shows the branch name for an attached repo and "detached HEAD" for a detached one` | `src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts` | Both chips render, only the detached one carries the class | Yes — `expected 1 to equal 2` (the detached row rendered nothing) |
| `shows no branch chip when a repo has no branch and is not detached` | same | Guard: a missing repo is not labelled detached | No, by design |
| `validateWorkspaceRepositories` (extended) | `src/services/__tests__/workspace.service.test.ts` | Pins the camelCase `isDetached` contract across three statuses | Yes — TS error without the type change |
| `renders the tracked branch with its ahead/behind counts and labels a detached repo` | `e2e/tests/workspace-manager.spec.ts` | Full-stack user-visible outcome: `main` + `↑2 ↓1`, and `detached HEAD` with no counts | Yes — `element(s) not found` for `.repo-branch.detached` |

Verified by reverting only the production change and re-running: the four `compute_ahead_behind` tests, `test_head_branch_reports_a_detached_head_as_no_branch`, the dialog unit test and the E2E test all fail with the messages above; restoring the fix makes them pass.

Full gate green: `npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib`, plus `npx playwright test e2e/tests/workspace-manager.spec.ts` (5 passed) and the snake_case grep.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_