### PR TITLE
Keep the clone token out of git's argv and out of clone errors

### DIFF
--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -44,6 +44,38 @@ pub(crate) fn sanitize_url_for_log(url: &str) -> String {
     }
 }
 
+/// Strip userinfo from every URL embedded in free-form text.
+///
+/// `sanitize_url_for_log` takes a string that IS a URL; git's stderr wraps the
+/// URL in prose — `fatal: unable to access
+/// 'https://x-access-token:TOKEN@github.com/o/r.git/': ...` — and that text is
+/// handed straight to the UI on a failed clone. Recent git anonymizes the URL
+/// in its own messages; older git, and messages produced by a remote helper,
+/// do not, and a URL the user typed with credentials in it reaches us intact
+/// either way.
+pub(crate) fn redact_credentials_in_text(text: &str) -> String {
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    while let Some(idx) = rest.find("://") {
+        let (head, tail) = rest.split_at(idx + 3);
+        out.push_str(head);
+        // The authority ends at the first delimiter; everything after it is
+        // path or surrounding prose and must survive untouched.
+        let end = tail
+            .find(|c: char| c.is_whitespace() || matches!(c, '/' | '?' | '#' | '\'' | '"'))
+            .unwrap_or(tail.len());
+        let authority = &tail[..end];
+        match authority.rfind('@') {
+            // rfind, not find: a password may itself contain '@'.
+            Some(at) => out.push_str(&authority[at + 1..]),
+            None => out.push_str(authority),
+        }
+        rest = &tail[end..];
+    }
+    out.push_str(rest);
+    out
+}
+
 /// Credential helper configuration
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -1096,6 +1128,48 @@ mod tests {
     fn test_sanitize_url_no_credentials() {
         let url = "https://example.com/path";
         assert_eq!(sanitize_url_for_log(url), url);
+    }
+
+    /// git's stderr embeds the URL in prose. The credential must be stripped
+    /// while the surrounding text — which is the whole diagnostic value of the
+    /// message — survives intact.
+    #[test]
+    fn test_redact_credentials_in_text_strips_userinfo_from_embedded_urls() {
+        assert_eq!(
+            redact_credentials_in_text(
+                "fatal: repository 'https://x-access-token:ghp_s3cret@github.com/o/r.git' not found"
+            ),
+            "fatal: repository 'https://github.com/o/r.git' not found"
+        );
+    }
+
+    /// Several URLs in one message must all be redacted, and a password that
+    /// itself contains `@` must not leave its tail behind.
+    #[test]
+    fn test_redact_credentials_in_text_handles_multiple_urls_and_at_in_password() {
+        let redacted = redact_credentials_in_text(
+            "warning: https://u:p@ss@host.example/a failed, retrying https://tok:s3cret@other.example/b",
+        );
+
+        assert!(!redacted.contains("p@ss"), "password leaked: {}", redacted);
+        assert!(!redacted.contains("s3cret"), "token leaked: {}", redacted);
+        assert!(redacted.contains("https://host.example/a"), "{}", redacted);
+        assert!(redacted.contains("https://other.example/b"), "{}", redacted);
+    }
+
+    /// No false positives: text with no credentials must come back byte-for-byte.
+    #[test]
+    fn test_redact_credentials_in_text_leaves_credential_free_text_untouched() {
+        for text in [
+            "error: pathspec 'foo' did not match",
+            "https://github.com/o/r.git",
+            // The `@` is in the path, not the authority.
+            "https://github.com/o/a@b.txt",
+            // SCP form carries no password.
+            "git@github.com:o/r.git",
+        ] {
+            assert_eq!(redact_credentials_in_text(text), text);
+        }
     }
 
     // ========================================================================

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -136,6 +136,91 @@ fn validate_clone_url(url: &str) -> Result<()> {
     Ok(())
 }
 
+/// Build the `git clone` invocation used by the CLI fallback path.
+///
+/// The token is deliberately NOT spliced into the URL. An argv is world
+/// readable in the process list for the whole life of the clone, and git
+/// echoes the URL back in its own error text, which the clone dialog renders.
+/// It is handed to git out of band instead, through a one-shot credential
+/// helper that reads it from the child's environment — the same mechanism the
+/// force-push path in remote.rs uses. As a side effect the token no longer has
+/// to survive URL syntax, so one containing `/`, `@` or `:` works.
+#[allow(clippy::too_many_arguments)]
+fn build_clone_command(
+    url: &str,
+    dest: &Path,
+    bare: bool,
+    branch: Option<&str>,
+    depth: Option<u32>,
+    filter: Option<&str>,
+    single_branch: bool,
+    token: Option<&str>,
+) -> std::process::Command {
+    let mut cmd = std::process::Command::new("git");
+    cmd.arg("clone");
+
+    if let Some(depth_val) = depth {
+        cmd.arg("--depth").arg(depth_val.to_string());
+    }
+
+    if let Some(filter_spec) = filter {
+        cmd.arg("--filter").arg(filter_spec);
+    }
+
+    if single_branch {
+        cmd.arg("--single-branch");
+    }
+
+    if bare {
+        cmd.arg("--bare");
+    }
+
+    if let Some(branch) = branch {
+        cmd.arg("--branch").arg(branch);
+    }
+
+    // `--` prevents URL/path from being parsed as a flag
+    // (defense against `--upload-pack=` style injection).
+    cmd.arg("--");
+    cmd.arg(url);
+    cmd.arg(dest);
+
+    // Only HTTPS can consume a token; the previous in-URL form was gated the
+    // same way, so an ssh:// or git:// clone keeps using the user's own
+    // credentials exactly as before.
+    if let (Some(token_value), true) = (token, url.starts_with("https://")) {
+        cmd.env("LEVIATHAN_CLONE_TOKEN", token_value);
+        // Two entries: the empty helper resets the list, so the token the
+        // caller gave us wins outright the way in-URL credentials did. Without
+        // the reset, a system helper holding a stale credential for the same
+        // host would answer first and the clone would fail where it used to
+        // succeed. Nothing is set when we have no token, so the user's own
+        // helper is untouched on every other clone.
+        cmd.env("GIT_CONFIG_COUNT", "2");
+        cmd.env("GIT_CONFIG_KEY_0", "credential.helper");
+        cmd.env("GIT_CONFIG_VALUE_0", "");
+        cmd.env("GIT_CONFIG_KEY_1", "credential.helper");
+        // `git` as the username matches the git2 path's fallback; every
+        // provider we support authenticates a token as the password and
+        // ignores the username.
+        cmd.env(
+            "GIT_CONFIG_VALUE_1",
+            "!f() { echo username=git; echo \"password=$LEVIATHAN_CLONE_TOKEN\"; }; f",
+        );
+    }
+
+    cmd
+}
+
+/// Wrap git's stderr in the error the clone dialog displays, with any
+/// credentials embedded in a URL stripped first.
+fn clone_failed(stderr: &str) -> LeviathanError {
+    LeviathanError::Custom(format!(
+        "git clone failed: {}",
+        crate::commands::credentials::redact_credentials_in_text(stderr.trim())
+    ))
+}
+
 /// Detect if a repository is a partial clone and extract the filter
 fn detect_partial_clone_status(repo: &git2::Repository) -> (bool, Option<String>) {
     let config = match repo.config() {
@@ -227,49 +312,16 @@ pub async fn clone_repository(
         if needs_cli {
             // git2 doesn't support --depth, --filter, or --single-branch, so fall back to git CLI
             let result = tokio::task::spawn_blocking(move || {
-                let mut cmd = std::process::Command::new("git");
-                cmd.arg("clone");
-
-                if let Some(depth_val) = depth {
-                    cmd.arg("--depth").arg(depth_val.to_string());
-                }
-
-                if let Some(ref filter_spec) = filter {
-                    cmd.arg("--filter").arg(filter_spec);
-                }
-
-                if single_branch {
-                    cmd.arg("--single-branch");
-                }
-
-                if bare {
-                    cmd.arg("--bare");
-                }
-
-                if let Some(ref branch) = branch {
-                    cmd.arg("--branch").arg(branch);
-                }
-
-                // If a token is provided, inject it into the URL for HTTPS authentication
-                let effective_url = if let Some(ref token) = token_clone {
-                    if url_clone.starts_with("https://") {
-                        url_clone.replacen(
-                            "https://",
-                            &format!("https://x-access-token:{}@", token),
-                            1,
-                        )
-                    } else {
-                        url_clone.clone()
-                    }
-                } else {
-                    url_clone.clone()
-                };
-
-                // `--` prevents URL/path from being parsed as a flag
-                // (defense against `--upload-pack=` style injection).
-                cmd.arg("--");
-                cmd.arg(&effective_url);
-                cmd.arg(&dest_path);
+                let mut cmd = build_clone_command(
+                    &url_clone,
+                    &dest_path,
+                    bare,
+                    branch.as_deref(),
+                    depth,
+                    filter.as_deref(),
+                    single_branch,
+                    token_clone.as_deref(),
+                );
 
                 // Spawned rather than run to completion so a cancel can kill it.
                 // stderr is drained on its own thread: git clone writes progress
@@ -357,10 +409,7 @@ pub async fn clone_repository(
                 let stderr = stderr_reader.join().unwrap_or_default();
 
                 if !status.success() {
-                    return Err(LeviathanError::Custom(format!(
-                        "git clone failed: {}",
-                        stderr.trim()
-                    )));
+                    return Err(clone_failed(&stderr));
                 }
 
                 git2::Repository::open(&dest_path).map_err(|e| {
@@ -776,6 +825,226 @@ mod tests {
         assert!(validate_clone_url("ftp://host/foo").is_err());
         // No colon at all → not a recognizable URL form
         assert!(validate_clone_url("plainstring").is_err());
+    }
+
+    // ========================================================================
+    // build_clone_command / clone_failed: the token must never reach argv
+    // ========================================================================
+
+    fn args_of(cmd: &std::process::Command) -> Vec<String> {
+        cmd.get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn env_of(cmd: &std::process::Command, key: &str) -> Option<String> {
+        cmd.get_envs()
+            .find(|(k, _)| *k == std::ffi::OsStr::new(key))
+            .and_then(|(_, v)| v)
+            .map(|v| v.to_string_lossy().into_owned())
+    }
+
+    /// The command line of a running process is readable by every other
+    /// process on the machine, so a token spliced into the clone URL is a
+    /// plaintext credential leak for the whole life of the clone.
+    #[test]
+    fn test_build_clone_command_keeps_the_token_out_of_argv() {
+        let cmd = build_clone_command(
+            "https://github.com/o/r.git",
+            Path::new("/tmp/x"),
+            false,
+            None,
+            Some(1),
+            None,
+            false,
+            Some("ghp_s3cret"),
+        );
+
+        let args = args_of(&cmd);
+        assert!(
+            args.iter().all(|a| !a.contains("ghp_s3cret")),
+            "token must not appear in argv: {:?}",
+            args
+        );
+        assert!(
+            args.iter().all(|a| !a.contains("x-access-token")),
+            "userinfo must not appear in argv: {:?}",
+            args
+        );
+        assert!(
+            args.contains(&"https://github.com/o/r.git".to_string()),
+            "the plain URL must still be passed to git: {:?}",
+            args
+        );
+    }
+
+    /// Keeping the token out of argv is only a fix if the clone still
+    /// authenticates: git must receive it out of band, through a credential
+    /// helper reading it from the child's environment.
+    #[test]
+    fn test_build_clone_command_hands_the_token_to_git_through_a_credential_helper() {
+        let cmd = build_clone_command(
+            "https://github.com/o/r.git",
+            Path::new("/tmp/x"),
+            false,
+            None,
+            Some(1),
+            None,
+            false,
+            Some("ghp_s3cret"),
+        );
+
+        assert_eq!(
+            env_of(&cmd, "LEVIATHAN_CLONE_TOKEN"),
+            Some("ghp_s3cret".to_string())
+        );
+        assert_eq!(env_of(&cmd, "GIT_CONFIG_COUNT"), Some("2".to_string()));
+        assert_eq!(
+            env_of(&cmd, "GIT_CONFIG_KEY_0"),
+            Some("credential.helper".to_string())
+        );
+        // The empty helper resets the list so a stale system helper cannot
+        // answer ahead of the token the caller handed us.
+        assert_eq!(env_of(&cmd, "GIT_CONFIG_VALUE_0"), Some(String::new()));
+        assert_eq!(
+            env_of(&cmd, "GIT_CONFIG_KEY_1"),
+            Some("credential.helper".to_string())
+        );
+        let helper = env_of(&cmd, "GIT_CONFIG_VALUE_1").expect("helper must be configured");
+        assert!(
+            helper.contains("$LEVIATHAN_CLONE_TOKEN"),
+            "helper must read the token from the environment: {}",
+            helper
+        );
+        assert!(
+            helper.contains("username=git"),
+            "helper must supply a username: {}",
+            helper
+        );
+    }
+
+    /// A token containing URL syntax characters could not survive the splice
+    /// into the URL; handing it over out of band means it no longer has to.
+    #[test]
+    fn test_build_clone_command_handles_a_token_with_url_special_characters() {
+        let cmd = build_clone_command(
+            "https://github.com/o/r.git",
+            Path::new("/tmp/x"),
+            false,
+            None,
+            Some(1),
+            None,
+            false,
+            Some("to/ken@we:ird"),
+        );
+
+        let args = args_of(&cmd);
+        assert!(
+            args.contains(&"https://github.com/o/r.git".to_string()),
+            "URL must be passed byte-for-byte: {:?}",
+            args
+        );
+        assert_eq!(
+            env_of(&cmd, "LEVIATHAN_CLONE_TOKEN"),
+            Some("to/ken@we:ird".to_string())
+        );
+    }
+
+    /// Guard (passes before and after the fix): the credential.helper reset
+    /// must never be set on a clone we have no token for, or it would disable
+    /// the user's own helper on an ordinary clone.
+    #[test]
+    fn test_build_clone_command_sets_no_credential_env_without_a_token() {
+        let no_token = build_clone_command(
+            "https://github.com/o/r.git",
+            Path::new("/tmp/x"),
+            false,
+            None,
+            Some(1),
+            None,
+            false,
+            None,
+        );
+        assert_eq!(no_token.get_envs().count(), 0);
+        assert!(args_of(&no_token).contains(&"https://github.com/o/r.git".to_string()));
+
+        // ssh:// cannot consume an HTTPS token — same gate as the old in-URL form.
+        let ssh = build_clone_command(
+            "ssh://git@host/o/r.git",
+            Path::new("/tmp/x"),
+            false,
+            None,
+            Some(1),
+            None,
+            false,
+            Some("ghp_s3cret"),
+        );
+        assert_eq!(env_of(&ssh, "LEVIATHAN_CLONE_TOKEN"), None);
+        assert_eq!(env_of(&ssh, "GIT_CONFIG_COUNT"), None);
+        assert!(args_of(&ssh).contains(&"ssh://git@host/o/r.git".to_string()));
+    }
+
+    /// Guard for the extraction: the flags the CLI path exists for, and the
+    /// `--` that stops a URL from being read as a flag, must all survive.
+    #[test]
+    fn test_build_clone_command_still_passes_the_shallow_and_filter_flags() {
+        let cmd = build_clone_command(
+            "https://github.com/o/r.git",
+            Path::new("/tmp/x"),
+            true,
+            Some("dev"),
+            Some(5),
+            Some("blob:none"),
+            true,
+            None,
+        );
+
+        assert_eq!(
+            args_of(&cmd),
+            vec![
+                "clone",
+                "--depth",
+                "5",
+                "--filter",
+                "blob:none",
+                "--single-branch",
+                "--bare",
+                "--branch",
+                "dev",
+                "--",
+                "https://github.com/o/r.git",
+                "/tmp/x",
+            ]
+        );
+    }
+
+    /// git's stderr is rendered verbatim by the clone dialog, so a URL
+    /// carrying credentials — one git did not anonymize, or one the user typed
+    /// with a password in it — would be displayed on screen.
+    #[test]
+    fn test_clone_failed_redacts_credentials_from_git_stderr() {
+        let err = clone_failed(
+            "fatal: unable to access 'https://x-access-token:ghp_s3cret@github.com/o/r.git/': The requested URL returned error: 404",
+        );
+        let msg = err.to_string();
+
+        assert!(
+            msg.contains("git clone failed:"),
+            "message must keep its prefix: {}",
+            msg
+        );
+        assert!(!msg.contains("ghp_s3cret"), "token leaked: {}", msg);
+        assert!(!msg.contains("x-access-token"), "userinfo leaked: {}", msg);
+        assert!(
+            msg.contains("github.com/o/r.git"),
+            "message must stay diagnostically useful: {}",
+            msg
+        );
+        assert!(
+            msg.contains("404"),
+            "git's own diagnosis must survive: {}",
+            msg
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What was broken

### The access token was passed to `git clone` as a command-line argument

`clone_repository` in `src-tauri/src/commands/repository.rs` falls back to the git CLI whenever `depth`, `filter` or `single_branch` is set. That path built an `effective_url` by splicing the token into the URL:

```rust
url_clone.replacen("https://", &format!("https://x-access-token:{}@", token), 1)
```

and passed it as an argv element after `--`. A process command line is world readable, so the token sat in `/proc/<pid>/cmdline` (and platform equivalents) for every local process to read for the entire life of the clone. `cloneRepository()` in `src/services/git.service.ts` auto-attaches the stored GitHub PAT to any `github.com` URL, so an ordinary shallow clone leaked the user's PAT with no opt-in. The git2 branch of the same function does this correctly via `CredentialsHelper::new_with_token`, so the two paths disagreed — and `remote.rs` (force push) already had the correct out-of-band pattern.

The splice was also plain broken for a token containing `/`, `@` or `:`: it produced a mangled URL.

### git's stderr, credentials included, was rendered on screen

The failure arm returned `LeviathanError::Custom(format!("git clone failed: {}", stderr.trim()))` and `lv-clone-dialog.ts` renders `result.error?.message` into `.error-message`. Modern git (>= ~2.13) anonymizes the URL in its own "unable to access" message, so on a current git this half is mitigated by git rather than by us — but not on older git, not for transports/remote helpers that bypass git's anonymizer, and not for a URL the user typed with credentials in it themselves (`validate_clone_url` accepts `https://user:pw@host/repo`).

## The fix

- **`src-tauri/src/commands/repository.rs`** — the CLI argv construction is extracted into a testable `build_clone_command`. The URL is passed verbatim; when a token is present on an `https://` URL it goes to git out of band via `LEVIATHAN_CLONE_TOKEN` + `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_*=credential.helper`, the same mechanism the force-push path in `remote.rs` uses. Two helper entries are set: an empty one first, which resets the helper list so the caller's token wins outright the way in-URL credentials did (without it, a system helper holding a stale credential for the same host would answer first and a clone that used to succeed would fail). Nothing is set when there is no token, or on a non-HTTPS URL, so the user's own helper is untouched on every other clone. As a side effect a token containing URL syntax characters now works.
- **`clone_failed`** wraps git's stderr and runs it through the new redactor before it reaches the UI (defence in depth for the cases git does not anonymize).
- **`src-tauri/src/commands/credentials.rs`** — new `redact_credentials_in_text`, next to the existing `sanitize_url_for_log`. That one takes a string that *is* a URL; this one strips userinfo from every URL embedded in prose, leaving the surrounding text intact. `rfind('@')` so a password containing `@` leaves no tail; SCP form (`git@host:path`) is deliberately untouched since it cannot carry a password.

The `--` before the URL, the flag-injection validation, the cancel/timeout loop, the stderr drain thread and the git2 branch are all unchanged. No frontend change is needed — the dialog already renders whatever message the backend returns — so there is no new E2E surface.

## Tests

| Test | File | Covers | Fails without the fix |
| --- | --- | --- | --- |
| `test_build_clone_command_keeps_the_token_out_of_argv` | repository.rs | happy path — the leak itself | Yes — argv was `["clone", "--depth", "1", "--", "https://x-access-token:ghp_s3cret@github.com/o/r.git", "/tmp/x"]` |
| `test_build_clone_command_hands_the_token_to_git_through_a_credential_helper` | repository.rs | happy path — the clone still authenticates | Yes — pre-fix the command set no environment at all, every `env_of` returned `None` |
| `test_build_clone_command_handles_a_token_with_url_special_characters` | repository.rs | edge case — token with `/`, `@`, `:` | Yes — the splice produced `https://x-access-token:to/ken@we:ird@github.com/o/r.git` |
| `test_build_clone_command_sets_no_credential_env_without_a_token` | repository.rs | guard — no token, and ssh:// with a token | No (guard, passes both ways): ensures the helper reset can never disable a user's own helper |
| `test_build_clone_command_still_passes_the_shallow_and_filter_flags` | repository.rs | guard — the extraction preserves every flag and the `--` | No (guard, passes both ways) |
| `test_clone_failed_redacts_credentials_from_git_stderr` | repository.rs | error path | Yes — `git clone failed: fatal: unable to access 'https://x-access-token:ghp_s3cret@github.com/o/r.git/': ...` |
| `test_redact_credentials_in_text_strips_userinfo_from_embedded_urls` | credentials.rs | happy path — prose around the URL survives | Yes — returned the input verbatim |
| `test_redact_credentials_in_text_handles_multiple_urls_and_at_in_password` | credentials.rs | edge case — two URLs, `@` inside the password | Yes |
| `test_redact_credentials_in_text_leaves_credential_free_text_untouched` | credentials.rs | edge case — no false positives (`@` in a path, SCP form, no `://`) | No (guard, passes both ways) |

Verified by reverting only the production code (restoring the in-URL splice, the raw `format!`, and making the redactor an identity function) with the tests left in place: the six marked above failed, the three guards passed. Full gate green — lint, typecheck, unit, `cargo fmt --check`, `cargo clippy --all-targets -D warnings`, `cargo test --lib`. The touched modules were also run against git 2.55 to rule out version skew (no test spawns git; the redactor matches URL structure, not git's phrasing).

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_