### PR TITLE
Align the TypeScript AI provider literal with the serde wire format

### DIFF
--- a/e2e/tests/local-ai-settings.spec.ts
+++ b/e2e/tests/local-ai-settings.spec.ts
@@ -366,6 +366,63 @@ test.describe('Settings Dialog — Local AI', () => {
 });
 
 // =========================================================================
+// Settings Dialog: Cloud provider connection test
+// =========================================================================
+
+/**
+ * `open_ai` is the serde wire value of the Rust `OpenAi` variant
+ * (`#[serde(rename_all = "snake_case")]`) — the same string the real backend
+ * puts in the get_ai_providers payload.
+ */
+const mockOpenAiProvider = {
+  providerType: 'open_ai',
+  name: 'OpenAI',
+  available: false,
+  requiresApiKey: true,
+  // The Test button is disabled until a key is stored.
+  hasApiKey: true,
+  endpoint: 'https://api.openai.com/v1',
+  models: [],
+  selectedModel: null,
+};
+
+test.describe('Settings Dialog — Cloud provider test', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+  });
+
+  test('shows the provider name when an OpenAI test fails', async ({ page }) => {
+    await injectCommandMock(page, localAiMocks({
+      get_ai_providers: [...mockProvidersUnavailable, mockOpenAiProvider],
+      test_ai_provider: false,
+    }));
+    await openSettings(page);
+
+    const row = page.locator('lv-settings-dialog .setting-row', { hasText: 'OpenAI API Key' });
+    await row.getByRole('button', { name: 'Test' }).click();
+
+    await expect(page.locator('lv-settings-dialog .error-text')).toHaveText(
+      'OpenAI is not available. Check your API key and try again.'
+    );
+    await expect(row.locator('.status-indicator').last()).toContainText('Failed');
+  });
+
+  test('shows Working and no error when the OpenAI test succeeds', async ({ page }) => {
+    await injectCommandMock(page, localAiMocks({
+      get_ai_providers: [...mockProvidersUnavailable, mockOpenAiProvider],
+      test_ai_provider: true,
+    }));
+    await openSettings(page);
+
+    const row = page.locator('lv-settings-dialog .setting-row', { hasText: 'OpenAI API Key' });
+    await row.getByRole('button', { name: 'Test' }).click();
+
+    await expect(row.locator('.status-indicator').last()).toContainText('Working');
+    await expect(page.locator('lv-settings-dialog .error-text')).toHaveCount(0);
+  });
+});
+
+// =========================================================================
 // Commit Panel: AI Generate Button
 // =========================================================================
 

--- a/src-tauri/src/commands/ai.rs
+++ b/src-tauri/src/commands/ai.rs
@@ -876,14 +876,37 @@ mod tests {
     fn test_ai_provider_type_serialization() {
         use crate::services::ai::AiProviderType;
 
-        let provider = AiProviderType::OpenAi;
-        let json = serde_json::to_string(&provider).expect("Failed to serialize");
-        assert!(json.contains("open_ai") || json.contains("openai") || json.contains("OpenAi"));
+        // These exact strings are the IPC wire format and the on-disk key
+        // format of the persisted AI config. The TypeScript `AiProviderType`
+        // union in src/services/ai.service.ts must match them exactly, and
+        // renaming one would invalidate existing config files.
+        let expected = [
+            (AiProviderType::Ollama, "\"ollama\""),
+            (AiProviderType::LmStudio, "\"lm_studio\""),
+            (AiProviderType::OpenAi, "\"open_ai\""),
+            (AiProviderType::Anthropic, "\"anthropic\""),
+            (AiProviderType::GithubCopilot, "\"github_copilot\""),
+            (AiProviderType::GoogleGemini, "\"google_gemini\""),
+            (AiProviderType::LocalInference, "\"local_inference\""),
+        ];
 
-        let provider = AiProviderType::Anthropic;
-        let json = serde_json::to_string(&provider).expect("Failed to serialize");
+        for (variant, wire) in expected {
+            let json = serde_json::to_string(&variant).expect("Failed to serialize");
+            assert_eq!(json, wire, "wire format changed for {variant:?}");
+            let round_tripped: AiProviderType =
+                serde_json::from_str(wire).expect("Failed to deserialize");
+            assert_eq!(round_tripped, variant);
+        }
+
+        // Every variant must be covered above, so a newly added one fails here
+        // until its wire value is asserted.
+        assert_eq!(AiProviderType::all().len(), expected.len());
+
+        // "openai" is not a valid wire value — the snake_case rename makes it
+        // "open_ai". Guards against the TypeScript side drifting back.
         assert!(
-            json.contains("anthropic") || json.contains("Anthropic") || json.contains("ANTHROPIC")
+            serde_json::from_str::<AiProviderType>("\"openai\"").is_err(),
+            "\"openai\" must not deserialize"
         );
     }
 

--- a/src/components/dialogs/__tests__/lv-settings-dialog-ai.test.ts
+++ b/src/components/dialogs/__tests__/lv-settings-dialog-ai.test.ts
@@ -1,12 +1,16 @@
 /**
  * Settings Dialog AI Tests
  *
- * Tests that handleModelChange dispatches ai-settings-changed event.
+ * Tests that handleModelChange dispatches ai-settings-changed event, and that
+ * handleTestProvider reports the tested provider by name.
  */
 
 import { expect, fixture, html } from '@open-wc/testing';
 
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+/** Result returned by the mocked `test_ai_provider` command. */
+let testProviderResult: unknown = null;
 
 const mockInvoke: MockInvoke = async (command: string) => {
   if (command === 'plugin:notification|is_permission_granted') return false;
@@ -14,6 +18,8 @@ const mockInvoke: MockInvoke = async (command: string) => {
   switch (command) {
     case 'get_ai_providers':
       return [];
+    case 'test_ai_provider':
+      return testProviderResult;
     case 'set_ai_model':
       return null;
     case 'set_ai_provider':
@@ -80,5 +86,58 @@ describe('lv-settings-dialog AI events', () => {
     await (el as any).handleProviderSelect('ollama');
 
     expect(eventFired).to.be.true;
+  });
+});
+
+describe('lv-settings-dialog provider test feedback', () => {
+  beforeEach(() => {
+    testProviderResult = null;
+  });
+
+  it('names the provider in the failure message', async () => {
+    const el = await fixture<LvSettingsDialog>(
+      html`<lv-settings-dialog></lv-settings-dialog>`,
+    );
+
+    testProviderResult = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleTestProvider('open_ai');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const aiError = (el as any).aiError as string | null;
+    expect(aiError).to.equal('OpenAI is not available. Check your API key and try again.');
+    expect(aiError).to.not.contain('undefined');
+  });
+
+  it('records a failed status for the tested provider', async () => {
+    const el = await fixture<LvSettingsDialog>(
+      html`<lv-settings-dialog></lv-settings-dialog>`,
+    );
+
+    testProviderResult = false;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleTestProvider('open_ai');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).providerTestStatus['open_ai']).to.equal('failed');
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).testingProvider).to.be.null;
+  });
+
+  it('clears the error and records success when the test passes', async () => {
+    const el = await fixture<LvSettingsDialog>(
+      html`<lv-settings-dialog></lv-settings-dialog>`,
+    );
+
+    testProviderResult = true;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (el as any).aiError = 'stale error';
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    await (el as any).handleTestProvider('open_ai');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).aiError).to.be.null;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    expect((el as any).providerTestStatus['open_ai']).to.equal('success');
   });
 });

--- a/src/services/__tests__/ai.service.test.ts
+++ b/src/services/__tests__/ai.service.test.ts
@@ -27,7 +27,7 @@ const mockResults: Record<string, unknown> = {
         selectedModel: 'llama3.2',
       },
       {
-        providerType: 'openai',
+        providerType: 'open_ai',
         name: 'OpenAI',
         available: false,
         requiresApiKey: true,
@@ -71,7 +71,7 @@ describe('AI Service Types', () => {
     it('should have correct display names', () => {
       expect(getProviderDisplayName('ollama')).to.equal('Ollama');
       expect(getProviderDisplayName('lm_studio')).to.equal('LM Studio');
-      expect(getProviderDisplayName('openai')).to.equal('OpenAI');
+      expect(getProviderDisplayName('open_ai')).to.equal('OpenAI');
       expect(getProviderDisplayName('anthropic')).to.equal('Anthropic Claude');
       expect(getProviderDisplayName('github_copilot')).to.equal('GitHub Models');
       expect(getProviderDisplayName('google_gemini')).to.equal('Google Gemini');
@@ -81,11 +81,75 @@ describe('AI Service Types', () => {
     it('should correctly identify API key requirements', () => {
       expect(providerRequiresApiKey('ollama')).to.be.false;
       expect(providerRequiresApiKey('lm_studio')).to.be.false;
-      expect(providerRequiresApiKey('openai')).to.be.true;
+      expect(providerRequiresApiKey('open_ai')).to.be.true;
       expect(providerRequiresApiKey('anthropic')).to.be.true;
       expect(providerRequiresApiKey('github_copilot')).to.be.true;
       expect(providerRequiresApiKey('google_gemini')).to.be.true;
       expect(providerRequiresApiKey('local_inference')).to.be.false;
+    });
+  });
+
+  describe('AiProviderType wire contract', () => {
+    // The exact strings serde emits for the Rust AiProviderType enum
+    // (`#[serde(rename_all = "snake_case")]`). Keep in sync with the Rust
+    // guard test `test_ai_provider_type_serialization`.
+    const wireProviderTypes: AiProviderType[] = [
+      'ollama',
+      'lm_studio',
+      'open_ai',
+      'anthropic',
+      'github_copilot',
+      'google_gemini',
+      'local_inference',
+    ];
+
+    it('maps every providerType the backend emits to a display name', () => {
+      wireProviderTypes.forEach((type) => {
+        const displayName = getProviderDisplayName(type);
+        expect(displayName, `no display name for "${type}"`).to.be.a('string');
+        expect(displayName, `empty display name for "${type}"`).to.not.equal('');
+      });
+    });
+
+    it('agrees with the requiresApiKey flag the backend sends', () => {
+      // Shaped exactly as get_ai_providers serializes its payload.
+      const payload: AiProviderInfo[] = [
+        {
+          providerType: 'open_ai',
+          name: 'OpenAI',
+          available: false,
+          requiresApiKey: true,
+          hasApiKey: true,
+          endpoint: 'https://api.openai.com/v1',
+          models: [],
+          selectedModel: null,
+        },
+        {
+          providerType: 'local_inference',
+          name: 'Local AI (Embedded)',
+          available: false,
+          requiresApiKey: false,
+          hasApiKey: false,
+          endpoint: '',
+          models: [],
+          selectedModel: null,
+        },
+      ];
+
+      payload.forEach((provider) => {
+        expect(
+          providerRequiresApiKey(provider.providerType),
+          `requiresApiKey mismatch for "${provider.providerType}"`,
+        ).to.equal(provider.requiresApiKey);
+      });
+    });
+
+    it('does not recognise the legacy openai spelling', () => {
+      // 'openai' is not a value the backend can emit or deserialize, so the
+      // helpers must not treat it as a known provider.
+      const legacy = 'openai' as AiProviderType;
+      expect(getProviderDisplayName(legacy)).to.be.undefined;
+      expect(providerRequiresApiKey(legacy)).to.be.false;
     });
   });
 
@@ -110,7 +174,7 @@ describe('AI Service Types', () => {
 
     it('should have correct structure for cloud provider', () => {
       const provider: AiProviderInfo = {
-        providerType: 'openai',
+        providerType: 'open_ai',
         name: 'OpenAI',
         available: false,
         requiresApiKey: true,
@@ -120,7 +184,7 @@ describe('AI Service Types', () => {
         selectedModel: null,
       };
 
-      expect(provider.providerType).to.equal('openai');
+      expect(provider.providerType).to.equal('open_ai');
       expect(provider.available).to.be.false;
       expect(provider.requiresApiKey).to.be.true;
       expect(provider.hasApiKey).to.be.false;
@@ -235,7 +299,7 @@ describe('AI Service Behavior', () => {
 describe('AI Provider Workflow', () => {
   it('should check provider availability before generation', () => {
     const provider: AiProviderInfo = {
-      providerType: 'openai',
+      providerType: 'open_ai',
       name: 'OpenAI',
       available: false,
       requiresApiKey: true,
@@ -266,7 +330,7 @@ describe('AI Provider Workflow', () => {
   });
 
   it('should require API key for cloud providers', () => {
-    const cloudProviders: AiProviderType[] = ['openai', 'anthropic', 'github_copilot', 'google_gemini'];
+    const cloudProviders: AiProviderType[] = ['open_ai', 'anthropic', 'github_copilot', 'google_gemini'];
     const localProviders: AiProviderType[] = ['ollama', 'lm_studio'];
 
     cloudProviders.forEach((type) => {

--- a/src/services/ai.service.ts
+++ b/src/services/ai.service.ts
@@ -8,8 +8,13 @@ import type { CommandResult } from '../types/api.types.ts';
 
 /**
  * AI provider types
+ *
+ * These literals are the serde wire format of the Rust `AiProviderType` enum,
+ * which is annotated `#[serde(rename_all = "snake_case")]`. That means the
+ * `OpenAi` variant crosses the IPC boundary (and is persisted in the AI config
+ * file) as `open_ai` — not `openai`.
  */
-export type AiProviderType = 'ollama' | 'lm_studio' | 'openai' | 'anthropic' | 'github_copilot' | 'google_gemini' | 'local_inference';
+export type AiProviderType = 'ollama' | 'lm_studio' | 'open_ai' | 'anthropic' | 'github_copilot' | 'google_gemini' | 'local_inference';
 
 /**
  * AI provider information
@@ -296,7 +301,7 @@ export function getProviderDisplayName(providerType: AiProviderType): string {
       return 'Ollama';
     case 'lm_studio':
       return 'LM Studio';
-    case 'openai':
+    case 'open_ai':
       return 'OpenAI';
     case 'anthropic':
       return 'Anthropic Claude';
@@ -313,5 +318,5 @@ export function getProviderDisplayName(providerType: AiProviderType): string {
  * Check if a provider requires an API key
  */
 export function providerRequiresApiKey(providerType: AiProviderType): boolean {
-  return providerType === 'openai' || providerType === 'anthropic' || providerType === 'github_copilot' || providerType === 'google_gemini';
+  return providerType === 'open_ai' || providerType === 'anthropic' || providerType === 'github_copilot' || providerType === 'google_gemini';
 }


### PR DESCRIPTION
## What was broken

### `AiProviderType` in TypeScript declared a literal the backend never emits

`AiProviderType` in `src-tauri/src/services/ai/mod.rs` carries `#[serde(rename_all = "snake_case")]` over a variant named `OpenAi`, so the value that actually crosses the IPC boundary — in `AiProviderInfo.providerType` from `get_ai_providers`, in `get_active_ai_provider`, and in the persisted AI config file — is the string `open_ai`. Every other variant round-trips fine (`lm_studio`, `github_copilot`, `google_gemini`, `local_inference` all match), but the TS union in `src/services/ai.service.ts` declared `'openai'` — a literal the backend can neither emit nor deserialize.

Both helpers in that file branched on the fictional literal:

- `getProviderDisplayName` had `case 'openai'`, so for the real runtime value it fell through its exhaustive switch and returned `undefined`.
- `providerRequiresApiKey` compared `providerType === 'openai'`, so it returned `false` for OpenAI.

**User-visible symptom:** `handleTestProvider` in `src/components/dialogs/lv-settings-dialog.ts` builds its failure message from `getProviderDisplayName(providerType)`. Clicking **Test** on a misconfigured OpenAI key rendered:

> undefined is not available. Check your API key and try again.

The rest of the AI settings UI happened to be immune because it reads `p.name` / `p.requiresApiKey` straight off the backend payload and echoes the backend's own `providerType` string back, so no serde deserialization failure occurs today — but `providerRequiresApiKey` was already silently wrong for OpenAI, and any new code writing the literal itself (e.g. `setAiProvider('openai')`) would have been rejected by serde.

**Why CI was blind to it:** the unit tests fed the helpers the same fictional `'openai'` literal, and the Rust guard test `test_ai_provider_type_serialization` asserted `json.contains("open_ai") || json.contains("openai") || json.contains("OpenAi")` — a disjunction that passes for any spelling. That is exactly how the two sides drifted apart.

## The fix

Align TypeScript to the wire format (`'open_ai'`) — three literals in `src/services/ai.service.ts`, plus a comment recording where the strings come from. No production Rust changed.

Renaming the Rust variant with `#[serde(rename = "openai")]` was the wrong direction: `AiConfig.providers` is a `HashMap<AiProviderType, ProviderSettings>` and `active_provider` is an `AiProviderType`, so the enum's serde name is also the persisted key format. An existing config file containing `open_ai` would fail to deserialize, `AiConfig::load` would return `Err`, and every provider's saved endpoint, model and API key would go with it.

`lv-settings-dialog.ts` needed no edit — it only ever passes `provider.providerType` (the backend's own string) through, so it becomes correct once the helpers accept `open_ai`.

The Rust guard test is tightened so the contract cannot drift silently again: exact wire value for all seven variants, a round-trip deserialize for each, a count assertion so a newly added variant fails until its wire value is asserted, and a negative case proving `"openai"` does not deserialize.

## Tests

| Test | File | Covers | Fails without fix |
| --- | --- | --- | --- |
| `should have correct display names` | `src/services/__tests__/ai.service.test.ts` | happy path | ✅ `expected undefined to equal 'OpenAI'` |
| `should correctly identify API key requirements` | `src/services/__tests__/ai.service.test.ts` | happy path | ✅ `expected false to be true` |
| `should require API key for cloud providers` | `src/services/__tests__/ai.service.test.ts` | happy path | ✅ `expected false to be true` |
| `maps every providerType the backend emits to a display name` | `src/services/__tests__/ai.service.test.ts` | contract, all 7 wire values | ✅ `no display name for "open_ai": expected undefined to be a string` |
| `agrees with the requiresApiKey flag the backend sends` | `src/services/__tests__/ai.service.test.ts` | contract vs. real `get_ai_providers` payload shape | ✅ `requiresApiKey mismatch for "open_ai": expected false to equal true` |
| `does not recognise the legacy openai spelling` | `src/services/__tests__/ai.service.test.ts` | edge case | ✅ `expected 'OpenAI' to be undefined` |
| `names the provider in the failure message` | `src/components/dialogs/__tests__/lv-settings-dialog-ai.test.ts` | error path (the reported symptom) | ✅ `expected 'undefined is not available…' to equal 'OpenAI is not available…'` |
| `records a failed status for the tested provider` | `src/components/dialogs/__tests__/lv-settings-dialog-ai.test.ts` | error path completeness | — |
| `clears the error and records success when the test passes` | `src/components/dialogs/__tests__/lv-settings-dialog-ai.test.ts` | happy path | — |
| `shows the provider name when an OpenAI test fails` | `e2e/tests/local-ai-settings.spec.ts` | E2E through the rendered `.error-text` banner | ✅ banner read `"undefined is not available. Check your API key and try again."` |
| `shows Working and no error when the OpenAI test succeeds` | `e2e/tests/local-ai-settings.spec.ts` | E2E happy path | — |
| `test_ai_provider_type_serialization` | `src-tauri/src/commands/ai.rs` | regression lock on the wire contract | ✅ (against drift) `assertion left == right failed: wire format changed for OpenAi — left: "openai", right: "open_ai"` when `#[serde(rename = "openai")]` is added to the variant; the old disjunction accepted it silently |

### Verified failing without the fix

Reverting only `src/services/ai.service.ts` to `main` and re-running: **7 of 7 discriminating unit tests failed** with the messages above, and the E2E banner assertion failed with the literal user-facing string `"undefined is not available. Check your API key and try again."`. The Rust guard was proven by temporarily adding `#[serde(rename = "openai")]` to the `OpenAi` variant — the new assertion catches it, the old one did not. Fix restored; the full `local-ai-settings.spec.ts` suite passes (27 passed).

### Gate

`npm run lint` · `npm run typecheck` · `npm test` (4448 passed) · `cargo fmt --check` · `cargo clippy --all-targets -D warnings` · `cargo test --lib` — all green. The CLAUDE.md snake_case grep returns the same 3 pre-existing matches as `main`; `'open_ai'` here is a string *value* on a type alias, not an object-literal key passed to `invokeCommand`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_