### PR TITLE
List pre-merge-commit in the Hooks dialog

### DIFF
--- a/src-tauri/src/commands/hooks.rs
+++ b/src-tauri/src/commands/hooks.rs
@@ -386,6 +386,17 @@ const HOOKS: &[(&str, &str)] = &[
         "Run after checkout. Used for environment setup.",
     ),
     (
+        "pre-merge-commit",
+        // Leviathan runs this as a blocking hook on merge and on the merge leg
+        // of pull, exactly as git does. Leaving it out of this list meant the
+        // dialog never listed it: a merge vetoed by a broken hook (husky
+        // installs these under core.hooksPath) had no entry to read, edit or
+        // toggle off — the toggle is the only way to disable a hook — and the
+        // footer's "N of M hooks configured" undercounted the hooks that
+        // actually gate the user's operations.
+        "Run before the automatic merge commit. A non-zero exit stops the commit and leaves the merge to be completed or aborted.",
+    ),
+    (
         "post-merge",
         "Run after a merge. Used for dependency installation.",
     ),
@@ -610,6 +621,107 @@ mod tests {
         assert!(names.contains(&"pre-commit"));
         assert!(names.contains(&"commit-msg"));
         assert!(names.contains(&"pre-push"));
+    }
+
+    #[tokio::test]
+    async fn test_get_hooks_lists_every_hook_the_app_can_run() {
+        // The dialog is data-driven off get_hooks, so a hook the app invokes
+        // but does not list is a hook the user cannot inspect, edit, disable or
+        // delete — and one the "N of M hooks configured" footer never counts.
+        let repo = TestRepo::with_initial_commit();
+        let hooks = get_hooks(repo.path_str()).await.unwrap();
+        let names: Vec<&str> = hooks.iter().map(|h| h.name.as_str()).collect();
+
+        for blocking in [
+            "pre-commit",
+            "commit-msg",
+            "pre-merge-commit",
+            "pre-rebase",
+            "pre-push",
+        ] {
+            assert!(
+                names.contains(&blocking),
+                "the dialog must list every hook the app runs, missing: {blocking}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn test_pre_merge_commit_hook_has_a_description() {
+        // get_hook falls back to unwrap_or_default() for an unlisted name, so an
+        // omission shows as blank help text rather than an error.
+        let repo = TestRepo::with_initial_commit();
+        let hook = get_hook(repo.path_str(), "pre-merge-commit".to_string())
+            .await
+            .unwrap();
+        assert!(
+            !hook.description.is_empty(),
+            "the dialog shows this hook's description"
+        );
+        assert!(hook.description.to_lowercase().contains("merge"));
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_pre_merge_commit_hook_can_be_inspected_and_disabled() {
+        // The reported dead end: a merge vetoed by a broken pre-merge-commit
+        // hook, with no entry in the dialog to read it or toggle it off.
+        let repo = TestRepo::with_initial_commit();
+        let initial = repo.current_branch();
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature", &[("feature.txt", "content")]);
+        repo.checkout_branch(&initial);
+
+        repo.install_hook("pre-merge-commit", "#!/bin/sh\necho denied 1>&2\nexit 1\n");
+
+        let listed = get_hooks(repo.path_str()).await.unwrap();
+        let hook = listed
+            .iter()
+            .find(|h| h.name == "pre-merge-commit")
+            .expect("the hook that is blocking merges must appear in the dialog");
+        assert!(hook.exists);
+        assert!(hook.enabled);
+        assert!(
+            hook.content.as_deref().unwrap().contains("denied"),
+            "its script must be readable"
+        );
+
+        // Disable it through the same command the dialog's toggle calls.
+        toggle_hook(repo.path_str(), "pre-merge-commit".to_string(), false)
+            .await
+            .unwrap();
+        let listed = get_hooks(repo.path_str()).await.unwrap();
+        let hook = listed
+            .iter()
+            .find(|h| h.name == "pre-merge-commit")
+            .expect("a disabled hook stays listed so the toggle can turn it back on");
+        assert!(hook.exists);
+        assert!(!hook.enabled);
+
+        // The repair is real: the merge the hook was vetoing now completes.
+        // no_ff forces the automatic merge commit, so the hook would run.
+        crate::commands::merge::merge(
+            repo.path_str(),
+            "feature".to_string(),
+            Some(true),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        assert_eq!(
+            git_repo
+                .head()
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .parent_count(),
+            2,
+            "disabling the hook let the merge commit be created"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What was broken

### Hooks dialog cannot manage `pre-merge-commit`, a hook the app actually runs

`src-tauri/src/commands/hooks.rs` defines `const HOOKS: &[(&str, &str)]` — the single source of truth for `get_hooks` (which the Hooks dialog is entirely data-driven off: `this.hooks.map(hook => this.renderHookItem(hook))`, plus the `N of M hooks configured` footer) and for the description `get_hook` returns. It listed pre-commit, prepare-commit-msg, commit-msg, post-commit, pre-rebase, post-rewrite, post-checkout, post-merge, pre-push, the four server-side hooks, pre-auto-gc, pre-applypatch and post-applypatch — but **not** `pre-merge-commit`.

Yet `pre-merge-commit` is one of only three hooks the app itself invokes as a *blocking* hook:

- `src-tauri/src/commands/merge.rs` calls `run_hook_blocking(&repo, "pre-merge-commit", &[], None)` before creating the automatic merge commit;
- `src-tauri/src/commands/remote.rs` does the same on the merge leg of pull;
- hooks.rs's own runner doc comment already names it: *"Run a blocking hook (pre-commit, commit-msg, pre-merge-commit, pre-push)"*.

Consequences for a user whose merge or pull is being vetoed by a broken `pre-merge-commit` hook (husky installs these under `core.hooksPath`, which this module already resolves):

- the Hooks dialog shows **no entry at all** — no script to read, no Delete button, and no toggle, which the module's own comments call "the only way to re-enable" a hook;
- the `N of M hooks configured` footer undercounts the hooks that actually gate the user's operations;
- `get_hook("pre-merge-commit")` misses in `HOOKS.iter().find(...)` and falls through `unwrap_or_default()`, so even a direct lookup renders blank help text.

## The fix

One entry added to `HOOKS`, placed immediately before `post-merge` so the two merge hooks sit adjacent in the dialog's list (array order is list order):

```rust
(
    "pre-merge-commit",
    "Run before the automatic merge commit. A non-zero exit stops the commit and leaves the merge to be completed or aborted.",
),
```

That is the whole change. `get_hooks` iterates `HOOKS` and applies the `.disabled` / executable-bit logic per name; `get_hook`'s description lookup now finds a non-empty string; `save_hook`, `toggle_hook` and `delete_hook` take the name as a parameter and are name-agnostic — so the dialog now lists, reads, edits, toggles and deletes this hook with **no frontend change**. The description states the real behaviour: a veto stops the commit but leaves the merge resumable, which is exactly what `merge.rs` implements by returning *without* `cleanup_state`.

`HOOK_TEMPLATES` in `lv-hooks-dialog.ts` is deliberately untouched — only three hooks ship a template and the template bar renders conditionally via `hasTemplate()`, so the new hook simply shows no template bar. No dead end.

## Tests

All in the existing `#[cfg(test)] mod tests` of `src-tauri/src/commands/hooks.rs`.

| Test | Covers | Fails without the fix with |
| --- | --- | --- |
| `test_get_hooks_lists_every_hook_the_app_can_run` | Happy path — every name the app passes to `run_hook_blocking` (`pre-commit`, `commit-msg`, `pre-merge-commit`, `pre-rebase`, `pre-push`) is listed | `the dialog must list every hook the app runs, missing: pre-merge-commit` |
| `test_pre_merge_commit_hook_can_be_inspected_and_disabled` (unix) | Error path / the reported user story — a vetoing hook installed with `TestRepo::install_hook` must appear with its readable script, be disable-able through the same `toggle_hook` the dialog's toggle calls, stay listed while disabled (so it can be turned back on), and the previously-blocked `no_ff` merge must then succeed with a clean state and a 2-parent HEAD | `the hook that is blocking merges must appear in the dialog` |
| `test_pre_merge_commit_hook_has_a_description` | Edge case — the silent `unwrap_or_default()` fallback in `get_hook` | `the dialog shows this hook's description` |

**Verified they bite:** with only the `HOOKS` entry reverted and the tests kept, all three fail with the messages above (`test result: FAILED. 22 passed; 3 failed`); restored, all 25 hooks tests pass. Full gate green: lint, typecheck, unit, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib`. The hooks tests were also re-run under git 2.55 (25 passed) even though nothing here parses git CLI output.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_