### PR TITLE
docs: add Arch Linux (AUR) installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,23 @@ Pre-built binaries are available from the [Releases](https://github.com/hegsie/L
 | macOS (ARM64) | `.dmg` |
 | Windows | `.msi` or `.exe` |
 | Linux | `.deb` or `.AppImage` |
+| Arch Linux | [AUR](https://aur.archlinux.org/packages/leviathan-bin) |
+
+### Arch Linux (AUR)
+
+Leviathan is available on the AUR as [`leviathan-bin`](https://aur.archlinux.org/packages/leviathan-bin), repackaged from the official `.deb` release:
+
+```bash
+# Using an AUR helper
+yay -S leviathan-bin
+
+# Or manually
+git clone https://aur.archlinux.org/leviathan-bin.git
+cd leviathan-bin
+makepkg -si
+```
+
+This package is community-maintained and is not an official Leviathan release channel.
 
 ### Build from Source
 


### PR DESCRIPTION
Adds an installation path for Arch Linux users. `leviathan-bin` is now published on the AUR, repackaged from the official `Leviathan_0.7.0_amd64.deb` release asset:

https://aur.archlinux.org/packages/leviathan-bin

**Disclosure:** I maintain that AUR package. It tracks the GitHub releases, verifies the `.deb` by sha256, and ships the binary unstripped — so what gets installed is byte-identical to what you publish.

The change is 17 added lines: one row in the Download table and a short `### Arch Linux (AUR)` subsection under Installation. Nothing removed.
