### PR TITLE
Report a downloaded local model as available before it is loaded

### DIFF
--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -108,11 +108,12 @@ pub async fn generate_commit_message(
         .map_err(LeviathanError::OperationFailed)
 }
 
-/// Check if AI is available (any provider is configured and available)
+/// Check if AI is available (a provider is configured and reachable, or a
+/// local model is downloaded and will be loaded on the first request)
 #[command]
 pub async fn is_ai_available(state: State<'_, AiState>) -> Result<bool> {
     let service = state.read().await;
-    let result = service.find_available_provider().await.is_some();
+    let result = service.has_available_provider().await;
     tracing::debug!("is_ai_available check: {}", result);
     Ok(result)
 }

--- a/src-tauri/src/services/ai/mod.rs
+++ b/src-tauri/src/services/ai/mod.rs
@@ -709,12 +709,16 @@ impl AiService {
         let local = local_state.read().await;
         let downloaded = local.model_manager.list_downloaded().unwrap_or_default();
 
-        if downloaded.is_empty() {
-            return Ok(()); // No models downloaded — nothing to load
-        }
-
-        // Pick the first (best) downloaded model and look up its registry entry
-        let model = &downloaded[0];
+        // Pick the first model whose GGUF file is actually on disk and look up
+        // its registry entry. A directory left with only its metadata cannot be
+        // loaded, and trying would leave the provider stuck in the error state.
+        let model = match downloaded
+            .iter()
+            .find(|m| m.status == local::model_manager::ModelStatus::Downloaded)
+        {
+            Some(m) => m,
+            None => return Ok(()), // Nothing loadable — nothing to do
+        };
         let meta = local
             .registry
             .get_by_id(&model.id)
@@ -729,6 +733,35 @@ impl AiService {
 
         tracing::info!("Lazy-loading local model: {}", display_name);
         self.load_local_model(&model_path, display_name, meta).await
+    }
+
+    /// True if a downloaded local model is waiting to be lazy-loaded.
+    ///
+    /// The GGUF file must be present: a model directory left with only its
+    /// metadata is not loadable, so it does not count. `list_downloaded` also
+    /// ignores in-flight downloads, whose metadata is written last.
+    pub async fn has_loadable_local_model(&self) -> bool {
+        let local_state = match &self.local_ai_state {
+            Some(s) => s,
+            None => return false,
+        };
+        let local = local_state.read().await;
+        local
+            .model_manager
+            .list_downloaded()
+            .unwrap_or_default()
+            .iter()
+            .any(|m| m.status == local::model_manager::ModelStatus::Downloaded)
+    }
+
+    /// Whether an AI request would succeed right now.
+    ///
+    /// A downloaded-but-unloaded local model counts as available: the model is
+    /// only ever loaded on demand (see [`AiService::ensure_local_model_loaded`]),
+    /// never at startup, so reporting it as unavailable would hide AI features
+    /// that do in fact work after every restart.
+    pub async fn has_available_provider(&self) -> bool {
+        self.find_available_provider().await.is_some() || self.has_loadable_local_model().await
     }
 
     /// Find the first available provider, preferring the active one
@@ -1014,5 +1047,104 @@ mod tests {
         let all = AiProviderType::all();
         assert!(all.contains(&AiProviderType::LocalInference));
         assert_eq!(all.len(), 7);
+    }
+
+    // --- Local-model availability -------------------------------------------
+    //
+    // A local GGUF model is never loaded at startup (see
+    // `ensure_local_model_loaded`): loading is deferred to the first inference
+    // request. These tests pin that a downloaded-but-unloaded model still
+    // reports as available, and that a half-deleted model directory does not.
+
+    /// Build an `AiService` with no configured cloud provider, wired to a
+    /// models directory under `models_dir`.
+    fn service_with_models(models_dir: std::path::PathBuf) -> (AiService, tempfile::TempDir) {
+        let config_dir = tempfile::tempdir().unwrap();
+        let mut service = AiService::new(config_dir.path().to_path_buf());
+        service.set_local_ai_state(crate::commands::local_ai::create_local_ai_state(models_dir));
+        (service, config_dir)
+    }
+
+    /// Write a model directory the way `ModelManager` lays one out. Without the
+    /// GGUF file it is the half-downloaded/half-deleted shape that
+    /// `list_downloaded` reports as `ModelStatus::Error`.
+    fn write_model(models_dir: &std::path::Path, id: &str, with_gguf: bool) {
+        let model_dir = models_dir.join(id);
+        std::fs::create_dir_all(&model_dir).unwrap();
+        let meta = format!(
+            r#"{{
+                "id": "{id}",
+                "displayName": "Test Model",
+                "sizeBytes": 9,
+                "sha256": "abc",
+                "architecture": "test",
+                "contextLength": 2048
+            }}"#
+        );
+        std::fs::write(model_dir.join("model_meta.json"), meta).unwrap();
+        if with_gguf {
+            std::fs::write(model_dir.join("model.gguf"), b"fake data").unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn test_downloaded_but_unloaded_local_model_counts_as_available() {
+        let models = tempfile::tempdir().unwrap();
+        write_model(models.path(), "ready-model", true);
+        let (service, _cfg) = service_with_models(models.path().to_path_buf());
+
+        // Nothing has been loaded: this is the state after every app restart.
+        assert!(!service
+            .test_provider(AiProviderType::LocalInference)
+            .await
+            .unwrap());
+        assert_eq!(
+            service.get_local_model_status().await,
+            providers::LocalModelStatus::Unloaded
+        );
+
+        // ...yet a generate request would lazily load it and succeed, so the
+        // `is_ai_available` command must not report AI as unconfigured.
+        assert!(service.has_loadable_local_model().await);
+        assert!(service.has_available_provider().await);
+    }
+
+    #[tokio::test]
+    async fn test_no_downloaded_model_is_not_loadable() {
+        // An empty models directory.
+        let models = tempfile::tempdir().unwrap();
+        let (service, _cfg) = service_with_models(models.path().to_path_buf());
+        assert!(!service.has_loadable_local_model().await);
+
+        // ...and the pre-wiring state, before `set_local_ai_state` is called.
+        let config_dir = tempfile::tempdir().unwrap();
+        let unwired = AiService::new(config_dir.path().to_path_buf());
+        assert!(!unwired.has_loadable_local_model().await);
+    }
+
+    #[tokio::test]
+    async fn test_model_directory_without_gguf_is_not_loadable() {
+        // Metadata left behind without the weights: nothing can be loaded from
+        // it, so it must not light up the AI affordances.
+        let models = tempfile::tempdir().unwrap();
+        write_model(models.path(), "broken-model", false);
+        let (service, _cfg) = service_with_models(models.path().to_path_buf());
+
+        assert!(!service.has_loadable_local_model().await);
+    }
+
+    #[tokio::test]
+    async fn test_ensure_local_model_loaded_skips_a_model_with_no_gguf() {
+        let models = tempfile::tempdir().unwrap();
+        write_model(models.path(), "broken-model", false);
+        let (service, _cfg) = service_with_models(models.path().to_path_buf());
+
+        // Attempting to load the missing GGUF would fail and leave the provider
+        // parked in `Error`; it must be skipped instead.
+        assert!(service.ensure_local_model_loaded().await.is_ok());
+        assert_eq!(
+            service.get_local_model_status().await,
+            providers::LocalModelStatus::Unloaded
+        );
     }
 }


### PR DESCRIPTION
## What was broken

### A downloaded local model counted as "no AI configured" after every restart

For a user whose only AI provider is a downloaded local GGUF model, `is_ai_available` returned `false` on every launch — even though generating a commit message would have worked.

The chain:

- `is_ai_available` (`src-tauri/src/commands/ai.rs`) was `service.find_available_provider().await.is_some()`.
- `AiService::find_available_provider` (`src-tauri/src/services/ai/mod.rs`) only treats `LocalInference` as available when its engine is already loaded — the code says so: *"only if already loaded — no lazy load here"*.
- Nothing loads a model at startup. `lib.rs` setup only wires `set_local_ai_state`, with *"Model loading is deferred to first inference request"*, so `get_local_model_status()` is `Unloaded` on every launch.
- But `generate_commit_message` and `generate_text` both start with `ensure_local_model_loaded()`, which lists downloaded models and loads one. **Generation succeeded while the availability command said there was no provider.**

User-visible fallout: `lv-commit-panel.ts` rendered the sparkle button with the title "Configure an AI provider in Settings" and routed the click to `handleOpenSettings` instead of `handleGenerateMessage`; the Vibe Check / Split Check row (gated on `aiAvailable && stagedCount > 0`) was hidden entirely; `startAiAvailabilityPolling()` then polled every 5s for 12 attempts (~60s) waiting for a startup auto-load that does not exist, and gave up. `lv-merge-editor.ts` and `lv-changelog-dialog.ts` gate their AI affordances on the same command. The workaround was to open Settings > Local AI and press **Load**, every session.

### A half-deleted model directory would have created a new dead end

`ModelManager::list_downloaded` returns entries with `status: ModelStatus::Error` for a directory that has `model_meta.json` but no `model.gguf`, and `ensure_local_model_loaded` blindly took `downloaded[0]`. A naive "list_downloaded() is non-empty" availability check would therefore enable the sparkle button for a model that can never load, and the lazy loader would `set_loading()` → fail on the missing path → `set_error()`, parking the provider in the error state.

## The fix

Backend only — the panel already re-renders off the command's result, so the sparkle button and the Vibe row light up as soon as it returns `true`. No TypeScript changed.

1. **`AiService::has_loadable_local_model`** (new) — true when the wired `SharedLocalAiState` lists a model whose GGUF file is actually on disk (`status == ModelStatus::Downloaded`). Returns `false` when `local_ai_state` was never set, so it can never report a phantom model.
2. **`AiService::has_available_provider`** (new) — `find_available_provider().is_some() || has_loadable_local_model()`.
3. **`is_ai_available`** now calls `has_available_provider()`; its doc comment says so.
4. **`ensure_local_model_loaded`** picks the first entry with `status == Downloaded` instead of `downloaded[0]`, and returns `Ok(())` when there is nothing loadable — so availability and the lazy-load path agree on exactly the same set of models.

`find_available_provider` is deliberately **not** changed: returning the `LocalInference` provider while its engine is empty would make generation fail with "No model loaded" instead of falling through to a configured cloud provider. `generate_commit_message` / `generate_text` keep using it, after their lazy load.

## Tests

All in the existing `#[cfg(test)] mod tests` of `src-tauri/src/services/ai/mod.rs`, using `tempfile` + `#[tokio::test]`. Two helpers build an `AiService` with no configured cloud provider wired to a temp models dir, and write a model directory with or without its `model.gguf`. No network, no llama backend touched on the passing path.

| Test | Covers | Fails without the fix |
| --- | --- | --- |
| `test_downloaded_but_unloaded_local_model_counts_as_available` | Happy path — the finding itself. Pins that nothing is loaded (`test_provider(LocalInference)` false, status `Unloaded`), then asserts `has_available_provider()` and `has_loadable_local_model()`. | **Yes** — `assertion failed: service.has_available_provider().await` |
| `test_no_downloaded_model_is_not_loadable` | Negative path: empty models dir, and an `AiService` whose `set_local_ai_state` was never called. | No — guard only, passes both ways by design (it protects the `None` branch and does not depend on a local Ollama being absent). |
| `test_model_directory_without_gguf_is_not_loadable` | Edge case: `model_meta.json` with no `model.gguf` must not count as available. | **Yes** — with a plain `!list_downloaded().is_empty()` check: `assertion failed: !service.has_loadable_local_model().await` |
| `test_ensure_local_model_loaded_skips_a_model_with_no_gguf` | Error path of the lazy loader: the broken entry is skipped, provider stays `Unloaded`. | **Yes** — with `downloaded[0]`: `assertion failed: service.ensure_local_model_loaded().await.is_ok()`, preceded by a panic inside `llama-cpp-2` loading the missing file. |

Each "yes" row was verified by reverting only that half of the production change, re-running the test, and observing the failure quoted above, then restoring.

Full gate green: `npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_