### PR TITLE
Stop global single-key shortcuts firing behind an open modal

### DIFF
--- a/e2e/tests/keyboard.spec.ts
+++ b/e2e/tests/keyboard.spec.ts
@@ -294,6 +294,34 @@ test.describe('Staging Shortcuts', () => {
     const stageFilesCommands = await findCommand(page, 'stage_files');
     expect(stageFilesCommands.length).toBeGreaterThan(0);
   });
+
+  // The shortcuts dialog is exactly where a user presses a key to see what it
+  // does — and 's' went straight through to stage-all, behind the modal that
+  // covers the file-status panel, so nothing on screen changed.
+  test('s must not stage while the keyboard shortcuts dialog is open', async ({ page }) => {
+    await startCommandCapture(page);
+
+    await page.keyboard.press('?');
+    await expect(dialogs.keyboardShortcuts.dialog).toBeVisible();
+
+    await page.keyboard.press('s');
+    // Two auto-retrying UI round trips after the press, which give a stray
+    // stage every chance to land before the count is read.
+    await expect(dialogs.keyboardShortcuts.dialog).toBeVisible();
+    await page.keyboard.press('Escape');
+    await expect(dialogs.keyboardShortcuts.dialog).not.toBeVisible();
+
+    expect(
+      (await findCommand(page, 'stage_files')).length,
+      'nothing may be staged behind the modal'
+    ).toBe(0);
+
+    // The same key with no overlay in the way does reach git — so the
+    // assertion above is about the modal, not about a dead harness.
+    await page.keyboard.press('s');
+    await waitForCommand(page, 'stage_files');
+    expect((await findCommand(page, 'stage_files')).length).toBe(1);
+  });
 });
 
 // Note: Cmd+R cannot be tested directly as it triggers browser refresh.

--- a/src/components/dialogs/__tests__/lv-keyboard-shortcuts-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-keyboard-shortcuts-dialog.test.ts
@@ -24,6 +24,7 @@ const mockInvoke: MockInvoke = () => Promise.resolve(null);
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
 import { expect, fixture, html } from '@open-wc/testing';
 import { keyboardService } from '../../../services/keyboard.service.ts';
+import { resetOverlayStack } from '../../../utils/overlay-stack.ts';
 import type { LvKeyboardShortcutsDialog } from '../lv-keyboard-shortcuts-dialog.ts';
 import '../lv-keyboard-shortcuts-dialog.ts';
 
@@ -47,8 +48,10 @@ async function openDialog(): Promise<LvKeyboardShortcutsDialog> {
 
 describe('lv-keyboard-shortcuts-dialog recording mode', () => {
   afterEach(() => {
-    // Never leave the service disabled for the next test.
+    // Never leave the service disabled — or an overlay registered — for the
+    // next test.
     keyboardService.setEnabled(true);
+    resetOverlayStack();
   });
 
   it('does not run a shortcut while capturing its replacement', async () => {
@@ -91,6 +94,13 @@ describe('lv-keyboard-shortcuts-dialog recording mode', () => {
       internalOf(el).cancelEditing();
       await el.updateComplete;
 
+      // The assertion is that cancelEditing re-enabled the service. The dialog
+      // has to be closed to see it: an open dialog now blocks plain keys on
+      // purpose, so that reading "S — Stage all changes" and pressing S does
+      // not stage the working tree.
+      el.open = false;
+      await el.updateComplete;
+
       document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
 
       expect(fired, 'shortcuts work again after cancelling').to.equal(1);
@@ -123,6 +133,33 @@ describe('lv-keyboard-shortcuts-dialog recording mode', () => {
       expect(fired, 'shortcuts must survive a mid-recording teardown').to.equal(1);
     } finally {
       keyboardService.unregister('test-teardown');
+    }
+  });
+
+  // The finding: the dialog silenced the service only while RECORDING. Merely
+  // reading the shortcut list and trying a key ran it — on the one screen
+  // built for pressing keys to see what they do.
+  it('does not run a plain-key shortcut while the dialog is merely open', async () => {
+    let fired = 0;
+    keyboardService.register('test-merely-open', {
+      key: 'y',
+      action: () => { fired++; },
+      description: 'destructive probe',
+      category: 'Test',
+    });
+
+    const el = await openDialog();
+    try {
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
+      expect(fired, 'no shortcut may run behind the open dialog').to.equal(0);
+
+      el.open = false;
+      await el.updateComplete;
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
+      expect(fired, 'and it works again once the dialog closes').to.equal(1);
+    } finally {
+      keyboardService.unregister('test-merely-open');
     }
   });
 });

--- a/src/services/__tests__/keyboard.service.test.ts
+++ b/src/services/__tests__/keyboard.service.test.ts
@@ -1,6 +1,7 @@
 import { expect } from '@open-wc/testing';
 import type { Shortcut } from '../keyboard.service.ts';
 import { keyboardService } from '../keyboard.service.ts';
+import { pushOverlay, removeOverlay, resetOverlayStack } from '../../utils/overlay-stack.ts';
 
 // Clear localStorage before tests
 const STORAGE_KEY = 'leviathan-keyboard-settings';
@@ -442,3 +443,111 @@ describe('keyboard shortcuts must not hijack a <select>', () => {
   });
 });
 
+
+describe('modal overlays own the keyboard', () => {
+  // Every shortcut lives on `document`, so a plain `s` behind an open dialog
+  // staged the whole working tree and `u` unstaged it — with the file-status
+  // panel hidden behind the overlay, so nothing visibly happened.
+  afterEach(() => {
+    resetOverlayStack();
+    keyboardService.setEnabled(true);
+  });
+
+  it('does not run a plain-key shortcut while a dialog covers the app, and restores it on close', () => {
+    let fired = 0;
+    keyboardService.register('test-overlay-plain', {
+      key: 'y',
+      description: 'destructive probe',
+      category: 'Test',
+      action: () => {
+        fired++;
+      },
+    });
+
+    const dialog = {};
+    try {
+      pushOverlay(dialog);
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
+      expect(fired, 'no shortcut may run behind an overlay').to.equal(0);
+
+      removeOverlay(dialog);
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
+      expect(fired, 'and it works again once the dialog closes').to.equal(1);
+    } finally {
+      keyboardService.unregister('test-overlay-plain');
+    }
+  });
+
+  it('keeps blocking while a dialog remains under the one that closed', () => {
+    let fired = 0;
+    keyboardService.register('test-overlay-nested', {
+      key: 'y',
+      description: 'destructive probe',
+      category: 'Test',
+      action: () => {
+        fired++;
+      },
+    });
+
+    const dialog = {};
+    const palette = {};
+    try {
+      pushOverlay(dialog);
+      pushOverlay(palette);
+      removeOverlay(palette);
+
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'y' }));
+
+      expect(fired, 'the dialog underneath still covers the app').to.equal(0);
+    } finally {
+      keyboardService.unregister('test-overlay-nested');
+    }
+  });
+
+  it('does not drive vim navigation behind a dialog', () => {
+    let down = 0;
+    keyboardService.setVimMode(true);
+    keyboardService.setVimActions({
+      navigateDown: () => {
+        down++;
+      },
+    });
+
+    const dialog = {};
+    try {
+      pushOverlay(dialog);
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'j' }));
+      expect(down, 'j must not move the graph behind a modal').to.equal(0);
+
+      removeOverlay(dialog);
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'j' }));
+      expect(down, 'and it moves again once the dialog closes').to.equal(1);
+    } finally {
+      keyboardService.setVimMode(false);
+      keyboardService.setVimActions({});
+    }
+  });
+
+  it('still runs Ctrl/Cmd combos while a dialog covers the app', () => {
+    // The guard must not kill Cmd+P, Cmd+, or Ctrl+Enter from inside a dialog:
+    // those are deliberate and unambiguous.
+    let fired = 0;
+    keyboardService.register('test-overlay-mod', {
+      key: 'r',
+      ctrl: true,
+      description: 'mod probe',
+      category: 'Test',
+      action: () => {
+        fired++;
+      },
+    });
+
+    try {
+      pushOverlay({});
+      document.dispatchEvent(new KeyboardEvent('keydown', { key: 'r', ctrlKey: true }));
+      expect(fired, 'modifier combos stay live behind an overlay').to.equal(1);
+    } finally {
+      keyboardService.unregister('test-overlay-mod');
+    }
+  });
+});

--- a/src/services/keyboard.service.ts
+++ b/src/services/keyboard.service.ts
@@ -3,6 +3,8 @@
  * Global keyboard shortcut handling for the application
  */
 
+import { isOverlayOpen } from '../utils/overlay-stack.ts';
+
 export interface Shortcut {
   key: string;
   ctrl?: boolean;
@@ -481,6 +483,17 @@ class KeyboardService {
    */
   private handleKeyDown(e: KeyboardEvent): void {
     if (!this.enabled) return;
+
+    // A modal owns the keyboard while it is up. Every shortcut here is
+    // registered on `document` and fired regardless of what was on screen, so
+    // a plain `s` behind an open dialog staged the entire working tree and `u`
+    // unstaged it — invisibly, because the overlay covers the file-status
+    // panel the change would have shown up in. The Keyboard Shortcuts dialog
+    // was the worst of it: the one screen where users press a key to see what
+    // it does, and it silenced the service only while RECORDING a new binding.
+    // Combos carrying Ctrl/Cmd stay live: those are deliberate and
+    // unambiguous, and dialogs are opened with them (Cmd+P, Cmd+,).
+    if (isOverlayOpen() && !e.ctrlKey && !e.metaKey) return;
 
     // Don't handle shortcuts when typing in inputs
     // Use composedPath() to find the actual target inside shadow DOM

--- a/src/utils/__tests__/overlay-stack.test.ts
+++ b/src/utils/__tests__/overlay-stack.test.ts
@@ -10,6 +10,7 @@ import {
   pushOverlay,
   removeOverlay,
   isTopOverlay,
+  isOverlayOpen,
   resetOverlayStack,
 } from '../overlay-stack.ts';
 
@@ -78,5 +79,24 @@ describe('overlay-stack', () => {
 
     expect(isTopOverlay(a)).to.be.true;
     expect(isTopOverlay(b)).to.be.false;
+  });
+
+  it('reports whether anything is covering the app', () => {
+    // Global single-key shortcuts ask this before running: a plain `s` behind
+    // an open dialog used to stage the whole working tree.
+    const dialog = {};
+    const palette = {};
+
+    expect(isOverlayOpen(), 'nothing open').to.be.false;
+
+    pushOverlay(dialog);
+    expect(isOverlayOpen(), 'a dialog is up').to.be.true;
+
+    pushOverlay(palette);
+    removeOverlay(palette);
+    expect(isOverlayOpen(), 'the dialog underneath is still up').to.be.true;
+
+    removeOverlay(dialog);
+    expect(isOverlayOpen(), 'everything closed').to.be.false;
   });
 });

--- a/src/utils/overlay-stack.ts
+++ b/src/utils/overlay-stack.ts
@@ -38,6 +38,20 @@ export function isTopOverlay(owner: object): boolean {
   return stack.length === 0 || stack[stack.length - 1] === owner;
 }
 
+/**
+ * True while any overlay is registered — something is covering the app.
+ *
+ * Global single-key shortcuts consult this. They live on `document` and fired
+ * no matter what was on screen, so a plain `s` behind an open dialog staged
+ * the whole working tree and `u` unstaged it, with the file-status panel
+ * hidden behind the overlay so nothing visibly changed. Unlike `isTopOverlay`,
+ * an empty stack means "nothing is open" — there is no unregistered-overlay
+ * case to be lenient about. See keyboard.service.
+ */
+export function isOverlayOpen(): boolean {
+  return stack.length > 0;
+}
+
 /** Test seam: drop all registrations. */
 export function resetOverlayStack(): void {
   stack.length = 0;


### PR DESCRIPTION
## What was broken

### Global single-key shortcuts fire behind open modals, including the shortcuts dialog itself

`KeyboardService.handleKeyDown` (`src/services/keyboard.service.ts`) bailed only on `!this.enabled`, on a text-field/`<select>` target, and on components with their own key handling. It had no notion of an open dialog — the file imported nothing at all.

Every shortcut is registered on `document`, so while **any** modal was up (all app dialogs either render `<lv-modal open>` or push themselves onto the overlay stack), a plain `s` still ran `stage-all` and `u` ran `unstage-all` through app-shell's `dispatchToFileStatus` — which even reveals the hidden right panel and refreshes status first. It really staged the working tree, behind an overlay covering the file-status panel, with no feedback at all. Vim `j/k/g/G//` drove the graph behind the modal the same way.

The Keyboard Shortcuts dialog was the worst case: the one screen built for pressing a key to see what it does. It called `keyboardService.setEnabled(false)` only inside `startEditing()` (recording a new binding), never while merely open, and its own document listener handles nothing but Escape and recording keys. So pressing `s` right after reading the row "Stage all changes" staged everything, and `u` destroyed a carefully curated partial staging.

## The fix

The app already owns the right primitive — `src/utils/overlay-stack.ts`, which every dialog pushes itself onto (directly, or via `lv-modal`).

1. `src/utils/overlay-stack.ts` — new `isOverlayOpen()` next to `isTopOverlay()`. Unlike `isTopOverlay`, an empty stack means "nothing is open"; there is no unregistered-overlay leniency to preserve.
2. `src/services/keyboard.service.ts` — one guard at the top of `handleKeyDown`:

```ts
if (isOverlayOpen() && !e.ctrlKey && !e.metaKey) return;
```

Placement and scope:

- **Before** `composedPath()`, before the local-handler bail and before `handleVimKey`, so vim keys are covered too.
- **Ctrl/Cmd combos stay live.** `Cmd+P` (palette), `Cmd+,` (settings), `Ctrl+Enter` (commit) and `Ctrl+D`/`Ctrl+U` paging are deliberate and unambiguous — and dialogs are opened with them.
- **Escape is unaffected in practice.** Dialogs keep their own `document` Escape listeners (already gated on `isTopOverlay`), and app-shell's global `close-diff` arm already returned early while a modal was open. Context menus do not register on the overlay stack, so Escape still dismisses them.
- No dialog source changed: `lv-keyboard-shortcuts-dialog` already pushes itself onto the stack when open, so the single guard covers it and every other overlay. Its recording-time `setEnabled(false)` is left as is.
- No Rust, no Tauri arg shapes, no new events or toasts — the UI event/feedback consistency checklist is unaffected.

## Tests

| Test | File | Covers | Fails without the fix |
| --- | --- | --- | --- |
| `reports whether anything is covering the app` | `src/utils/__tests__/overlay-stack.test.ts` | the predicate: empty → false, push → true, nested pop → still true, all closed → false | n/a (tests the new predicate itself) |
| `does not run a plain-key shortcut while a dialog covers the app, and restores it on close` | `src/services/__tests__/keyboard.service.test.ts` | happy-path bug + that the guard is not permanent | **yes** — `AssertionError: no shortcut may run behind an overlay: expected 1 to equal 0` |
| `keeps blocking while a dialog remains under the one that closed` | `src/services/__tests__/keyboard.service.test.ts` | edge: nested overlays, top one closed | **yes** — `AssertionError: the dialog underneath still covers the app: expected 1 to equal 0` |
| `does not drive vim navigation behind a dialog` | `src/services/__tests__/keyboard.service.test.ts` | edge: guard sits before `handleVimKey` | **yes** — `AssertionError: j must not move the graph behind a modal: expected 1 to equal 0` |
| `still runs Ctrl/Cmd combos while a dialog covers the app` | `src/services/__tests__/keyboard.service.test.ts` | over-blocking guard: `Cmd+P`/`Cmd+,`/`Ctrl+Enter` from inside a dialog | no, by design — it pins that the fix did not go too far |
| `does not run a plain-key shortcut while the dialog is merely open` | `src/components/dialogs/__tests__/lv-keyboard-shortcuts-dialog.test.ts` | the finding's exact scenario | **yes** — `AssertionError: no shortcut may run behind the open dialog: expected 1 to equal 0` |
| `s must not stage while the keyboard shortcuts dialog is open` | `e2e/tests/keyboard.spec.ts` | full stack: `?` opens the dialog, `s` behind it must reach no `stage_files`; after Escape the same key does | **yes** — `Error: nothing may be staged behind the modal / Expected: 0 / Received: 1` |

The e2e test asserts **zero** `stage_files` while the modal is up, then presses `s` again with nothing in the way and requires exactly one — so the negative cannot pass by way of a dead harness. Two auto-retrying UI round trips sit between the modal-time press and the count, giving a stray stage every chance to land. No `waitForTimeout`, no `shadowRoot.querySelector`.

One existing test — `re-enables shortcuts once recording is cancelled` — asserted that a plain `y` fires while the dialog is still **open**, i.e. it encoded the bug. It now closes the dialog before dispatching, keeping `expect(fired).to.equal(1)`; it still fails if `cancelEditing` stops re-enabling the service, which was its point.

## Verification

- Reverted only the guard line and re-ran: the six rows marked **yes** above failed with the messages quoted; `still runs Ctrl/Cmd combos` and both surviving recording tests still passed. Restored and everything green.
- `npm run lint` OK, `npm run typecheck` OK, `npm test` OK (4448 unit tests), full Playwright suite OK (1141 passed) — the guard causes no fallout in any other dialog or shortcut flow. `cargo fmt --check` clean; no Rust touched.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_