### PR TITLE
Add an Export/Import dialog so archive, patch and bundle are reachable

### DIFF
--- a/e2e/tests/export-import-dialog.spec.ts
+++ b/e2e/tests/export-import-dialog.spec.ts
@@ -1,0 +1,213 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupOpenRepository } from '../fixtures/tauri-mock';
+import {
+  startCommandCaptureWithMocks,
+  findCommand,
+  getCapturedCommands,
+  injectCommandError,
+  openViaCommandPalette,
+  waitForRepositoryChanged,
+} from '../fixtures/test-helpers';
+
+/**
+ * The archive / patch / bundle backend was fully built and fully wrapped in
+ * git.service.ts, but nothing in the UI ever reached it. These specs drive the
+ * new lv-export-import-dialog end-to-end from the surfaces a user actually
+ * has: the command palette, the commit context menu and the ref context menu.
+ */
+
+const ARCHIVE_FILES = ['README.md', 'src/main.ts', 'src/app.ts'];
+const BUNDLE_HEADS = [
+  { name: 'refs/heads/imported-branch', oid: 'c'.repeat(40) },
+  { name: 'refs/tags/v2.0', oid: 'd'.repeat(40) },
+];
+
+async function setupMocks(page: Page, extra: Record<string, unknown> = {}): Promise<void> {
+  await startCommandCaptureWithMocks(page, {
+    get_archive_files: ARCHIVE_FILES,
+    create_archive: '/tmp/repo.zip',
+    create_patch: ['/tmp/patches/0001-a.patch'],
+    apply_patch: null,
+    apply_patch_to_index: null,
+    bundle_create: { bundlePath: '/tmp/x.bundle', refsCount: 3, objectsCount: 42 },
+    bundle_list_heads: BUNDLE_HEADS,
+    bundle_verify: { isValid: true, refs: BUNDLE_HEADS, requires: [], message: null },
+    bundle_unbundle: BUNDLE_HEADS,
+    'plugin:dialog|save': '/tmp/repo.zip',
+    'plugin:dialog|open': '/tmp/fix.patch',
+    ...extra,
+  });
+}
+
+const dialog = 'lv-export-import-dialog';
+
+async function rightClickOnCommitRow(page: Page, rowIndex = 0): Promise<void> {
+  const graphCanvas = page.locator('lv-graph-canvas');
+  await expect(graphCanvas).toBeVisible();
+  const innerCanvas = graphCanvas.locator('canvas[role="img"]');
+  await expect(innerCanvas).toBeAttached();
+
+  const graphHandle = await graphCanvas.elementHandle();
+  await page.waitForFunction(
+    (el) =>
+      ((el as HTMLElement & { sortedNodesByRow?: unknown[] })?.sortedNodesByRow?.length ?? 0) > 0,
+    graphHandle,
+  );
+
+  const box = await graphCanvas.boundingBox();
+  if (!box) throw new Error('Canvas not found');
+  const rowHeight = 32;
+  const headerHeight = 32;
+  await page.mouse.click(box.x + 400, box.y + headerHeight + rowIndex * rowHeight + rowHeight / 2, {
+    button: 'right',
+  });
+}
+
+/**
+ * The graph is a canvas, so a ref chip has no DOM node to right-click. Drive
+ * the same `ref-context-menu` event the canvas hit-test dispatches.
+ */
+async function openRefContextMenu(page: Page, refName: string): Promise<void> {
+  const graphCanvas = page.locator('lv-graph-canvas');
+  await expect(graphCanvas).toBeVisible();
+  const handle = await graphCanvas.elementHandle();
+  await page.evaluate(
+    ({ el, name }) => {
+      el?.dispatchEvent(
+        new CustomEvent('ref-context-menu', {
+          detail: {
+            refName: name,
+            fullName: `refs/heads/${name}`,
+            refType: 'localBranch',
+            isHead: false,
+            position: { x: 200, y: 200 },
+          },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    },
+    { el: handle, name: refName },
+  );
+}
+
+test.describe('Export / Import dialog', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+  });
+
+  test('exports an archive from the command palette', async ({ page }) => {
+    await setupMocks(page);
+    await openViaCommandPalette(page, 'Export archive');
+
+    await expect(page.locator(`${dialog} lv-modal[open]`)).toBeVisible();
+    await expect(page.locator(`${dialog} [data-testid="archive-file-count"]`)).toHaveText(
+      `${ARCHIVE_FILES.length} files`,
+    );
+
+    await page.locator(`${dialog} [data-testid="archive-export"]`).click();
+
+    await expect
+      .poll(async () => (await findCommand(page, 'create_archive')).length)
+      .toBeGreaterThan(0);
+    const [call] = await findCommand(page, 'create_archive');
+    expect((call.args as { treeRef?: string }).treeRef).toBe('HEAD');
+    await expect(page.locator('lv-toast-container').getByText(/Archive written to/)).toBeVisible();
+  });
+
+  test('shows an archive failure inside the dialog instead of dead-ending', async ({ page }) => {
+    await setupMocks(page);
+    await injectCommandError(page, 'create_archive', 'fatal: not a valid object name');
+    await openViaCommandPalette(page, 'Export archive');
+    await expect(page.locator(`${dialog} lv-modal[open]`)).toBeVisible();
+
+    await page.locator(`${dialog} [data-testid="archive-export"]`).click();
+
+    await expect(page.locator(`${dialog} [data-testid="dialog-error"]`)).toContainText(
+      'not a valid object name',
+    );
+    await expect(page.locator(`${dialog} lv-modal[open]`)).toBeVisible();
+  });
+
+  test('checks a patch and then applies it, refreshing the repository', async ({ page }) => {
+    await setupMocks(page);
+    await openViaCommandPalette(page, 'Apply patch file');
+    await expect(page.locator(`${dialog} lv-modal[open]`)).toBeVisible();
+
+    await page.locator(`${dialog} [data-testid="patch-choose-file"]`).click();
+    await expect(page.locator(`${dialog} [data-testid="chosen-patch-file"]`)).toHaveText(
+      '/tmp/fix.patch',
+    );
+
+    await page.locator(`${dialog} [data-testid="patch-check"]`).click();
+    await expect(page.locator('lv-toast-container').getByText(/applies cleanly/)).toBeVisible();
+    await expect(page.locator(`${dialog} lv-modal[open]`)).toBeVisible();
+
+    const refreshed = await waitForRepositoryChanged(page, async () => {
+      await page.locator(`${dialog} [data-testid="patch-apply"]`).click();
+    });
+    expect(refreshed, 'applying a patch must refresh the repository view').toBe(true);
+
+    const applies = await findCommand(page, 'apply_patch');
+    expect(applies.some((c) => !(c.args as { checkOnly?: boolean }).checkOnly)).toBe(true);
+    await expect(page.locator(`${dialog} lv-modal[open]`)).toBeHidden();
+  });
+
+  test('imports a bundle and refreshes the repository', async ({ page }) => {
+    await setupMocks(page, { 'plugin:dialog|open': '/tmp/x.bundle' });
+    await openViaCommandPalette(page, 'Import bundle');
+    await expect(page.locator(`${dialog} lv-modal[open]`)).toBeVisible();
+
+    await page.locator(`${dialog} [data-testid="bundle-choose-file"]`).click();
+    await expect(page.locator(dialog).getByText('refs/heads/imported-branch')).toBeVisible();
+
+    const refreshed = await waitForRepositoryChanged(page, async () => {
+      await page.locator(`${dialog} [data-testid="bundle-import"]`).click();
+    });
+    expect(refreshed, 'importing refs must refresh the repository view').toBe(true);
+
+    expect((await findCommand(page, 'bundle_unbundle')).length).toBe(1);
+    const commands = await getCapturedCommands(page);
+    const unbundleAt = commands.findIndex((c) => c.command === 'bundle_unbundle');
+    const refreshAt = commands.findIndex(
+      (c, i) => i > unbundleAt && c.command === 'open_repository',
+    );
+    expect(refreshAt, 'the repository is re-read after the import').toBeGreaterThan(unbundleAt);
+    await expect(page.locator('lv-toast-container').getByText(/Imported 2 refs/)).toBeVisible();
+  });
+
+  test('opens the Patch tab with the right-clicked commit pre-checked', async ({ page }) => {
+    await setupMocks(page);
+    await rightClickOnCommitRow(page, 0);
+
+    const menu = page.locator('.context-menu');
+    await expect(menu).toBeVisible();
+    const oid = await menu.locator('.context-menu-oid').textContent();
+    await menu.getByText('Create patch…').click();
+
+    await expect(page.locator(`${dialog} lv-modal[open]`)).toBeVisible();
+    const checked = page.locator(`${dialog} input[type="checkbox"]:checked`);
+    await expect(checked).toHaveCount(1);
+    await expect(await checked.getAttribute('data-oid')).toContain((oid ?? '').trim());
+  });
+
+  test('opens the Archive tab on the ref the context menu was opened for', async ({ page }) => {
+    await setupMocks(page);
+    await openRefContextMenu(page, 'feature/test');
+
+    const menu = page.locator('.context-menu');
+    await expect(menu).toBeVisible();
+    await menu.getByText('Export archive…').click();
+
+    await expect(page.locator(`${dialog} lv-modal[open]`)).toBeVisible();
+    // The deep link, not the HEAD default the palette entry would have shown.
+    await expect(page.locator(`${dialog} #archive-ref`)).toHaveValue('feature/test');
+    await expect
+      .poll(async () =>
+        (await findCommand(page, 'get_archive_files')).map(
+          (c) => (c.args as { treeRef?: string }).treeRef,
+        ),
+      )
+      .toContain('feature/test');
+  });
+});

--- a/src/__tests__/app-shell-destructive-guards.test.ts
+++ b/src/__tests__/app-shell-destructive-guards.test.ts
@@ -1108,7 +1108,11 @@ describe('app-shell destructive guards', () => {
       // the lock held, the ONLY enabled items may be the read-only ones. A new
       // mutating button that forgets the binding fails here without anyone
       // having to remember to add it to a list.
-      const READ_ONLY = ['create tag', 'create branch'];
+      // "create patch" only opens the export/import dialog on its Patch tab.
+      // Writing .patch files touches a folder the user picks, never the
+      // working tree or a ref; the dialog's own Apply — which does — takes
+      // this same lock and is bound to it.
+      const READ_ONLY = ['create tag', 'create branch', 'create patch'];
       const el = shellOnRepo();
       document.body.appendChild(el);
       try {

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -47,6 +47,7 @@ import './components/dialogs/lv-keyboard-shortcuts-dialog.ts';
 import './components/dialogs/lv-remote-dialog.ts';
 import './components/dialogs/lv-changelog-dialog.ts';
 import './components/dialogs/lv-clean-dialog.ts';
+import './components/dialogs/lv-export-import-dialog.ts';
 import './components/dialogs/lv-bisect-dialog.ts';
 import './components/dialogs/lv-submodule-dialog.ts';
 import './components/dialogs/lv-worktree-dialog.ts';
@@ -84,6 +85,7 @@ import type { LvInteractiveRebaseDialog } from './components/dialogs/lv-interact
 import type { LvProfileManagerDialog } from './components/dialogs/lv-profile-manager-dialog.ts';
 import type { LvReflogDialog } from './components/dialogs/lv-reflog-dialog.ts';
 import type { LvCleanDialog } from './components/dialogs/lv-clean-dialog.ts';
+import type { LvExportImportDialog } from './components/dialogs/lv-export-import-dialog.ts';
 import type { LvRemoteDialog } from './components/dialogs/lv-remote-dialog.ts';
 import type { LvRepositoryHealthDialog } from './components/dialogs/lv-repository-health-dialog.ts';
 import type { LvChangelogDialog } from './components/dialogs/lv-changelog-dialog.ts';
@@ -760,6 +762,7 @@ export class AppShell extends LitElement {
   @query('lv-create-tag-dialog') private createTagDialog?: LvCreateTagDialog;
   @query('lv-create-branch-dialog') private createBranchDialog?: LvCreateBranchDialog;
   @query('lv-cherry-pick-dialog') private cherryPickDialog?: LvCherryPickDialog;
+  @query('lv-export-import-dialog') private exportImportDialog?: LvExportImportDialog;
   @query('#app-rebase-dialog') private interactiveRebaseDialog?: LvInteractiveRebaseDialog;
   @query('lv-profile-manager-dialog') private profileManagerDialog?: LvProfileManagerDialog;
   @query('lv-reflog-dialog') private reflogDialog?: LvReflogDialog;
@@ -1444,6 +1447,12 @@ export class AppShell extends LitElement {
             dismissed: 'clean cancelled',
             running: 'clean',
             clearFlag: () => { this.showClean = false; },
+          },
+          // No clearFlag: this dialog owns its own open state via open()/close(),
+          // like lv-create-branch-dialog.
+          'lv-export-import-dialog': {
+            dismissed: 'export/import cancelled',
+            running: 'patch/bundle operation',
           },
           'lv-reflog-dialog': {
             dismissed: 'undo history closed',
@@ -3078,6 +3087,24 @@ export class AppShell extends LitElement {
     }
   }
 
+  /** Not gated on isRefOperationInFlight(): opening the dialog writes no git
+   * state, same as Create tag / Create branch above. */
+  private handleCreatePatchFromContext(): void {
+    const commit = this.contextMenu.commit;
+    this.contextMenu = { ...this.contextMenu, visible: false };
+    if (commit) {
+      this.exportImportDialog?.open({ tab: 'patch', patchMode: 'create', commitOid: commit.oid });
+    }
+  }
+
+  private handleExportArchiveFromContext(): void {
+    const refName = this.refContextMenu.refName;
+    this.refContextMenu = { ...this.refContextMenu, visible: false };
+    if (refName) {
+      this.exportImportDialog?.open({ tab: 'archive', ref: refName });
+    }
+  }
+
   /**
    * Create a fixup commit targeting the selected commit
    * Requires staged changes. The fixup commit will be marked with "fixup! <original-message>"
@@ -3911,6 +3938,53 @@ export class AppShell extends LitElement {
         category: 'action',
         icon: 'tag',
         action: this.requiresRepository(() => this.createTagDialog?.open()),
+      },
+      {
+        id: 'export-archive',
+        label: 'Export archive…',
+        category: 'action',
+        icon: 'file',
+        action: this.requiresRepository(() => this.exportImportDialog?.open({ tab: 'archive' })),
+      },
+      {
+        id: 'create-patch',
+        label: 'Create patch from commits…',
+        category: 'action',
+        icon: 'commit',
+        action: this.requiresRepository(() =>
+          this.exportImportDialog?.open({
+            tab: 'patch',
+            patchMode: 'create',
+            commitOid: this.selectedCommit?.oid,
+          }),
+        ),
+      },
+      {
+        id: 'apply-patch',
+        label: 'Apply patch file…',
+        category: 'action',
+        icon: 'commit',
+        action: this.requiresRepository(() =>
+          this.exportImportDialog?.open({ tab: 'patch', patchMode: 'apply' }),
+        ),
+      },
+      {
+        id: 'create-bundle',
+        label: 'Create bundle…',
+        category: 'action',
+        icon: 'file',
+        action: this.requiresRepository(() =>
+          this.exportImportDialog?.open({ tab: 'bundle', bundleMode: 'create' }),
+        ),
+      },
+      {
+        id: 'import-bundle',
+        label: 'Import bundle…',
+        category: 'action',
+        icon: 'file',
+        action: this.requiresRepository(() =>
+          this.exportImportDialog?.open({ tab: 'bundle', bundleMode: 'import' }),
+        ),
       },
       {
         id: 'settings',
@@ -5280,6 +5354,15 @@ export class AppShell extends LitElement {
                 </svg>
                 Create branch
               </button>
+              <button class="context-menu-item" @click=${this.handleCreatePatchFromContext}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                  <polyline points="14 2 14 8 20 8"></polyline>
+                  <line x1="12" y1="18" x2="12" y2="12"></line>
+                  <line x1="9" y1="15" x2="15" y2="15"></line>
+                </svg>
+                Create patch…
+              </button>
               <div class="context-menu-divider"></div>
               <div class="context-menu-submenu">
                 <span class="context-menu-label">Reset to this commit</span>
@@ -5426,6 +5509,19 @@ export class AppShell extends LitElement {
                         Delete tag
                       </button>
                     `}
+              <!-- Rendered for local branches, remote branches AND tags: an
+                   archive is a read-only export of whatever tree the ref points
+                   at, so offering it for only one ref type would be an
+                   inconsistency the user has to discover by right-clicking. -->
+              <div class="context-menu-divider"></div>
+              <button class="context-menu-item" @click=${this.handleExportArchiveFromContext}>
+                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                  <polyline points="21 8 21 21 3 21 3 8"></polyline>
+                  <rect x="1" y="3" width="22" height="5"></rect>
+                  <line x1="10" y1="12" x2="14" y2="12"></line>
+                </svg>
+                Export archive…
+              </button>
             </div>
           `
         : ''}
@@ -5678,6 +5774,16 @@ export class AppShell extends LitElement {
           @branch-created=${(e: CustomEvent<{ repositoryPath?: string }>) =>
             this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null)}
         ></lv-create-branch-dialog>
+        <lv-export-import-dialog
+          .repositoryPath=${this.activeRepository.repository.path}
+          .branches=${this.branches}
+          .tags=${this.graphCanvas?.getTagTips() ?? []}
+          .commits=${this.graphCanvas?.getLoadedCommits() ?? []}
+          @patch-applied=${(e: CustomEvent<{ repositoryPath?: string }>) =>
+            this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null)}
+          @bundle-imported=${(e: CustomEvent<{ repositoryPath?: string }>) =>
+            this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null)}
+        ></lv-export-import-dialog>
         <lv-cherry-pick-dialog
           .repositoryPath=${this.activeRepository.repository.path}
           .currentBranch=${this.activeRepository.currentBranch?.shorthand ?? 'HEAD'}

--- a/src/components/dialogs/__tests__/lv-dialog-operation-in-flight.test.ts
+++ b/src/components/dialogs/__tests__/lv-dialog-operation-in-flight.test.ts
@@ -34,6 +34,7 @@ import '../lv-create-branch-dialog.ts';
 import '../lv-credentials-dialog.ts';
 import '../lv-repository-health-dialog.ts';
 import '../lv-changelog-dialog.ts';
+import '../lv-export-import-dialog.ts';
 
 /**
  * tag → [private in-flight field, value that means "running"].
@@ -61,6 +62,7 @@ const IN_FLIGHT_FIELDS: Array<[string, string, unknown]> = [
   ['lv-credentials-dialog', 'testing', true],
   ['lv-repository-health-dialog', 'runningAction', 'gc'],
   ['lv-changelog-dialog', 'isGenerating', true],
+  ['lv-export-import-dialog', 'operationRunning', true],
 ];
 
 type Probe = HTMLElement & { operationInFlight?: boolean };

--- a/src/components/dialogs/__tests__/lv-export-import-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-export-import-dialog.test.ts
@@ -137,13 +137,14 @@ function lastToast(): { type: string; message: string } | undefined {
 
 async function openDialogAt(
   opts: ExportImportOpenOptions,
+  commits: Commit[] = COMMITS,
 ): Promise<LvExportImportDialog> {
   const el = await fixture<LvExportImportDialog>(html`
     <lv-export-import-dialog
       .repositoryPath=${REPO_PATH}
       .branches=${BRANCHES}
       .tags=${TAGS}
-      .commits=${COMMITS}
+      .commits=${commits}
     ></lv-export-import-dialog>
   `);
   el.open(opts);
@@ -166,6 +167,11 @@ function modalOf(el: LvExportImportDialog): LvModal {
 
 async function click(el: LvExportImportDialog, selector: string): Promise<void> {
   q<HTMLButtonElement>(el, selector).click();
+  await settle(el);
+}
+
+/** Let a pending answer land and the dialog re-render on it. */
+async function settle(el: LvExportImportDialog): Promise<void> {
   await el.updateComplete;
   await new Promise((r) => setTimeout(r, 0));
   await el.updateComplete;
@@ -281,6 +287,35 @@ describe('lv-export-import-dialog', () => {
         outputPath: '/tmp/patches',
       });
       expect(lastToast()?.type).to.equal('success');
+    });
+
+    it('breaks a commit-time tie with graph order, never child before parent', async () => {
+      // Git stamps commit times to the second, so a parent and the child made
+      // right after it routinely share one. Timestamp alone cannot order them,
+      // and a stable sort would leave them in the order they were ticked.
+      const TIED_CHILD = '5'.repeat(40);
+      const TIED_PARENT = '4'.repeat(40);
+      const tied = [
+        makeCommit(TIED_CHILD, 'child change', 500),
+        makeCommit(TIED_PARENT, 'parent change', 500),
+      ];
+      dialogOpenResult = '/tmp/patches';
+      const el = await openDialogAt({ tab: 'patch', patchMode: 'create' }, tied);
+
+      // Ticked newest-first, exactly how the list reads top to bottom.
+      q<HTMLInputElement>(el, `input[data-oid="${TIED_CHILD}"]`).click();
+      await el.updateComplete;
+      q<HTMLInputElement>(el, `input[data-oid="${TIED_PARENT}"]`).click();
+      await el.updateComplete;
+
+      await click(el, '[data-testid="patch-create"]');
+
+      // Parent first, or `git am` cannot replay the series.
+      expect(argsOf('create_patch')).to.deep.equal({
+        path: REPO_PATH,
+        commitOids: [TIED_PARENT, TIED_CHILD],
+        outputPath: '/tmp/patches',
+      });
     });
 
     it('pre-checks the commit it was deep-linked from', async () => {
@@ -452,6 +487,47 @@ describe('lv-export-import-dialog', () => {
       const warn = q<HTMLElement>(el, '[data-testid="bundle-unimportable"]');
       expect(warn.textContent).to.contain('prerequisite');
       expect(warn.textContent).to.contain('f'.repeat(40));
+    });
+
+    it('ignores a late inspection for a bundle that is no longer the chosen one', async () => {
+      // The Choose button stays live while an inspection runs, so a second
+      // pick can overtake the first. The first bundle's verdict must not be
+      // shown for — or unlock Import on — the bundle chosen after it.
+      const settleVerify: Array<(v: unknown) => void> = [];
+      overrides['bundle_verify'] = () =>
+        new Promise((resolve) => {
+          settleVerify.push(resolve);
+        });
+
+      dialogOpenResult = '/tmp/stale.bundle';
+      const el = await openDialogAt({ tab: 'bundle', bundleMode: 'import' });
+      await click(el, '[data-testid="bundle-choose-file"]');
+
+      dialogOpenResult = '/tmp/current.bundle';
+      await click(el, '[data-testid="bundle-choose-file"]');
+
+      expect(settleVerify).to.have.length(2);
+
+      // The bundle chosen second answers first: it cannot be applied here.
+      settleVerify[1]({
+        isValid: false,
+        refs: BUNDLE_HEADS,
+        requires: ['f'.repeat(40)],
+        message: 'repository lacks these prerequisite commits',
+      });
+      await settle(el);
+
+      // The bundle chosen first answers late, and says it is applicable.
+      settleVerify[0]({ isValid: true, refs: BUNDLE_HEADS, requires: [], message: null });
+      await settle(el);
+
+      expect(q<HTMLElement>(el, '[data-testid="chosen-bundle-file"]').textContent?.trim()).to.equal(
+        '/tmp/current.bundle',
+      );
+      expect(q<HTMLButtonElement>(el, '[data-testid="bundle-import"]').disabled).to.be.true;
+      expect(q<HTMLElement>(el, '[data-testid="bundle-unimportable"]').textContent).to.contain(
+        'prerequisite',
+      );
     });
 
     it('import dispatches bundle-imported with the pinned path and toasts the ref count', async () => {

--- a/src/components/dialogs/__tests__/lv-export-import-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-export-import-dialog.test.ts
@@ -1,0 +1,517 @@
+/**
+ * Export / Import Dialog Tests
+ *
+ * These render the REAL lv-export-import-dialog, mock only the Tauri invoke
+ * layer (git commands AND the dialog plugin's file pickers), and verify the
+ * component calls the right commands with the right arguments and shows the
+ * user what happened.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+const invokeHistory: Array<{ command: string; args?: unknown }> = [];
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-export-import-dialog.ts';
+import type { LvExportImportDialog, ExportImportOpenOptions } from '../lv-export-import-dialog.ts';
+import type { LvModal } from '../lv-modal.ts';
+import type { Branch, Commit } from '../../../types/git.types.ts';
+import { uiStore } from '../../../stores/index.ts';
+import { resetOverlayStack } from '../../../utils/overlay-stack.ts';
+import { tryAcquireRefOp, isRefOpRunning, resetRefOpLocks } from '../../../utils/ref-lock.ts';
+
+const REPO_PATH = '/test/repo';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+function makeBranch(shorthand: string, isRemote = false): Branch {
+  return {
+    name: isRemote ? `refs/remotes/${shorthand}` : `refs/heads/${shorthand}`,
+    shorthand,
+    isHead: shorthand === 'main',
+    isRemote,
+    upstream: null,
+    targetOid: 'a'.repeat(40),
+    isStale: false,
+  };
+}
+
+function makeCommit(oid: string, summary: string, timestamp: number): Commit {
+  return {
+    oid,
+    shortId: oid.substring(0, 7),
+    message: summary,
+    summary,
+    body: null,
+    author: { name: 'A', email: 'a@example.com', timestamp },
+    committer: { name: 'A', email: 'a@example.com', timestamp },
+    parentIds: [],
+    timestamp,
+  };
+}
+
+const BRANCHES = [makeBranch('main'), makeBranch('feature/x'), makeBranch('origin/main', true)];
+const TAGS = [{ name: 'v1.0', oid: 'b'.repeat(40) }];
+
+const OID_NEW = '3'.repeat(40);
+const OID_MID = '2'.repeat(40);
+const OID_OLD = '1'.repeat(40);
+// Newest-first, exactly the order the graph hands them over.
+const COMMITS = [
+  makeCommit(OID_NEW, 'newest change', 300),
+  makeCommit(OID_MID, 'middle change', 200),
+  makeCommit(OID_OLD, 'oldest change', 100),
+];
+
+const ARCHIVE_FILES = ['README.md', 'src/main.ts', 'src/app.ts'];
+const BUNDLE_HEADS = [
+  { name: 'refs/heads/main', oid: 'c'.repeat(40) },
+  { name: 'refs/tags/v2.0', oid: 'd'.repeat(40) },
+];
+
+// ── Mock plumbing ──────────────────────────────────────────────────────────
+let dialogOpenResult: string | string[] | null = null;
+let dialogSaveResult: string | null = null;
+/** command → override that wins over the default answer. */
+let overrides: Record<string, () => Promise<unknown>> = {};
+
+function setupMocks(): void {
+  mockInvoke = (command) => {
+    const override = overrides[command];
+    if (override) return override();
+    switch (command) {
+      case 'get_archive_files':
+        return Promise.resolve(ARCHIVE_FILES);
+      case 'create_archive':
+        return Promise.resolve(dialogSaveResult);
+      case 'create_patch':
+        return Promise.resolve(['/out/0001-a.patch']);
+      case 'apply_patch':
+      case 'apply_patch_to_index':
+        return Promise.resolve(null);
+      case 'bundle_create':
+        return Promise.resolve({ bundlePath: '/tmp/x.bundle', refsCount: 4, objectsCount: 42 });
+      case 'bundle_list_heads':
+        return Promise.resolve(BUNDLE_HEADS);
+      case 'bundle_verify':
+        return Promise.resolve({ isValid: true, refs: BUNDLE_HEADS, requires: [], message: null });
+      case 'bundle_unbundle':
+        return Promise.resolve(BUNDLE_HEADS);
+      case 'plugin:dialog|open':
+        return Promise.resolve(dialogOpenResult);
+      case 'plugin:dialog|save':
+        return Promise.resolve(dialogSaveResult);
+      case 'plugin:notification|is_permission_granted':
+        return Promise.resolve(false);
+      default:
+        return Promise.resolve(null);
+    }
+  };
+}
+
+function calls(name: string): Array<{ command: string; args?: unknown }> {
+  return invokeHistory.filter((h) => h.command === name);
+}
+
+function argsOf(name: string): Record<string, unknown> {
+  const found = calls(name);
+  expect(found.length, `expected an invoke of ${name}`).to.be.greaterThan(0);
+  return found[found.length - 1].args as Record<string, unknown>;
+}
+
+function lastToast(): { type: string; message: string } | undefined {
+  const toasts = uiStore.getState().toasts;
+  return toasts[toasts.length - 1];
+}
+
+async function openDialogAt(
+  opts: ExportImportOpenOptions,
+): Promise<LvExportImportDialog> {
+  const el = await fixture<LvExportImportDialog>(html`
+    <lv-export-import-dialog
+      .repositoryPath=${REPO_PATH}
+      .branches=${BRANCHES}
+      .tags=${TAGS}
+      .commits=${COMMITS}
+    ></lv-export-import-dialog>
+  `);
+  el.open(opts);
+  await el.updateComplete;
+  // The dialog reveals the modal in a microtask after its reset render.
+  await new Promise((r) => setTimeout(r, 0));
+  await el.updateComplete;
+  return el;
+}
+
+function q<T extends Element>(el: LvExportImportDialog, selector: string): T {
+  const found = el.shadowRoot?.querySelector<T>(selector);
+  expect(found, `expected ${selector} in the dialog`).to.exist;
+  return found as T;
+}
+
+function modalOf(el: LvExportImportDialog): LvModal {
+  return q<LvModal>(el, 'lv-modal');
+}
+
+async function click(el: LvExportImportDialog, selector: string): Promise<void> {
+  q<HTMLButtonElement>(el, selector).click();
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 0));
+  await el.updateComplete;
+}
+
+describe('lv-export-import-dialog', () => {
+  beforeEach(() => {
+    resetOverlayStack();
+    resetRefOpLocks();
+    invokeHistory.length = 0;
+    overrides = {};
+    dialogOpenResult = null;
+    dialogSaveResult = null;
+    uiStore.setState({ toasts: [] });
+    setupMocks();
+  });
+
+  // ── Archive ──────────────────────────────────────────────────────────────
+  describe('archive', () => {
+    it('loads the file preview for the ref it was opened on', async () => {
+      const el = await openDialogAt({ tab: 'archive', ref: 'v1.0' });
+
+      expect(argsOf('get_archive_files')).to.deep.equal({
+        path: REPO_PATH,
+        treeRef: 'v1.0',
+      });
+      const count = q<HTMLElement>(el, '[data-testid="archive-file-count"]');
+      expect(count.textContent?.trim()).to.equal('3 files');
+      // The deep-linked ref is the one the select shows, not a HEAD fallback.
+      expect(q<HTMLSelectElement>(el, '#archive-ref').value).to.equal('v1.0');
+    });
+
+    it('exports to the path chosen in the save dialog', async () => {
+      dialogSaveResult = '/tmp/repo.zip';
+      const el = await openDialogAt({ tab: 'archive', ref: 'v1.0' });
+
+      await click(el, '[data-testid="archive-export"]');
+
+      expect(argsOf('create_archive')).to.deep.equal({
+        path: REPO_PATH,
+        outputPath: '/tmp/repo.zip',
+        treeRef: 'v1.0',
+        format: 'zip',
+        prefix: undefined,
+      });
+      expect(lastToast()?.type).to.equal('success');
+      expect(lastToast()?.message).to.contain('/tmp/repo.zip');
+    });
+
+    it('suggests a filename whose extension follows the format select', async () => {
+      dialogSaveResult = '/tmp/repo.tar.gz';
+      const el = await openDialogAt({ tab: 'archive' });
+
+      const format = q<HTMLSelectElement>(el, '#archive-format');
+      format.value = 'tar.gz';
+      format.dispatchEvent(new Event('change'));
+      await el.updateComplete;
+
+      await click(el, '[data-testid="archive-export"]');
+
+      const saveArgs = argsOf('plugin:dialog|save') as { options?: { defaultPath?: string } };
+      const defaultPath =
+        saveArgs.options?.defaultPath ?? (saveArgs as { defaultPath?: string }).defaultPath;
+      expect(defaultPath, 'the picker must suggest the selected format').to.be.a('string');
+      expect(defaultPath as string).to.match(/\.tar\.gz$/);
+      expect(argsOf('create_archive').format).to.equal('tar.gz');
+    });
+
+    it('keeps the dialog open and shows the backend message when the export fails', async () => {
+      dialogSaveResult = '/tmp/repo.zip';
+      overrides['create_archive'] = () =>
+        Promise.reject(new Error('fatal: not a valid object name'));
+      const el = await openDialogAt({ tab: 'archive' });
+
+      await click(el, '[data-testid="archive-export"]');
+
+      expect(q<HTMLElement>(el, '[data-testid="dialog-error"]').textContent).to.contain(
+        'not a valid object name',
+      );
+      expect(modalOf(el).open, 'a failure must not be a dead end').to.be.true;
+      expect(el.pinnedRepositoryPathIfOpen).to.equal(REPO_PATH);
+    });
+
+    it('treats a cancelled save picker as a cancel, not a failure', async () => {
+      dialogSaveResult = null;
+      const el = await openDialogAt({ tab: 'archive' });
+
+      await click(el, '[data-testid="archive-export"]');
+
+      expect(calls('create_archive')).to.have.length(0);
+      expect(el.shadowRoot?.querySelector('[data-testid="dialog-error"]')).to.be.null;
+      expect(modalOf(el).open).to.be.true;
+    });
+  });
+
+  // ── Patch ────────────────────────────────────────────────────────────────
+  describe('patch', () => {
+    it('numbers the patch series oldest-first', async () => {
+      dialogOpenResult = '/tmp/patches';
+      const el = await openDialogAt({ tab: 'patch', patchMode: 'create' });
+
+      // Ticked newest-first, the same order the graph lists them.
+      q<HTMLInputElement>(el, `input[data-oid="${OID_NEW}"]`).click();
+      await el.updateComplete;
+      q<HTMLInputElement>(el, `input[data-oid="${OID_OLD}"]`).click();
+      await el.updateComplete;
+
+      await click(el, '[data-testid="patch-create"]');
+
+      expect(argsOf('create_patch')).to.deep.equal({
+        path: REPO_PATH,
+        commitOids: [OID_OLD, OID_NEW],
+        outputPath: '/tmp/patches',
+      });
+      expect(lastToast()?.type).to.equal('success');
+    });
+
+    it('pre-checks the commit it was deep-linked from', async () => {
+      const el = await openDialogAt({ tab: 'patch', patchMode: 'create', commitOid: OID_MID });
+      expect(q<HTMLInputElement>(el, `input[data-oid="${OID_MID}"]`).checked).to.be.true;
+    });
+
+    it('Check runs a dry run and applies nothing', async () => {
+      dialogOpenResult = '/tmp/fix.patch';
+      const el = await openDialogAt({ tab: 'patch', patchMode: 'apply' });
+      await click(el, '[data-testid="patch-check"]'); // disabled: no file yet
+      expect(calls('apply_patch')).to.have.length(0);
+
+      await click(el, '[data-testid="patch-choose-file"]');
+      await click(el, '[data-testid="patch-check"]');
+
+      const applyCalls = calls('apply_patch');
+      expect(applyCalls).to.have.length(1);
+      expect((applyCalls[0].args as { checkOnly?: boolean }).checkOnly).to.be.true;
+      expect(applyCalls.filter((c) => !(c.args as { checkOnly?: boolean }).checkOnly)).to.have.length(
+        0,
+      );
+      expect(lastToast()?.message).to.contain('applies cleanly');
+      expect(modalOf(el).open, 'a check leaves the dialog open').to.be.true;
+    });
+
+    it('applies to the repo it was opened on, not the tab that is active now', async () => {
+      dialogOpenResult = '/tmp/fix.patch';
+      const el = await openDialogAt({ tab: 'patch', patchMode: 'apply' });
+      await click(el, '[data-testid="patch-choose-file"]');
+
+      // The user switches tabs behind the open modal.
+      el.repositoryPath = '/other/repo';
+      await el.updateComplete;
+
+      let detail: { repositoryPath?: string } | null = null;
+      el.addEventListener('patch-applied', (e) => {
+        detail = (e as CustomEvent<{ repositoryPath?: string }>).detail;
+      });
+
+      await click(el, '[data-testid="patch-apply"]');
+
+      expect(argsOf('apply_patch')).to.deep.equal({
+        path: REPO_PATH,
+        patchPath: '/tmp/fix.patch',
+        checkOnly: undefined,
+      });
+      expect(detail).to.not.be.null;
+      expect(detail!.repositoryPath).to.equal(REPO_PATH);
+    });
+
+    it('applies to the index through apply_patch_to_index', async () => {
+      dialogOpenResult = '/tmp/fix.patch';
+      const el = await openDialogAt({ tab: 'patch', patchMode: 'apply' });
+      await click(el, '[data-testid="patch-choose-file"]');
+
+      const indexRadio = q<HTMLInputElement>(el, 'input[name="patch-target"][value="index"]');
+      indexRadio.click();
+      await el.updateComplete;
+
+      await click(el, '[data-testid="patch-apply"]');
+
+      expect(calls('apply_patch_to_index')).to.have.length(1);
+      expect(calls('apply_patch')).to.have.length(0);
+    });
+
+    it('reports a failed apply inline, dispatches nothing, and releases the lock', async () => {
+      dialogOpenResult = '/tmp/fix.patch';
+      overrides['apply_patch'] = () => Promise.reject(new Error('patch does not apply'));
+      const el = await openDialogAt({ tab: 'patch', patchMode: 'apply' });
+      await click(el, '[data-testid="patch-choose-file"]');
+
+      let dispatched = false;
+      el.addEventListener('patch-applied', () => {
+        dispatched = true;
+      });
+
+      await click(el, '[data-testid="patch-apply"]');
+
+      expect(q<HTMLElement>(el, '[data-testid="dialog-error"]').textContent).to.contain(
+        'patch does not apply',
+      );
+      expect(dispatched, 'a failed apply must not claim the repo changed').to.be.false;
+      expect(isRefOpRunning(REPO_PATH), 'the lock is released in a finally').to.be.false;
+      expect(modalOf(el).open).to.be.true;
+    });
+
+    it('greys out Apply while another operation holds the repository', async () => {
+      dialogOpenResult = '/tmp/fix.patch';
+      const el = await openDialogAt({ tab: 'patch', patchMode: 'apply' });
+      await click(el, '[data-testid="patch-choose-file"]');
+
+      tryAcquireRefOp(REPO_PATH);
+      await el.updateComplete;
+
+      const apply = q<HTMLButtonElement>(el, '[data-testid="patch-apply"]');
+      expect(apply.disabled).to.be.true;
+      apply.click();
+      await el.updateComplete;
+      expect(calls('apply_patch')).to.have.length(0);
+    });
+
+    it('disables Apply and Check until a patch file is chosen', async () => {
+      const el = await openDialogAt({ tab: 'patch', patchMode: 'apply' });
+      expect(q<HTMLButtonElement>(el, '[data-testid="patch-apply"]').disabled).to.be.true;
+      expect(q<HTMLButtonElement>(el, '[data-testid="patch-check"]').disabled).to.be.true;
+    });
+
+    it('refuses dismissal while an apply is in flight', async () => {
+      dialogOpenResult = '/tmp/fix.patch';
+      let release: (() => void) | null = null;
+      overrides['apply_patch'] = () =>
+        new Promise((resolve) => {
+          release = () => resolve(null);
+        });
+      const el = await openDialogAt({ tab: 'patch', patchMode: 'apply' });
+      await click(el, '[data-testid="patch-choose-file"]');
+
+      q<HTMLButtonElement>(el, '[data-testid="patch-apply"]').click();
+      await el.updateComplete;
+      expect(el.operationInFlight).to.be.true;
+
+      // The × / Escape route: lv-modal drops `open` then dispatches `close`.
+      modalOf(el).close();
+      await el.updateComplete;
+      expect(modalOf(el).open, 'an in-flight apply owns the dialog').to.be.true;
+
+      release!();
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 0));
+      await el.updateComplete;
+      expect(el.operationInFlight).to.be.false;
+      expect(modalOf(el).open).to.be.false;
+    });
+  });
+
+  // ── Bundle ───────────────────────────────────────────────────────────────
+  describe('bundle', () => {
+    it('verifies and lists the heads of the chosen bundle', async () => {
+      dialogOpenResult = '/tmp/x.bundle';
+      const el = await openDialogAt({ tab: 'bundle', bundleMode: 'import' });
+
+      await click(el, '[data-testid="bundle-choose-file"]');
+
+      expect(argsOf('bundle_list_heads')).to.deep.equal({ bundlePath: '/tmp/x.bundle' });
+      expect(argsOf('bundle_verify')).to.deep.equal({
+        path: REPO_PATH,
+        bundlePath: '/tmp/x.bundle',
+      });
+      const text = el.shadowRoot?.textContent ?? '';
+      expect(text).to.contain('refs/heads/main');
+      expect(text).to.contain('refs/tags/v2.0');
+    });
+
+    it('disables Import for a bundle whose prerequisites are missing', async () => {
+      dialogOpenResult = '/tmp/x.bundle';
+      overrides['bundle_verify'] = () =>
+        Promise.resolve({
+          isValid: false,
+          refs: BUNDLE_HEADS,
+          requires: ['f'.repeat(40)],
+          message: 'repository lacks these prerequisite commits',
+        });
+      const el = await openDialogAt({ tab: 'bundle', bundleMode: 'import' });
+
+      await click(el, '[data-testid="bundle-choose-file"]');
+
+      expect(q<HTMLButtonElement>(el, '[data-testid="bundle-import"]').disabled).to.be.true;
+      const warn = q<HTMLElement>(el, '[data-testid="bundle-unimportable"]');
+      expect(warn.textContent).to.contain('prerequisite');
+      expect(warn.textContent).to.contain('f'.repeat(40));
+    });
+
+    it('import dispatches bundle-imported with the pinned path and toasts the ref count', async () => {
+      dialogOpenResult = '/tmp/x.bundle';
+      const el = await openDialogAt({ tab: 'bundle', bundleMode: 'import' });
+      await click(el, '[data-testid="bundle-choose-file"]');
+
+      let detail: { repositoryPath?: string; refs?: unknown[] } | null = null;
+      el.addEventListener('bundle-imported', (e) => {
+        detail = (e as CustomEvent<{ repositoryPath?: string; refs?: unknown[] }>).detail;
+      });
+
+      await click(el, '[data-testid="bundle-import"]');
+
+      expect(argsOf('bundle_unbundle')).to.deep.equal({
+        path: REPO_PATH,
+        bundlePath: '/tmp/x.bundle',
+      });
+      expect(detail).to.not.be.null;
+      expect(detail!.repositoryPath).to.equal(REPO_PATH);
+      expect(lastToast()?.message).to.contain('Imported 2 refs');
+      expect(isRefOpRunning(REPO_PATH)).to.be.false;
+    });
+
+    it('creates with --all by default and with explicit refs when it is off', async () => {
+      dialogSaveResult = '/tmp/out.bundle';
+      const el = await openDialogAt({ tab: 'bundle', bundleMode: 'create' });
+
+      await click(el, '[data-testid="bundle-create"]');
+      expect(argsOf('bundle_create')).to.deep.equal({
+        path: REPO_PATH,
+        bundlePath: '/tmp/out.bundle',
+        refs: [],
+        all: true,
+      });
+      expect(lastToast()?.message).to.contain('4 refs, 42 objects');
+
+      // Success closes the dialog; reopen for the explicit-refs half.
+      const el2 = await openDialogAt({ tab: 'bundle', bundleMode: 'create' });
+      q<HTMLInputElement>(el2, '#bundle-all').click();
+      await el2.updateComplete;
+      q<HTMLInputElement>(el2, 'input[data-ref="refs/heads/main"]').click();
+      await el2.updateComplete;
+
+      await click(el2, '[data-testid="bundle-create"]');
+      expect(argsOf('bundle_create')).to.deep.equal({
+        path: REPO_PATH,
+        bundlePath: '/tmp/out.bundle',
+        refs: ['refs/heads/main'],
+        all: false,
+      });
+    });
+
+    it('disables Create when --all is off and nothing is ticked', async () => {
+      const el = await openDialogAt({ tab: 'bundle', bundleMode: 'create' });
+      q<HTMLInputElement>(el, '#bundle-all').click();
+      await el.updateComplete;
+
+      expect(q<HTMLButtonElement>(el, '[data-testid="bundle-create"]').disabled).to.be.true;
+      expect(calls('bundle_create')).to.have.length(0);
+    });
+  });
+});

--- a/src/components/dialogs/index.ts
+++ b/src/components/dialogs/index.ts
@@ -25,3 +25,4 @@ export { LvCredentialsDialog } from './lv-credentials-dialog.ts';
 export { LvGitHubDialog } from './lv-github-dialog.ts';
 export { LvProfileManagerDialog } from './lv-profile-manager-dialog.ts';
 export { LvCherryPickDialog } from './lv-cherry-pick-dialog.ts';
+export { LvExportImportDialog } from './lv-export-import-dialog.ts';

--- a/src/components/dialogs/lv-export-import-dialog.ts
+++ b/src/components/dialogs/lv-export-import-dialog.ts
@@ -289,6 +289,10 @@ export class LvExportImportDialog extends LitElement {
   @state() private bundleHeads: BundleRef[] = [];
   @state() private bundleVerifyResult: BundleVerifyResult | null = null;
   @state() private bundleInspecting = false;
+  /** Bumped for every bundle inspection. A slow answer for the file that was
+   * chosen first must not land on the file that is chosen now, or a stale
+   * `isValid` would enable Import for a bundle nobody verified. */
+  private bundleInspectSeq = 0;
 
   @query('lv-modal') private modal!: LvModal;
 
@@ -365,6 +369,9 @@ export class LvExportImportDialog extends LitElement {
     this.bundleHeads = [];
     this.bundleVerifyResult = null;
     this.bundleInspecting = false;
+    // An inspection still in flight from the previous open must not report
+    // into the freshly reset dialog.
+    this.bundleInspectSeq++;
   }
 
   /** Cancel / × / Escape / overlay all honour the same rule. */
@@ -519,10 +526,22 @@ export class LvExportImportDialog extends LitElement {
     // hands commits over NEWEST-first, so passing the selection through in
     // list order would number the series backwards and make `git am` replay
     // it in reverse. Order by commit time, oldest first.
-    const byOid = new Map(this.commits.map((c) => [c.oid, c]));
-    const oids = [...this.selectedCommits].sort(
-      (a, b) => (byOid.get(a)?.timestamp ?? 0) - (byOid.get(b)?.timestamp ?? 0),
+    //
+    // Commit times are second-resolution, so a parent and its child can carry
+    // the SAME timestamp (scripted or rapid-fire history). Sort is stable, so
+    // those would keep the order they were ticked in and could number a child
+    // before its parent, which `git am` cannot replay. Fall back to graph
+    // order, which is newest-first, so an ancestor always wins the tie.
+    const order = new Map(
+      this.commits.map((c, i) => [c.oid, { timestamp: c.timestamp, index: i }]),
     );
+    const oids = [...this.selectedCommits].sort((a, b) => {
+      const ea = order.get(a);
+      const eb = order.get(b);
+      const byTime = (ea?.timestamp ?? 0) - (eb?.timestamp ?? 0);
+      if (byTime !== 0) return byTime;
+      return (eb?.index ?? Number.MAX_SAFE_INTEGER) - (ea?.index ?? Number.MAX_SAFE_INTEGER);
+    });
 
     this.operationRunning = true;
     this.error = '';
@@ -687,6 +706,10 @@ export class LvExportImportDialog extends LitElement {
     this.bundleVerifyResult = null;
     this.bundleInspecting = true;
     this.error = '';
+    // The Choose button stays live while this runs, so the user can pick a
+    // second bundle before the first answer arrives. Only the newest request
+    // is allowed to write the heads / verify result the Import button reads.
+    const seq = ++this.bundleInspectSeq;
     try {
       // Two separate questions: what the bundle CONTAINS (readable even when
       // this repo lacks the prerequisites) and whether it can be APPLIED here.
@@ -694,6 +717,7 @@ export class LvExportImportDialog extends LitElement {
         gitService.bundleListHeads(file),
         gitService.bundleVerify(this.pinnedRepoPath, file),
       ]);
+      if (seq !== this.bundleInspectSeq) return;
       if (heads.success) {
         this.bundleHeads = heads.data ?? [];
       } else {
@@ -705,9 +729,12 @@ export class LvExportImportDialog extends LitElement {
         this.error = verify.error?.message ?? 'Failed to verify the bundle';
       }
     } catch (err) {
+      if (seq !== this.bundleInspectSeq) return;
       this.error = err instanceof Error ? err.message : 'Failed to read the bundle';
     } finally {
-      this.bundleInspecting = false;
+      // A superseded request must leave the spinner alone — the newer one owns
+      // it and is still running.
+      if (seq === this.bundleInspectSeq) this.bundleInspecting = false;
     }
   }
 

--- a/src/components/dialogs/lv-export-import-dialog.ts
+++ b/src/components/dialogs/lv-export-import-dialog.ts
@@ -1,0 +1,1206 @@
+/**
+ * Export / Import Dialog Component
+ *
+ * The archive, patch and bundle commands were fully implemented in the
+ * backend and fully wrapped in git.service.ts, but nothing in the UI ever
+ * called them: no dialog, no context-menu item, no palette entry. A user
+ * could not export an archive, produce or apply a patch, or create/verify/
+ * import a bundle at all. This dialog is the missing surface, and it is one
+ * dialog rather than three because the three flows share the same shape —
+ * pick a ref/commit/file, pick a destination, run one command — and because a
+ * single instance keeps the tab-close sweep and the working-tree lock in one
+ * place instead of three.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state, query } from 'lit/decorators.js';
+import { sharedStyles, buttonStyles } from '../../styles/shared-styles.ts';
+import * as gitService from '../../services/git.service.ts';
+import type { BundleRef, BundleVerifyResult } from '../../services/git.service.ts';
+import { openDialog, saveDialog } from '../../services/dialog.service.ts';
+import { showToast } from '../../services/notification.service.ts';
+import type { Branch, Commit } from '../../types/git.types.ts';
+import './lv-modal.ts';
+import type { LvModal } from './lv-modal.ts';
+import {
+  tryAcquireRefOp,
+  releaseRefOp,
+  warnRepositoryBusy,
+  RefLockController,
+} from '../../utils/ref-lock.ts';
+
+export type ExportImportTab = 'archive' | 'patch' | 'bundle';
+export type PatchMode = 'create' | 'apply';
+export type BundleMode = 'create' | 'import';
+type ArchiveFormat = 'zip' | 'tar' | 'tar.gz';
+type PatchTarget = 'worktree' | 'index';
+
+export interface ExportImportOpenOptions {
+  tab?: ExportImportTab;
+  patchMode?: PatchMode;
+  bundleMode?: BundleMode;
+  /** Pre-select this ref on the Archive tab (from the graph ref menu). */
+  ref?: string;
+  /** Pre-check this commit on the Patch tab (from the commit menu). */
+  commitOid?: string;
+}
+
+/** How many rows of a potentially huge list are rendered at once. */
+const MAX_ROWS = 200;
+
+function basename(path: string): string {
+  const parts = path.split(/[\\/]/).filter(Boolean);
+  return parts[parts.length - 1] ?? 'repository';
+}
+
+/** Make a ref safe to drop into a suggested filename. */
+function sanitizeForFilename(ref: string): string {
+  return ref.replace(/[^\w.-]+/g, '-').replace(/^-+|-+$/g, '') || 'HEAD';
+}
+
+@customElement('lv-export-import-dialog')
+export class LvExportImportDialog extends LitElement {
+  static styles = [
+    sharedStyles,
+    buttonStyles,
+    css`
+      .tabs {
+        display: flex;
+        border-bottom: 1px solid var(--color-border);
+        gap: 0;
+        margin-bottom: var(--spacing-md);
+      }
+
+      .tab {
+        padding: var(--spacing-sm) var(--spacing-md);
+        border: none;
+        background: none;
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-sm);
+        font-weight: var(--font-weight-medium);
+        cursor: pointer;
+        border-bottom: 2px solid transparent;
+      }
+
+      .tab:hover {
+        color: var(--color-text-primary);
+        background: var(--color-bg-hover);
+      }
+
+      .tab.active {
+        color: var(--color-primary);
+        border-bottom-color: var(--color-primary);
+      }
+
+      .body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-md);
+        min-width: 520px;
+        max-width: 620px;
+      }
+
+      .field {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-xs);
+      }
+
+      .field label {
+        font-size: var(--font-size-sm);
+        font-weight: var(--font-weight-medium);
+        color: var(--color-text-secondary);
+      }
+
+      .field select,
+      .field input[type='text'] {
+        padding: var(--spacing-sm);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-primary);
+        color: var(--color-text-primary);
+        font-size: var(--font-size-sm);
+        font-family: inherit;
+      }
+
+      .row {
+        display: flex;
+        gap: var(--spacing-md);
+        align-items: flex-end;
+      }
+
+      .row > .field {
+        flex: 1;
+      }
+
+      .list {
+        max-height: 220px;
+        overflow-y: auto;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-primary);
+      }
+
+      .list-row {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-sm);
+        padding: 4px var(--spacing-sm);
+        font-size: var(--font-size-sm);
+        color: var(--color-text-primary);
+      }
+
+      .list-row.pinned {
+        background: var(--color-bg-tertiary);
+      }
+
+      .mono {
+        font-family: var(--font-family-mono, monospace);
+        color: var(--color-text-secondary);
+      }
+
+      .truncate {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .hint {
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+      }
+
+      .error {
+        padding: var(--spacing-sm) var(--spacing-md);
+        background: var(--color-error-bg);
+        border: 1px solid var(--color-error);
+        border-radius: var(--radius-md);
+        color: var(--color-error);
+        font-size: var(--font-size-sm);
+        word-break: break-word;
+      }
+
+      .warning {
+        padding: var(--spacing-sm) var(--spacing-md);
+        background: var(--color-warning-bg, var(--color-bg-tertiary));
+        border: 1px solid var(--color-warning, var(--color-border));
+        border-radius: var(--radius-md);
+        color: var(--color-text-primary);
+        font-size: var(--font-size-sm);
+        word-break: break-word;
+      }
+
+      .radio-row {
+        display: flex;
+        gap: var(--spacing-lg);
+      }
+
+      .radio-row label,
+      .check-row label {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-xs);
+        font-size: var(--font-size-sm);
+        color: var(--color-text-primary);
+        cursor: pointer;
+      }
+
+      .check-row {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-sm);
+      }
+
+      .chosen-file {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        word-break: break-all;
+      }
+
+      .empty {
+        padding: var(--spacing-md);
+        text-align: center;
+        color: var(--color-text-muted);
+        font-size: var(--font-size-sm);
+      }
+    `,
+  ];
+
+  /** Bound live to the active tab — never used for IPC, see pinnedRepoPath. */
+  @property({ type: String }) repositoryPath = '';
+  @property({ attribute: false }) branches: Branch[] = [];
+  @property({ attribute: false }) tags: Array<{ name: string; oid: string }> = [];
+  @property({ attribute: false }) commits: Commit[] = [];
+
+  /**
+   * The repo this dialog was opened for, captured at open(). `repositoryPath`
+   * follows the active tab, so a tab switch behind the open modal would
+   * otherwise make Apply/Import land in the wrong repository.
+   */
+  private pinnedRepoPath = '';
+  private isOpen = false;
+
+  /** The pinned repo while open, else null — lets the host sweep close this
+   * dialog when that repo's tab goes away. */
+  public get pinnedRepositoryPathIfOpen(): string | null {
+    return this.isOpen ? this.pinnedRepoPath : null;
+  }
+
+  /** The one flag dismiss()/handleModalClose() refuse on, so the host sweep
+   * can never announce a cancellation that did not happen. */
+  public get operationInFlight(): boolean {
+    return this.operationRunning;
+  }
+
+  /** Observe the shared working-tree lock so Apply/Import go grey while
+   * another surface holds it, instead of staying lit and only toasting. */
+  private lock = new RefLockController(this, () => this.pinnedRepoPath || this.repositoryPath);
+
+  @state() private tab: ExportImportTab = 'archive';
+  @state() private operationRunning = false;
+  @state() private error = '';
+
+  // ── Archive ──────────────────────────────────────────────────────────────
+  @state() private archiveRef = 'HEAD';
+  @state() private archiveFormat: ArchiveFormat = 'zip';
+  @state() private archivePrefix = '';
+  @state() private previewFiles: string[] = [];
+  @state() private previewLoading = false;
+  /** A deep-linked ref that is not in branches/tags (a detached or filtered
+   * ref) still has to appear in the select, or the deep link would silently
+   * fall back to HEAD and export the wrong tree. */
+  @state() private extraRef = '';
+
+  // ── Patch ────────────────────────────────────────────────────────────────
+  @state() private patchMode: PatchMode = 'create';
+  @state() private commitFilter = '';
+  @state() private selectedCommits: ReadonlySet<string> = new Set<string>();
+  /** Deep-linked commit, kept visible even when the filter or the row cap
+   * would otherwise hide the row the user just right-clicked. */
+  @state() private pinnedCommitOid = '';
+  @state() private patchFile = '';
+  @state() private patchTarget: PatchTarget = 'worktree';
+
+  // ── Bundle ───────────────────────────────────────────────────────────────
+  @state() private bundleMode: BundleMode = 'create';
+  @state() private bundleAllRefs = true;
+  @state() private selectedRefs: ReadonlySet<string> = new Set<string>();
+  @state() private bundleFile = '';
+  @state() private bundleHeads: BundleRef[] = [];
+  @state() private bundleVerifyResult: BundleVerifyResult | null = null;
+  @state() private bundleInspecting = false;
+
+  @query('lv-modal') private modal!: LvModal;
+
+  public open(opts: ExportImportOpenOptions = {}): void {
+    // An operation already owns this component; reset() would clear
+    // `operationRunning` and re-enable the action button for a second
+    // concurrent run against the same working tree.
+    if (this.operationRunning) return;
+
+    // Re-entering must NOT reset. Several entry points converge on this one
+    // instance (two context menus, five palette entries), and Ctrl+P fires
+    // even while the user is typing in this dialog — so re-opening would wipe
+    // a chosen patch file or a half-built commit selection.
+    if (this.isOpen) {
+      this.applyOptions(opts);
+      return;
+    }
+
+    this.reset();
+    this.pinnedRepoPath = this.repositoryPath;
+    this.isOpen = true;
+    this.applyOptions(opts);
+
+    // Reveal only AFTER the reset above has rendered, and only while still
+    // open, so a close() landing in this window cannot be undone.
+    void this.updateComplete.then(() => {
+      if (!this.isOpen) return;
+      this.modal.open = true;
+    });
+  }
+
+  public close(): void {
+    this.isOpen = false;
+    if (this.modal) this.modal.open = false;
+  }
+
+  private applyOptions(opts: ExportImportOpenOptions): void {
+    if (opts.tab) this.tab = opts.tab;
+    if (opts.patchMode) this.patchMode = opts.patchMode;
+    if (opts.bundleMode) this.bundleMode = opts.bundleMode;
+    if (opts.ref) {
+      this.archiveRef = opts.ref;
+      this.extraRef = this.knownRefs().includes(opts.ref) ? '' : opts.ref;
+    }
+    if (opts.commitOid) {
+      this.pinnedCommitOid = opts.commitOid;
+      this.selectedCommits = new Set([...this.selectedCommits, opts.commitOid]);
+    }
+    if (this.tab === 'archive') {
+      void this.loadArchivePreview();
+    }
+  }
+
+  private reset(): void {
+    this.tab = 'archive';
+    this.operationRunning = false;
+    this.error = '';
+    this.archiveRef = 'HEAD';
+    this.archiveFormat = 'zip';
+    this.archivePrefix = '';
+    this.previewFiles = [];
+    this.previewLoading = false;
+    this.extraRef = '';
+    this.patchMode = 'create';
+    this.commitFilter = '';
+    this.selectedCommits = new Set<string>();
+    this.pinnedCommitOid = '';
+    this.patchFile = '';
+    this.patchTarget = 'worktree';
+    this.bundleMode = 'create';
+    this.bundleAllRefs = true;
+    this.selectedRefs = new Set<string>();
+    this.bundleFile = '';
+    this.bundleHeads = [];
+    this.bundleVerifyResult = null;
+    this.bundleInspecting = false;
+  }
+
+  /** Cancel / × / Escape / overlay all honour the same rule. */
+  private dismiss(): void {
+    if (this.operationRunning) return;
+    this.close();
+  }
+
+  private handleModalClose(): void {
+    // lv-modal.close() sets open=false BEFORE dispatching, so without this the
+    // operation would carry on with no visible surface and report its result
+    // into a hidden dialog.
+    if (this.operationRunning) {
+      this.modal.open = true;
+      return;
+    }
+    this.isOpen = false;
+  }
+
+  private handleTabChange(tab: ExportImportTab): void {
+    this.tab = tab;
+    this.error = '';
+    if (tab === 'archive' && this.previewFiles.length === 0 && !this.previewLoading) {
+      void this.loadArchivePreview();
+    }
+  }
+
+  // ── Archive ──────────────────────────────────────────────────────────────
+
+  private knownRefs(): string[] {
+    const locals = this.branches.filter((b) => !b.isRemote).map((b) => b.shorthand);
+    const remotes = this.branches.filter((b) => b.isRemote).map((b) => b.shorthand);
+    return ['HEAD', ...locals, ...remotes, ...this.tags.map((t) => t.name)];
+  }
+
+  private archiveRefOptions(): string[] {
+    const known = this.knownRefs();
+    return this.extraRef && !known.includes(this.extraRef) ? [this.extraRef, ...known] : known;
+  }
+
+  private async loadArchivePreview(): Promise<void> {
+    const repoPath = this.pinnedRepoPath;
+    if (!repoPath) return;
+    const ref = this.archiveRef;
+    this.previewLoading = true;
+    this.error = '';
+    try {
+      const result = await gitService.getArchiveFiles(repoPath, ref);
+      // A ref change while this was in flight must not be overwritten by the
+      // stale answer.
+      if (this.archiveRef !== ref) return;
+      if (result.success) {
+        this.previewFiles = result.data ?? [];
+      } else {
+        this.previewFiles = [];
+        this.error = result.error?.message ?? 'Failed to list archive contents';
+      }
+    } catch (err) {
+      if (this.archiveRef !== ref) return;
+      this.previewFiles = [];
+      this.error = err instanceof Error ? err.message : 'Failed to list archive contents';
+    } finally {
+      if (this.archiveRef === ref) this.previewLoading = false;
+    }
+  }
+
+  private handleArchiveRefChange(e: Event): void {
+    this.archiveRef = (e.target as HTMLSelectElement).value;
+    void this.loadArchivePreview();
+  }
+
+  private get archiveExtension(): string {
+    return this.archiveFormat;
+  }
+
+  private async handleExportArchive(): Promise<void> {
+    const repoPath = this.pinnedRepoPath;
+    const ext = this.archiveExtension;
+    const suggested = `${basename(repoPath)}-${sanitizeForFilename(this.archiveRef)}.${ext}`;
+
+    const chosen = await saveDialog({
+      title: 'Export Archive',
+      defaultPath: suggested,
+      filters: [{ name: this.archiveFormat, extensions: [ext] }],
+    });
+    // Cancelling the picker is not a failure: no invoke, no error banner.
+    if (!chosen) return;
+
+    this.operationRunning = true;
+    this.error = '';
+    try {
+      const result = await gitService.createArchive(
+        repoPath,
+        chosen,
+        this.archiveRef,
+        this.archiveFormat,
+        this.archivePrefix.trim() || undefined,
+      );
+      if (result.success) {
+        showToast(`Archive written to ${chosen}`, 'success');
+        this.close();
+      } else {
+        this.error = result.error?.message ?? 'Failed to create archive';
+      }
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to create archive';
+    } finally {
+      this.operationRunning = false;
+    }
+  }
+
+  // ── Patch ────────────────────────────────────────────────────────────────
+
+  private visibleCommits(): { rows: Commit[]; total: number; pinned: Commit | null } {
+    const needle = this.commitFilter.trim().toLowerCase();
+    const matches = needle
+      ? this.commits.filter(
+          (c) =>
+            c.summary.toLowerCase().includes(needle) ||
+            c.shortId.toLowerCase().includes(needle) ||
+            c.oid.toLowerCase().startsWith(needle),
+        )
+      : this.commits;
+    const rows = matches.slice(0, MAX_ROWS);
+    const pinned =
+      this.pinnedCommitOid && !rows.some((c) => c.oid === this.pinnedCommitOid)
+        ? (this.commits.find((c) => c.oid === this.pinnedCommitOid) ?? null)
+        : null;
+    return { rows, total: matches.length, pinned };
+  }
+
+  private toggleCommit(oid: string): void {
+    const next = new Set(this.selectedCommits);
+    if (next.has(oid)) next.delete(oid);
+    else next.add(oid);
+    this.selectedCommits = next;
+  }
+
+  private async handleCreatePatch(): Promise<void> {
+    if (this.selectedCommits.size === 0) return;
+    const repoPath = this.pinnedRepoPath;
+
+    const chosen = await openDialog({
+      title: 'Choose a folder for the patch files',
+      directory: true,
+    });
+    const dir = Array.isArray(chosen) ? (chosen[0] ?? null) : chosen;
+    if (!dir) return;
+
+    // The backend numbers the files 0001-, 0002-, ... in the order it is
+    // given, and stamps "Subject: [PATCH n/total]" the same way. The graph
+    // hands commits over NEWEST-first, so passing the selection through in
+    // list order would number the series backwards and make `git am` replay
+    // it in reverse. Order by commit time, oldest first.
+    const byOid = new Map(this.commits.map((c) => [c.oid, c]));
+    const oids = [...this.selectedCommits].sort(
+      (a, b) => (byOid.get(a)?.timestamp ?? 0) - (byOid.get(b)?.timestamp ?? 0),
+    );
+
+    this.operationRunning = true;
+    this.error = '';
+    try {
+      const result = await gitService.createPatch(repoPath, oids, dir);
+      if (result.success) {
+        const files = result.data ?? [];
+        showToast(
+          `Wrote ${files.length} patch file${files.length === 1 ? '' : 's'} to ${dir}`,
+          'success',
+        );
+        this.close();
+      } else {
+        this.error = result.error?.message ?? 'Failed to create patch files';
+      }
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to create patch files';
+    } finally {
+      this.operationRunning = false;
+    }
+  }
+
+  private async handleChoosePatchFile(): Promise<void> {
+    const chosen = await openDialog({
+      title: 'Choose a patch file',
+      filters: [{ name: 'Patch', extensions: ['patch', 'diff'] }],
+    });
+    const file = Array.isArray(chosen) ? (chosen[0] ?? null) : chosen;
+    if (!file) return;
+    this.patchFile = file;
+    this.error = '';
+  }
+
+  private async handleCheckPatch(): Promise<void> {
+    if (!this.patchFile) return;
+    const repoPath = this.pinnedRepoPath;
+    this.operationRunning = true;
+    this.error = '';
+    try {
+      // Dry run ONLY. It never falls through to a real apply — the user asked
+      // whether it would work, not for it to happen.
+      const result = await gitService.applyPatch(repoPath, this.patchFile, true);
+      if (result.success) {
+        showToast('Patch applies cleanly', 'success');
+      } else {
+        this.error = result.error?.message ?? 'Patch would not apply cleanly';
+      }
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Patch would not apply cleanly';
+    } finally {
+      this.operationRunning = false;
+    }
+  }
+
+  private async handleApplyPatch(): Promise<void> {
+    if (!this.patchFile) return;
+    const repoPath = this.pinnedRepoPath;
+    // Applying writes the working tree (or the index), so it serializes on the
+    // same lock as checkout/reset/clean.
+    if (!tryAcquireRefOp(repoPath)) {
+      warnRepositoryBusy();
+      return;
+    }
+
+    this.operationRunning = true;
+    this.error = '';
+    const target = this.patchTarget;
+    try {
+      const result =
+        target === 'index'
+          ? await gitService.applyPatchToIndex(repoPath, this.patchFile)
+          : await gitService.applyPatch(repoPath, this.patchFile);
+      if (result.success) {
+        showToast(
+          target === 'index' ? 'Patch applied to the index' : 'Patch applied to the working tree',
+          'success',
+        );
+        this.dispatchEvent(
+          new CustomEvent('patch-applied', {
+            detail: { repositoryPath: repoPath, target },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        this.close();
+      } else {
+        this.error = result.error?.message ?? 'Failed to apply patch';
+      }
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to apply patch';
+    } finally {
+      this.operationRunning = false;
+      releaseRefOp(repoPath);
+    }
+  }
+
+  // ── Bundle ───────────────────────────────────────────────────────────────
+
+  private bundleRefOptions(): string[] {
+    return [
+      ...this.branches.filter((b) => !b.isRemote).map((b) => `refs/heads/${b.shorthand}`),
+      ...this.tags.map((t) => `refs/tags/${t.name}`),
+    ];
+  }
+
+  private toggleBundleRef(ref: string): void {
+    const next = new Set(this.selectedRefs);
+    if (next.has(ref)) next.delete(ref);
+    else next.add(ref);
+    this.selectedRefs = next;
+  }
+
+  private async handleCreateBundle(): Promise<void> {
+    // The backend rejects "no refs and not --all"; the button is disabled for
+    // that combination so the user can never reach the error.
+    if (!this.bundleAllRefs && this.selectedRefs.size === 0) return;
+    const repoPath = this.pinnedRepoPath;
+
+    const chosen = await saveDialog({
+      title: 'Create Bundle',
+      defaultPath: `${basename(repoPath)}.bundle`,
+      filters: [{ name: 'Git bundle', extensions: ['bundle'] }],
+    });
+    if (!chosen) return;
+
+    this.operationRunning = true;
+    this.error = '';
+    try {
+      const result = await gitService.bundleCreate(
+        repoPath,
+        chosen,
+        this.bundleAllRefs ? [] : [...this.selectedRefs],
+        this.bundleAllRefs,
+      );
+      if (result.success) {
+        const data = result.data;
+        showToast(
+          `Bundle written — ${data?.refsCount ?? 0} refs, ${data?.objectsCount ?? 0} objects`,
+          'success',
+        );
+        this.close();
+      } else {
+        this.error = result.error?.message ?? 'Failed to create bundle';
+      }
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to create bundle';
+    } finally {
+      this.operationRunning = false;
+    }
+  }
+
+  private async handleChooseBundleFile(): Promise<void> {
+    const chosen = await openDialog({
+      title: 'Choose a bundle file',
+      filters: [{ name: 'Git bundle', extensions: ['bundle'] }],
+    });
+    const file = Array.isArray(chosen) ? (chosen[0] ?? null) : chosen;
+    if (!file) return;
+
+    this.bundleFile = file;
+    this.bundleHeads = [];
+    this.bundleVerifyResult = null;
+    this.bundleInspecting = true;
+    this.error = '';
+    try {
+      // Two separate questions: what the bundle CONTAINS (readable even when
+      // this repo lacks the prerequisites) and whether it can be APPLIED here.
+      const [heads, verify] = await Promise.all([
+        gitService.bundleListHeads(file),
+        gitService.bundleVerify(this.pinnedRepoPath, file),
+      ]);
+      if (heads.success) {
+        this.bundleHeads = heads.data ?? [];
+      } else {
+        this.error = heads.error?.message ?? 'Failed to read the bundle';
+      }
+      if (verify.success) {
+        this.bundleVerifyResult = verify.data ?? null;
+      } else if (!this.error) {
+        this.error = verify.error?.message ?? 'Failed to verify the bundle';
+      }
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to read the bundle';
+    } finally {
+      this.bundleInspecting = false;
+    }
+  }
+
+  private async handleImportBundle(): Promise<void> {
+    if (!this.bundleFile || !this.bundleVerifyResult?.isValid) return;
+    const repoPath = this.pinnedRepoPath;
+    // Unbundling writes refs into this repository.
+    if (!tryAcquireRefOp(repoPath)) {
+      warnRepositoryBusy();
+      return;
+    }
+
+    this.operationRunning = true;
+    this.error = '';
+    try {
+      const result = await gitService.bundleUnbundle(repoPath, this.bundleFile);
+      if (result.success) {
+        const refs = result.data ?? [];
+        showToast(`Imported ${refs.length} ref${refs.length === 1 ? '' : 's'}`, 'success');
+        this.dispatchEvent(
+          new CustomEvent('bundle-imported', {
+            detail: { repositoryPath: repoPath, refs },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        this.close();
+      } else {
+        this.error = result.error?.message ?? 'Failed to import the bundle';
+      }
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to import the bundle';
+    } finally {
+      this.operationRunning = false;
+      releaseRefOp(repoPath);
+    }
+  }
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  private renderArchive() {
+    const shown = this.previewFiles.slice(0, MAX_ROWS);
+    return html`
+      <div class="row">
+        <div class="field">
+          <label for="archive-ref">Source ref</label>
+          <!-- .selected on each option, not .value on the select: Lit commits
+               the select's own bindings BEFORE its children exist, so a .value
+               naming a deep-linked ref silently fell back to the first entry. -->
+          <select
+            id="archive-ref"
+            @change=${this.handleArchiveRefChange}
+            ?disabled=${this.operationRunning}
+          >
+            ${this.archiveRefOptions().map(
+              (r) => html`<option value=${r} .selected=${r === this.archiveRef}>${r}</option>`,
+            )}
+          </select>
+        </div>
+        <div class="field">
+          <label for="archive-format">Format</label>
+          <select
+            id="archive-format"
+            @change=${(e: Event) => {
+              this.archiveFormat = (e.target as HTMLSelectElement).value as ArchiveFormat;
+            }}
+            ?disabled=${this.operationRunning}
+          >
+            ${(['zip', 'tar', 'tar.gz'] as ArchiveFormat[]).map(
+              (f) => html`<option value=${f} .selected=${f === this.archiveFormat}>${f}</option>`,
+            )}
+          </select>
+        </div>
+      </div>
+
+      <div class="field">
+        <label for="archive-prefix">Prefix folder (optional)</label>
+        <input
+          id="archive-prefix"
+          type="text"
+          placeholder="my-project"
+          .value=${this.archivePrefix}
+          @input=${(e: Event) => {
+            this.archivePrefix = (e.target as HTMLInputElement).value;
+          }}
+          ?disabled=${this.operationRunning}
+        />
+        <span class="hint">Nests every entry under this directory inside the archive.</span>
+      </div>
+
+      <div class="field">
+        <label>Contents</label>
+        ${this.previewLoading
+          ? html`<div class="empty">Reading the tree…</div>`
+          : html`
+              <div class="hint" data-testid="archive-file-count">
+                ${this.previewFiles.length} file${this.previewFiles.length === 1 ? '' : 's'}
+              </div>
+              <div class="list">
+                ${shown.length === 0
+                  ? html`<div class="empty">No files in this tree</div>`
+                  : shown.map((f) => html`<div class="list-row mono truncate">${f}</div>`)}
+              </div>
+              ${this.previewFiles.length > MAX_ROWS
+                ? html`<span class="hint"
+                    >Showing first ${MAX_ROWS} of ${this.previewFiles.length}</span
+                  >`
+                : nothing}
+            `}
+      </div>
+    `;
+  }
+
+  private renderPatchCreate() {
+    const { rows, total, pinned } = this.visibleCommits();
+    const row = (c: Commit, isPinned: boolean) => html`
+      <label class="list-row ${isPinned ? 'pinned' : ''}">
+        <input
+          type="checkbox"
+          .checked=${this.selectedCommits.has(c.oid)}
+          @change=${() => this.toggleCommit(c.oid)}
+          ?disabled=${this.operationRunning}
+          data-oid=${c.oid}
+        />
+        <span class="mono">${c.shortId}</span>
+        <span class="truncate">${c.summary}</span>
+      </label>
+    `;
+    return html`
+      <div class="field">
+        <label for="commit-filter">Commits</label>
+        <input
+          id="commit-filter"
+          type="text"
+          placeholder="Filter by summary or id"
+          .value=${this.commitFilter}
+          @input=${(e: Event) => {
+            this.commitFilter = (e.target as HTMLInputElement).value;
+          }}
+          ?disabled=${this.operationRunning}
+        />
+        <div class="list">
+          ${pinned ? row(pinned, true) : nothing}
+          ${rows.length === 0 && !pinned
+            ? html`<div class="empty">No commits match</div>`
+            : rows.map((c) => row(c, false))}
+        </div>
+        ${total > MAX_ROWS
+          ? html`<span class="hint">Showing first ${MAX_ROWS} of ${total}</span>`
+          : nothing}
+        <span class="hint" data-testid="patch-selected-count"
+          >${this.selectedCommits.size} selected — files are numbered oldest first</span
+        >
+      </div>
+    `;
+  }
+
+  private renderPatchApply() {
+    return html`
+      <div class="field">
+        <label>Patch file</label>
+        <div class="check-row">
+          <button
+            class="btn btn-secondary"
+            data-testid="patch-choose-file"
+            @click=${this.handleChoosePatchFile}
+            ?disabled=${this.operationRunning}
+          >
+            Choose patch file…
+          </button>
+          <span class="chosen-file" data-testid="chosen-patch-file"
+            >${this.patchFile || 'No file chosen'}</span
+          >
+        </div>
+      </div>
+
+      <div class="field">
+        <label>Apply to</label>
+        <div class="radio-row">
+          <label>
+            <input
+              type="radio"
+              name="patch-target"
+              value="worktree"
+              .checked=${this.patchTarget === 'worktree'}
+              @change=${() => {
+                this.patchTarget = 'worktree';
+              }}
+              ?disabled=${this.operationRunning}
+            />
+            Working tree
+          </label>
+          <label>
+            <input
+              type="radio"
+              name="patch-target"
+              value="index"
+              .checked=${this.patchTarget === 'index'}
+              @change=${() => {
+                this.patchTarget = 'index';
+              }}
+              ?disabled=${this.operationRunning}
+            />
+            Index (staged)
+          </label>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderPatch() {
+    return html`
+      <div class="radio-row">
+        <label>
+          <input
+            type="radio"
+            name="patch-mode"
+            .checked=${this.patchMode === 'create'}
+            @change=${() => {
+              this.patchMode = 'create';
+              this.error = '';
+            }}
+            ?disabled=${this.operationRunning}
+          />
+          Create patch files
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="patch-mode"
+            .checked=${this.patchMode === 'apply'}
+            @change=${() => {
+              this.patchMode = 'apply';
+              this.error = '';
+            }}
+            ?disabled=${this.operationRunning}
+          />
+          Apply a patch file
+        </label>
+      </div>
+      ${this.patchMode === 'create' ? this.renderPatchCreate() : this.renderPatchApply()}
+    `;
+  }
+
+  private renderBundleCreate() {
+    return html`
+      <div class="check-row">
+        <input
+          id="bundle-all"
+          type="checkbox"
+          .checked=${this.bundleAllRefs}
+          @change=${(e: Event) => {
+            this.bundleAllRefs = (e.target as HTMLInputElement).checked;
+          }}
+          ?disabled=${this.operationRunning}
+        />
+        <label for="bundle-all">Include all refs (--all)</label>
+      </div>
+      ${this.bundleAllRefs
+        ? nothing
+        : html`
+            <div class="field">
+              <label>Refs to include</label>
+              <div class="list">
+                ${this.bundleRefOptions().length === 0
+                  ? html`<div class="empty">No local refs to bundle</div>`
+                  : this.bundleRefOptions().map(
+                      (r) => html`
+                        <label class="list-row">
+                          <input
+                            type="checkbox"
+                            .checked=${this.selectedRefs.has(r)}
+                            @change=${() => this.toggleBundleRef(r)}
+                            ?disabled=${this.operationRunning}
+                            data-ref=${r}
+                          />
+                          <span class="mono truncate">${r}</span>
+                        </label>
+                      `,
+                    )}
+              </div>
+            </div>
+          `}
+    `;
+  }
+
+  private renderBundleImport() {
+    const verify = this.bundleVerifyResult;
+    return html`
+      <div class="field">
+        <label>Bundle file</label>
+        <div class="check-row">
+          <button
+            class="btn btn-secondary"
+            data-testid="bundle-choose-file"
+            @click=${this.handleChooseBundleFile}
+            ?disabled=${this.operationRunning}
+          >
+            Choose bundle…
+          </button>
+          <span class="chosen-file" data-testid="chosen-bundle-file"
+            >${this.bundleFile || 'No file chosen'}</span
+          >
+        </div>
+      </div>
+
+      ${this.bundleInspecting ? html`<div class="empty">Reading the bundle…</div>` : nothing}
+      ${this.bundleFile && !this.bundleInspecting
+        ? html`
+            <div class="field">
+              <label>This bundle contains</label>
+              <div class="list">
+                ${this.bundleHeads.length === 0
+                  ? html`<div class="empty">This bundle contains no refs</div>`
+                  : this.bundleHeads.map(
+                      (r) => html`
+                        <div class="list-row">
+                          <span class="mono">${r.oid.substring(0, 7)}</span>
+                          <span class="truncate">${r.name}</span>
+                        </div>
+                      `,
+                    )}
+              </div>
+            </div>
+          `
+        : nothing}
+      ${verify && !verify.isValid
+        ? html`
+            <div class="warning" data-testid="bundle-unimportable">
+              <div>${verify.message ?? 'This bundle cannot be imported into this repository.'}</div>
+              ${verify.requires.length > 0
+                ? html`
+                    <div class="hint">Missing prerequisite commits</div>
+                    ${verify.requires.map((oid) => html`<div class="mono">${oid}</div>`)}
+                  `
+                : nothing}
+            </div>
+          `
+        : nothing}
+    `;
+  }
+
+  private renderBundle() {
+    return html`
+      <div class="radio-row">
+        <label>
+          <input
+            type="radio"
+            name="bundle-mode"
+            .checked=${this.bundleMode === 'create'}
+            @change=${() => {
+              this.bundleMode = 'create';
+              this.error = '';
+            }}
+            ?disabled=${this.operationRunning}
+          />
+          Create a bundle
+        </label>
+        <label>
+          <input
+            type="radio"
+            name="bundle-mode"
+            .checked=${this.bundleMode === 'import'}
+            @change=${() => {
+              this.bundleMode = 'import';
+              this.error = '';
+            }}
+            ?disabled=${this.operationRunning}
+          />
+          Import a bundle
+        </label>
+      </div>
+      ${this.bundleMode === 'create' ? this.renderBundleCreate() : this.renderBundleImport()}
+    `;
+  }
+
+  private renderFooterAction() {
+    if (this.tab === 'archive') {
+      return html`
+        <button
+          class="btn btn-primary"
+          data-testid="archive-export"
+          @click=${this.handleExportArchive}
+          ?disabled=${this.operationRunning}
+        >
+          ${this.operationRunning ? 'Exporting…' : 'Export archive'}
+        </button>
+      `;
+    }
+
+    if (this.tab === 'patch') {
+      if (this.patchMode === 'create') {
+        return html`
+          <button
+            class="btn btn-primary"
+            data-testid="patch-create"
+            @click=${this.handleCreatePatch}
+            ?disabled=${this.operationRunning || this.selectedCommits.size === 0}
+          >
+            ${this.operationRunning ? 'Writing…' : 'Create patch files…'}
+          </button>
+        `;
+      }
+      return html`
+        <button
+          class="btn btn-secondary"
+          data-testid="patch-check"
+          @click=${this.handleCheckPatch}
+          ?disabled=${this.operationRunning || !this.patchFile}
+        >
+          Check
+        </button>
+        <button
+          class="btn btn-primary"
+          data-testid="patch-apply"
+          @click=${this.handleApplyPatch}
+          ?disabled=${this.operationRunning || !this.patchFile || this.lock.busy}
+        >
+          ${this.operationRunning ? 'Applying…' : 'Apply'}
+        </button>
+      `;
+    }
+
+    if (this.bundleMode === 'create') {
+      return html`
+        <button
+          class="btn btn-primary"
+          data-testid="bundle-create"
+          @click=${this.handleCreateBundle}
+          ?disabled=${this.operationRunning ||
+          (!this.bundleAllRefs && this.selectedRefs.size === 0)}
+        >
+          ${this.operationRunning ? 'Writing…' : 'Create bundle…'}
+        </button>
+      `;
+    }
+    return html`
+      <button
+        class="btn btn-primary"
+        data-testid="bundle-import"
+        @click=${this.handleImportBundle}
+        ?disabled=${this.operationRunning ||
+        !this.bundleVerifyResult?.isValid ||
+        this.lock.busy}
+      >
+        ${this.operationRunning ? 'Importing…' : 'Import refs'}
+      </button>
+    `;
+  }
+
+  render() {
+    return html`
+      <lv-modal modalTitle="Export / Import" @close=${this.handleModalClose}>
+        <div class="body">
+          <div class="tabs" role="tablist">
+            ${(['archive', 'patch', 'bundle'] as ExportImportTab[]).map(
+              (t) => html`
+                <button
+                  class="tab ${this.tab === t ? 'active' : ''}"
+                  role="tab"
+                  aria-selected=${this.tab === t ? 'true' : 'false'}
+                  data-tab=${t}
+                  @click=${() => this.handleTabChange(t)}
+                  ?disabled=${this.operationRunning}
+                >
+                  ${t === 'archive' ? 'Archive' : t === 'patch' ? 'Patch' : 'Bundle'}
+                </button>
+              `,
+            )}
+          </div>
+
+          ${this.tab === 'archive'
+            ? this.renderArchive()
+            : this.tab === 'patch'
+              ? this.renderPatch()
+              : this.renderBundle()}
+
+          ${this.error ? html`<div class="error" data-testid="dialog-error">${this.error}</div>` : nothing}
+        </div>
+
+        <div slot="footer">
+          <button class="btn btn-secondary" @click=${this.dismiss} ?disabled=${this.operationRunning}>
+            Cancel
+          </button>
+          ${this.renderFooterAction()}
+        </div>
+      </lv-modal>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lv-export-import-dialog': LvExportImportDialog;
+  }
+}


### PR DESCRIPTION
## What was broken

### Archive, bundle and patch flows are unreachable from the UI

The whole archive/patch/bundle feature set was a dead end. The backends are implemented and hardened (`src-tauri/src/commands/archive.rs`, `bundle.rs`, `patch.rs` — flag-injection defence, binary-patch support, refused-ref reporting), every command is registered in `src-tauri/src/lib.rs`, and all nine calls are wrapped in `src/services/git.service.ts`:

`createPatch`, `applyPatch`, `applyPatchToIndex`, `createArchive`, `getArchiveFiles`, `bundleCreate`, `bundleVerify`, `bundleListHeads`, `bundleUnbundle`

…and **nothing ever called them**. A grep for those nine identifiers across `src/components/**`, `src/app-shell.ts`, `src/stores/**`, `src/utils/**` and `e2e/**` returned zero hits; the only references were the three service-level unit test files. No dialog, no command-palette entry, no context-menu item. A user could not export an archive, produce or apply a patch, or create/verify/import a bundle at all.

## The fix

One new repo-scoped dialog, `src/components/dialogs/lv-export-import-dialog.ts`, with **Archive / Patch / Bundle** tabs, plus the entry points that reach it. `src/services/git.service.ts` is **not touched** — the wrappers were already correct; only the UI was missing.

**Entry points**
- Command palette: `Export archive…`, `Create patch from commits…`, `Apply patch file…`, `Create bundle…`, `Import bundle…` (all through `requiresRepository`).
- Commit context menu: `Create patch…`, deep-linked to that commit (pre-checked).
- Ref context menu: `Export archive…`, rendered for **all three** ref types (local branch / remote branch / tag) so the affordance is not something the user has to discover by right-clicking the right kind of chip. Deep-links the ref into the Archive tab; a ref not present in the branch/tag lists is prepended to the select so the deep link can never silently fall back to `HEAD`.

**Per tab**
- **Archive** — ref select, format select (`zip` / `tar` / `tar.gz`), optional prefix, and a live file preview from `getArchiveFiles` (first 200 paths + a total count). The suggested filename's extension follows the format select. Export goes through `saveDialog`, then `createArchive`.
- **Patch, create** — filterable commit checklist with the deep-linked commit pinned visible, then a folder picker and `createPatch`.
- **Patch, apply** — file picker, working-tree/index radio, a **Check** button that runs `applyPatch(..., checkOnly: true)` and never falls through to a real apply, and **Apply** which runs `applyPatch` / `applyPatchToIndex`.
- **Bundle, create** — `--all` by default, or an explicit `refs/heads/*` + `refs/tags/*` checklist. Create is disabled for "not `--all` and nothing ticked" so the user can never reach the backend's `Either refs must be provided…` error.
- **Bundle, import** — runs `bundleListHeads` (contents, readable even without the prerequisites) **and** `bundleVerify` (applicability). Import stays disabled unless `isValid`; an invalid bundle renders its message plus the missing prerequisite oids.

**Conventions honoured**
- Pins the repository at `open()`; every IPC call uses the pin, never the live `repositoryPath` prop, so a tab switch behind the open modal cannot redirect an apply/import at the wrong repo.
- Exposes `pinnedRepositoryPathIfOpen` / `operationInFlight` and is registered in app-shell's `sweepRepoScopedDialogs` table, so a tab close mid-operation cannot announce a cancellation that did not happen. `dismiss()` and `handleModalClose()` refuse on the same flag the getter reports.
- The two mutating flows (patch apply, unbundle) claim the shared working-tree lock, release it in a `finally`, and bind their buttons to `RefLockController.busy`. Both dispatch an event (`patch-applied` / `bundle-imported`) that app-shell routes through `refreshConflictDialogRepo` → `handleRefresh()`, per the CLAUDE.md rule.
- Every failure sets an inline `.error` banner and leaves the dialog open; every path that closes toasts first; a cancelled file picker is a cancel, not a failure (no invoke, no error banner). No `console.error`-only branch.

**One correctness detail:** `create_patch` numbers its output `0001-`, `0002-`, … and stamps `Subject: [PATCH n/total]` **in the order the oids are given**, while the graph hands commits over newest-first. The dialog sorts the selection by commit timestamp ascending before calling `createPatch`; without that a multi-commit series is numbered backwards and `git am` replays it in reverse.

`src/__tests__/app-shell-destructive-guards.test.ts`'s structural read-only allowlist gains `create patch`: the menu item only opens the dialog, and writing `.patch` files targets a folder the user picks — never the working tree or a ref. The dialog's own **Apply**, which does mutate, is bound to the lock.

## Tests

| Layer | File | Covers |
| --- | --- | --- |
| Unit | `src/components/dialogs/__tests__/lv-export-import-dialog.test.ts` | 19 tests — archive preview/export/format/failure/cancel, patch ordering + deep-link + dry-run + pinned repo + index target + failure + lock + dismissal refusal, bundle list/verify/import/create/disabled states |
| Unit | `src/components/dialogs/__tests__/lv-dialog-operation-in-flight.test.ts` | new row `['lv-export-import-dialog', 'operationRunning', true]` — asserts `operationInFlight` tracks the very flag `dismiss()` refuses on |
| Unit | `src/__tests__/app-shell-destructive-guards.test.ts` | existing structural guard re-run against the new commit-menu item |
| E2E | `e2e/tests/export-import-dialog.spec.ts` | 6 specs — palette archive export + toast, archive failure shown inside the dialog, check-then-apply with a real repository refresh, bundle import with refresh + imported ref listed, commit context menu deep-link, ref context menu deep-link |

### Verified to fail without the fix

Each production behaviour was reverted individually and its test re-run:

| Reverted | Failing test | Message |
| --- | --- | --- |
| the oldest-first timestamp sort in `handleCreatePatch` | numbers the patch series oldest-first | `expected { Object (path, commitOids, …) } to deeply equal …` (oids arrive newest-first) |
| `pinnedRepoPath` → `repositoryPath` in `handleApplyPatch` | applies to the repo it was opened on, not the tab that is active now | `expected { Object (path, patchPath, …) } to deeply equal …` |
| `releaseRefOp` moved out of the `finally` | reports a failed apply inline, dispatches nothing, and releases the lock | `the lock is released in a finally: expected true to be false` |
| archive extension hardcoded to `zip` | suggests a filename whose extension follows the format select | `expected 'repo-HEAD.zip' to match /\.tar\.gz$/` |
| `isValid` dropped from the Import `?disabled` binding | disables Import for a bundle whose prerequisites are missing | `expected false to be true` |
| the in-flight guard in `handleModalClose` | refuses dismissal while an apply is in flight | `an in-flight apply owns the dialog: expected false to be true` |
| the `operationInFlight` getter renamed | lv-export-import-dialog reports operationRunning through operationInFlight | getter missing — plus the pinned/in-flight pairing test |
| all app-shell wiring (`git checkout origin/main -- src/app-shell.ts`) | all 6 E2E specs | `locator.waitFor: Test timeout` — the dialog is unreachable, which is the finding itself |

## Gate

```
LINT OK
TYPECHECK OK
UNIT OK        (4461 passed, 0 failed)
```
E2E: `export-import-dialog.spec.ts` 6/6, plus `context-menus`, `dialogs`, `tag-context-menu`, `keyboard` and `graph` re-run green (151 passed) since this touches two context menus and the palette. No Rust changed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_