### PR TITLE
Report background model download failures outside the Settings dialog

### DIFF
--- a/e2e/fixtures/tauri-mock.ts
+++ b/e2e/fixtures/tauri-mock.ts
@@ -649,7 +649,32 @@ export async function setupTauriMocks(
       // Deep clone mock data into mutable state that mutations can update
       const state = JSON.parse(JSON.stringify(mockData)) as typeof defaultMockData;
 
-      const handler = (command: string, args?: Record<string, unknown>): unknown => {
+      // === Backend event delivery ===
+      // Tauri's `listen()` registers a JS callback through `transformCallback`
+      // and then invokes `plugin:event|listen` with that callback's id. Keep
+      // both so tests can emit backend events the app really listens to.
+      const eventCallbacks = new Map<number, (e: unknown) => void>();
+      const eventListeners = new Map<number, { event: string; cb: (e: unknown) => void }>();
+      let nextCallbackId = 1;
+
+      // `unlisten()` from @tauri-apps/api calls into the event plugin's own
+      // internals before the IPC round trip, so it has to exist for teardown.
+      (window as unknown as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+        unregisterListener: () => {},
+      };
+
+      (window as unknown as Record<string, unknown>).__EMIT_TAURI_EVENT__ = (
+        event: string,
+        payload: unknown
+      ) => {
+        for (const listener of eventListeners.values()) {
+          if (listener.event === event) {
+            listener.cb({ event, id: 0, payload });
+          }
+        }
+      };
+
+      const commandHandler = (command: string, args?: Record<string, unknown>): unknown => {
         switch (command) {
           case 'open_repository':
           case 'get_repository_info':
@@ -1076,12 +1101,31 @@ export async function setupTauriMocks(
         }
       };
 
+      const handler = (command: string, args?: Record<string, unknown>): unknown => {
+        switch (command) {
+          case 'plugin:event|listen': {
+            const cb = eventCallbacks.get(args?.handler as number);
+            const id = nextCallbackId++;
+            if (cb) eventListeners.set(id, { event: args?.event as string, cb });
+            return id;
+          }
+          case 'plugin:event|unlisten':
+            eventListeners.delete(args?.eventId as number);
+            return null;
+        }
+        return commandHandler(command, args);
+      };
+
       // Set up the Tauri internals mock
       (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {
         invoke: async (command: string, args?: Record<string, unknown>) => {
           return handler(command, args);
         },
-        transformCallback: () => 0,
+        transformCallback: (cb: (e: unknown) => void) => {
+          const id = nextCallbackId++;
+          eventCallbacks.set(id, cb);
+          return id;
+        },
         convertFileSrc: (path: string) => path,
       };
 

--- a/e2e/fixtures/test-helpers.ts
+++ b/e2e/fixtures/test-helpers.ts
@@ -292,3 +292,27 @@ export async function startCommandCaptureWithMocks(
     };
   }, overrides);
 }
+
+/**
+ * Deliver a backend Tauri event to every listener the app registered.
+ *
+ * Backend-driven flows (e.g. a model download that fails minutes after the
+ * command returned) can only be exercised by emitting the event the Rust side
+ * would emit. Requires the mock installed by `setupTauriMocks`.
+ */
+export async function emitBackendEvent(
+  page: Page,
+  event: string,
+  payload: unknown
+): Promise<void> {
+  await page.evaluate(
+    ({ event: name, payload: data }) => {
+      const emit = (window as unknown as {
+        __EMIT_TAURI_EVENT__?: (event: string, payload: unknown) => void;
+      }).__EMIT_TAURI_EVENT__;
+      if (!emit) throw new Error('Tauri event mock is not installed');
+      emit(name, data);
+    },
+    { event, payload }
+  );
+}

--- a/e2e/tests/local-ai-settings.spec.ts
+++ b/e2e/tests/local-ai-settings.spec.ts
@@ -6,6 +6,7 @@ import {
   injectCommandError,
   findCommand,
   waitForCommand,
+  emitBackendEvent,
 } from '../fixtures/test-helpers';
 import { RightPanelPage } from '../pages/panels.page';
 
@@ -114,6 +115,12 @@ function localAiMocks(overrides: Record<string, unknown> = {}) {
 async function openSettings(page: Page) {
   await page.keyboard.press('Meta+,');
   await expect(page.locator('lv-settings-dialog')).toBeVisible();
+}
+
+/** Close the settings dialog, which unmounts it along with its listeners */
+async function closeSettings(page: Page) {
+  await page.locator('lv-modal:has(lv-settings-dialog) .close-btn[aria-label="Close"]').click();
+  await expect(page.locator('lv-settings-dialog')).toHaveCount(0);
 }
 
 /** Force the commit panel to re-check AI availability */
@@ -362,6 +369,70 @@ test.describe('Settings Dialog — Local AI', () => {
     // Both should show Load buttons since model status is 'unloaded'
     const loadButtons = page.locator('lv-settings-dialog .setting-row button', { hasText: 'Load' });
     await expect(loadButtons).toHaveCount(2);
+  });
+
+  // A model download runs for minutes in a backend task and reports its outcome
+  // only over a Tauri event. Users routinely close Settings while it runs, and
+  // closing Settings unmounts the dialog along with its listeners — so the
+  // failure has to be reported by something that outlives the dialog.
+  test('a download that fails after Settings is closed still tells the user', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, localAiMocks({ download_model: null }));
+    await openSettings(page);
+
+    const modelRow = page.locator('lv-settings-dialog .setting-row', { hasText: 'Ultra-Light' });
+    await modelRow.getByRole('button', { name: 'Download' }).click();
+    await waitForCommand(page, 'download_model');
+
+    await closeSettings(page);
+
+    await emitBackendEvent(page, 'model-download-error', {
+      modelId: 'gemma-3-1b-q4km',
+      error: 'Network unreachable',
+    });
+
+    const toastMessage = page.locator('lv-toast-container .toast.error .toast-message');
+    await expect(toastMessage).toBeVisible();
+    await expect(toastMessage).toContainText('Network unreachable');
+  });
+
+  test('a model that downloads but fails to load is reported after Settings is closed', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, localAiMocks({ download_model: null }));
+    await openSettings(page);
+
+    const modelRow = page.locator('lv-settings-dialog .setting-row', { hasText: 'Ultra-Light' });
+    await modelRow.getByRole('button', { name: 'Download' }).click();
+    await waitForCommand(page, 'download_model');
+
+    await closeSettings(page);
+
+    await emitBackendEvent(page, 'model-download-complete', {
+      modelId: 'gemma-3-1b-q4km',
+      loaded: false,
+      loadError: 'Out of memory',
+    });
+
+    const toastMessage = page.locator('lv-toast-container .toast.error .toast-message');
+    await expect(toastMessage).toBeVisible();
+    await expect(toastMessage).toContainText('Out of memory');
+  });
+
+  test('cancelling a download after Settings is closed does not look like a failure', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, localAiMocks({ download_model: null }));
+    await openSettings(page);
+
+    const modelRow = page.locator('lv-settings-dialog .setting-row', { hasText: 'Ultra-Light' });
+    await modelRow.getByRole('button', { name: 'Download' }).click();
+    await waitForCommand(page, 'download_model');
+
+    await closeSettings(page);
+
+    // The backend reports a user-requested cancel on the failure event too.
+    await emitBackendEvent(page, 'model-download-error', {
+      modelId: 'gemma-3-1b-q4km',
+      error: 'Download cancelled',
+    });
+
+    await expect(page.locator('lv-toast-container .toast.error')).toHaveCount(0);
   });
 });
 

--- a/src/__tests__/app-shell-model-download-alerts.test.ts
+++ b/src/__tests__/app-shell-model-download-alerts.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Background model-download failures must reach the user.
+ *
+ * `download_model` returns as soon as the download is spawned; a multi-hundred
+ * megabyte download then runs for minutes and reports its outcome only over a
+ * Tauri event. The only listeners lived in the Settings dialog, which app-shell
+ * unmounts on close — so closing Settings during a download meant a later
+ * network drop, full disk or refused load produced nothing at all: no toast, no
+ * banner, and a user left wondering why they have no AI. The shell owns the
+ * listener now, for as long as the app is running.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type EventCallback = (e: { event: string; id: number; payload: unknown }) => void;
+
+const listeners = new Map<number, { event: string; cb: EventCallback }>();
+const callbacks = new Map<number, EventCallback>();
+let nextId = 1;
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  transformCallback: (cb: EventCallback) => {
+    const id = nextId++;
+    callbacks.set(id, cb);
+    return id;
+  },
+  invoke: (command: string, args?: Record<string, unknown>): Promise<unknown> => {
+    if (command === 'plugin:event|listen') {
+      const cb = callbacks.get(args?.handler as number);
+      const id = nextId++;
+      if (cb) listeners.set(id, { event: args?.event as string, cb });
+      return Promise.resolve(id);
+    }
+    if (command === 'plugin:event|unlisten') {
+      listeners.delete(args?.eventId as number);
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(null);
+  },
+};
+
+// `unlisten()` pokes the event plugin's own internals before the IPC call.
+(globalThis as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+  unregisterListener: () => {},
+};
+
+/** Deliver a backend event exactly as the Tauri event plugin would. */
+function emit(event: string, payload: unknown): void {
+  for (const listener of [...listeners.values()]) {
+    if (listener.event === event) listener.cb({ event, id: 1, payload });
+  }
+}
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { AppShell } from '../app-shell.ts';
+import '../app-shell.ts';
+import { uiStore } from '../stores/index.ts';
+
+async function shell(): Promise<AppShell> {
+  const el = await fixture<AppShell>(html`<lv-app-shell></lv-app-shell>`);
+  await el.updateComplete;
+  // The listeners are registered over async IPC in connectedCallback.
+  await waitForListener('model-download-error');
+  await waitForListener('model-download-complete');
+  // Registration lands in the mock before the shell records its unlisten, so
+  // let the remaining promise jobs run before anyone tears the shell down.
+  for (let i = 0; i < 5; i++) await new Promise((resolve) => setTimeout(resolve, 0));
+  return el;
+}
+
+async function waitForListener(event: string): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if ([...listeners.values()].some((l) => l.event === event)) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`no listener was ever registered for ${event}`);
+}
+
+function errorToasts() {
+  return uiStore.getState().toasts.filter((t) => t.type === 'error');
+}
+
+describe('app-shell model download alerts', () => {
+  beforeEach(() => {
+    uiStore.setState({ toasts: [] });
+    // Drop listeners left behind by an earlier shell so each test only ever
+    // observes the shell it just mounted.
+    listeners.clear();
+  });
+
+  afterEach(() => {
+    uiStore.setState({ toasts: [] });
+  });
+
+  it('surfaces a background download failure while Settings is closed', async () => {
+    const el = await shell();
+    expect(
+      (el as unknown as { showSettings: boolean }).showSettings,
+      'Settings must be closed for this to be the reported bug'
+    ).to.be.false;
+
+    emit('model-download-error', { modelId: 'qwen-2.5-1.5b', error: 'Disk full' });
+
+    const toast = errorToasts()[0];
+    expect(toast, 'the failure must be reported by the shell').to.not.be.undefined;
+    expect(toast.message).to.contain('Disk full');
+    expect(toast.message).to.contain('qwen-2.5-1.5b');
+  });
+
+  it('surfaces a model that downloaded but would not load', async () => {
+    await shell();
+
+    emit('model-download-complete', {
+      modelId: 'qwen-2.5-1.5b',
+      loaded: false,
+      loadError: 'llama.cpp init failed',
+    });
+
+    const toast = errorToasts()[0];
+    expect(toast, 'a model that will not load must be reported').to.not.be.undefined;
+    expect(toast.message).to.contain('llama.cpp init failed');
+  });
+
+  it('says nothing when a download completes and loads', async () => {
+    await shell();
+
+    emit('model-download-complete', { modelId: 'qwen-2.5-1.5b', loaded: true });
+
+    expect(errorToasts(), 'a successful download is not an error').to.have.lengthOf(0);
+  });
+
+  it('stops listening once the shell is torn down', async () => {
+    const el = await shell();
+    el.remove();
+    // Tauri's unlisten deregisters over IPC, so let those promises settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    uiStore.setState({ toasts: [] });
+
+    emit('model-download-error', { modelId: 'qwen-2.5-1.5b', error: 'Disk full' });
+
+    expect(errorToasts(), 'the listener must be released with the shell').to.have.lengthOf(0);
+  });
+});

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -124,6 +124,7 @@ import {
 import { searchIndexService } from './services/search-index.service.ts';
 import { embeddingIndexService } from './services/embedding-index.service.ts';
 import { initOAuthListener } from './services/oauth.service.ts';
+import * as localAiService from './services/local-ai.service.ts';
 import { emit, type UnlistenFn } from '@tauri-apps/api/event';
 
 /**
@@ -1709,6 +1710,9 @@ export class AppShell extends LitElement {
     // Set up update notification listeners
     this.setupUpdateListeners();
 
+    // Surface background model-download failures even when Settings is closed
+    this.setupModelDownloadListeners();
+
     // Initialize OAuth deep link listener
     initOAuthListener().catch((e) => {
       log.warn('Failed to initialize OAuth listener:', e);
@@ -1859,6 +1863,15 @@ export class AppShell extends LitElement {
       showToast(`Update failed: ${error.message}`, 'error', 8000);
     });
     this.updateUnlisteners.push(unlistenError);
+  }
+
+  /**
+   * Model downloads run in a backend task and outlive the Settings dialog that
+   * started them, so the shell - not the dialog - owns the failure listener.
+   * Without it a download that fails after Settings is closed is silent.
+   */
+  private async setupModelDownloadListeners(): Promise<void> {
+    this.updateUnlisteners.push(await localAiService.listenForModelDownloadFailures());
   }
 
   /**

--- a/src/components/dialogs/__tests__/lv-settings-dialog-download-events.test.ts
+++ b/src/components/dialogs/__tests__/lv-settings-dialog-download-events.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Settings Dialog — download event reporting.
+ *
+ * `download_model` reports its outcome over Tauri events long after the command
+ * returned. A download that failed already showed in the AI banner, but a model
+ * that downloaded and then could NOT be loaded (`loaded: false` plus a
+ * `loadError`) was dropped on the floor: the handler only refreshed the model
+ * list, so the user saw the download finish and no AI appear, with no error
+ * anywhere. Both outcomes must reach the banner.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type EventCallback = (e: { event: string; id: number; payload: unknown }) => void;
+
+const listeners = new Map<number, { event: string; cb: EventCallback }>();
+const callbacks = new Map<number, EventCallback>();
+let nextId = 1;
+
+const mockInvoke = (command: string, args?: Record<string, unknown>): Promise<unknown> => {
+  if (command === 'plugin:event|listen') {
+    const cb = callbacks.get(args?.handler as number);
+    const id = nextId++;
+    if (cb) listeners.set(id, { event: args?.event as string, cb });
+    return Promise.resolve(id);
+  }
+  if (command === 'plugin:event|unlisten') {
+    listeners.delete(args?.eventId as number);
+    return Promise.resolve(null);
+  }
+
+  switch (command) {
+    case 'plugin:notification|is_permission_granted':
+      return Promise.resolve(false);
+    case 'get_ai_providers':
+      return Promise.resolve([]);
+    case 'get_app_version':
+      return Promise.resolve('0.1.0');
+    case 'get_settings':
+      return Promise.resolve({});
+    case 'get_system_capabilities':
+      return Promise.resolve({ hasGpu: false, gpuName: null, totalRam: 8 });
+    case 'get_downloaded_models':
+    case 'get_available_models':
+    case 'get_available_diff_tools':
+    case 'get_graph_color_schemes':
+      return Promise.resolve([]);
+    case 'get_model_status':
+    case 'get_local_model_status':
+      return Promise.resolve({ loaded: false, modelId: null });
+    case 'get_mcp_status':
+      return Promise.resolve({ servers: [], totalTools: 0 });
+    default:
+      return Promise.resolve(null);
+  }
+};
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: mockInvoke,
+  transformCallback: (cb: EventCallback) => {
+    const id = nextId++;
+    callbacks.set(id, cb);
+    return id;
+  },
+};
+
+// `unlisten()` pokes the event plugin's own internals before the IPC call.
+(globalThis as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+  unregisterListener: () => {},
+};
+
+/** Deliver a backend event exactly as the Tauri event plugin would. */
+function emit(event: string, payload: unknown): void {
+  for (const listener of [...listeners.values()]) {
+    if (listener.event === event) listener.cb({ event, id: 1, payload });
+  }
+}
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-settings-dialog.ts';
+import type { LvSettingsDialog } from '../lv-settings-dialog.ts';
+
+async function waitForListener(event: string): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if ([...listeners.values()].some((l) => l.event === event)) return;
+    await new Promise((resolve) => setTimeout(resolve, 5));
+  }
+  throw new Error(`no listener was ever registered for ${event}`);
+}
+
+async function createDialog(): Promise<LvSettingsDialog> {
+  const el = await fixture<LvSettingsDialog>(html`<lv-settings-dialog></lv-settings-dialog>`);
+  await el.updateComplete;
+  await waitForListener('model-download-complete');
+  await waitForListener('model-download-error');
+  return el;
+}
+
+function bannerText(el: LvSettingsDialog): string {
+  return el.shadowRoot!.querySelector('.error-text')?.textContent ?? '';
+}
+
+describe('lv-settings-dialog download events', () => {
+  beforeEach(() => {
+    listeners.clear();
+  });
+
+  // Control: proves the harness really delivers events to the dialog, so the
+  // load-failure assertion below is about the handler, not a dead emit().
+  it('shows a download failure in the AI banner', async () => {
+    const el = await createDialog();
+
+    emit('model-download-error', { modelId: 'm1', error: 'Network unreachable' });
+    await el.updateComplete;
+
+    expect(bannerText(el)).to.contain('m1');
+    expect(bannerText(el)).to.contain('Network unreachable');
+  });
+
+  it('shows a load failure in the AI banner', async () => {
+    const el = await createDialog();
+
+    emit('model-download-complete', {
+      modelId: 'qwen-2.5-1.5b',
+      loaded: false,
+      loadError: 'Insufficient memory',
+    });
+    await el.updateComplete;
+
+    expect(bannerText(el), 'a model that downloaded but will not load must be reported')
+      .to.contain('qwen-2.5-1.5b');
+    expect(bannerText(el)).to.contain('Insufficient memory');
+  });
+
+  it('falls back to a generic reason when the backend sends no loadError', async () => {
+    const el = await createDialog();
+
+    emit('model-download-complete', { modelId: 'm1', loaded: false });
+    await el.updateComplete;
+
+    expect(bannerText(el)).to.contain('m1');
+    expect(bannerText(el)).to.contain('unknown error');
+  });
+
+  it('clears the progress row and reports no error when the model loads', async () => {
+    const el = await createDialog();
+    const dialog = el as unknown as {
+      downloadProgress: Record<string, unknown>;
+      aiError: string | null;
+    };
+    dialog.downloadProgress = {
+      m1: { modelId: 'm1', downloadedBytes: 1, totalBytes: 2, percentage: 50 },
+    };
+
+    let notified = false;
+    const onChanged = () => {
+      notified = true;
+    };
+    window.addEventListener('ai-settings-changed', onChanged);
+
+    emit('model-download-complete', { modelId: 'm1', loaded: true });
+    await el.updateComplete;
+    window.removeEventListener('ai-settings-changed', onChanged);
+
+    expect(dialog.downloadProgress).to.not.have.property('m1');
+    expect(dialog.aiError, 'a successful load is not an error').to.be.null;
+    expect(notified, 'other components must hear about the new provider').to.be.true;
+  });
+});

--- a/src/components/dialogs/lv-settings-dialog.ts
+++ b/src/components/dialogs/lv-settings-dialog.ts
@@ -795,7 +795,7 @@ export class LvSettingsDialog extends LitElement {
       };
     });
 
-    this.downloadCompleteUnlisten = await listen<{ modelId: string; loaded?: boolean }>('model-download-complete', (event) => {
+    this.downloadCompleteUnlisten = await listen<{ modelId: string; loaded?: boolean; loadError?: string }>('model-download-complete', (event) => {
       // Remove from progress tracking and refresh the model list
       const { [event.payload.modelId]: _, ...rest } = this.downloadProgress;
       this.downloadProgress = rest;
@@ -805,6 +805,10 @@ export class LvSettingsDialog extends LitElement {
       if (event.payload.loaded) {
         this.loadAiProviders();
         window.dispatchEvent(new CustomEvent('ai-settings-changed'));
+      } else if (event.payload.loaded === false) {
+        // The download succeeded but the engine refused the model - the user
+        // still has no AI, so say so instead of silently refreshing the list.
+        this.aiError = `Loading failed for ${event.payload.modelId}: ${event.payload.loadError ?? 'unknown error'}`;
       }
     });
 

--- a/src/services/__tests__/local-ai.service.download-events.test.ts
+++ b/src/services/__tests__/local-ai.service.download-events.test.ts
@@ -1,0 +1,137 @@
+/**
+ * Local AI Service — background download failure reporting.
+ *
+ * `download_model` returns as soon as the download is spawned and reports the
+ * outcome minutes later over a Tauri event. The only listeners used to live in
+ * the Settings dialog, which app-shell destroys when it closes, so a download
+ * that failed after the user closed Settings produced no toast, no banner and
+ * no explanation — the user just never got a model. The app-level listener
+ * added here has to survive that, without mistaking a user-requested cancel or
+ * a successful load for a failure.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type EventCallback = (e: { event: string; id: number; payload: unknown }) => void;
+
+/** Every live listener, so unlisten and multi-listener delivery are testable. */
+const listeners = new Map<number, { event: string; cb: EventCallback }>();
+const callbacks = new Map<number, EventCallback>();
+let nextId = 1;
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  transformCallback: (cb: EventCallback) => {
+    const id = nextId++;
+    callbacks.set(id, cb);
+    return id;
+  },
+  invoke: (command: string, args?: Record<string, unknown>): Promise<unknown> => {
+    if (command === 'plugin:event|listen') {
+      const cb = callbacks.get(args?.handler as number);
+      const id = nextId++;
+      if (cb) listeners.set(id, { event: args?.event as string, cb });
+      return Promise.resolve(id);
+    }
+    if (command === 'plugin:event|unlisten') {
+      listeners.delete(args?.eventId as number);
+      return Promise.resolve(null);
+    }
+    return Promise.resolve(null);
+  },
+};
+
+// `unlisten()` from @tauri-apps/api pokes the event plugin's own internals
+// before invoking `plugin:event|unlisten`, so it has to exist for teardown.
+(globalThis as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+  unregisterListener: () => {},
+};
+
+/** Deliver a backend event exactly as the Tauri event plugin would. */
+function emit(event: string, payload: unknown): void {
+  for (const listener of [...listeners.values()]) {
+    if (listener.event === event) listener.cb({ event, id: 1, payload });
+  }
+}
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect } from '@open-wc/testing';
+import type { UnlistenFn } from '@tauri-apps/api/event';
+import { listenForModelDownloadFailures } from '../local-ai.service.ts';
+import { uiStore } from '../../stores/ui.store.ts';
+
+function toasts() {
+  return uiStore.getState().toasts;
+}
+
+describe('local-ai.service background download failures', () => {
+  let unlisten: UnlistenFn | undefined;
+
+  beforeEach(async () => {
+    uiStore.setState({ toasts: [] });
+    listeners.clear();
+    unlisten = await listenForModelDownloadFailures();
+  });
+
+  afterEach(() => {
+    unlisten?.();
+    unlisten = undefined;
+    uiStore.setState({ toasts: [] });
+  });
+
+  it('toasts the failure when a background download errors', () => {
+    emit('model-download-error', {
+      modelId: 'qwen-2.5-1.5b',
+      error: 'Network unreachable',
+    });
+
+    const toast = toasts().find((t) => t.type === 'error');
+    expect(toast, 'a failed download must be reported').to.not.be.undefined;
+    expect(toast!.message).to.contain('qwen-2.5-1.5b');
+    expect(toast!.message).to.contain('Network unreachable');
+  });
+
+  it('toasts when a downloaded model cannot be loaded', () => {
+    emit('model-download-complete', {
+      modelId: 'qwen-2.5-1.5b',
+      loaded: false,
+      loadError: 'Out of memory',
+    });
+
+    const toast = toasts().find((t) => t.type === 'error');
+    expect(toast, 'a model that will not load must be reported').to.not.be.undefined;
+    expect(toast!.message).to.contain('Out of memory');
+  });
+
+  it('stays quiet when the model downloads and loads', () => {
+    emit('model-download-complete', { modelId: 'qwen-2.5-1.5b', loaded: true });
+
+    expect(toasts(), 'a successful download is not an error').to.have.lengthOf(0);
+  });
+
+  it('stays quiet when the complete event omits the loaded flag', () => {
+    emit('model-download-complete', { modelId: 'qwen-2.5-1.5b' });
+
+    expect(toasts(), 'only an explicit loaded:false is a failure').to.have.lengthOf(0);
+  });
+
+  it('stays quiet when the user cancelled the download', () => {
+    emit('model-download-error', { modelId: 'qwen-2.5-1.5b', error: 'Download cancelled' });
+
+    expect(toasts(), 'a user-requested cancel is not a failure').to.have.lengthOf(0);
+  });
+
+  it('stops toasting after the returned unlisten runs', async () => {
+    unlisten!();
+    unlisten = undefined;
+    // Tauri's unlisten deregisters over IPC, so let those promises settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    emit('model-download-error', { modelId: 'qwen-2.5-1.5b', error: 'Disk full' });
+    emit('model-download-complete', {
+      modelId: 'qwen-2.5-1.5b',
+      loaded: false,
+      loadError: 'Out of memory',
+    });
+
+    expect(toasts(), 'both listeners must be removed').to.have.lengthOf(0);
+  });
+});

--- a/src/services/local-ai.service.ts
+++ b/src/services/local-ai.service.ts
@@ -3,8 +3,10 @@
  * Manages local model inference, downloads, and system capabilities
  */
 
-import { invokeCommand } from './tauri-api.ts';
+import { invokeCommand, listenToEvent } from './tauri-api.ts';
+import { showToast } from './notification.service.ts';
 import type { CommandResult } from '../types/api.types.ts';
+import type { UnlistenFn } from '@tauri-apps/api/event';
 
 /**
  * GPU vendor types
@@ -169,6 +171,55 @@ export async function unloadModel(): Promise<CommandResult<void>> {
     window.dispatchEvent(new CustomEvent('ai-settings-changed'));
   }
   return result;
+}
+
+/**
+ * The backend's error text for a download the user asked to cancel.
+ * A cancel is reported on the same event as a genuine failure, so it has to be
+ * recognised by its message and left un-toasted.
+ */
+const CANCELLED_ERROR = 'Download cancelled';
+
+/**
+ * Report background model download/load failures for the life of the app.
+ *
+ * `download_model` returns as soon as the download is spawned and only reports
+ * the outcome minutes later over a Tauri event. The Settings dialog that
+ * started the download is destroyed when it closes, taking its listeners with
+ * it, so without an app-level listener a failed download is completely silent
+ * and the user is left with no model and no explanation.
+ *
+ * Returns a single unlisten that removes both listeners.
+ */
+export async function listenForModelDownloadFailures(): Promise<UnlistenFn> {
+  const unlistenError = await listenToEvent<{ modelId: string; error: string }>(
+    'model-download-error',
+    ({ modelId, error }) => {
+      // A user-requested cancel arrives on this event too - not a failure.
+      if (error === CANCELLED_ERROR) return;
+      showToast(`Model download failed for ${modelId}: ${error}`, 'error', 8000);
+    }
+  );
+
+  const unlistenComplete = await listenToEvent<{
+    modelId: string;
+    loaded?: boolean;
+    loadError?: string;
+  }>('model-download-complete', ({ modelId, loaded, loadError }) => {
+    // Only an explicit `loaded: false` is a failure; the success emitters send
+    // `loaded: true` and other callers may omit the flag entirely.
+    if (loaded !== false) return;
+    showToast(
+      `${modelId} downloaded but failed to load: ${loadError ?? 'unknown error'}`,
+      'error',
+      8000
+    );
+  });
+
+  return () => {
+    unlistenError();
+    unlistenComplete();
+  };
 }
 
 /**


### PR DESCRIPTION
## What was broken

### Model download errors are silently lost once the Settings dialog closes

`download_model` (`src-tauri/src/commands/local_ai.rs`) spawns the download in a `tokio::spawn` task and returns immediately — "Spawn download in background so the command returns immediately". The outcome of a multi-hundred-megabyte transfer arrives minutes later, on a Tauri event only:

- failure → `model-download-error` with `{ modelId, error }`
- downloaded, but the inference engine refused it → `model-download-complete` with `{ modelId, loaded: false, loadError }`

The only listeners for those events lived in `setupDownloadListeners()` in `src/components/dialogs/lv-settings-dialog.ts`, registered in `connectedCallback` and torn down in `disconnectedCallback`. `app-shell.ts` renders the dialog conditionally (`${this.showSettings ? html`<lv-modal …><lv-settings-dialog …>` : nothing}`) and `handleCloseSettings` sets `showSettings = false`, so **closing Settings destroys the element and its listeners**.

Since these downloads take minutes, users routinely close Settings while one runs. A subsequent network drop, full disk or checksum mismatch then produced nothing at all: no toast, no banner, no explanation. The user later finds no model and no AI, and no reason why.

`lv-commit-panel.ts` also listens to `model-download-complete`, but only acts when `loaded` is true, so it does not cover this either.

Separately, the `loaded: false` case was silent **even with the dialog open**: the complete handler typed the payload as `{ modelId, loaded?: boolean }`, ignored `loadError` entirely, and only refreshed the model list.

Both violate the project rule "Error paths must never be silent".

## The fix

- **`src/services/local-ai.service.ts`** — new `listenForModelDownloadFailures()`. It listens for both events and toasts an error for a failed download and for a model that downloaded but would not load, returning a single unlisten that removes both listeners. A user-requested cancel arrives on the *same* error event with the literal message `"Download cancelled"` (`model_manager.rs` `do_download`), so that message is recognised and left un-toasted. Only an explicit `loaded: false` is treated as a load failure — the success emitters send `loaded: true`, and other emitters may omit the flag.
- **`src/app-shell.ts`** — `setupModelDownloadListeners()` registers that listener in `connectedCallback`, next to the existing update listeners, and pushes its unlisten onto the `updateUnlisteners` array `disconnectedCallback` already drains. A backend task outlives any dialog, so the shell owns the listener.
- **`src/components/dialogs/lv-settings-dialog.ts`** — the complete-event payload is widened to include `loadError`, and an `else if (loaded === false)` branch fills the existing inline AI banner with `Loading failed for <model>: <reason>`. The dialog keeps its own banner; the toast covers the closed-dialog case.

### Test infrastructure

The E2E Tauri mock stubbed `transformCallback: () => 0` and had no `plugin:event|listen` case, so **no spec could exercise a backend-event-driven flow at all**. `e2e/fixtures/tauri-mock.ts` now keeps the registered callbacks, handles `plugin:event|listen` / `plugin:event|unlisten`, stubs `__TAURI_EVENT_PLUGIN_INTERNALS__.unregisterListener` (which `unlisten()` calls before the IPC round trip), and exposes `window.__EMIT_TAURI_EVENT__`. `e2e/fixtures/test-helpers.ts` gains `emitBackendEvent(page, event, payload)`.

## Tests

| File | Test | Fails without the fix |
| --- | --- | --- |
| `src/services/__tests__/local-ai.service.download-events.test.ts` | toasts the failure when a background download errors | ✅ |
| | toasts when a downloaded model cannot be loaded | ✅ |
| | stays quiet when the model downloads and loads | ✅ |
| | stays quiet when the complete event omits the loaded flag | ✅ |
| | stays quiet when the user cancelled the download | ✅ |
| | stops toasting after the returned unlisten runs | ✅ |
| `src/__tests__/app-shell-model-download-alerts.test.ts` | surfaces a background download failure while Settings is closed | ✅ |
| | surfaces a model that downloaded but would not load | ✅ |
| | says nothing when a download completes and loads | ✅ |
| | stops listening once the shell is torn down | ✅ |
| `src/components/dialogs/__tests__/lv-settings-dialog-download-events.test.ts` | shows a download failure in the AI banner (control) | ❌ passes before and after — proves the harness really delivers events |
| | shows a load failure in the AI banner | ✅ |
| | falls back to a generic reason when the backend sends no loadError | ✅ |
| | clears the progress row and reports no error when the model loads | ❌ passes before and after — guards the new `else if` against flagging a success |
| `e2e/tests/local-ai-settings.spec.ts` | a download that fails after Settings is closed still tells the user | ✅ |
| | a model that downloads but fails to load is reported after Settings is closed | ✅ |
| | cancelling a download after Settings is closed does not look like a failure | ❌ passes before and after — guards the cancel exemption |

### Verified non-vacuous

With the three production files reverted (tests and fixtures kept), re-running gives:

- `local-ai.service.download-events.test.ts` — all 6 fail: `SyntaxError: The requested module './../local-ai.service.ts' does not provide an export named 'listenForModelDownloadFailures'`
- `app-shell-model-download-alerts.test.ts` — all 4 fail: `Error: no listener was ever registered for model-download-error`
- `lv-settings-dialog-download-events.test.ts` — the two load-failure tests fail: `AssertionError: a model that downloaded but will not load must be reported: expected '' to include 'qwen-2.5-1.5b'`; the control and success tests still pass
- E2E — both failure-reporting cases fail: `expect(locator).toBeVisible() failed … element(s) not found` on `lv-toast-container .toast.error .toast-message`; the cancel case still passes

Restored, the full gate is green: `npm run lint`, `npm run typecheck`, `npm test`, and the whole Playwright suite (1143 passed, 3 skipped) — the mock change touches every spec, so the entire E2E suite was run, not just the local-AI spec.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_