### PR TITLE
Make a failed semantic search fall back to keyword search and tell the user

### DIFF
--- a/e2e/tests/search-bar.spec.ts
+++ b/e2e/tests/search-bar.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
-import { setupOpenRepository } from '../fixtures/tauri-mock';
-import { startCommandCapture, findCommand, injectCommandError, injectCommandMock, waitForCommand } from '../fixtures/test-helpers';
+import { setupOpenRepository, setupTauriMocks, initializeRepositoryStore, defaultMockData } from '../fixtures/tauri-mock';
+import { startCommandCapture, startCommandCaptureWithMocks, findCommand, injectCommandError, injectCommandMock, waitForCommand } from '../fixtures/test-helpers';
 
 /**
  * E2E tests for Search Bar
@@ -589,5 +589,88 @@ test.describe('Search Bar - UI Outcome Verification', () => {
 
     // The graph canvas should still be visible (not crashed) even with zero results
     await expect(graphCanvas).toBeVisible();
+  });
+});
+
+
+test.describe('Semantic Search Fallback', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+  });
+
+  /**
+   * Apply a semantic-mode filter to the graph canvas.
+   *
+   * NOTE: this deliberately sets the same `.searchFilter` property app-shell's
+   * template binds, instead of typing into the search bar. lv-search-bar's
+   * `search-change` event is `composed`, so app-shell's listener on
+   * <lv-toolbar> receives BOTH the toolbar's re-dispatched `{ filter }` event
+   * and the search bar's own raw-filter event; the raw one arrives last and
+   * leaves app-shell's searchFilter `undefined`. That plumbing defect is out
+   * of scope here — driving the canvas property directly still exercises the
+   * real component and the real graph-notice -> toast wiring.
+   */
+  async function applySemanticFilter(page: import('@playwright/test').Page, query: string): Promise<void> {
+    await page.evaluate((q) => {
+      const shell = document.querySelector('lv-app-shell');
+      const canvas = shell?.shadowRoot?.querySelector('lv-graph-canvas') as unknown as {
+        searchFilter: Record<string, string> | null;
+      } | null;
+      if (!canvas) throw new Error('lv-graph-canvas not found');
+      canvas.searchFilter = {
+        query: q,
+        author: '',
+        dateFrom: '',
+        dateTo: '',
+        filePath: '',
+        branch: '',
+        searchMode: 'semantic',
+      };
+    }, query);
+  }
+
+  test('semantic search failure shows keyword results and an unavailable toast', async ({ page }) => {
+    await expect(page.locator('lv-graph-canvas')).toBeVisible();
+    await startCommandCaptureWithMocks(page, {
+      semantic_search: { __error__: 'Embedding model not downloaded' },
+      search_commits: [defaultMockData.commits[0]],
+    });
+
+    await applySemanticFilter(page, 'authentication rework');
+
+    // The failure must be announced, not silently read as "no matches"
+    await expect(
+      page.locator('lv-toast-container .toast .toast-message', {
+        hasText: 'Semantic search is unavailable',
+      })
+    ).toBeVisible();
+
+    // ...and the promised keyword fallback must actually have run
+    const searches = await findCommand(page, 'search_commits');
+    expect(searches.length).toBeGreaterThan(0);
+    expect((searches[0].args as { query?: string }).query).toBe('authentication rework');
+  });
+
+  test('successful semantic search neither falls back nor toasts', async ({ page }) => {
+    await expect(page.locator('lv-graph-canvas')).toBeVisible();
+    await startCommandCaptureWithMocks(page, {
+      semantic_search: [
+        { oid: defaultMockData.commits[0].oid, distance: 0.1, summary: 'Initial commit' },
+      ],
+      search_commits: [],
+    });
+
+    await applySemanticFilter(page, 'authentication rework');
+    await waitForCommand(page, 'semantic_search');
+    // The load finishes with the commit refetch; wait for it so a late
+    // keyword fallback would still be captured before the assertions.
+    await waitForCommand(page, 'get_commit_total');
+
+    await expect(
+      page.locator('lv-toast-container .toast .toast-message', {
+        hasText: 'Semantic search is unavailable',
+      })
+    ).toHaveCount(0);
+    expect(await findCommand(page, 'search_commits')).toHaveLength(0);
   });
 });

--- a/src/components/graph/__tests__/lv-graph-canvas.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas.test.ts
@@ -1944,4 +1944,124 @@ describe('lv-graph-canvas', () => {
       expect((el as any).commits.length).to.equal(defaultCommits.length + 1);
     });
   });
+
+  // ── Semantic search fallback ─────────────────────────────────────────
+  describe('semantic search fallback', () => {
+    beforeEach(() => {
+      clearGraphCacheForTests();
+    });
+
+    /** Layer semantic/keyword answers on top of the default mocks */
+    function setupSemanticMocks(opts: {
+      semantic: 'throw' | Array<{ oid: string; distance: number; summary: string }>;
+      keyword?: Commit[];
+    }): void {
+      setupDefaultMocks();
+      const base = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'semantic_search') {
+          if (opts.semantic === 'throw') throw new Error('Embedding model not downloaded');
+          return opts.semantic;
+        }
+        if (command === 'search_commits') return opts.keyword ?? [];
+        return base(command, args);
+      };
+    }
+
+    async function applySemanticQuery(el: LvGraphCanvas, query: string): Promise<void> {
+      el.searchFilter = {
+        query,
+        author: '',
+        dateFrom: '',
+        dateTo: '',
+        filePath: '',
+        branch: '',
+        searchMode: 'semantic',
+      };
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 200));
+      await el.updateComplete;
+    }
+
+    function matchedOids(el: LvGraphCanvas): Set<string> {
+      return (el as unknown as { matchedCommitOids: Set<string> }).matchedCommitOids;
+    }
+
+    function collectNotices(el: LvGraphCanvas): Array<{ message: string; type?: string }> {
+      const notices: Array<{ message: string; type?: string }> = [];
+      el.addEventListener('graph-notice', (e) => {
+        notices.push((e as CustomEvent<{ message: string; type?: string }>).detail);
+      });
+      return notices;
+    }
+
+    it('falls back to keyword search when semantic search fails', async () => {
+      setupSemanticMocks({ semantic: 'throw', keyword: [commit2] });
+      const el = await renderCanvas();
+      clearHistory();
+
+      await applySemanticQuery(el, 'auth rework');
+
+      // The keyword block must actually run after the semantic failure
+      expect(findCommands('search_commits').length).to.equal(1);
+      expect(matchedOids(el).has(commit2.oid)).to.be.true;
+    });
+
+    it('notifies the user when semantic search is unavailable', async () => {
+      setupSemanticMocks({ semantic: 'throw', keyword: [commit2] });
+      const el = await renderCanvas();
+      clearHistory();
+      const notices = collectNotices(el);
+
+      await applySemanticQuery(el, 'auth rework');
+
+      expect(notices.length).to.equal(1);
+      expect(notices[0].type).to.equal('info');
+      expect(notices[0].message).to.contain('Semantic search is unavailable');
+    });
+
+    it('still notifies when the keyword fallback also finds nothing', async () => {
+      setupSemanticMocks({ semantic: 'throw', keyword: [] });
+      const el = await renderCanvas();
+      clearHistory();
+      const notices = collectNotices(el);
+
+      await applySemanticQuery(el, 'auth rework');
+
+      // A broken index must not look identical to "no commits matched"
+      expect(findCommands('search_commits').length).to.equal(1);
+      expect(matchedOids(el).size).to.equal(0);
+      expect(notices.length).to.equal(1);
+    });
+
+    it('shows the unavailable notice only once while the user keeps typing', async () => {
+      setupSemanticMocks({ semantic: 'throw', keyword: [commit2] });
+      const el = await renderCanvas();
+      clearHistory();
+      const notices = collectNotices(el);
+
+      // The search bar has no debounce: one search per keystroke
+      await applySemanticQuery(el, 'auth');
+      await applySemanticQuery(el, 'auth rework');
+
+      expect(notices.length).to.equal(1);
+      // ...but the keyword fallback still runs for every query
+      expect(findCommands('search_commits').length).to.equal(2);
+    });
+
+    it('does not fall back when semantic search returns no matches', async () => {
+      setupSemanticMocks({ semantic: [], keyword: [commit1] });
+      const el = await renderCanvas();
+      clearHistory();
+      const notices = collectNotices(el);
+
+      await applySemanticQuery(el, 'auth rework');
+
+      // A semantic search that RAN and found nothing genuinely means
+      // "no matches" — no keyword fallback, no notice
+      expect(findCommands('search_commits').length).to.equal(0);
+      expect(matchedOids(el).size).to.equal(0);
+      expect(notices.length).to.equal(0);
+    });
+  });
 });

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -582,6 +582,10 @@ export class LvGraphCanvas extends LitElement {
   private commits: GraphCommit[] = [];
   private realCommits: Map<string, Commit> = new Map();
   private matchedCommitOids: Set<string> = new Set(); // For search highlighting
+  // Semantic search re-runs on every keystroke (the search bar has no
+  // debounce), so the "semantic search unavailable" notice is shown once per
+  // repo and re-armed only when a semantic search succeeds again.
+  private semanticFailureNotifiedFor: string | null = null;
   private refsByCommit: RefsByCommit = {};
   private loadVersion = 0; // Incremented on each load to cancel stale requests
   private statsDebounceTimer: ReturnType<typeof setTimeout> | null = null;
@@ -1161,6 +1165,10 @@ export class LvGraphCanvas extends LitElement {
 
       // If search is active, also fetch matching commits for highlighting
       this.matchedCommitOids.clear();
+      // A semantic search that never RAN (model missing, embedding index not
+      // built, ONNX error) must not read as "no matches" — remember it so the
+      // keyword block below still runs.
+      let semanticFailed = false;
       if (hasSearch && this.searchFilter?.searchMode === 'semantic' && this.searchFilter?.query) {
         // Semantic search via embedding index
         try {
@@ -1176,13 +1184,36 @@ export class LvGraphCanvas extends LitElement {
           for (const result of semanticResults) {
             this.matchedCommitOids.add(result.oid);
           }
+          // Semantic search works again — re-arm the unavailable notice
+          this.semanticFailureNotifiedFor = null;
           log.debug(`Semantic search matched ${this.matchedCommitOids.size} commits`);
         } catch (err) {
           log.warn('Semantic search failed, falling back to keyword search:', err);
-          // Fall through to keyword search below
+          // A superseded load must not notify over the newest one
+          if (this.loadVersion !== currentVersion) return;
+          semanticFailed = true;
+          // The component can't toast itself — app-shell listens for
+          // graph-notice (same wiring as the jump-to-HEAD notice).
+          if (this.semanticFailureNotifiedFor !== repoPath) {
+            this.semanticFailureNotifiedFor = repoPath;
+            this.dispatchEvent(
+              new CustomEvent('graph-notice', {
+                detail: {
+                  message: 'Semantic search is unavailable — showing keyword results instead',
+                  type: 'info',
+                },
+                bubbles: true,
+                composed: true,
+              })
+            );
+          }
         }
       }
-      if (hasSearch && this.matchedCommitOids.size === 0 && this.searchFilter?.searchMode !== 'semantic') {
+      if (
+        hasSearch &&
+        this.matchedCommitOids.size === 0 &&
+        (this.searchFilter?.searchMode !== 'semantic' || semanticFailed)
+      ) {
         // Keyword search: try the search index first for faster results
         const indexResults = await searchIndexService.search(repoPath, {
           query: this.searchFilter?.query || undefined,


### PR DESCRIPTION
## What was broken

### Semantic-search failure never fell back to keyword search, despite claiming to

In `loadCommits()` in `src/components/graph/lv-graph-canvas.ts`, the semantic branch's `catch` logged `"Semantic search failed, falling back to keyword search"` with the comment `// Fall through to keyword search below`. The block immediately below was guarded by:

```ts
if (hasSearch && this.matchedCommitOids.size === 0 && this.searchFilter?.searchMode !== 'semantic') {
```

which is false in exactly the mode that just failed. So after a failure **nothing ran**: `matchedCommitOids` stayed empty, zero commits were highlighted, and there was no toast, no error banner and no fallback results — a broken embedding index looked identical to "no commits matched".

The failure is reachable in normal use: `embeddingIndexService.semanticSearch()` awaits `invoke('semantic_search')` with no `try`/`catch`, so a missing model, an embedding index that was never built, or an ONNX error rejects straight into that `catch`.

## The fix

* Track the failure in a local `semanticFailed` flag and widen the keyword guard to `(this.searchFilter?.searchMode !== 'semantic' || semanticFailed)`, so the fallback the log message promises actually runs. A semantic search that *ran* and returned zero results still means "no matches", so the mode check is kept for that case rather than deleted.
* Announce the failure through the existing `graph-notice` event, which `app-shell` already turns into a toast (the same wiring the jump-to-HEAD notice uses) — the component has no toast of its own, and per the repo's UI rules an error path must never be silent.
* `lv-search-bar` emits a search on **every keystroke with no debounce**, so a naive per-failure toast would raise one toast per character. The notice is therefore shown once per repository and re-armed only when a semantic search succeeds again. The keyword fallback itself still runs for every query.
* The `catch` re-checks `loadVersion` before notifying, so a superseded load cannot toast over a newer one.

## Tests

| Test | Level | Covers |
| --- | --- | --- |
| `falls back to keyword search when semantic search fails` | unit | happy path of the fix: `search_commits` is invoked once and its results land in `matchedCommitOids` |
| `notifies the user when semantic search is unavailable` | unit | error path: exactly one `graph-notice`, `type: 'info'`, message names the unavailability |
| `still notifies when the keyword fallback also finds nothing` | unit | edge case: a broken index must not read as "no commits matched" — fallback runs and the notice still fires with zero results |
| `shows the unavailable notice only once while the user keeps typing` | unit | edge case: two queries in a row produce ONE notice but TWO keyword searches (no-debounce spam guard) |
| `does not fall back when semantic search returns no matches` | unit | over-reach guard: a successful empty result does not fall back and does not toast (passes before and after by design) |
| `semantic search failure shows keyword results and an unavailable toast` | e2e | user-visible outcome: real toast rendered by app-shell, real `search_commits` carrying the query |
| `successful semantic search neither falls back nor toasts` | e2e | the fix does not turn every semantic search into a double search |

### Verified to fail without the fix

Reverting the production change and re-running:

* unit 1 — `AssertionError: expected 0 to equal 1` (`search_commits` never invoked)
* unit 2, 3, 4 — `AssertionError: expected 0 to equal 1` (no `graph-notice` dispatched at all)
* e2e "…shows keyword results and an unavailable toast" — `expect(locator).toBeVisible() failed / element(s) not found` (no toast)

Reverting only the widened guard (keeping the notice) fails unit 1, 3 and 4 (test 4 as `expected 0 to equal 2` — the fallback stops running per query). Reverting only the `graph-notice` dispatch (keeping the guard) fails unit 2, 3 and 4. Unit 5 and the second e2e pass in every configuration, as intended.

## Note found while testing (not fixed here)

The e2e tests drive the canvas's `.searchFilter` property — the same one `app-shell` binds — rather than typing into the search bar, because of a separate pre-existing defect: `lv-search-bar`'s `search-change` event is `composed`, so `app-shell`'s listener on `<lv-toolbar>` receives **both** the toolbar's re-dispatched `{ filter }` event and the search bar's own raw-filter event. The raw one arrives last, so `e.detail.filter` is `undefined` and `app-shell`'s `searchFilter` ends up `undefined` — no filter ever reaches the graph for keyword or semantic search. That is a different bug in different files and is left to its own change; the reason is recorded in a comment on the e2e helper.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_