### PR TITLE
Give each file-history entry the path the file had at that commit

### DIFF
--- a/e2e/tests/file-history.spec.ts
+++ b/e2e/tests/file-history.spec.ts
@@ -25,7 +25,7 @@ import {
  * to access internal elements.
  */
 
-const MOCK_COMMITS = [
+const MOCK_COMMIT_OBJECTS = [
   {
     oid: 'abc123def456789',
     shortId: 'abc123d',
@@ -59,6 +59,18 @@ const MOCK_COMMITS = [
     parentIds: [],
     timestamp: Math.floor(Date.now() / 1000) - 604800,
   },
+];
+
+/**
+ * File history entries as the backend returns them: each commit paired with the
+ * path the file had in THAT commit. The oldest entry predates a rename, so it
+ * carries the old path — diffing or blaming it under 'src/main.ts' would fail
+ * with "File not found in commit".
+ */
+const MOCK_ENTRIES = [
+  { commit: MOCK_COMMIT_OBJECTS[0], pathAtCommit: 'src/main.ts' },
+  { commit: MOCK_COMMIT_OBJECTS[1], pathAtCommit: 'src/main.ts' },
+  { commit: MOCK_COMMIT_OBJECTS[2], pathAtCommit: 'src/old-main.ts' },
 ];
 
 /**
@@ -99,7 +111,7 @@ test.describe('File History - Commit List', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
     await startCommandCaptureWithMocks(page, {
-      get_file_history: MOCK_COMMITS,
+      get_file_history: MOCK_ENTRIES,
     });
     await showFileHistory(page);
   });
@@ -171,7 +183,7 @@ test.describe('File History - Selection', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
     await startCommandCaptureWithMocks(page, {
-      get_file_history: MOCK_COMMITS,
+      get_file_history: MOCK_ENTRIES,
     });
     await showFileHistory(page);
   });
@@ -204,7 +216,7 @@ test.describe('File History - Close', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
     await startCommandCaptureWithMocks(page, {
-      get_file_history: MOCK_COMMITS,
+      get_file_history: MOCK_ENTRIES,
     });
     await showFileHistory(page);
   });
@@ -224,7 +236,7 @@ test.describe('File History - View Diff', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
     await startCommandCaptureWithMocks(page, {
-      get_file_history: MOCK_COMMITS,
+      get_file_history: MOCK_ENTRIES,
     });
     await showFileHistory(page);
   });
@@ -254,13 +266,91 @@ test.describe('File History - View Diff', () => {
 });
 
 // --------------------------------------------------------------------------
+// Renamed Files — the path a row acts on must be the path AT THAT COMMIT
+// --------------------------------------------------------------------------
+test.describe('File History - Renamed Files', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+    await startCommandCaptureWithMocks(page, {
+      get_file_history: MOCK_ENTRIES,
+      get_commit_file_diff: {
+        path: 'src/old-main.ts',
+        oldPath: null,
+        status: 'added',
+        hunks: [],
+        isBinary: false,
+        isImage: false,
+        imageType: null,
+        additions: 0,
+        deletions: 0,
+      },
+      get_file_blame: {
+        path: 'src/old-main.ts',
+        lines: [],
+        totalLines: 0,
+      },
+    });
+    await showFileHistory(page);
+  });
+
+  test('View on a pre-rename entry diffs the old path, not the current one', async ({ page }) => {
+    await page.locator('lv-file-history .view-diff-btn').nth(2).click();
+
+    // The diff pane header shows the historical path the diff was taken for.
+    await expect(page.locator('.diff-path')).toHaveText('src/old-main.ts');
+
+    await waitForCommand(page, 'get_commit_file_diff');
+    const commands = await findCommand(page, 'get_commit_file_diff');
+    expect(commands.length).toBeGreaterThan(0);
+    const args = commands[0].args as Record<string, unknown>;
+    expect(args.filePath).toBe('src/old-main.ts');
+    expect(args.commitOid).toBe('ghi345jkl678901');
+  });
+
+  test('View on a post-rename entry still diffs the current path', async ({ page }) => {
+    await page.locator('lv-file-history .view-diff-btn').first().click();
+
+    await expect(page.locator('.diff-path')).toHaveText('src/main.ts');
+    await waitForCommand(page, 'get_commit_file_diff');
+    const commands = await findCommand(page, 'get_commit_file_diff');
+    expect(commands.length).toBeGreaterThan(0);
+    const args = commands[0].args as Record<string, unknown>;
+    expect(args.filePath).toBe('src/main.ts');
+  });
+
+  test('View blame at this commit on a pre-rename entry blames the old path', async ({ page }) => {
+    await page.locator('lv-file-history .commit-item').nth(2).click({ button: 'right' });
+    await expect(page.locator('lv-file-history .context-menu')).toBeVisible();
+    await page
+      .locator('lv-file-history .context-menu-item')
+      .filter({ hasText: 'View blame' })
+      .click();
+
+    await expect(page.locator('lv-blame-view')).toBeAttached();
+
+    await waitForCommand(page, 'get_file_blame');
+    const commands = await findCommand(page, 'get_file_blame');
+    expect(commands.length).toBeGreaterThan(0);
+    const args = commands[0].args as Record<string, unknown>;
+    expect(args.filePath).toBe('src/old-main.ts');
+  });
+
+  test('the historical path is shown on pre-rename entries only', async ({ page }) => {
+    const items = page.locator('lv-file-history .commit-item');
+    await expect(items.nth(2).locator('.commit-path')).toHaveText('src/old-main.ts');
+    await expect(items.nth(0).locator('.commit-path')).toHaveCount(0);
+    await expect(items.nth(1).locator('.commit-path')).toHaveCount(0);
+  });
+});
+
+// --------------------------------------------------------------------------
 // Context Menu
 // --------------------------------------------------------------------------
 test.describe('File History - Context Menu', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
     await startCommandCaptureWithMocks(page, {
-      get_file_history: MOCK_COMMITS,
+      get_file_history: MOCK_ENTRIES,
     });
     await showFileHistory(page);
   });
@@ -336,7 +426,7 @@ test.describe('File History - Loading State', () => {
   test.beforeEach(async ({ page }) => {
     await setupOpenRepository(page);
     await startCommandCaptureWithMocks(page, {
-      get_file_history: MOCK_COMMITS,
+      get_file_history: MOCK_ENTRIES,
     });
   });
 
@@ -357,7 +447,7 @@ test.describe('File History - Error Scenarios', () => {
   test('get_file_history failure should show error state or toast', async ({ page }) => {
     // Set up command capture with a valid initial response so the component can mount
     await startCommandCaptureWithMocks(page, {
-      get_file_history: MOCK_COMMITS,
+      get_file_history: MOCK_ENTRIES,
     });
 
     // Inject an error so the next call to get_file_history will fail

--- a/src-tauri/src/commands/commit.rs
+++ b/src-tauri/src/commands/commit.rs
@@ -6,7 +6,7 @@ use std::sync::{Mutex, OnceLock};
 use tauri::command;
 
 use crate::error::{LeviathanError, Result};
-use crate::models::Commit;
+use crate::models::{Commit, FileHistoryEntry};
 
 /// Cached full revwalk (OIDs only) per repository for the all-branches graph
 /// walk. Paging a raw revwalk with `skip` is O(skip) per request and re-walks
@@ -1511,14 +1511,20 @@ pub async fn search_commits(
     Ok(results)
 }
 
-/// Get all commits that modified a specific file
+/// Get all commits that modified a specific file, each paired with the path
+/// the file had in that commit.
+///
+/// The path is per-entry, not per-request: following a rename backwards means
+/// older entries refer to the file under its old name, and a caller that
+/// diffed or blamed them under the file's current name would get
+/// "File not found in commit" for a commit this very list says touched it.
 #[command]
 pub async fn get_file_history(
     path: String,
     file_path: String,
     limit: Option<usize>,
     follow_renames: Option<bool>,
-) -> Result<Vec<Commit>> {
+) -> Result<Vec<FileHistoryEntry>> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
     let mut revwalk = repo.revwalk()?;
@@ -1541,11 +1547,11 @@ pub async fn get_file_history(
 
     let limit_count = limit.unwrap_or(500);
     let should_follow = follow_renames.unwrap_or(true);
-    let mut commits = Vec::new();
+    let mut entries: Vec<FileHistoryEntry> = Vec::new();
     let mut current_path = file_path.clone();
 
     for oid_result in revwalk {
-        if commits.len() >= limit_count {
+        if entries.len() >= limit_count {
             break;
         }
 
@@ -1644,7 +1650,14 @@ pub async fn get_file_history(
         }
 
         if file_modified {
-            commits.push(Commit::from_git2(&commit));
+            // Recorded BEFORE the rename is followed: at the renaming commit
+            // the file already exists in that commit's tree under the NEW
+            // name, so the new name is the right path there. Only commits
+            // older than the rename get the old name.
+            entries.push(FileHistoryEntry {
+                commit: Commit::from_git2(&commit),
+                path_at_commit: current_path.clone(),
+            });
 
             // Follow the rename backwards
             if let Some(old_path) = renamed_from {
@@ -1653,7 +1666,7 @@ pub async fn get_file_history(
         }
     }
 
-    Ok(commits)
+    Ok(entries)
 }
 
 #[cfg(test)]
@@ -1748,7 +1761,7 @@ mod tests {
         )
         .await
         .unwrap();
-        let summaries: Vec<String> = following.iter().map(|c| c.summary.clone()).collect();
+        let summaries: Vec<String> = following.iter().map(|e| e.commit.summary.clone()).collect();
 
         assert!(
             summaries.iter().any(|s| s == "Add original"),
@@ -1782,13 +1795,156 @@ mod tests {
         )
         .await
         .unwrap();
-        let summaries: Vec<String> = not_following.iter().map(|c| c.summary.clone()).collect();
+        let summaries: Vec<String> = not_following
+            .iter()
+            .map(|e| e.commit.summary.clone())
+            .collect();
 
         assert!(
             !summaries.iter().any(|s| s == "Add original"),
             "not following must not reach past the rename, got {:?}",
             summaries
         );
+    }
+
+    /// Every entry must carry the path the file had in ITS commit.
+    ///
+    /// Following a rename makes pre-rename commits reachable, but a bare
+    /// `Commit` says nothing about where the file lived then, so the UI had
+    /// only the file's current path to offer for diff/blame — a name that did
+    /// not exist yet at those commits.
+    #[tokio::test]
+    async fn test_file_history_entries_carry_the_path_at_each_commit() {
+        let repo = TestRepo::with_initial_commit();
+
+        // Topology-inconsistent timestamps, as in the rename tests above.
+        commit_file_at(&repo, "Add original", "old-name.txt", "line one\n", 1_000);
+        commit_file_at(
+            &repo,
+            "Edit original",
+            "old-name.txt",
+            "line one\nline two\n",
+            3_000,
+        );
+        commit_rename_at(&repo, "old-name.txt", "new-name.txt", "Rename it", 2_000);
+        commit_file_at(
+            &repo,
+            "Edit after rename",
+            "new-name.txt",
+            "line one\nline two\nline three\n",
+            4_000,
+        );
+
+        let entries = get_file_history(
+            repo.path_str(),
+            "new-name.txt".to_string(),
+            None,
+            Some(true),
+        )
+        .await
+        .unwrap();
+
+        let path_for = |summary: &str| -> String {
+            entries
+                .iter()
+                .find(|e| e.commit.summary == summary)
+                .unwrap_or_else(|| panic!("missing entry {:?}", summary))
+                .path_at_commit
+                .clone()
+        };
+
+        assert_eq!(
+            path_for("Add original"),
+            "old-name.txt",
+            "a commit older than the rename must report the OLD path"
+        );
+        assert_eq!(
+            path_for("Edit original"),
+            "old-name.txt",
+            "edits under the old name must report the OLD path"
+        );
+        assert_eq!(
+            path_for("Rename it"),
+            "new-name.txt",
+            "at the renaming commit the file already exists under the new name"
+        );
+        assert_eq!(path_for("Edit after rename"), "new-name.txt");
+    }
+
+    /// The point of the per-entry path: it is actually diffable.
+    ///
+    /// The second half of this test is what every UI click on a pre-rename row
+    /// used to do — pass the file's current name — and it still fails, which is
+    /// exactly why the entry has to carry its own path.
+    #[tokio::test]
+    async fn test_file_history_path_at_commit_is_diffable() {
+        let repo = TestRepo::with_initial_commit();
+
+        commit_file_at(&repo, "Add original", "old-name.txt", "line one\n", 1_000);
+        commit_rename_at(&repo, "old-name.txt", "new-name.txt", "Rename it", 2_000);
+
+        let entries = get_file_history(
+            repo.path_str(),
+            "new-name.txt".to_string(),
+            None,
+            Some(true),
+        )
+        .await
+        .unwrap();
+
+        let entry = entries
+            .iter()
+            .find(|e| e.commit.summary == "Add original")
+            .expect("pre-rename commit must be listed");
+
+        let ok = crate::commands::diff::get_commit_file_diff(
+            repo.path_str(),
+            entry.commit.oid.clone(),
+            entry.path_at_commit.clone(),
+            None,
+        )
+        .await
+        .expect("the path the entry reports must be diffable at that commit");
+        assert_eq!(ok.path, "old-name.txt");
+
+        let err = crate::commands::diff::get_commit_file_diff(
+            repo.path_str(),
+            entry.commit.oid.clone(),
+            "new-name.txt".to_string(),
+            None,
+        )
+        .await
+        .expect_err("the file's CURRENT name does not exist at that commit");
+        assert!(
+            err.to_string().contains("File not found in commit"),
+            "unexpected error: {}",
+            err
+        );
+    }
+
+    /// Edge case: nothing was renamed, so every entry keeps the requested path.
+    #[tokio::test]
+    async fn test_file_history_entries_use_the_requested_path_when_nothing_was_renamed() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Modify README", &[("README.md", "# Updated")]);
+        repo.create_commit("Modify again", &[("README.md", "# Updated again")]);
+
+        let entries = get_file_history(
+            repo.path_str(),
+            "README.md".to_string(),
+            Some(100),
+            Some(true),
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(entries.len(), 3);
+        for entry in &entries {
+            assert_eq!(
+                entry.path_at_commit, "README.md",
+                "no rename happened, so every entry keeps the requested path"
+            );
+        }
     }
 
     #[tokio::test]
@@ -2487,8 +2643,8 @@ mod tests {
         .await;
 
         assert!(result.is_ok());
-        let commits = result.unwrap();
-        assert_eq!(commits.len(), 3); // Initial + 2 modifications
+        let entries = result.unwrap();
+        assert_eq!(entries.len(), 3); // Initial + 2 modifications
     }
 
     #[tokio::test]
@@ -2506,8 +2662,8 @@ mod tests {
         .await;
 
         assert!(result.is_ok());
-        let commits = result.unwrap();
-        assert_eq!(commits.len(), 2);
+        let entries = result.unwrap();
+        assert_eq!(entries.len(), 2);
     }
 
     #[tokio::test]
@@ -2523,8 +2679,8 @@ mod tests {
         .await;
 
         assert!(result.is_ok());
-        let commits = result.unwrap();
-        assert!(commits.is_empty());
+        let entries = result.unwrap();
+        assert!(entries.is_empty());
     }
 
     #[tokio::test]

--- a/src-tauri/src/models/commit.rs
+++ b/src-tauri/src/models/commit.rs
@@ -17,6 +17,20 @@ pub struct Commit {
     pub timestamp: i64,
 }
 
+/// One entry of a file's history: the commit, plus the path the file had in
+/// that commit.
+///
+/// Following a rename backwards rewrites the path being tracked, so an entry
+/// older than the rename must carry its own path. Diffing or blaming such a
+/// commit under the file's CURRENT name fails — the file did not exist under
+/// that name yet — which turns every pre-rename row in the UI into a dead end.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FileHistoryEntry {
+    pub commit: Commit,
+    pub path_at_commit: String,
+}
+
 /// Git signature (author/committer)
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]

--- a/src/components/panels/__tests__/lv-file-history.test.ts
+++ b/src/components/panels/__tests__/lv-file-history.test.ts
@@ -2,8 +2,10 @@
  * Unit tests for lv-file-history component.
  *
  * Verifies:
- *   - the context "View blame" action dispatches a `show-blame` event (which
- *     app-shell now listens for on <lv-file-history>).
+ *   - diff and blame actions use the path the file had AT THAT COMMIT, which
+ *     differs from the file's current path for entries older than a rename.
+ *   - the historical path is surfaced on those rows.
+ *   - a failed history load shows an error and lists nothing.
  *   - clipboard copy failures show an error toast instead of failing silently.
  */
 
@@ -19,45 +21,102 @@ let mockInvoke: MockInvoke = () => Promise.resolve(null);
 };
 
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
-import { expect, fixture, html } from '@open-wc/testing';
+import { expect, fixture, html, waitUntil } from '@open-wc/testing';
 import { uiStore } from '../../../stores/ui.store.ts';
-import type { Commit } from '../../../types/git.types.ts';
+import type { Commit, FileHistoryEntry } from '../../../types/git.types.ts';
 import type { LvFileHistory } from '../lv-file-history.ts';
 import '../lv-file-history.ts';
 
 const REPO_PATH = '/test/repo';
+const CURRENT_PATH = 'src/main.ts';
+const OLD_PATH = 'src/old-main.ts';
 
-const mockCommit: Commit = {
-  oid: 'abc123def456',
-  shortId: 'abc123d',
-  summary: 'Test commit',
-  message: 'Test commit',
-  body: null,
-  timestamp: Math.floor(Date.now() / 1000),
-  author: { name: 'Test User', email: 'test@example.com', timestamp: Math.floor(Date.now() / 1000) },
-  committer: { name: 'Test User', email: 'test@example.com', timestamp: Math.floor(Date.now() / 1000) },
-  parentIds: [],
+const now = Math.floor(Date.now() / 1000);
+
+function commit(oid: string, shortId: string, summary: string): Commit {
+  return {
+    oid,
+    shortId,
+    summary,
+    message: summary,
+    body: null,
+    timestamp: now,
+    author: { name: 'Test User', email: 'test@example.com', timestamp: now },
+    committer: { name: 'Test User', email: 'test@example.com', timestamp: now },
+    parentIds: [],
+  };
+}
+
+/** Entry from after the rename — its path is the file's current path. */
+const postRename: FileHistoryEntry = {
+  commit: commit('aaa111', 'aaa111a', 'Edit after rename'),
+  pathAtCommit: CURRENT_PATH,
+};
+
+/** Entry from before the rename — the file lived under a different name. */
+const preRename: FileHistoryEntry = {
+  commit: commit('bbb222', 'bbb222b', 'Add original'),
+  pathAtCommit: OLD_PATH,
 };
 
 async function renderHistory(): Promise<LvFileHistory> {
   const el = await fixture<LvFileHistory>(
     html`<lv-file-history
       .repositoryPath=${REPO_PATH}
-      .filePath=${'src/main.ts'}
+      .filePath=${CURRENT_PATH}
     ></lv-file-history>`
   );
-  await el.updateComplete;
+  await waitUntil(
+    () => el.shadowRoot!.querySelectorAll('.commit-item').length === 2,
+    'file history entries never rendered'
+  );
   return el;
 }
 
 describe('lv-file-history', () => {
   beforeEach(() => {
     uiStore.setState({ toasts: [] });
-    mockInvoke = async () => null;
+    mockInvoke = async (command: string) => {
+      if (command === 'get_file_history') return [postRename, preRename];
+      return null;
+    };
+  });
+
+  describe('view-diff event', () => {
+    it('dispatches view-diff with the path the file had at that commit', async () => {
+      const el = await renderHistory();
+
+      let received: { commitOid: string; filePath: string } | null = null;
+      el.addEventListener('view-diff', (e) => {
+        received = (e as CustomEvent).detail;
+      });
+
+      const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.view-diff-btn');
+      buttons[1].click();
+
+      expect(received).to.not.be.null;
+      expect(received!.commitOid).to.equal(preRename.commit.oid);
+      expect(received!.filePath).to.equal(OLD_PATH);
+    });
+
+    it('uses the current path for an entry that was not renamed', async () => {
+      const el = await renderHistory();
+
+      let received: { commitOid: string; filePath: string } | null = null;
+      el.addEventListener('view-diff', (e) => {
+        received = (e as CustomEvent).detail;
+      });
+
+      const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.view-diff-btn');
+      buttons[0].click();
+
+      expect(received).to.not.be.null;
+      expect(received!.filePath).to.equal(CURRENT_PATH);
+    });
   });
 
   describe('show-blame event', () => {
-    it('dispatches show-blame with the file path and commit oid', async () => {
+    it('dispatches show-blame with the path the file had at that commit', async () => {
       const el = await renderHistory();
 
       let received: { filePath: string; commitOid: string } | null = null;
@@ -66,13 +125,67 @@ describe('lv-file-history', () => {
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (el as any).contextMenu = { visible: true, x: 0, y: 0, commit: mockCommit };
+      (el as any).contextMenu = { visible: true, x: 0, y: 0, entry: preRename };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (el as any).handleContextViewBlame();
 
       expect(received).to.not.be.null;
-      expect(received!.filePath).to.equal('src/main.ts');
-      expect(received!.commitOid).to.equal(mockCommit.oid);
+      expect(received!.filePath).to.equal(OLD_PATH);
+      expect(received!.commitOid).to.equal(preRename.commit.oid);
+    });
+
+    it('uses the current path when the file was not renamed', async () => {
+      const el = await renderHistory();
+
+      let received: { filePath: string; commitOid: string } | null = null;
+      el.addEventListener('show-blame', (e) => {
+        received = (e as CustomEvent).detail;
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).contextMenu = { visible: true, x: 0, y: 0, entry: postRename };
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (el as any).handleContextViewBlame();
+
+      expect(received).to.not.be.null;
+      expect(received!.filePath).to.equal(CURRENT_PATH);
+      expect(received!.commitOid).to.equal(postRename.commit.oid);
+    });
+  });
+
+  describe('historical path display', () => {
+    it('shows the historical path only on entries whose path differs', async () => {
+      const el = await renderHistory();
+
+      const items = el.shadowRoot!.querySelectorAll('.commit-item');
+      expect(items[0].querySelector('.commit-path')).to.be.null;
+
+      const historical = items[1].querySelector('.commit-path');
+      expect(historical).to.not.be.null;
+      expect(historical!.textContent!.trim()).to.equal(OLD_PATH);
+    });
+  });
+
+  describe('error handling', () => {
+    it('shows the error message and no entries when history fails', async () => {
+      mockInvoke = async (command: string) => {
+        if (command === 'get_file_history') throw new Error('boom');
+        return null;
+      };
+
+      const el = await fixture<LvFileHistory>(
+        html`<lv-file-history
+          .repositoryPath=${REPO_PATH}
+          .filePath=${CURRENT_PATH}
+        ></lv-file-history>`
+      );
+      await waitUntil(
+        () => el.shadowRoot!.querySelector('.error') !== null,
+        'error state never rendered'
+      );
+
+      expect(el.shadowRoot!.querySelectorAll('.commit-item').length).to.equal(0);
+      expect(el.shadowRoot!.querySelector('.error')!.textContent).to.contain('boom');
     });
   });
 
@@ -86,7 +199,7 @@ describe('lv-file-history', () => {
       });
 
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (el as any).contextMenu = { visible: true, x: 0, y: 0, commit: mockCommit };
+      (el as any).contextMenu = { visible: true, x: 0, y: 0, entry: postRename };
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (el as any).handleContextCopyHash();
 

--- a/src/components/panels/lv-file-history.ts
+++ b/src/components/panels/lv-file-history.ts
@@ -8,13 +8,13 @@ import { customElement, property, state } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showToast } from '../../services/notification.service.ts';
-import type { Commit } from '../../types/git.types.ts';
+import type { FileHistoryEntry } from '../../types/git.types.ts';
 
 interface HistoryContextMenuState {
   visible: boolean;
   x: number;
   y: number;
-  commit: Commit | null;
+  entry: FileHistoryEntry | null;
 }
 
 @customElement('lv-file-history')
@@ -192,6 +192,13 @@ export class LvFileHistory extends LitElement {
         height: 12px;
       }
 
+      .commit-path {
+        font-family: var(--font-mono);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
       .view-diff-btn {
         padding: var(--spacing-xs) var(--spacing-sm);
         font-size: var(--font-size-xs);
@@ -263,11 +270,11 @@ export class LvFileHistory extends LitElement {
   @property({ type: String }) repositoryPath = '';
   @property({ type: String }) filePath = '';
 
-  @state() private commits: Commit[] = [];
+  @state() private entries: FileHistoryEntry[] = [];
   @state() private loading = false;
   @state() private error: string | null = null;
   @state() private selectedCommit: string | null = null;
-  @state() private contextMenu: HistoryContextMenuState = { visible: false, x: 0, y: 0, commit: null };
+  @state() private contextMenu: HistoryContextMenuState = { visible: false, x: 0, y: 0, entry: null };
 
   private handleDocumentClick = (): void => {
     if (this.contextMenu.visible) {
@@ -296,7 +303,7 @@ export class LvFileHistory extends LitElement {
   private async loadHistory(): Promise<void> {
     this.loading = true;
     this.error = null;
-    this.commits = [];
+    this.entries = [];
 
     try {
       const result = await gitService.getFileHistory(
@@ -307,7 +314,7 @@ export class LvFileHistory extends LitElement {
       );
 
       if (result.success && result.data) {
-        this.commits = result.data;
+        this.entries = result.data;
       } else if (!result.success) {
         this.error = result.error?.message ?? 'Failed to load file history';
       }
@@ -323,19 +330,22 @@ export class LvFileHistory extends LitElement {
     this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
   }
 
-  private handleCommitClick(commit: Commit): void {
-    this.selectedCommit = commit.oid;
+  private handleCommitClick(entry: FileHistoryEntry): void {
+    this.selectedCommit = entry.commit.oid;
     this.dispatchEvent(new CustomEvent('commit-selected', {
-      detail: { commit },
+      detail: { commit: entry.commit },
       bubbles: true,
       composed: true,
     }));
   }
 
-  private handleViewDiff(e: Event, commit: Commit): void {
+  private handleViewDiff(e: Event, entry: FileHistoryEntry): void {
     e.stopPropagation();
     this.dispatchEvent(new CustomEvent('view-diff', {
-      detail: { commitOid: commit.oid, filePath: this.filePath },
+      // The path the file had AT THAT COMMIT, not this.filePath: before a
+      // rename the current name does not exist in that commit's tree and the
+      // diff would fail with "File not found in commit".
+      detail: { commitOid: entry.commit.oid, filePath: entry.pathAtCommit },
       bubbles: true,
       composed: true,
     }));
@@ -365,43 +375,45 @@ export class LvFileHistory extends LitElement {
   }
 
   // Context menu handlers
-  private handleContextMenuOpen(e: MouseEvent, commit: Commit): void {
+  private handleContextMenuOpen(e: MouseEvent, entry: FileHistoryEntry): void {
     e.preventDefault();
     e.stopPropagation();
-    this.contextMenu = { visible: true, x: e.clientX, y: e.clientY, commit };
+    this.contextMenu = { visible: true, x: e.clientX, y: e.clientY, entry };
   }
 
   private handleContextViewDiff(): void {
-    const commit = this.contextMenu.commit;
-    if (!commit) return;
+    const entry = this.contextMenu.entry;
+    if (!entry) return;
     this.contextMenu = { ...this.contextMenu, visible: false };
-    this.handleViewDiff(new Event('click'), commit);
+    this.handleViewDiff(new Event('click'), entry);
   }
 
   private handleContextShowCommit(): void {
-    const commit = this.contextMenu.commit;
-    if (!commit) return;
+    const entry = this.contextMenu.entry;
+    if (!entry) return;
     this.contextMenu = { ...this.contextMenu, visible: false };
-    this.handleCommitClick(commit);
+    this.handleCommitClick(entry);
   }
 
   private handleContextViewBlame(): void {
-    const commit = this.contextMenu.commit;
-    if (!commit) return;
+    const entry = this.contextMenu.entry;
+    if (!entry) return;
     this.contextMenu = { ...this.contextMenu, visible: false };
     this.dispatchEvent(new CustomEvent('show-blame', {
-      detail: { filePath: this.filePath, commitOid: commit.oid },
+      // Same reason as view-diff: blaming a pre-rename commit under the file's
+      // current name fails, the file did not exist under it yet.
+      detail: { filePath: entry.pathAtCommit, commitOid: entry.commit.oid },
       bubbles: true,
       composed: true,
     }));
   }
 
   private async handleContextCopyHash(): Promise<void> {
-    const commit = this.contextMenu.commit;
-    if (!commit) return;
+    const entry = this.contextMenu.entry;
+    if (!entry) return;
     this.contextMenu = { ...this.contextMenu, visible: false };
     try {
-      await navigator.clipboard.writeText(commit.oid);
+      await navigator.clipboard.writeText(entry.commit.oid);
     } catch (err) {
       console.error('Failed to copy hash:', err);
       showToast('Failed to copy hash to clipboard', 'error');
@@ -423,7 +435,7 @@ export class LvFileHistory extends LitElement {
           </div>
         </div>
         ${!this.loading ? html`
-          <span class="commit-count">${this.commits.length} commits</span>
+          <span class="commit-count">${this.entries.length} commits</span>
         ` : nothing}
         <button class="close-btn" @click=${this.handleClose} title="Close">
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -438,23 +450,23 @@ export class LvFileHistory extends LitElement {
           ? html`<div class="loading">Loading history...</div>`
           : this.error
             ? html`<div class="error">${this.error}</div>`
-          : this.commits.length === 0
+          : this.entries.length === 0
             ? html`<div class="empty">No history found for this file</div>`
             : html`
                 <div class="commit-list">
-                  ${this.commits.map(commit => html`
+                  ${this.entries.map(entry => html`
                     <div
-                      class="commit-item ${this.selectedCommit === commit.oid ? 'selected' : ''}"
-                      @click=${() => this.handleCommitClick(commit)}
-                      @contextmenu=${(e: MouseEvent) => this.handleContextMenuOpen(e, commit)}
+                      class="commit-item ${this.selectedCommit === entry.commit.oid ? 'selected' : ''}"
+                      @click=${() => this.handleCommitClick(entry)}
+                      @contextmenu=${(e: MouseEvent) => this.handleContextMenuOpen(e, entry)}
                     >
                       <div class="commit-row">
-                        <span class="commit-oid">${commit.shortId}</span>
-                        <span class="commit-summary">${commit.summary}</span>
+                        <span class="commit-oid">${entry.commit.shortId}</span>
+                        <span class="commit-summary">${entry.commit.summary}</span>
                         <button
                           class="view-diff-btn"
-                          @click=${(e: Event) => this.handleViewDiff(e, commit)}
-                          title="View diff at this commit"
+                          @click=${(e: Event) => this.handleViewDiff(e, entry)}
+                          title="View diff of ${entry.pathAtCommit} at this commit"
                         >
                           View
                         </button>
@@ -465,15 +477,18 @@ export class LvFileHistory extends LitElement {
                             <path d="M20 21v-2a4 4 0 0 0-4-4H8a4 4 0 0 0-4 4v2"></path>
                             <circle cx="12" cy="7" r="4"></circle>
                           </svg>
-                          ${commit.author.name}
+                          ${entry.commit.author.name}
                         </span>
                         <span class="commit-date">
                           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                             <circle cx="12" cy="12" r="10"></circle>
                             <polyline points="12 6 12 12 16 14"></polyline>
                           </svg>
-                          ${this.formatDate(commit.timestamp)}
+                          ${this.formatDate(entry.commit.timestamp)}
                         </span>
+                        ${entry.pathAtCommit !== this.filePath
+                          ? html`<span class="commit-path" title="${entry.pathAtCommit}">${entry.pathAtCommit}</span>`
+                          : nothing}
                       </div>
                     </div>
                   `)}
@@ -485,7 +500,7 @@ export class LvFileHistory extends LitElement {
   }
 
   private renderContextMenu() {
-    if (!this.contextMenu.visible || !this.contextMenu.commit) return nothing;
+    if (!this.contextMenu.visible || !this.contextMenu.entry) return nothing;
 
     const { x, y } = this.contextMenu;
 

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -227,6 +227,7 @@ import type { UnlistenFn } from "@tauri-apps/api/event";
 import type {
   Repository,
   Commit,
+  FileHistoryEntry,
   Branch,
   BranchTrackingInfo,
   Remote,
@@ -1897,15 +1898,16 @@ export async function getImageVersions(
 }
 
 /**
- * Get all commits that modified a specific file
+ * Get all commits that modified a specific file, each paired with the path the
+ * file had in that commit (which differs from `filePath` before a rename).
  */
 export async function getFileHistory(
   repoPath: string,
   filePath: string,
   limit?: number,
   followRenames?: boolean,
-): Promise<CommandResult<Commit[]>> {
-  return invokeCommand<Commit[]>("get_file_history", {
+): Promise<CommandResult<FileHistoryEntry[]>> {
+  return invokeCommand<FileHistoryEntry[]>("get_file_history", {
     path: repoPath,
     filePath,
     limit,

--- a/src/types/git.types.ts
+++ b/src/types/git.types.ts
@@ -44,6 +44,17 @@ export interface Commit {
   timestamp: number;
 }
 
+/** One entry of a file's history: a commit plus the path the file had there. */
+export interface FileHistoryEntry {
+  commit: Commit;
+  /**
+   * Path the file had in that commit. Differs from the file's current path for
+   * commits older than a rename — diffing or blaming those under the current
+   * path fails, because the file did not exist under that name yet.
+   */
+  pathAtCommit: string;
+}
+
 export interface Signature {
   name: string;
   email: string;


### PR DESCRIPTION
## What was broken

### Pre-rename file-history entries were dead ends

`get_file_history` follows renames, so commits from before a rename **are** returned. But it returned a bare `Vec<Commit>`, which carries no per-commit path — so every pre-rename entry reached the UI stripped of the one thing that makes it usable.

`lv-file-history` therefore had only the file's current path to offer, and dispatched `filePath: this.filePath` for **every** row, on both actions:

- `handleViewDiff` → `view-diff` → app-shell `handleFileHistoryViewDiff` → `get_commit_file_diff`
- `handleContextViewBlame` → `show-blame` → app-shell `handleShowBlame` → `get_file_blame`

For a commit where the file still lived under its old name, that path does not exist in the commit's tree:

- `get_commit_file_diff` pathspec-filters to zero deltas and returns `OperationFailed("File not found in commit")`
- `get_file_blame` fails the same way at `tree.get_path` / `repo.blame_file`

So clicking **View** or **View blame at this commit** on a legitimate, listed history entry produced an error with no way forward — the diff for that commit was simply unreachable.

## The fix

The path is a property of the *entry*, not of the request, so it now travels with it.

- **`src-tauri/src/models/commit.rs`** — new `FileHistoryEntry { commit, path_at_commit }`.
- **`src-tauri/src/commands/commit.rs`** — `get_file_history` returns `Vec<FileHistoryEntry>`. The path is recorded **before** the rename is followed backwards: at the renaming commit the file already exists in that commit's tree under the *new* name, so only commits older than the rename get the old name.
- **`src/types/git.types.ts` / `src/services/git.service.ts`** — matching `FileHistoryEntry` type; `getFileHistory` returns `FileHistoryEntry[]`.
- **`src/components/panels/lv-file-history.ts`** — entries replace commits throughout; `view-diff` and `show-blame` carry `entry.pathAtCommit`. A row whose path differs from the file's current one renders that historical name in its meta line (and in the View button's tooltip), so a pre-rename entry is not silently confusing.

`app-shell.ts` needs no change: `handleFileHistoryViewDiff` and `handleShowBlame` already pass `e.detail.filePath` through verbatim, and `getDiffPath()` renders `diffCommitFile.filePath` — so the diff header now names the historical path on its own.

The `commit-selected` detail shape is deliberately unchanged (`{ commit }`): app-shell only reveals the commit in the graph, which is path-independent, so adding an unconsumed field would be dead code.

## Tests

| Layer | Test | Covers |
| --- | --- | --- |
| Rust | `test_file_history_entries_carry_the_path_at_each_commit` | Happy path + the bug: pre-rename entries report the old path, the renaming commit and later report the new one |
| Rust | `test_file_history_path_at_commit_is_diffable` | End to end: the reported path diffs cleanly at that commit, while the file's *current* name still errors `File not found in commit` (the old click behaviour) |
| Rust | `test_file_history_entries_use_the_requested_path_when_nothing_was_renamed` | Edge case: no rename → every entry keeps the requested path |
| Rust | existing four `get_file_history` tests | Updated to the new type; limit still counts entries, missing file still empty |
| Unit | `dispatches view-diff with the path the file had at that commit` | Pre-rename row diffs the old path |
| Unit | `uses the current path for an entry that was not renamed` | Post-rename row is unaffected |
| Unit | `dispatches show-blame with the path the file had at that commit` | Pre-rename row blames the old path |
| Unit | `uses the current path when the file was not renamed` | Post-rename row is unaffected |
| Unit | `shows the historical path only on entries whose path differs` | Historical name rendered on the right rows only |
| Unit | `shows the error message and no entries when history fails` | Error path: `.error` shown, zero rows (guards the entries reset) |
| Unit | `shows an error toast when copying a hash fails` | Existing test, updated to the new context-menu shape |
| E2E | `View on a pre-rename entry diffs the old path, not the current one` | UI outcome: diff header reads `src/old-main.ts`, and `get_commit_file_diff` went out with that path |
| E2E | `View on a post-rename entry still diffs the current path` | No regression on unrenamed rows |
| E2E | `View blame at this commit on a pre-rename entry blames the old path` | Blame pane opens, `get_file_blame` went out with the old path |
| E2E | `the historical path is shown on pre-rename entries only` | Rows 0/1 have no `.commit-path`, row 2 shows the old name |

## Verified to fail without the fix

Reverting only the production behaviour and re-running:

- Rust `test_file_history_entries_carry_the_path_at_each_commit` — `assertion left == right failed: a commit older than the rename must report the OLD path / left: "new-name.txt" / right: "old-name.txt"`
- Rust `test_file_history_path_at_commit_is_diffable` — `the path the entry reports must be diffable at that commit: OperationFailed("File not found in commit")`
- Unit view-diff / show-blame — `AssertionError: expected 'src/main.ts' to equal 'src/old-main.ts'`
- Unit historical-path display — `AssertionError: expected null not to be null`
- E2E all three rename tests — `Expected: "src/old-main.ts" / Received: "src/main.ts"`, and `element(s) not found` for `.commit-path`

Full gate green: lint, typecheck, unit (`npm test`), `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --lib`, plus `file-history.spec.ts` E2E (31 passed) and the snake_case grep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_