### PR TITLE
Give the content, diff and pickaxe search backend a way in

### DIFF
--- a/e2e/tests/search-dialog.spec.ts
+++ b/e2e/tests/search-dialog.spec.ts
@@ -1,0 +1,140 @@
+import { test, expect } from '@playwright/test';
+import { setupOpenRepository } from '../fixtures/tauri-mock';
+import {
+  startCommandCaptureWithMocks,
+  findCommand,
+  injectCommandError,
+  openViaCommandPalette,
+} from '../fixtures/test-helpers';
+
+/**
+ * E2E tests for the content/diff/pickaxe search dialog.
+ *
+ * The backend commands existed but nothing in the app called them: there was
+ * no way for a user to grep their files, search the current diff, or find the
+ * commit that introduced a string. These tests drive the flow the way a user
+ * does — palette entry, query, Enter — and verify the result rows actually
+ * take them somewhere.
+ */
+
+const FILE_RESULT = [
+  {
+    filePath: 'src/main.ts',
+    matchCount: 1,
+    matches: [
+      {
+        filePath: 'src/main.ts',
+        lineNumber: 42,
+        lineContent: 'const token = getToken();',
+        matchStart: 6,
+        matchEnd: 11,
+      },
+    ],
+  },
+];
+
+const BLAME_RESULT = {
+  path: 'src/main.ts',
+  lines: [
+    {
+      lineNumber: 1,
+      content: 'import { app } from "./app";',
+      commitOid: 'abc123def456',
+      commitShortId: 'abc123d',
+      authorName: 'Alice',
+      authorEmail: 'alice@example.com',
+      timestamp: Math.floor(Date.now() / 1000) - 86400,
+      summary: 'Initial commit',
+      isBoundary: false,
+    },
+  ],
+  totalLines: 1,
+};
+
+async function runSearch(page: import('@playwright/test').Page, query: string): Promise<void> {
+  const dialog = page.locator('lv-search-dialog[open]');
+  await dialog.waitFor({ state: 'attached' });
+  await dialog.locator('.query-input').fill(query);
+  await dialog.locator('.query-input').press('Enter');
+}
+
+test.describe('Search dialog', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+  });
+
+  test('finds text in files and shows the match', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, { search_in_files: FILE_RESULT });
+    await openViaCommandPalette(page, 'Search in files');
+    await runSearch(page, 'token');
+
+    const row = page.locator('lv-search-dialog[open] .result-item').first();
+    await expect(row).toBeVisible();
+    await expect(row).toContainText(':42');
+    await expect(row).toContainText('const token = getToken();');
+    await expect(page.locator('lv-search-dialog[open] .result-file')).toContainText('src/main.ts');
+
+    const calls = await findCommand(page, 'search_in_files');
+    expect(calls.length).toBeGreaterThan(0);
+    expect((calls[0].args as { query: string }).query).toBe('token');
+  });
+
+  test('clicking a file result opens blame for that file', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {
+      search_in_files: FILE_RESULT,
+      get_file_blame: BLAME_RESULT,
+    });
+    await openViaCommandPalette(page, 'Search in files');
+    await runSearch(page, 'token');
+
+    await page.locator('lv-search-dialog[open] .result-item').first().click();
+
+    await expect(page.locator('lv-search-dialog[open]')).toHaveCount(0);
+    await expect(page.locator('lv-blame-view')).toBeVisible();
+    await expect(page.locator('lv-blame-view')).toContainText('src/main.ts');
+  });
+
+  test('a backend failure is shown inside the dialog', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {});
+    await injectCommandError(page, 'search_in_files', 'fatal: invalid regex');
+    await openViaCommandPalette(page, 'Search in files');
+    await runSearch(page, 'to(ken');
+
+    const dialog = page.locator('lv-search-dialog[open]');
+    await expect(dialog.locator('.error')).toBeVisible();
+    await expect(dialog.locator('.error')).toContainText('fatal: invalid regex');
+    await expect(dialog).toHaveCount(1);
+  });
+
+  test('an empty diff search reports no matches', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, { search_in_diff: [] });
+    await openViaCommandPalette(page, 'Search in current diff');
+    await runSearch(page, 'token');
+
+    await expect(page.locator('lv-search-dialog[open] .empty')).toContainText('No matches found');
+  });
+
+  test('finding commits that changed text reveals the commit', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {
+      search_commits_by_content: [
+        {
+          oid: 'abc123def456',
+          shortOid: 'abc123d',
+          message: 'Initial commit',
+          authorName: 'Test User',
+          authorDate: Math.floor(Date.now() / 1000),
+          matches: [{ filePath: 'src/main.ts', lineNumber: null, lineContent: null }],
+        },
+      ],
+    });
+    await openViaCommandPalette(page, 'Find commits that changed text');
+    await runSearch(page, 'token');
+
+    const row = page.locator('lv-search-dialog[open] .result-item').first();
+    await expect(row).toContainText('abc123d');
+    await row.click();
+
+    await expect(page.locator('lv-search-dialog[open]')).toHaveCount(0);
+    await expect(page.locator('lv-commit-details .commit-message')).toContainText('Initial commit');
+  });
+});

--- a/src/__tests__/app-shell-search-dialog.test.ts
+++ b/src/__tests__/app-shell-search-dialog.test.ts
@@ -1,0 +1,122 @@
+/**
+ * Tests for the app-shell half of the content-search wiring.
+ *
+ * The search backend was unreachable because nothing opened a surface for it:
+ * these pin the three palette entries to the dialog and its mode, pin them to
+ * requiresRepository (so they warn instead of dying on the welcome screen),
+ * and pin the diff-result navigation — including the miss, which must report
+ * itself rather than being a dead click.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+const mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect } from '@open-wc/testing';
+import type { AppShell } from '../app-shell.ts';
+import { uiStore } from '../stores/ui.store.ts';
+import '../app-shell.ts';
+
+interface PaletteCommand {
+  id: string;
+  label: string;
+  action: () => void;
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+function createAppShell(withRepo: boolean): AppShell {
+  const el = document.createElement('lv-app-shell') as AppShell;
+  (el as any).activeRepository = withRepo
+    ? {
+        repository: { path: '/repo/a', name: 'a' },
+        status: [
+          { path: 'src/a.ts', status: 'modified', isStaged: false, isConflicted: false },
+          { path: 'src/b.ts', status: 'modified', isStaged: true, isConflicted: false },
+        ],
+      }
+    : null;
+  return el;
+}
+
+function getCommand(el: AppShell, id: string): PaletteCommand {
+  const commands: PaletteCommand[] = (el as any).getPaletteCommands();
+  const cmd = commands.find((c) => c.id === id);
+  if (!cmd) throw new Error(`palette command "${id}" not found`);
+  return cmd;
+}
+
+const MODES: Array<{ id: string; mode: string }> = [
+  { id: 'search-in-files', mode: 'files' },
+  { id: 'search-in-diff', mode: 'diff' },
+  { id: 'search-commit-content', mode: 'commits' },
+];
+
+describe('app-shell search dialog wiring', () => {
+  beforeEach(() => {
+    uiStore.setState({ toasts: [] });
+  });
+
+  for (const { id, mode } of MODES) {
+    it(`"${id}" opens the search dialog in ${mode} mode`, () => {
+      const el = createAppShell(true);
+      getCommand(el, id).action();
+
+      expect((el as any).showSearchDialog, 'dialog opened').to.equal(true);
+      expect((el as any).searchDialogMode, 'mode preselected').to.equal(mode);
+    });
+
+    it(`"${id}" warns instead of opening with no repository`, () => {
+      const el = createAppShell(false);
+      getCommand(el, id).action();
+
+      expect((el as any).showSearchDialog, 'dialog stays shut').to.not.equal(true);
+      const warnings = uiStore
+        .getState()
+        .toasts.filter((t) => t.message === 'Please open a repository first');
+      expect(warnings.length, 'requiresRepository warning shown').to.equal(1);
+    });
+  }
+
+  it('show-working-diff opens the matching working-tree entry', () => {
+    const el = createAppShell(true);
+    (el as any).handleShowWorkingDiff(
+      new CustomEvent('show-working-diff', { detail: { filePath: 'src/a.ts', staged: false } })
+    );
+
+    expect((el as any).showDiff, 'diff pane opened').to.equal(true);
+    expect((el as any).diffFile?.path).to.equal('src/a.ts');
+    expect((el as any).diffFile?.isStaged, 'matched the staged flag from the search').to.equal(false);
+  });
+
+  it('show-working-diff prefers the entry with the searched staged flag', () => {
+    const el = createAppShell(true);
+    (el as any).handleShowWorkingDiff(
+      new CustomEvent('show-working-diff', { detail: { filePath: 'src/b.ts', staged: true } })
+    );
+
+    expect((el as any).diffFile?.path).to.equal('src/b.ts');
+    expect((el as any).diffFile?.isStaged).to.equal(true);
+  });
+
+  it('show-working-diff reports a file that is no longer changed', () => {
+    const el = createAppShell(true);
+    (el as any).handleShowWorkingDiff(
+      new CustomEvent('show-working-diff', { detail: { filePath: 'gone.ts', staged: false } })
+    );
+
+    expect((el as any).showDiff, 'no diff opened').to.not.equal(true);
+    const infos = uiStore
+      .getState()
+      .toasts.filter((t) => t.message.includes('no longer in the working-tree changes'));
+    expect(infos.length, 'the miss is reported, not silent').to.equal(1);
+  });
+});

--- a/src/__tests__/app-shell-search-dialog.test.ts
+++ b/src/__tests__/app-shell-search-dialog.test.ts
@@ -86,6 +86,30 @@ describe('app-shell search dialog wiring', () => {
     });
   }
 
+  it('records the mode the dialog moved to, so the next open is not dirty-checked away', async () => {
+    // `.mode` is a dirty-checked binding: if app-shell keeps pushing the mode
+    // it last set while the dialog sits on another one, reopening in that mode
+    // assigns nothing and the dialog stays where the user left it.
+    const el = createAppShell(true);
+    document.body.appendChild(el);
+    await (el as any).updateComplete;
+    getCommand(el, 'search-in-files').action();
+    await (el as any).updateComplete;
+
+    const dialog = el.shadowRoot!.querySelector('lv-search-dialog');
+    expect(dialog === null, 'the search dialog is rendered').to.be.false;
+    dialog!.dispatchEvent(
+      new CustomEvent('mode-changed', {
+        detail: { mode: 'commits' },
+        bubbles: true,
+        composed: true,
+      })
+    );
+
+    expect((el as any).searchDialogMode, 'app-shell owns the mode').to.equal('commits');
+    el.remove();
+  });
+
   it('show-working-diff opens the matching working-tree entry', () => {
     const el = createAppShell(true);
     (el as any).handleShowWorkingDiff(

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -5527,6 +5527,7 @@ export class AppShell extends LitElement {
           .mode=${this.searchDialogMode}
           .repositoryPath=${this.activeRepository.repository.path}
           @close=${() => { this.showSearchDialog = false; }}
+          @mode-changed=${(e: CustomEvent<{ mode: SearchDialogMode }>) => { this.searchDialogMode = e.detail.mode; }}
           @show-blame=${this.handleShowBlame}
           @show-working-diff=${this.handleShowWorkingDiff}
         ></lv-search-dialog>

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -43,6 +43,7 @@ import './components/dialogs/lv-conflict-resolution-dialog.ts';
 import type { GitflowFinishContext } from './components/dialogs/lv-conflict-resolution-dialog.ts';
 import './components/dialogs/lv-command-palette.ts';
 import './components/dialogs/lv-reflog-dialog.ts';
+import './components/dialogs/lv-search-dialog.ts';
 import './components/dialogs/lv-keyboard-shortcuts-dialog.ts';
 import './components/dialogs/lv-remote-dialog.ts';
 import './components/dialogs/lv-changelog-dialog.ts';
@@ -83,6 +84,7 @@ import type { LvCherryPickDialog } from './components/dialogs/lv-cherry-pick-dia
 import type { LvInteractiveRebaseDialog } from './components/dialogs/lv-interactive-rebase-dialog.ts';
 import type { LvProfileManagerDialog } from './components/dialogs/lv-profile-manager-dialog.ts';
 import type { LvReflogDialog } from './components/dialogs/lv-reflog-dialog.ts';
+import type { SearchDialogMode } from './components/dialogs/lv-search-dialog.ts';
 import type { LvCleanDialog } from './components/dialogs/lv-clean-dialog.ts';
 import type { LvRemoteDialog } from './components/dialogs/lv-remote-dialog.ts';
 import type { LvRepositoryHealthDialog } from './components/dialogs/lv-repository-health-dialog.ts';
@@ -658,6 +660,11 @@ export class AppShell extends LitElement {
 
   // Reflog dialog
   @state() private showReflog = false;
+
+  // Content/diff/pickaxe search dialog. The `show[A-Z]` name is load-bearing:
+  // closeRepoScopedDialogs() enumerates Lit's reactive properties for it.
+  @state() private showSearchDialog = false;
+  @state() private searchDialogMode: SearchDialogMode = 'files';
 
   // Keyboard shortcuts dialog
   @state() private showShortcuts = false;
@@ -1449,6 +1456,11 @@ export class AppShell extends LitElement {
             dismissed: 'undo history closed',
             running: 'reset',
             clearFlag: () => { this.showReflog = false; },
+          },
+          'lv-search-dialog': {
+            dismissed: 'search closed',
+            running: 'search',
+            clearFlag: () => { this.showSearchDialog = false; },
           },
           'lv-remote-dialog': {
             dismissed: 'remote management closed',
@@ -3459,11 +3471,17 @@ export class AppShell extends LitElement {
   }
 
   private handleFileSelected(e: CustomEvent<{ file: StatusEntry; isPartiallyStaged?: boolean }>): void {
+    this.openWorkingTreeDiff(e.detail.file, e.detail.isPartiallyStaged ?? false);
+  }
+
+  /** Shared by the file list and the diff search, so both route conflicts and
+   * blame teardown identically. */
+  private openWorkingTreeDiff(file: StatusEntry, isPartiallyStaged = false): void {
     // A conflicted file is resolved in the merge editor, never shown as a raw
     // diff — its working-tree content is git's conflict-marker text. Open the
     // dialog on the file that was actually clicked.
-    if (e.detail.file.isConflicted) {
-      this.openConflictDialogFromState(e.detail.file.path);
+    if (file.isConflicted) {
+      this.openConflictDialogFromState(file.path);
       return;
     }
     // Close blame if open
@@ -3471,8 +3489,8 @@ export class AppShell extends LitElement {
     this.blameFile = null;
     this.blameCommitOid = null;
     // Working directory file selected - show diff
-    this.diffFile = e.detail.file;
-    this.diffFilePartiallyStaged = e.detail.isPartiallyStaged ?? false;
+    this.diffFile = file;
+    this.diffFilePartiallyStaged = isPartiallyStaged;
     this.diffCommitFile = null;
     this.showDiff = true;
   }
@@ -3786,6 +3804,34 @@ export class AppShell extends LitElement {
     this.blameFile = e.detail.filePath;
     this.blameCommitOid = e.detail.commitOid ?? null;
     this.showBlame = true;
+  }
+
+  private openSearchDialog(mode: SearchDialogMode): void {
+    this.searchDialogMode = mode;
+    this.showSearchDialog = true;
+  }
+
+  /**
+   * A hit from the diff search opens that file's working-tree diff.
+   *
+   * The search ran against `git diff` output, so the file was modified when
+   * the query ran — but a stage/discard/refresh in between can retire the
+   * entry. Reporting the miss keeps the row from being a dead click.
+   */
+  private handleShowWorkingDiff(e: CustomEvent<{ filePath: string; staged: boolean }>): void {
+    const status = this.activeRepository?.status ?? [];
+    const entry =
+      status.find((f) => f.path === e.detail.filePath && f.isStaged === e.detail.staged) ??
+      status.find((f) => f.path === e.detail.filePath);
+    if (!entry) {
+      showToast(
+        'That file is no longer in the working-tree changes — refresh and search again',
+        'info',
+        4000,
+      );
+      return;
+    }
+    this.openWorkingTreeDiff(entry);
   }
 
   private handleSearchChange(e: CustomEvent<{ filter: SearchFilter }>): void {
@@ -4170,6 +4216,27 @@ export class AppShell extends LitElement {
         icon: 'search',
         shortcut: `${mod}F`,
         action: () => this.handleToggleSearch(),
+      },
+      {
+        id: 'search-in-files',
+        label: 'Search in files',
+        category: 'action',
+        icon: 'search',
+        action: this.requiresRepository(() => this.openSearchDialog('files')),
+      },
+      {
+        id: 'search-in-diff',
+        label: 'Search in current diff',
+        category: 'action',
+        icon: 'search',
+        action: this.requiresRepository(() => this.openSearchDialog('diff')),
+      },
+      {
+        id: 'search-commit-content',
+        label: 'Find commits that changed text',
+        category: 'action',
+        icon: 'search',
+        action: this.requiresRepository(() => this.openSearchDialog('commits')),
       },
       {
         id: 'stage-all',
@@ -5454,6 +5521,15 @@ export class AppShell extends LitElement {
           }}
           @show-commit=${(e: CustomEvent<{ oid: string }>) => { this.showReflog = false; this.revealCommitInGraph(e.detail.oid); }}
         ></lv-reflog-dialog>
+
+        <lv-search-dialog
+          ?open=${this.showSearchDialog}
+          .mode=${this.searchDialogMode}
+          .repositoryPath=${this.activeRepository.repository.path}
+          @close=${() => { this.showSearchDialog = false; }}
+          @show-blame=${this.handleShowBlame}
+          @show-working-diff=${this.handleShowWorkingDiff}
+        ></lv-search-dialog>
       ` : ''}
 
       <lv-keyboard-shortcuts-dialog

--- a/src/components/dialogs/__tests__/lv-search-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-search-dialog.test.ts
@@ -1,0 +1,381 @@
+/**
+ * Tests for lv-search-dialog — the UI half of the repository content search.
+ *
+ * `search_in_files`, `search_in_diff` and `search_commits_by_content` shipped
+ * with typed wrappers and a Rust test suite but no caller anywhere in the app.
+ * These tests pin the three modes to the three commands, pin the option
+ * checkboxes to the camelCase args they must produce, and pin every result row
+ * to the navigation event that makes it more than a printed line.
+ *
+ * The dialog's `repositoryPath` is live-bound to the ACTIVE repository, and
+ * repo switching is a document-level shortcut that fires straight through the
+ * overlay — so a mid-search switch must drop both the rows and any response
+ * still in flight, or a click navigates repo B using a hit found in repo A.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeCalls: Array<{ command: string; args?: unknown }> = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeCalls.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import { resetOverlayStack, pushOverlay, removeOverlay } from '../../../utils/overlay-stack.ts';
+import { deepActiveElement } from '../../../utils/focus.ts';
+import '../lv-search-dialog.ts';
+
+const REPO_A = '/repo/a';
+const REPO_B = '/repo/b';
+
+type Dialog = HTMLElement & {
+  updateComplete: Promise<unknown>;
+  repositoryPath: string;
+  mode: 'files' | 'diff' | 'commits';
+  open: boolean;
+  pinnedRepositoryPathIfOpen: string | null;
+  close: () => void;
+};
+
+function fileHit(filePath = 'src/a.ts') {
+  return {
+    filePath,
+    matchCount: 1,
+    matches: [
+      {
+        filePath,
+        lineNumber: 12,
+        lineContent: 'const token = 1;',
+        matchStart: 6,
+        matchEnd: 11,
+      },
+    ],
+  };
+}
+
+function diffHit(filePath = 'src/a.ts') {
+  return {
+    filePath,
+    lineNumber: 7,
+    lineContent: '+const token = 2;',
+    matchStart: 7,
+    matchEnd: 12,
+  };
+}
+
+function commitHit(oid: string) {
+  return {
+    oid,
+    shortOid: oid.slice(0, 7),
+    message: 'Introduce the token',
+    authorName: 'Ada',
+    authorDate: 1700000000,
+    matches: [{ filePath: 'src/a.ts', lineNumber: null, lineContent: null }],
+  };
+}
+
+async function settle(el: Dialog): Promise<void> {
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 0));
+  await el.updateComplete;
+}
+
+async function openOn(path = REPO_A, mode: Dialog['mode'] = 'files'): Promise<Dialog> {
+  const el = await fixture<Dialog>(
+    html`<lv-search-dialog
+      .repositoryPath=${path}
+      .mode=${mode}
+      .open=${true}
+    ></lv-search-dialog>`
+  );
+  await settle(el);
+  return el;
+}
+
+function q<T extends Element>(el: Dialog, sel: string): T | null {
+  return el.shadowRoot!.querySelector<T>(sel);
+}
+
+function rows(el: Dialog): HTMLButtonElement[] {
+  return [...el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.result-item')];
+}
+
+async function type(el: Dialog, value: string): Promise<void> {
+  const input = q<HTMLInputElement>(el, '.query-input')!;
+  input.value = value;
+  input.dispatchEvent(new InputEvent('input'));
+  await el.updateComplete;
+}
+
+async function search(el: Dialog): Promise<void> {
+  q<HTMLButtonElement>(el, '.search-btn')!.click();
+  await settle(el);
+}
+
+function setMode(el: Dialog, label: string): void {
+  const btn = [...el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.mode-btn')].find(
+    (b) => b.textContent?.trim() === label
+  );
+  expect(btn, `"${label}" mode button present`).to.not.be.undefined;
+  btn!.click();
+}
+
+function argsFor(command: string): Record<string, unknown> | undefined {
+  return invokeCalls.find((c) => c.command === command)?.args as
+    | Record<string, unknown>
+    | undefined;
+}
+
+describe('lv-search-dialog', () => {
+  beforeEach(() => {
+    invokeCalls.length = 0;
+    resetOverlayStack();
+    mockInvoke = () => Promise.resolve(null);
+  });
+
+  it('files mode searches the pinned repo and renders grouped matches', async () => {
+    mockInvoke = (command) =>
+      command === 'search_in_files' ? Promise.resolve([fileHit()]) : Promise.resolve(null);
+
+    const el = await openOn();
+    await type(el, 'token');
+    await search(el);
+
+    expect(argsFor('search_in_files')?.path, 'searched the pinned repo').to.equal(REPO_A);
+    expect(q(el, '.result-file')!.textContent).to.contain('src/a.ts');
+    const row = rows(el)[0];
+    expect(row, 'a result row rendered').to.not.be.undefined;
+    expect(row.textContent).to.contain(':12');
+    expect(row.textContent).to.contain('const token = 1;');
+    expect(row.querySelector('.result-match')!.textContent, 'match highlighted').to.equal('token');
+  });
+
+  it('files options reach the backend as camelCase', async () => {
+    mockInvoke = () => Promise.resolve([]);
+    const el = await openOn();
+    await type(el, 'token');
+
+    q<HTMLInputElement>(el, '.opt-case')!.click();
+    q<HTMLInputElement>(el, '.opt-regex')!.click();
+    const pattern = q<HTMLInputElement>(el, '.pattern-input')!;
+    pattern.value = '*.ts';
+    pattern.dispatchEvent(new InputEvent('input'));
+    await el.updateComplete;
+
+    await search(el);
+
+    expect(argsFor('search_in_files')).to.deep.equal({
+      path: REPO_A,
+      query: 'token',
+      caseSensitive: true,
+      regex: true,
+      filePattern: '*.ts',
+      maxResults: 500,
+    });
+  });
+
+  it('a failed search shows an inline error and no rows', async () => {
+    mockInvoke = () => Promise.reject({ message: 'fatal: bad regex' });
+    const el = await openOn();
+    await type(el, 'token');
+    await search(el);
+
+    expect(q(el, '.error')!.textContent).to.contain('fatal: bad regex');
+    expect(rows(el).length, 'no rows behind the error').to.equal(0);
+    expect(el.open, 'the dialog stays open so the inline error is readable').to.be.true;
+  });
+
+  it('no matches renders the empty state', async () => {
+    mockInvoke = () => Promise.resolve([]);
+    const el = await openOn();
+    await type(el, 'nothing-here');
+    await search(el);
+
+    expect(q(el, '.empty')!.textContent).to.contain('No matches found');
+    expect(rows(el).length).to.equal(0);
+  });
+
+  it('a blank query never invokes a search', async () => {
+    const el = await openOn();
+    await type(el, '   ');
+
+    expect(q<HTMLButtonElement>(el, '.search-btn')!.disabled, 'Search disabled').to.be.true;
+    q<HTMLInputElement>(el, '.query-input')!.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'Enter' })
+    );
+    await settle(el);
+
+    expect(invokeCalls.length, 'no command invoked').to.equal(0);
+  });
+
+  it('clicking a file match asks for blame and closes', async () => {
+    mockInvoke = () => Promise.resolve([fileHit()]);
+    const el = await openOn();
+    await type(el, 'token');
+    await search(el);
+
+    const seen: Array<{ filePath: string }> = [];
+    el.addEventListener('show-blame', (e) => {
+      seen.push((e as CustomEvent<{ filePath: string }>).detail);
+    });
+    rows(el)[0].click();
+    await el.updateComplete;
+
+    expect(seen).to.deep.equal([{ filePath: 'src/a.ts' }]);
+    expect(el.open, 'dialog closed behind the navigation').to.be.false;
+  });
+
+  it('diff mode searches the staged diff and opens that file diff', async () => {
+    mockInvoke = (command) =>
+      command === 'search_in_diff' ? Promise.resolve([diffHit()]) : Promise.resolve(null);
+
+    const el = await openOn();
+    setMode(el, 'Diff');
+    await el.updateComplete;
+    q<HTMLInputElement>(el, '.opt-staged')!.click();
+    await type(el, 'token');
+    await search(el);
+
+    expect(argsFor('search_in_diff')).to.deep.equal({
+      path: REPO_A,
+      query: 'token',
+      staged: true,
+    });
+
+    const seen: Array<{ filePath: string; staged: boolean }> = [];
+    el.addEventListener('show-working-diff', (e) => {
+      seen.push((e as CustomEvent<{ filePath: string; staged: boolean }>).detail);
+    });
+    rows(el)[0].click();
+    await el.updateComplete;
+
+    expect(seen).to.deep.equal([{ filePath: 'src/a.ts', staged: true }]);
+    expect(el.open).to.be.false;
+  });
+
+  it('commits mode uses the pickaxe command and reveals the commit', async () => {
+    mockInvoke = (command) =>
+      command === 'search_commits_by_content'
+        ? Promise.resolve([commitHit('abc123def456')])
+        : Promise.resolve(null);
+
+    const el = await openOn();
+    setMode(el, 'Commits');
+    await el.updateComplete;
+    q<HTMLInputElement>(el, '.opt-regex')!.click();
+    q<HTMLInputElement>(el, '.opt-ignore-case')!.click();
+    await type(el, 'token');
+    await search(el);
+
+    // Asserting the command NAME pins this to searchCommitsByContent, not the
+    // legacy searchInCommits wrapper.
+    expect(argsFor('search_commits_by_content')).to.deep.equal({
+      path: REPO_A,
+      searchText: 'token',
+      regex: true,
+      ignoreCase: true,
+      maxCount: 100,
+    });
+
+    const seen: Array<{ oid: string }> = [];
+    el.addEventListener('show-commit', (e) => {
+      seen.push((e as CustomEvent<{ oid: string }>).detail);
+    });
+    rows(el)[0].click();
+    await el.updateComplete;
+
+    expect(seen).to.deep.equal([{ oid: 'abc123def456' }]);
+    expect(el.open).to.be.false;
+  });
+
+  it('a capped result set says so, an uncapped one does not', async () => {
+    const many = (n: number) =>
+      Array.from({ length: n }, (_, i) => commitHit(`${i}`.padStart(12, '0')));
+
+    mockInvoke = () => Promise.resolve(many(100));
+    const el = await openOn();
+    setMode(el, 'Commits');
+    await el.updateComplete;
+    await type(el, 'token');
+    await search(el);
+    expect(q(el, '.result-summary')!.textContent).to.contain('showing the first 100');
+
+    mockInvoke = () => Promise.resolve(many(99));
+    await search(el);
+    expect(q(el, '.result-summary')!.textContent).to.not.contain('showing the first');
+  });
+
+  it('switching repositories drops the previous repo results', async () => {
+    mockInvoke = () => Promise.resolve([fileHit()]);
+    const el = await openOn();
+    await type(el, 'token');
+    await search(el);
+    expect(rows(el).length, 'repo A rows shown').to.equal(1);
+
+    el.repositoryPath = REPO_B;
+    await settle(el);
+
+    expect(rows(el).length, 'repo A rows dropped').to.equal(0);
+    expect(q(el, '.notice')!.textContent).to.contain('Repository changed');
+    expect(el.pinnedRepositoryPathIfOpen, 're-pinned').to.equal(REPO_B);
+
+    invokeCalls.length = 0;
+    await search(el);
+    expect(argsFor('search_in_files')?.path, 'next search targets repo B').to.equal(REPO_B);
+  });
+
+  it('a response that lands after the repo switch is discarded', async () => {
+    let release: (value: unknown) => void = () => {};
+    mockInvoke = () => new Promise((resolve) => { release = resolve; });
+
+    const el = await openOn();
+    await type(el, 'token');
+    q<HTMLButtonElement>(el, '.search-btn')!.click();
+    await el.updateComplete;
+
+    el.repositoryPath = REPO_B;
+    await settle(el);
+
+    release([fileHit()]);
+    await settle(el);
+
+    expect(rows(el).length, 'stale repo A response discarded').to.equal(0);
+  });
+
+  it('exposes the sweep contract and owns Escape only on top', async () => {
+    mockInvoke = () => Promise.resolve([]);
+    const el = await openOn();
+
+    expect(el.pinnedRepositoryPathIfOpen).to.equal(REPO_A);
+
+    const other = {};
+    pushOverlay(other);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await el.updateComplete;
+    expect(el.open, 'a dialog below the top overlay ignores Escape').to.be.true;
+
+    removeOverlay(other);
+    pushOverlay(el);
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape' }));
+    await el.updateComplete;
+    expect(el.open, 'the top overlay closes on Escape').to.be.false;
+    expect(el.pinnedRepositoryPathIfOpen, 'closed dialogs are not swept').to.be.null;
+  });
+
+  it('moves focus into the query input when it opens', async () => {
+    mockInvoke = () => Promise.resolve([]);
+    const el = await openOn();
+    await new Promise((r) => requestAnimationFrame(() => r(null)));
+
+    expect(deepActiveElement()).to.equal(q(el, '.query-input'));
+  });
+});

--- a/src/components/dialogs/__tests__/lv-search-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-search-dialog.test.ts
@@ -30,6 +30,7 @@ const invokeCalls: Array<{ command: string; args?: unknown }> = [];
 
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
 import { expect, fixture, html } from '@open-wc/testing';
+import { render } from 'lit';
 import { resetOverlayStack, pushOverlay, removeOverlay } from '../../../utils/overlay-stack.ts';
 import { deepActiveElement } from '../../../utils/focus.ts';
 import '../lv-search-dialog.ts';
@@ -369,6 +370,131 @@ describe('lv-search-dialog', () => {
     await el.updateComplete;
     expect(el.open, 'the top overlay closes on Escape').to.be.false;
     expect(el.pinnedRepositoryPathIfOpen, 'closed dialogs are not swept').to.be.null;
+  });
+
+  it('switching mode discards a search still in flight', async () => {
+    let release: (value: unknown) => void = () => {};
+    mockInvoke = () => new Promise((resolve) => { release = resolve; });
+
+    const el = await openOn();
+    await type(el, 'token');
+    q<HTMLButtonElement>(el, '.search-btn')!.click();
+    await el.updateComplete;
+
+    setMode(el, 'Diff');
+    await settle(el);
+
+    release([fileHit()]);
+    await settle(el);
+
+    expect(
+      !!q(el, '.empty'),
+      'no "No matches found" for a search diff mode never ran'
+    ).to.be.false;
+    expect(rows(el).length, 'the files response does not paint under diff mode').to.equal(0);
+    expect(q(el, '.status')?.textContent ?? '', 'back to the prompt').to.contain('Enter a search');
+  });
+
+  it('reports a mode the user changed so reopening lands on the parent mode', async () => {
+    mockInvoke = () => Promise.resolve([]);
+
+    // Mirrors app-shell: the parent owns the mode and pushes it through a
+    // dirty-checked `.mode` binding, so an unreported internal change would
+    // make the next open a no-op and leave the dialog on the wrong mode.
+    const host = document.createElement('div');
+    document.body.appendChild(host);
+    let parentMode: Dialog['mode'] = 'files';
+    let open = true;
+    const paint = () =>
+      render(
+        html`<lv-search-dialog
+          .repositoryPath=${REPO_A}
+          .mode=${parentMode}
+          .open=${open}
+          @mode-changed=${(e: Event) => {
+            parentMode = (e as CustomEvent<{ mode: Dialog['mode'] }>).detail.mode;
+          }}
+        ></lv-search-dialog>`,
+        host
+      );
+
+    paint();
+    const el = host.querySelector('lv-search-dialog') as Dialog;
+    await settle(el);
+
+    setMode(el, 'Commits');
+    await settle(el);
+    expect(parentMode, 'the parent is told which mode the dialog moved to').to.equal('commits');
+
+    open = false;
+    paint();
+    await settle(el);
+
+    // Reopened by the "search in files" palette entry.
+    parentMode = 'files';
+    open = true;
+    paint();
+    await settle(el);
+
+    expect(el.mode, 'reopened in the mode the parent asked for').to.equal('files');
+    host.remove();
+  });
+
+  it('highlights a match reported at a UTF-8 byte offset', async () => {
+    // 'héllo ' is 7 UTF-8 bytes but 6 UTF-16 code units, so slicing the string
+    // with the backend's byte offsets would highlight 'ken' instead of 'token'.
+    mockInvoke = () =>
+      Promise.resolve([
+        {
+          filePath: 'src/a.ts',
+          matchCount: 1,
+          matches: [
+            {
+              filePath: 'src/a.ts',
+              lineNumber: 3,
+              lineContent: 'héllo token',
+              matchStart: 7,
+              matchEnd: 12,
+            },
+          ],
+        },
+      ]);
+
+    const el = await openOn();
+    await type(el, 'token');
+    await search(el);
+
+    const row = rows(el)[0];
+    expect(row.querySelector('.result-match')!.textContent, 'highlight lands on the match').to.equal(
+      'token'
+    );
+    expect(row.textContent, 'the line still reads whole').to.contain('héllo token');
+  });
+
+  it('a diff row opens the side its match was found on', async () => {
+    mockInvoke = (command) =>
+      command === 'search_in_diff' ? Promise.resolve([diffHit()]) : Promise.resolve(null);
+
+    const el = await openOn();
+    setMode(el, 'Diff');
+    await el.updateComplete;
+    q<HTMLInputElement>(el, '.opt-staged')!.click();
+    await type(el, 'token');
+    await search(el);
+
+    // Flipping the radio afterwards must not re-aim rows already on screen:
+    // they came out of the staged diff.
+    q<HTMLInputElement>(el, '.opt-unstaged')!.click();
+    await el.updateComplete;
+
+    const seen: Array<{ filePath: string; staged: boolean }> = [];
+    el.addEventListener('show-working-diff', (e) => {
+      seen.push((e as CustomEvent<{ filePath: string; staged: boolean }>).detail);
+    });
+    rows(el)[0].click();
+    await el.updateComplete;
+
+    expect(seen).to.deep.equal([{ filePath: 'src/a.ts', staged: true }]);
   });
 
   it('moves focus into the query input when it opens', async () => {

--- a/src/components/dialogs/index.ts
+++ b/src/components/dialogs/index.ts
@@ -11,6 +11,7 @@ export { LvInteractiveRebaseDialog } from './lv-interactive-rebase-dialog.ts';
 export { LvConflictResolutionDialog } from './lv-conflict-resolution-dialog.ts';
 export { LvCommandPalette, type PaletteCommand } from './lv-command-palette.ts';
 export { LvReflogDialog } from './lv-reflog-dialog.ts';
+export { LvSearchDialog, type SearchDialogMode } from './lv-search-dialog.ts';
 export { LvKeyboardShortcutsDialog } from './lv-keyboard-shortcuts-dialog.ts';
 export { LvRemoteDialog } from './lv-remote-dialog.ts';
 export { LvCleanDialog } from './lv-clean-dialog.ts';

--- a/src/components/dialogs/lv-search-dialog.ts
+++ b/src/components/dialogs/lv-search-dialog.ts
@@ -34,6 +34,10 @@ export type SearchDialogMode = 'files' | 'diff' | 'commits';
 const FILE_MATCH_CAP = 500;
 const COMMIT_CAP = 100;
 
+/** Reused so a result list of hundreds of rows does not build one per row. */
+const UTF8_ENCODER = new TextEncoder();
+const UTF8_DECODER = new TextDecoder();
+
 @customElement('lv-search-dialog')
 export class LvSearchDialog extends LitElement {
   static styles = [
@@ -399,6 +403,12 @@ export class LvSearchDialog extends LitElement {
   @state() private repoChanged = false;
   @state() private fileResults: SearchFileResult[] = [];
   @state() private diffResults: SearchResult[] = [];
+  /**
+   * The staged flag the rows on screen were found with. The radio can be
+   * flipped after a search, so reading `staged` at click time would open the
+   * opposite side of the diff from the one the match came from.
+   */
+  @state() private diffResultsStaged = false;
   @state() private commitResults: SearchCommit[] = [];
 
   /**
@@ -505,10 +515,21 @@ export class LvSearchDialog extends LitElement {
   private setMode(mode: SearchDialogMode): void {
     if (this.mode === mode) return;
     this.mode = mode;
+    // A search still in flight belongs to the mode we just left: bumping the
+    // token drops its response, so it cannot mark the new mode searched and
+    // report a false "No matches found" over results it never produced.
+    this.searchToken++;
+    this.searching = false;
     // The result arrays are per-mode, so only the shared banners need clearing.
     this.error = null;
     this.capped = false;
     this.searched = false;
+    // The mode is parent-owned: without telling app-shell, its `.mode` binding
+    // still holds the value it last pushed, so reopening the dialog in that
+    // same mode would be dirty-checked away and land on this one instead.
+    this.dispatchEvent(
+      new CustomEvent('mode-changed', { detail: { mode }, bubbles: true, composed: true }),
+    );
   }
 
   private get canSearch(): boolean {
@@ -548,10 +569,12 @@ export class LvSearchDialog extends LitElement {
           this.fail(result.error?.message);
         }
       } else if (mode === 'diff') {
-        const result = await gitService.searchInDiff(repoPath, query, this.staged);
+        const staged = this.staged;
+        const result = await gitService.searchInDiff(repoPath, query, staged);
         if (token !== this.searchToken) return;
         if (result.success) {
           this.diffResults = result.data ?? [];
+          this.diffResultsStaged = staged;
           this.finishSuccess();
         } else {
           this.fail(result.error?.message);
@@ -623,14 +646,22 @@ export class LvSearchDialog extends LitElement {
     this.close();
   }
 
+  /**
+   * `matchStart`/`matchEnd` are UTF-8 BYTE offsets — the backend finds them with
+   * Rust's `str::find`. JavaScript string indices are UTF-16 code units, so
+   * slicing the string with them mis-highlights every line that carries a
+   * non-ASCII character before the match. Slice the encoded bytes instead.
+   */
   private renderHighlighted(content: string, start: number, end: number) {
-    if (end <= start || start < 0 || start >= content.length) {
+    const bytes = UTF8_ENCODER.encode(content);
+    if (end <= start || start < 0 || start >= bytes.length) {
       return html`${content}`;
     }
-    const safeEnd = Math.min(end, content.length);
-    return html`${content.slice(0, start)}<mark
-        class="result-match"
-      >${content.slice(start, safeEnd)}</mark>${content.slice(safeEnd)}`;
+    const safeEnd = Math.min(end, bytes.length);
+    const before = UTF8_DECODER.decode(bytes.subarray(0, start));
+    const match = UTF8_DECODER.decode(bytes.subarray(start, safeEnd));
+    const after = UTF8_DECODER.decode(bytes.subarray(safeEnd));
+    return html`${before}<mark class="result-match">${match}</mark>${after}`;
   }
 
   private formatDate(timestamp: number): string {
@@ -893,7 +924,7 @@ export class LvSearchDialog extends LitElement {
           () =>
             this.emitAndClose('show-working-diff', {
               filePath: m.filePath,
-              staged: this.staged,
+              staged: this.diffResultsStaged,
             }),
           '',
           html`

--- a/src/components/dialogs/lv-search-dialog.ts
+++ b/src/components/dialogs/lv-search-dialog.ts
@@ -1,0 +1,942 @@
+/**
+ * Search Dialog
+ *
+ * The UI half of the repository content-search backend. `search_in_files`
+ * (git grep), `search_in_diff` and `search_commits_by_content` (pickaxe) all
+ * shipped with typed service wrappers and a full Rust test suite, but nothing
+ * in the app ever called them: the only search a user could reach was the
+ * toolbar bar, which dims the graph by commit message/author/date/branch via
+ * the search index. "Find this text in my files", "search the diff I am
+ * looking at" and "which commit introduced this string" had no entry point at
+ * all.
+ *
+ * Every result row here lands somewhere real — a file match opens blame for
+ * that file, a diff match opens that file's working-tree diff, a commit match
+ * is revealed in the graph — so the dialog is a way into the app rather than a
+ * dead-end list.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { sharedStyles } from '../../styles/shared-styles.ts';
+import * as gitService from '../../services/git.service.ts';
+import type {
+  SearchResult,
+  SearchFileResult,
+  SearchCommit,
+} from '../../services/git.service.ts';
+import { pushOverlay, removeOverlay, isTopOverlay } from '../../utils/overlay-stack.ts';
+import { containsDeepActiveElement } from '../../utils/focus.ts';
+
+export type SearchDialogMode = 'files' | 'diff' | 'commits';
+
+/** Mirrors the backend defaults so the "narrow your search" hint is truthful. */
+const FILE_MATCH_CAP = 500;
+const COMMIT_CAP = 100;
+
+@customElement('lv-search-dialog')
+export class LvSearchDialog extends LitElement {
+  static styles = [
+    sharedStyles,
+    css`
+      :host {
+        display: none;
+        position: fixed;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        z-index: var(--z-modal, 200);
+      }
+
+      :host([open]) {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+      }
+
+      .overlay {
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background: rgba(0, 0, 0, 0.5);
+        backdrop-filter: blur(2px);
+      }
+
+      .dialog {
+        position: relative;
+        display: flex;
+        flex-direction: column;
+        width: 760px;
+        max-width: 92vw;
+        max-height: 80vh;
+        background: var(--color-bg-secondary);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-lg);
+        box-shadow: var(--shadow-lg);
+        overflow: hidden;
+      }
+
+      .header {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: var(--spacing-md) var(--spacing-lg);
+        border-bottom: 1px solid var(--color-border);
+        background: var(--color-bg-tertiary);
+      }
+
+      .header-left {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-sm);
+      }
+
+      .header-icon {
+        width: 20px;
+        height: 20px;
+        color: var(--color-primary);
+      }
+
+      .title {
+        font-size: var(--font-size-lg);
+        font-weight: var(--font-weight-semibold);
+        color: var(--color-text-primary);
+      }
+
+      .subtitle {
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+      }
+
+      .close-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        width: 28px;
+        height: 28px;
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        color: var(--color-text-secondary);
+        cursor: pointer;
+      }
+
+      .close-btn:hover {
+        background: var(--color-bg-hover);
+        color: var(--color-text-primary);
+      }
+
+      .close-btn svg {
+        width: 16px;
+        height: 16px;
+      }
+
+      .controls {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-sm);
+        padding: var(--spacing-md) var(--spacing-lg);
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      .modes {
+        display: flex;
+        gap: 0;
+      }
+
+      .mode-btn {
+        padding: var(--spacing-xs) var(--spacing-md);
+        font-size: var(--font-size-sm);
+        border: 1px solid var(--color-border);
+        background: var(--color-bg-tertiary);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+      }
+
+      .mode-btn:first-child {
+        border-radius: var(--radius-sm) 0 0 var(--radius-sm);
+      }
+
+      .mode-btn:last-child {
+        border-radius: 0 var(--radius-sm) var(--radius-sm) 0;
+      }
+
+      .mode-btn + .mode-btn {
+        border-left: none;
+      }
+
+      .mode-btn.active {
+        background: var(--color-primary);
+        border-color: var(--color-primary);
+        color: white;
+      }
+
+      .query-row {
+        display: flex;
+        gap: var(--spacing-sm);
+      }
+
+      .query-input {
+        flex: 1;
+        padding: var(--spacing-xs) var(--spacing-sm);
+        font-size: var(--font-size-sm);
+        font-family: var(--font-mono);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        background: var(--color-bg-primary);
+        color: var(--color-text-primary);
+      }
+
+      .search-btn {
+        padding: var(--spacing-xs) var(--spacing-lg);
+        font-size: var(--font-size-sm);
+        border: 1px solid var(--color-primary);
+        border-radius: var(--radius-sm);
+        background: var(--color-primary);
+        color: white;
+        cursor: pointer;
+      }
+
+      .search-btn:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .options {
+        display: flex;
+        flex-wrap: wrap;
+        align-items: center;
+        gap: var(--spacing-md);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary);
+      }
+
+      .options label {
+        display: flex;
+        align-items: center;
+        gap: 4px;
+        cursor: pointer;
+      }
+
+      .pattern-input {
+        flex: 1;
+        min-width: 140px;
+        padding: 2px var(--spacing-sm);
+        font-size: var(--font-size-xs);
+        font-family: var(--font-mono);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        background: var(--color-bg-primary);
+        color: var(--color-text-primary);
+      }
+
+      .content {
+        flex: 1;
+        overflow-y: auto;
+        padding: var(--spacing-md) var(--spacing-lg);
+      }
+
+      .status,
+      .empty {
+        padding: var(--spacing-lg);
+        text-align: center;
+        color: var(--color-text-muted);
+        font-size: var(--font-size-sm);
+      }
+
+      .error {
+        padding: var(--spacing-sm) var(--spacing-md);
+        border: 1px solid var(--color-error);
+        border-radius: var(--radius-sm);
+        background: var(--color-error-bg);
+        color: var(--color-error);
+        font-size: var(--font-size-sm);
+        word-break: break-word;
+      }
+
+      .notice {
+        margin-bottom: var(--spacing-sm);
+        padding: var(--spacing-xs) var(--spacing-sm);
+        border-radius: var(--radius-sm);
+        background: var(--color-warning-bg);
+        color: var(--color-warning);
+        font-size: var(--font-size-xs);
+      }
+
+      .result-summary {
+        margin-bottom: var(--spacing-sm);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+      }
+
+      .result-group {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        margin-bottom: var(--spacing-sm);
+      }
+
+      .result-file {
+        font-size: var(--font-size-xs);
+        font-weight: var(--font-weight-semibold);
+        font-family: var(--font-mono);
+        color: var(--color-primary);
+        padding: var(--spacing-xs) var(--spacing-sm);
+        background: var(--color-bg-tertiary);
+        border-radius: var(--radius-sm);
+      }
+
+      .result-item {
+        display: flex;
+        align-items: baseline;
+        gap: var(--spacing-sm);
+        width: 100%;
+        text-align: left;
+        padding: var(--spacing-xs) var(--spacing-sm);
+        border: none;
+        border-radius: var(--radius-sm);
+        background: transparent;
+        cursor: pointer;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-primary);
+      }
+
+      .result-item:hover,
+      .result-item:focus-visible {
+        background: var(--color-bg-hover);
+        outline: none;
+      }
+
+      .result-line {
+        font-family: var(--font-mono);
+        color: var(--color-text-muted);
+        flex-shrink: 0;
+      }
+
+      .result-path {
+        font-family: var(--font-mono);
+        color: var(--color-text-secondary);
+        white-space: nowrap;
+        flex-shrink: 0;
+      }
+
+      .result-content {
+        flex: 1;
+        font-family: var(--font-mono);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .result-match {
+        background: var(--color-warning-bg);
+        color: var(--color-warning);
+        border-radius: 2px;
+        padding: 0 1px;
+      }
+
+      .commit-item {
+        flex-direction: column;
+        align-items: stretch;
+        gap: 2px;
+      }
+
+      .commit-top {
+        display: flex;
+        align-items: baseline;
+        gap: var(--spacing-sm);
+      }
+
+      .commit-oid {
+        font-family: var(--font-mono);
+        color: var(--color-primary);
+        flex-shrink: 0;
+      }
+
+      .commit-message {
+        flex: 1;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .commit-meta {
+        display: flex;
+        gap: var(--spacing-md);
+        color: var(--color-text-muted);
+        font-size: 10px;
+      }
+
+      .commit-files {
+        font-family: var(--font-mono);
+        color: var(--color-text-muted);
+        font-size: 10px;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    `,
+  ];
+
+  @property({ type: Boolean, reflect: true }) open = false;
+  @property({ type: String }) repositoryPath = '';
+  @property({ type: String }) mode: SearchDialogMode = 'files';
+
+  @state() private query = '';
+  @state() private caseSensitive = false;
+  @state() private useRegex = false;
+  @state() private filePattern = '';
+  @state() private staged = false;
+  @state() private ignoreCase = false;
+
+  @state() private searching = false;
+  @state() private searched = false;
+  @state() private capped = false;
+  @state() private error: string | null = null;
+  @state() private repoChanged = false;
+  @state() private fileResults: SearchFileResult[] = [];
+  @state() private diffResults: SearchResult[] = [];
+  @state() private commitResults: SearchCommit[] = [];
+
+  /**
+   * Repo captured when the dialog opened. `repositoryPath` is live-bound to
+   * the ACTIVE repository and rebinds the instant the user Ctrl+Tabs — a
+   * document-level shortcut this overlay does not block. Every search targets
+   * the pinned path, so the rows on screen and the repository they navigate
+   * into can never disagree.
+   */
+  private pinnedRepoPath = '';
+
+  /** The repo this dialog is pinned to while open, or null when closed. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.open ? this.pinnedRepoPath : null;
+  }
+
+  /**
+   * Bumped by every search AND by every re-pin: a response is applied only if
+   * its token is still current, so a slow git grep against repo A cannot paint
+   * its rows over repo B after a tab switch.
+   */
+  private searchToken = 0;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    document.addEventListener('keydown', this.handleKeyDown);
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    removeOverlay(this);
+    document.removeEventListener('keydown', this.handleKeyDown);
+  }
+
+  // Pinning happens BEFORE the render that follows it, so the dropped results
+  // never paint: doing it in updated() would queue a second update and flash
+  // the previous repository's rows.
+  willUpdate(changedProps: Map<string, unknown>): void {
+    const opening = changedProps.has('open') && this.open;
+    const switchedWhileOpen = this.open && !opening && changedProps.has('repositoryPath');
+    if ((opening || switchedWhileOpen) && this.repositoryPath !== this.pinnedRepoPath) {
+      this.repin(switchedWhileOpen);
+    }
+  }
+
+  updated(changedProps: Map<string, unknown>): void {
+    if (changedProps.has('open')) {
+      if (this.open) {
+        pushOverlay(this);
+        this.focusInitialControl();
+      } else {
+        removeOverlay(this);
+      }
+    }
+  }
+
+  /**
+   * Re-aim at the active repository and drop everything the previous one
+   * produced. Leaving the rows up would let a click navigate repo B using a
+   * hit found in repo A.
+   */
+  private repin(announce: boolean): void {
+    this.pinnedRepoPath = this.repositoryPath;
+    this.searchToken++;
+    this.fileResults = [];
+    this.diffResults = [];
+    this.commitResults = [];
+    this.error = null;
+    this.searched = false;
+    this.capped = false;
+    this.searching = false;
+    this.repoChanged = announce;
+  }
+
+  /**
+   * A search dialog's first control is its query field — unlike the
+   * destructive dialogs, no row here carries an action that can be fired by a
+   * stray Enter, so starting in the input is safe and saves a Tab.
+   */
+  private focusInitialControl(): void {
+    requestAnimationFrame(() => {
+      if (!this.open) return;
+      if (containsDeepActiveElement(this)) return;
+      const input = this.shadowRoot?.querySelector('.query-input') as HTMLElement | null;
+      input?.focus();
+    });
+  }
+
+  private handleKeyDown = (e: KeyboardEvent): void => {
+    // Only the topmost overlay owns Escape — every dialog listens on document.
+    if (!this.open || !isTopOverlay(this)) return;
+    if (e.key === 'Escape') this.close();
+  };
+
+  private handleOverlayClick(e: MouseEvent): void {
+    if (e.target === e.currentTarget) this.close();
+  }
+
+  public close(): void {
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+  }
+
+  private setMode(mode: SearchDialogMode): void {
+    if (this.mode === mode) return;
+    this.mode = mode;
+    // The result arrays are per-mode, so only the shared banners need clearing.
+    this.error = null;
+    this.capped = false;
+    this.searched = false;
+  }
+
+  private get canSearch(): boolean {
+    return !!this.query.trim() && !this.searching;
+  }
+
+  private async runSearch(): Promise<void> {
+    if (!this.canSearch) return;
+    const repoPath = this.pinnedRepoPath;
+    if (!repoPath) return;
+
+    const query = this.query.trim();
+    const mode = this.mode;
+    const token = ++this.searchToken;
+
+    this.searching = true;
+    this.error = null;
+    this.capped = false;
+    this.repoChanged = false;
+
+    try {
+      if (mode === 'files') {
+        const result = await gitService.searchInFiles(
+          repoPath,
+          query,
+          this.caseSensitive,
+          this.useRegex,
+          this.filePattern.trim() || undefined,
+          FILE_MATCH_CAP,
+        );
+        if (token !== this.searchToken) return;
+        if (result.success) {
+          this.fileResults = result.data ?? [];
+          this.capped = this.totalFileMatches >= FILE_MATCH_CAP;
+          this.finishSuccess();
+        } else {
+          this.fail(result.error?.message);
+        }
+      } else if (mode === 'diff') {
+        const result = await gitService.searchInDiff(repoPath, query, this.staged);
+        if (token !== this.searchToken) return;
+        if (result.success) {
+          this.diffResults = result.data ?? [];
+          this.finishSuccess();
+        } else {
+          this.fail(result.error?.message);
+        }
+      } else {
+        const result = await gitService.searchCommitsByContent(
+          repoPath,
+          query,
+          this.useRegex,
+          this.ignoreCase,
+          COMMIT_CAP,
+        );
+        if (token !== this.searchToken) return;
+        if (result.success) {
+          this.commitResults = result.data ?? [];
+          this.capped = this.commitResults.length >= COMMIT_CAP;
+          this.finishSuccess();
+        } else {
+          this.fail(result.error?.message);
+        }
+      }
+    } catch (err) {
+      if (token === this.searchToken) {
+        this.fail(err instanceof Error ? err.message : undefined);
+      }
+    } finally {
+      if (token === this.searchToken) this.searching = false;
+    }
+  }
+
+  private finishSuccess(): void {
+    this.error = null;
+    this.searched = true;
+  }
+
+  /**
+   * The dialog stays open on failure, so the error belongs inline in the
+   * results area — a toast would be dismissed behind the overlay the user is
+   * still looking at.
+   */
+  private fail(message?: string): void {
+    this.error = message ?? 'Search failed';
+    this.fileResults = [];
+    this.diffResults = [];
+    this.commitResults = [];
+    this.capped = false;
+    this.searched = true;
+  }
+
+  private get totalFileMatches(): number {
+    return this.fileResults.reduce((sum, f) => sum + f.matches.length, 0);
+  }
+
+  private get hasResults(): boolean {
+    if (this.mode === 'files') return this.fileResults.length > 0;
+    if (this.mode === 'diff') return this.diffResults.length > 0;
+    return this.commitResults.length > 0;
+  }
+
+  private handleQueryKeyDown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      void this.runSearch();
+    }
+  }
+
+  private emitAndClose(type: string, detail: unknown): void {
+    this.dispatchEvent(new CustomEvent(type, { detail, bubbles: true, composed: true }));
+    this.close();
+  }
+
+  private renderHighlighted(content: string, start: number, end: number) {
+    if (end <= start || start < 0 || start >= content.length) {
+      return html`${content}`;
+    }
+    const safeEnd = Math.min(end, content.length);
+    return html`${content.slice(0, start)}<mark
+        class="result-match"
+      >${content.slice(start, safeEnd)}</mark>${content.slice(safeEnd)}`;
+  }
+
+  private formatDate(timestamp: number): string {
+    return new Date(timestamp * 1000).toLocaleString();
+  }
+
+  render() {
+    return html`
+      <div class="overlay" @click=${this.handleOverlayClick}></div>
+      <div class="dialog">
+        <div class="header">
+          <div class="header-left">
+            <svg class="header-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="11" cy="11" r="8"></circle>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            </svg>
+            <div>
+              <div class="title">Search</div>
+              <div class="subtitle">Find text in files, in the current diff, or in history</div>
+            </div>
+          </div>
+          <button class="close-btn" @click=${this.close} aria-label="Close search">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <line x1="18" y1="6" x2="6" y2="18"></line>
+              <line x1="6" y1="6" x2="18" y2="18"></line>
+            </svg>
+          </button>
+        </div>
+
+        <div class="controls">
+          <div class="modes">
+            ${(
+              [
+                ['files', 'Files'],
+                ['diff', 'Diff'],
+                ['commits', 'Commits'],
+              ] as Array<[SearchDialogMode, string]>
+            ).map(
+              ([value, label]) => html`
+                <button
+                  class="mode-btn ${this.mode === value ? 'active' : ''}"
+                  type="button"
+                  aria-pressed=${this.mode === value ? 'true' : 'false'}
+                  @click=${() => this.setMode(value)}
+                >
+                  ${label}
+                </button>
+              `,
+            )}
+          </div>
+
+          <div class="query-row">
+            <input
+              class="query-input"
+              type="text"
+              placeholder=${this.mode === 'files'
+                ? 'Search tracked files…'
+                : this.mode === 'diff'
+                  ? 'Search the current diff…'
+                  : 'Find commits that added or removed…'}
+              aria-label="Search query"
+              .value=${this.query}
+              @input=${(e: InputEvent) => {
+                this.query = (e.target as HTMLInputElement).value;
+              }}
+              @keydown=${this.handleQueryKeyDown}
+            />
+            <button
+              class="search-btn"
+              ?disabled=${!this.canSearch}
+              @click=${() => void this.runSearch()}
+            >
+              ${this.searching ? 'Searching…' : 'Search'}
+            </button>
+          </div>
+
+          <div class="options">${this.renderModeOptions()}</div>
+        </div>
+
+        <div class="content">${this.renderResults()}</div>
+      </div>
+    `;
+  }
+
+  private renderModeOptions() {
+    if (this.mode === 'files') {
+      return html`
+        <label>
+          <input
+            type="checkbox"
+            class="opt-case"
+            .checked=${this.caseSensitive}
+            @change=${(e: Event) => {
+              this.caseSensitive = (e.target as HTMLInputElement).checked;
+            }}
+          />
+          Case sensitive
+        </label>
+        <label>
+          <input
+            type="checkbox"
+            class="opt-regex"
+            .checked=${this.useRegex}
+            @change=${(e: Event) => {
+              this.useRegex = (e.target as HTMLInputElement).checked;
+            }}
+          />
+          Regex
+        </label>
+        <input
+          class="pattern-input"
+          type="text"
+          placeholder="File pattern (e.g. *.ts)"
+          aria-label="File pattern"
+          .value=${this.filePattern}
+          @input=${(e: InputEvent) => {
+            this.filePattern = (e.target as HTMLInputElement).value;
+          }}
+          @keydown=${this.handleQueryKeyDown}
+        />
+      `;
+    }
+
+    if (this.mode === 'diff') {
+      return html`
+        <label>
+          <input
+            type="radio"
+            name="diff-source"
+            class="opt-unstaged"
+            .checked=${!this.staged}
+            @change=${() => {
+              this.staged = false;
+            }}
+          />
+          Unstaged
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="diff-source"
+            class="opt-staged"
+            .checked=${this.staged}
+            @change=${() => {
+              this.staged = true;
+            }}
+          />
+          Staged
+        </label>
+      `;
+    }
+
+    return html`
+      <label>
+        <input
+          type="checkbox"
+          class="opt-regex"
+          .checked=${this.useRegex}
+          @change=${(e: Event) => {
+            this.useRegex = (e.target as HTMLInputElement).checked;
+          }}
+        />
+        Regex
+      </label>
+      <label>
+        <input
+          type="checkbox"
+          class="opt-ignore-case"
+          .checked=${this.ignoreCase}
+          @change=${(e: Event) => {
+            this.ignoreCase = (e.target as HTMLInputElement).checked;
+          }}
+        />
+        Ignore case
+      </label>
+    `;
+  }
+
+  private renderResults() {
+    if (this.searching) return html`<div class="status">Searching…</div>`;
+    if (this.error) return html`<div class="error">${this.error}</div>`;
+
+    const notice = this.repoChanged
+      ? html`<div class="notice">Repository changed — run the search again</div>`
+      : nothing;
+
+    if (!this.searched) {
+      return html`${notice}
+        <div class="status">Enter a search and press Enter.</div>`;
+    }
+    if (!this.hasResults) {
+      return html`${notice}<div class="empty">No matches found</div>`;
+    }
+
+    return html`
+      ${notice}
+      <div class="result-summary">${this.summaryText()}</div>
+      ${this.mode === 'files'
+        ? this.renderFileResults()
+        : this.mode === 'diff'
+          ? this.renderDiffResults()
+          : this.renderCommitResults()}
+    `;
+  }
+
+  private summaryText(): string {
+    if (this.mode === 'files') {
+      const files = this.fileResults.length;
+      const matches = this.totalFileMatches;
+      const base = `${matches} ${matches === 1 ? 'match' : 'matches'} in ${files} ${
+        files === 1 ? 'file' : 'files'
+      }`;
+      return this.capped ? `${base} — showing the first ${FILE_MATCH_CAP}, narrow your search` : base;
+    }
+    if (this.mode === 'diff') {
+      const n = this.diffResults.length;
+      return `${n} ${n === 1 ? 'match' : 'matches'}`;
+    }
+    const n = this.commitResults.length;
+    const base = `${n} ${n === 1 ? 'commit' : 'commits'}`;
+    return this.capped ? `${base} — showing the first ${COMMIT_CAP}, narrow your search` : base;
+  }
+
+  private renderRowButton(onActivate: () => void, extraClass: string, body: unknown) {
+    return html`
+      <button class="result-item ${extraClass}" type="button" @click=${onActivate}>
+        ${body}
+      </button>
+    `;
+  }
+
+  private renderFileResults() {
+    return html`
+      ${this.fileResults.map(
+        (file) => html`
+          <div class="result-group">
+            <div class="result-file">${file.filePath}</div>
+            ${file.matches.map((m) =>
+              this.renderRowButton(
+                () => this.emitAndClose('show-blame', { filePath: file.filePath }),
+                '',
+                html`
+                  <span class="result-line">:${m.lineNumber}</span>
+                  <span class="result-content"
+                    >${this.renderHighlighted(m.lineContent, m.matchStart, m.matchEnd)}</span
+                  >
+                `,
+              ),
+            )}
+          </div>
+        `,
+      )}
+    `;
+  }
+
+  private renderDiffResults() {
+    return html`
+      ${this.diffResults.map((m) =>
+        this.renderRowButton(
+          () =>
+            this.emitAndClose('show-working-diff', {
+              filePath: m.filePath,
+              staged: this.staged,
+            }),
+          '',
+          html`
+            <span class="result-path">${m.filePath}</span>
+            <span class="result-line">:${m.lineNumber}</span>
+            <span class="result-content"
+              >${this.renderHighlighted(m.lineContent, m.matchStart, m.matchEnd)}</span
+            >
+          `,
+        ),
+      )}
+    `;
+  }
+
+  private renderCommitResults() {
+    return html`
+      ${this.commitResults.map((c) =>
+        this.renderRowButton(
+          () => this.emitAndClose('show-commit', { oid: c.oid }),
+          'commit-item',
+          html`
+            <span class="commit-top">
+              <span class="commit-oid">${c.shortOid}</span>
+              <span class="commit-message">${c.message}</span>
+            </span>
+            <span class="commit-meta">
+              <span>${c.authorName}</span>
+              <span>${this.formatDate(c.authorDate)}</span>
+            </span>
+            ${c.matches.length > 0
+              ? html`<span class="commit-files"
+                  >${c.matches.map((m) => m.filePath).join(', ')}</span
+                >`
+              : nothing}
+          `,
+        ),
+      )}
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lv-search-dialog': LvSearchDialog;
+  }
+}


### PR DESCRIPTION
## What was broken

### The repository content-search backend was unreachable from the UI

`search_in_files` (git grep), `search_in_diff` and `search_commits_by_content` (pickaxe) each shipped with a typed wrapper in `src/services/git.service.ts` and a full Rust test suite in `src-tauri/src/commands/search.rs` — and **zero call sites**. Grepping the repo for `searchInFiles` / `searchInDiff` / `searchCommitsByContent` returns only their definitions plus `src/services/__tests__/search.service.test.ts`. No component, store, service or command-palette entry ever invoked them.

The only search a user could reach was the palette's `id: 'search'` entry → `handleToggleSearch()` → `lv-search-bar`, which emits a `SearchFilter` consumed as a **graph dimming filter** and matches only message / author / date / file-path / branch through the search index.

So there was no path anywhere in the app to:

- "find this text in my files"
- "search the diff I am looking at"
- "which commit introduced this string"

A complete, tested feature set sat inert — and unexercisable, which is how latent bugs accumulate in it.

## The fix

A single new dialog, `lv-search-dialog`, with three modes wired to the three commands, opened from three new command-palette entries. It is modelled on `lv-reflog-dialog` (own overlay, not `lv-modal`) and on the result list `lv-workspace-manager-dialog` already renders for cross-workspace search.

**Every result row lands somewhere real** rather than printing a dead line:

| Mode | Command | Row click |
|---|---|---|
| Files | `search_in_files` | `show-blame` → blame view for that file |
| Diff | `search_in_diff` | `show-working-diff` → that file's working-tree diff |
| Commits | `search_commits_by_content` | `show-commit` → commit revealed in the graph |

Details that matter:

- **Pickaxe mode deliberately uses `searchCommitsByContent`**, not `searchInCommits`. The latter still parses a fragile `'|'`-separated format that a sibling PR covers; `search_commits_by_content` uses a NUL-separated `--format` and returns `oid`/`shortOid`. This PR therefore neither depends on nor touches that fix.
- **Errors render inline** in the results area, never as a toast. The dialog stays open on failure, so a toast would be dismissed behind the overlay the user is still looking at. `try/catch` around the await produces the same inline error.
- **A vanished diff hit reports itself.** `handleShowWorkingDiff` looks the file up in `activeRepository.status` by path + staged flag (falling back to path only); a miss shows an info toast rather than being a silent dead click.
- **Repository pinning.** `repositoryPath` is live-bound to the active repository and `Ctrl+Tab` is a document-level shortcut that fires straight through the overlay. The dialog pins the path it opened against, and a mid-session switch re-pins, clears all three result arrays and shows "Repository changed — run the search again". A `searchToken` is bumped by both a search and a re-pin, so a slow `git grep` against repo A cannot paint its rows over repo B — without it a click would navigate repo B using a hit found in repo A.
- **Overlay/sweep contracts honoured.** Tag ends in `-DIALOG` and reflects `open`, so `containsOpenModal()` treats it as blocking; it joins the overlay stack (`pushOverlay`/`removeOverlay`/`isTopOverlay`) so Escape reaches only the top dialog; it exposes `pinnedRepositoryPathIfOpen` so `collectRepoScopedDialogs()` discovers it from the DOM, and it has a `lv-search-dialog` entry in the sweep table with a `clearFlag`. It deliberately does **not** expose `operationInFlight` — a search is read-only and nothing must be kept alive past a tab close. The `showSearchDialog` name is load-bearing for `closeRepoScopedDialogs()`'s `/^show[A-Z]/` scan.
- **No keyboard shortcut added.** `Ctrl+F` is the existing search bar and `Ctrl+Shift+F` is already Fetch.
- `handleFileSelected`'s body moves into `openWorkingTreeDiff(file, isPartiallyStaged)` so the file list and the diff search route conflicted files and blame teardown identically.

**`src/services/git.service.ts` is unchanged**, so the three sibling PRs on that file do not conflict with this one. No Rust change either. The remaining unused wrappers (`searchInCommits`, `searchInCommitMessages`, `searchCommitsByFile`, `filterCommits`, `getBranchDiffCommits`, `getFileLog`) are left alone: deleting them would edit `git.service.ts` against those open PRs, and two of them duplicate what the existing search bar already does.

## Tests

All three suites are new-code tests, and each is written to fail against a half-done version of the change, not merely against a missing import.

| Suite | Test | Covers |
|---|---|---|
| `lv-search-dialog.test.ts` | files mode searches the pinned repo and renders grouped matches | happy path |
| | files options reach the backend as camelCase | `caseSensitive`/`regex`/`filePattern`/`maxResults` — fails if the options row is decorative |
| | a failed search shows an inline error and no rows | error path; dialog stays open |
| | no matches renders the empty state | edge case |
| | a blank query never invokes a search | edge case — button disabled, Enter records 0 invokes |
| | clicking a file match asks for blame and closes | `show-blame` detail + close |
| | diff mode searches the staged diff and opens that file diff | `staged: true` arg + `show-working-diff` |
| | commits mode uses the pickaxe command and reveals the commit | asserts the command **name** `search_commits_by_content`, pinning it away from `searchInCommits` |
| | a capped result set says so, an uncapped one does not | edge case (100 vs 99) |
| | switching repositories drops the previous repo results | re-pin guard |
| | a response that lands after the repo switch is discarded | `searchToken` guard |
| | exposes the sweep contract and owns Escape only on top | overlay stack + `pinnedRepositoryPathIfOpen` |
| | moves focus into the query input when it opens | focus |
| `app-shell-search-dialog.test.ts` | each new palette entry opens the dialog in its mode | 3 entries × mode |
| | each entry warns instead of opening with no repository | `requiresRepository` |
| | `show-working-diff` opens the matching working-tree entry | happy path |
| | `show-working-diff` prefers the entry with the searched staged flag | edge case |
| | `show-working-diff` reports a file that is no longer changed | the miss is not a dead click |
| `search-dialog.spec.ts` (E2E) | finds text in files and shows the match | palette → query → Enter, real rows |
| | clicking a file result opens blame for that file | verifies `lv-blame-view` actually appears |
| | a backend failure is shown inside the dialog | `injectCommandError`, inline `.error`, dialog still open |
| | an empty diff search reports no matches | empty state |
| | finding commits that changed text reveals the commit | verifies `lv-commit-details` shows the commit |

### Verified to fail without the fix

With `lv-search-dialog.ts` deleted and `app-shell.ts` / `dialogs/index.ts` reverted to `origin/main` (tests left in place):

- `lv-search-dialog.test.ts` — `❌ Could not import your test module` (13 tests, 0 run)
- `app-shell-search-dialog.test.ts` — **9 failed**: `Error: palette command "search-in-files" not found` (and `search-in-diff`, `search-commit-content`), plus `TypeError: el.handleShowWorkingDiff is not a function`
- `search-dialog.spec.ts` — **5 failed**, all `locator.waitFor: Test timeout of 30000ms exceeded` at `lv-search-dialog[open]`, because the palette has no such entry

Restored, all 22 unit tests and all 5 E2E tests pass.

### Gate

```
LINT OK
TYPECHECK OK
UNIT OK
```
plus `npx playwright test e2e/tests/search-dialog.spec.ts` → 5 passed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_