### PR TITLE
Refuse a second remote operation while one is still in flight

### DIFF
--- a/e2e/tests/remote-operations.spec.ts
+++ b/e2e/tests/remote-operations.spec.ts
@@ -407,6 +407,43 @@ test.describe('Push Operation', () => {
     await expect(pushBadge).toBeVisible();
     await expect(pushBadge).toHaveText('3');
   });
+
+  test('push refused while the repository is busy says so and keeps the badge', async ({ page }) => {
+    app = new AppPage(page);
+    await setupOpenRepository(page, withAheadBehind(3, 0));
+
+    const pushBadge = page.locator('.badge.push');
+    await expect(pushBadge).toBeVisible();
+    await expect(pushBadge).toHaveText('3');
+
+    // Exactly what the backend returns when an earlier push TIMED OUT and its
+    // blocking task is still running: the frontend's own push lock was
+    // released on that early return, so the retry reaches IPC and only the
+    // backend registry can refuse it.
+    await injectCommandError(
+      page,
+      'push',
+      'A push is already running for this repository. Wait for it to finish and try again — an operation that timed out can still be finishing in the background.'
+    );
+
+    const pushButton = page.getByRole('button', { name: /Push/i });
+    await pushButton.click();
+
+    const toast = page.locator('.toast');
+    await expect(toast).toBeVisible({ timeout: 5000 });
+    await expect(toast).toHaveClass(/error/);
+    await expect(toast).toContainText(/already running for this repository/i);
+    // NOT rewritten by the timeout rule into "increase the timeout in
+    // Settings", which sends the user to a setting that cannot help here.
+    await expect(toast).not.toContainText(/increase the timeout/i);
+    await expect(toast.getByRole('button', { name: 'Open Settings' })).toHaveCount(0);
+
+    // Nothing was pushed, so the ahead badge must survive, and the button must
+    // stay usable for the retry the message asks for.
+    await expect(pushBadge).toBeVisible();
+    await expect(pushBadge).toHaveText('3');
+    await expect(pushButton).toBeEnabled();
+  });
 });
 
 // ============================================================================

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -1,7 +1,7 @@
 //! Remote command handlers
 
 use std::path::Path;
-use tauri::{command, AppHandle, Emitter};
+use tauri::{command, AppHandle, Emitter, State};
 
 use crate::error::{LeviathanError, Result};
 use crate::models::{
@@ -10,6 +10,7 @@ use crate::models::{
 };
 use crate::services::cancellation::CancellationRegistry;
 use crate::services::credentials_service;
+use crate::services::remote_ops::{self, RemoteOp, RemoteOpRegistry};
 use crate::utils::{create_command, reject_flag_like};
 
 /// Add a new remote
@@ -142,6 +143,7 @@ pub async fn get_remotes(path: String) -> Result<Vec<Remote>> {
 #[command]
 pub async fn fetch(
     app_handle: AppHandle,
+    remote_ops_registry: State<'_, RemoteOpRegistry>,
     path: String,
     remote: Option<String>,
     prune: Option<bool>,
@@ -157,6 +159,25 @@ pub async fn fetch(
     // alt-tabbed back into the app. That is exactly the noise the background
     // fetch is documented to avoid.
     let quiet = quiet.unwrap_or(false);
+
+    // Claimed BEFORE the timeout wrapper, and handed to the blocking task
+    // below so it outlives a timed-out caller — see services/remote_ops.rs.
+    //
+    // A background fetch (window focus) YIELDS but never claims: it skips this
+    // round when the user has something running, and takes no slot of its own,
+    // so it can never refuse the user's next push. Its timer twin in
+    // services/autofetch_service.rs has always run alongside whatever the user
+    // is doing; making this one exclusive would break a working flow rather
+    // than fix the racing retry this guard is for.
+    let slot = if quiet {
+        if remote_ops_registry.running(Path::new(&path)).is_some() {
+            return Ok(());
+        }
+        None
+    } else {
+        Some(remote_ops_registry.acquire(Path::new(&path), RemoteOp::Fetch)?)
+    };
+
     let do_fetch = async move {
         let path_clone = path.clone();
         let prune_val = prune.unwrap_or(false);
@@ -164,8 +185,9 @@ pub async fn fetch(
         let remote_name_for_event = remote_name_owned.clone();
 
         // git2 fetch is blocking network I/O; offload to a blocking thread so
-        // it doesn't starve the Tokio runtime.
-        tokio::task::spawn_blocking(move || -> Result<()> {
+        // it doesn't starve the Tokio runtime. run_holding carries the slot
+        // into that thread, so it is released when the fetch really ends.
+        remote_ops::run_holding(slot, RemoteOp::Fetch, move || -> Result<()> {
             let repo = git2::Repository::open(Path::new(&path_clone))?;
             let mut git_remote = repo
                 .find_remote(&remote_name_owned)
@@ -186,8 +208,7 @@ pub async fn fetch(
             git_remote.fetch(&refspec_strs, Some(&mut fetch_opts), None)?;
             Ok(())
         })
-        .await
-        .map_err(|e| LeviathanError::Custom(format!("Fetch task failed: {}", e)))??;
+        .await?;
 
         // Emit success event, unless this fetch is a background one.
         if !quiet {
@@ -499,6 +520,7 @@ pub(crate) fn merge_fetched_commit(
 #[command]
 pub async fn pull(
     app_handle: AppHandle,
+    remote_ops_registry: State<'_, RemoteOpRegistry>,
     path: String,
     remote: Option<String>,
     branch: Option<String>,
@@ -507,6 +529,12 @@ pub async fn pull(
     timeout_secs: Option<u64>,
     _operation_id: Option<String>,
 ) -> Result<()> {
+    // Claimed before the timeout wrapper and released by the blocking task,
+    // not by this future — see services/remote_ops.rs. ensure_pullable below
+    // only refuses a repository that is ALREADY mid-merge, so it cannot see a
+    // pull that timed out and is still running.
+    let slot = remote_ops_registry.acquire(Path::new(&path), RemoteOp::Pull)?;
+
     let do_pull = async move {
         let path_for_task = path.clone();
         // NOT defaulted to "origin" here. The branch's configured upstream is
@@ -516,8 +544,10 @@ pub async fn pull(
 
         // Whole pull is git2 / blocking network I/O. Run it on a blocking
         // thread so the Tokio runtime stays responsive.
-        let (remote_name_returned, message) =
-            tokio::task::spawn_blocking(move || -> Result<(String, String)> {
+        let (remote_name_returned, message) = remote_ops::run_holding(
+            Some(slot),
+            RemoteOp::Pull,
+            move || -> Result<(String, String)> {
                 // Refuse before the network round trip if another operation is
                 // unresolved. merge() has always had this guard; pull never
                 // did, and its normal-merge branch calls repo.merge() a SECOND
@@ -640,9 +670,9 @@ pub async fn pull(
                 }
 
                 Ok((effective_remote, message))
-            })
-            .await
-            .map_err(|e| LeviathanError::Custom(format!("Pull task failed: {}", e)))??;
+            },
+        )
+        .await?;
 
         // Emit success event
         let _ = app_handle.emit(
@@ -860,6 +890,7 @@ pub(crate) fn push_branch(
 #[command]
 pub async fn push(
     app_handle: AppHandle,
+    remote_ops_registry: State<'_, RemoteOpRegistry>,
     path: String,
     remote: Option<String>,
     branch: Option<String>,
@@ -881,6 +912,13 @@ pub async fn push(
         reject_flag_like(r, "Remote name")?;
     }
 
+    // The claim this issue is about. Push has no abort point at all, so when
+    // the network timeout fires the git2/CLI push keeps running against the
+    // remote; the frontend push slot is released on that early return and the
+    // user's retry used to overlap the original. The slot travels into the
+    // blocking task below and is released only when the push really ends.
+    let slot = remote_ops_registry.acquire(Path::new(&path), RemoteOp::Push)?;
+
     let do_push = async move {
         let path_for_task = path.clone();
         let requested_remote = remote.clone();
@@ -892,20 +930,20 @@ pub async fn push(
 
         // git2/git-CLI push is blocking network I/O; offload so the runtime
         // stays responsive during slow remotes.
-        let (remote_name_returned, branch_name_returned) = tokio::task::spawn_blocking(move || {
-            push_branch(
-                &path_for_task,
-                requested_remote,
-                branch_for_task,
-                force_val,
-                use_force_with_lease,
-                use_push_tags,
-                set_upstream_val,
-                token,
-            )
-        })
-        .await
-        .map_err(|e| LeviathanError::Custom(format!("Push task failed: {}", e)))??;
+        let (remote_name_returned, branch_name_returned) =
+            remote_ops::run_holding(Some(slot), RemoteOp::Push, move || {
+                push_branch(
+                    &path_for_task,
+                    requested_remote,
+                    branch_for_task,
+                    force_val,
+                    use_force_with_lease,
+                    use_push_tags,
+                    set_upstream_val,
+                    token,
+                )
+            })
+            .await?;
 
         // Emit success event
         let mut message = format!(

--- a/src-tauri/src/error.rs
+++ b/src-tauri/src/error.rs
@@ -95,6 +95,16 @@ pub enum LeviathanError {
 
     #[error("Operation cancelled")]
     OperationCancelled,
+
+    /// A fetch/pull/push is already running against this repository.
+    ///
+    /// Distinct from OperationFailed so the UI can present it as "wait and
+    /// retry" rather than as a git failure: nothing went wrong, the work
+    /// simply has not finished yet. It is reachable specifically AFTER a
+    /// network timeout, when the abandoned blocking task is still live —
+    /// see services/remote_ops.rs.
+    #[error("{0}")]
+    RemoteOperationInFlight(String),
 }
 
 /// Serializable error response for IPC
@@ -135,6 +145,7 @@ impl From<LeviathanError> for ErrorResponse {
             LeviathanError::OAuth(_) => "OAUTH_ERROR",
             LeviathanError::OperationTimeout(_) => "OPERATION_TIMEOUT",
             LeviathanError::OperationCancelled => "OPERATION_CANCELLED",
+            LeviathanError::RemoteOperationInFlight(_) => "REMOTE_OPERATION_IN_FLIGHT",
         };
 
         ErrorResponse {
@@ -180,6 +191,7 @@ impl serde::Serialize for LeviathanError {
                 LeviathanError::OAuth(_) => "OAUTH_ERROR",
                 LeviathanError::OperationTimeout(_) => "OPERATION_TIMEOUT",
                 LeviathanError::OperationCancelled => "OPERATION_CANCELLED",
+                LeviathanError::RemoteOperationInFlight(_) => "REMOTE_OPERATION_IN_FLIGHT",
             }
             .to_string(),
             message: self.to_string(),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -24,6 +24,7 @@ use services::ai::AiState;
 use services::commit_index::SharedCommitIndex;
 use services::{
     create_ai_state, create_autofetch_state, create_update_state, CancellationRegistry,
+    RemoteOpRegistry,
 };
 
 /// Initialize the application
@@ -122,6 +123,7 @@ pub fn run() {
         .manage(create_autofetch_state())
         .manage(create_update_state())
         .manage(CancellationRegistry::default())
+        .manage(RemoteOpRegistry::default())
         .manage(SharedCommitIndex::default())
         .setup(|app| {
             // Initialize AI state with config directory

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -15,6 +15,7 @@ pub mod github_app;
 pub mod keyring_util;
 pub mod loopback_server;
 pub mod oauth;
+pub mod remote_ops;
 pub mod update_service;
 pub mod watcher_service;
 
@@ -23,5 +24,6 @@ pub use autofetch_service::{create_autofetch_state, AutoFetchState};
 pub use cancellation::CancellationRegistry;
 pub use credentials_service::CredentialsHelper;
 pub use git_service::GitService;
+pub use remote_ops::{RemoteOp, RemoteOpRegistry};
 pub use update_service::{create_update_state, UpdateState};
 pub use watcher_service::WatcherService;

--- a/src-tauri/src/services/remote_ops.rs
+++ b/src-tauri/src/services/remote_ops.rs
@@ -1,0 +1,381 @@
+//! Per-repository exclusion for the remote operations (fetch / pull / push).
+//!
+//! The frontend already refuses a second push or pull while one is running
+//! (`src/utils/ref-lock.ts`), but that lock is released the moment `invoke`
+//! returns — and `invoke` returns EARLY when the network timeout fires.
+//! `tokio::time::timeout` only drops the caller's future; it cannot cancel the
+//! `spawn_blocking` task underneath, and git2 push has no abort point at all.
+//! So after a timeout the frontend slot is free while the original push is
+//! still live against the remote, and the user's retry ran alongside it.
+//!
+//! The fix is a claim the BLOCKING TASK owns: `run_holding` moves the guard
+//! into the closure it hands to `spawn_blocking`, so the slot is released when
+//! that task finishes rather than when the command's future is dropped. The
+//! frontend locks stay as the fast path — they keep a second click from ever
+//! reaching IPC — and this registry is the actual guarantee.
+
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+use crate::error::{LeviathanError, Result};
+
+/// The remote operations that share one per-repository slot.
+///
+/// They share a single slot rather than one each because they are not
+/// independent: a pull moves HEAD and the working tree under a push that is
+/// reading refs, and a fetch that is pruning rewrites the very remote-tracking
+/// refs a pull just resolved.
+///
+/// The one exception is the background (window-focus) fetch, which yields to
+/// the slot but never takes it — see `run_holding`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RemoteOp {
+    Fetch,
+    Pull,
+    Push,
+}
+
+impl RemoteOp {
+    /// The operation as the refusal message names it to the user.
+    pub fn label(self) -> &'static str {
+        match self {
+            RemoteOp::Fetch => "fetch",
+            RemoteOp::Pull => "pull",
+            RemoteOp::Push => "push",
+        }
+    }
+
+    /// Capitalised form used in the "<Op> task failed" join error, which
+    /// predates this module and is worth keeping byte-for-byte.
+    fn task_label(self) -> &'static str {
+        match self {
+            RemoteOp::Fetch => "Fetch",
+            RemoteOp::Pull => "Pull",
+            RemoteOp::Push => "Push",
+        }
+    }
+}
+
+type InFlight = Arc<Mutex<HashMap<PathBuf, RemoteOp>>>;
+
+/// Recover rather than propagate a poisoned lock.
+///
+/// Nothing but `HashMap` insert/remove/get runs while the lock is held, so
+/// poisoning takes a panic elsewhere in the process. Failing to release on a
+/// poisoned lock would wedge the repository's slot for the rest of the
+/// session, which is strictly worse than continuing.
+fn lock(in_flight: &InFlight) -> MutexGuard<'_, HashMap<PathBuf, RemoteOp>> {
+    in_flight.lock().unwrap_or_else(|e| e.into_inner())
+}
+
+/// Repositories with a remote operation in flight, and which operation it is.
+///
+/// Registered as Tauri managed state; the `fetch`, `pull` and `push` commands
+/// take it as a `State` parameter.
+#[derive(Default)]
+pub struct RemoteOpRegistry {
+    in_flight: InFlight,
+}
+
+impl RemoteOpRegistry {
+    /// Claim `repo_path`'s slot, or report which operation already holds it.
+    ///
+    /// Rejects rather than queues: the caller is a user action that already
+    /// showed a spinner, and silently waiting behind a push to an unreachable
+    /// remote is indistinguishable from a hang.
+    pub fn acquire(&self, repo_path: &Path, op: RemoteOp) -> Result<RemoteOpGuard> {
+        let key = normalize(repo_path);
+        let mut in_flight = lock(&self.in_flight);
+        if let Some(running) = in_flight.get(&key) {
+            // Names the operation, and says the part the user cannot work
+            // out for themselves: after a network timeout the app looks idle
+            // — every spinner and lock was released — while the abandoned
+            // blocking task is still talking to the remote.
+            return Err(LeviathanError::RemoteOperationInFlight(format!(
+                "A {} is already running for this repository. Wait for it to \
+                 finish and try again — an operation that timed out can still \
+                 be finishing in the background.",
+                running.label()
+            )));
+        }
+        in_flight.insert(key.clone(), op);
+        Ok(RemoteOpGuard {
+            in_flight: Arc::clone(&self.in_flight),
+            key,
+        })
+    }
+
+    /// Which operation holds `repo_path`'s slot, if any.
+    ///
+    /// For the background fetch, which yields to the slot without taking it —
+    /// see `run_holding`.
+    pub fn running(&self, repo_path: &Path) -> Option<RemoteOp> {
+        // Resolved before the lock is taken: normalize() hits the filesystem.
+        let key = normalize(repo_path);
+        lock(&self.in_flight).get(&key).copied()
+    }
+}
+
+/// Releases the repository's slot on drop.
+///
+/// Held by the blocking task, not by the command's future — see the module
+/// docs. Dropping a `JoinHandle` does not cancel a `spawn_blocking` task, so
+/// tying the claim to the closure is what makes a timed-out operation keep
+/// holding its slot until it really finishes.
+#[derive(Debug)]
+pub struct RemoteOpGuard {
+    in_flight: InFlight,
+    key: PathBuf,
+}
+
+impl Drop for RemoteOpGuard {
+    fn drop(&mut self) {
+        lock(&self.in_flight).remove(&self.key);
+    }
+}
+
+/// Key repositories by their resolved path.
+///
+/// `/repo`, `/repo/` and `/repo/.` are the same repository, and the app builds
+/// paths from several sources (the tab store, a drag-and-drop, a recent-repos
+/// entry). Keying on the raw string would hand out two slots for one working
+/// tree. Falls back to the path as given when it cannot be resolved — a repo
+/// that has been deleted mid-operation still needs its slot released under the
+/// same key it was claimed with.
+fn normalize(repo_path: &Path) -> PathBuf {
+    repo_path
+        .canonicalize()
+        .unwrap_or_else(|_| repo_path.to_path_buf())
+}
+
+/// Run `work` on the blocking pool, carrying the repository's claim with it.
+///
+/// The guard is moved INTO the closure, so the slot outlives a caller that
+/// gave up: `tokio::time::timeout` drops the command's future, the blocking
+/// task carries on, and the next fetch/pull/push is refused until the work
+/// really finishes. Holding the guard anywhere else — in this function's own
+/// body, or in the command's future — frees it the instant the timeout fires,
+/// which is the bug.
+///
+/// `slot` is `None` for a caller that deliberately holds nothing: the
+/// window-focus background fetch, which yields to a running operation but must
+/// never hold the repository against one. The timer auto-fetch
+/// (`services/autofetch_service.rs`) has always run alongside whatever the user
+/// is doing, so making its window-focus twin the one background operation that
+/// can refuse a push would be a regression rather than a fix.
+pub async fn run_holding<T, F>(slot: Option<RemoteOpGuard>, op: RemoteOp, work: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(move || {
+        // Named so it is unmistakably the claim being carried, and dropped
+        // only when `work` has returned.
+        let _slot = slot;
+        work()
+    })
+    .await
+    .map_err(|e| LeviathanError::Custom(format!("{} task failed: {}", op.task_label(), e)))?
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::ErrorResponse;
+    use crate::test_utils::TestRepo;
+    use std::sync::mpsc;
+    use std::time::Duration;
+
+    /// Poll until `cond` holds, so a release that happens on the blocking pool
+    /// does not need a sleep long enough to be flaky.
+    async fn wait_until(mut cond: impl FnMut() -> bool) {
+        for _ in 0..200 {
+            if cond() {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        panic!("condition never became true");
+    }
+
+    #[test]
+    fn second_operation_on_the_same_repository_is_refused() {
+        let repo = TestRepo::new();
+        let registry = RemoteOpRegistry::default();
+
+        let _first = registry.acquire(&repo.path, RemoteOp::Push).unwrap();
+        let second = registry.acquire(&repo.path, RemoteOp::Push);
+
+        assert!(second.is_err(), "a second push must be refused");
+    }
+
+    #[test]
+    fn refusal_names_the_running_operation_and_carries_its_own_code() {
+        let repo = TestRepo::new();
+        let registry = RemoteOpRegistry::default();
+
+        let _push = registry.acquire(&repo.path, RemoteOp::Push).unwrap();
+        let err = registry.acquire(&repo.path, RemoteOp::Pull).unwrap_err();
+
+        let message = err.to_string();
+        assert!(
+            message.contains("push is already running"),
+            "refusal must name the operation that holds the slot: {}",
+            message
+        );
+        // The frontend matches this phrase to keep its timeout and
+        // repository-lock rules from rewriting the message — see
+        // src/services/error-suggestion.service.ts.
+        assert!(
+            message.contains("already running for this repository"),
+            "message: {}",
+            message
+        );
+        // The refusal is reachable precisely BECAUSE a timed-out operation is
+        // still live, so it has to say so.
+        assert!(message.contains("timed out"), "message: {}", message);
+        assert_eq!(
+            ErrorResponse::from(err).code,
+            "REMOTE_OPERATION_IN_FLIGHT",
+            "the rejection needs a code of its own so the UI can tell it apart"
+        );
+    }
+
+    #[test]
+    fn releasing_the_guard_frees_the_repository() {
+        let repo = TestRepo::new();
+        let registry = RemoteOpRegistry::default();
+
+        {
+            let _first = registry.acquire(&repo.path, RemoteOp::Fetch).unwrap();
+            assert_eq!(registry.running(&repo.path), Some(RemoteOp::Fetch));
+        }
+
+        assert_eq!(registry.running(&repo.path), None);
+        assert!(registry.acquire(&repo.path, RemoteOp::Push).is_ok());
+    }
+
+    #[test]
+    fn separate_repositories_do_not_block_each_other() {
+        let one = TestRepo::new();
+        let two = TestRepo::new();
+        let registry = RemoteOpRegistry::default();
+
+        let _first = registry.acquire(&one.path, RemoteOp::Push).unwrap();
+        assert!(
+            registry.acquire(&two.path, RemoteOp::Push).is_ok(),
+            "separate repositories have separate remotes and nothing to serialize"
+        );
+    }
+
+    #[test]
+    fn the_same_repository_spelled_differently_shares_one_slot() {
+        let repo = TestRepo::new();
+        let registry = RemoteOpRegistry::default();
+
+        let _first = registry.acquire(&repo.path, RemoteOp::Push).unwrap();
+        let same_repo_other_spelling = repo.path.join(".");
+
+        assert!(
+            registry
+                .acquire(&same_repo_other_spelling, RemoteOp::Push)
+                .is_err(),
+            "'/repo' and '/repo/.' are one working tree and must share one slot"
+        );
+    }
+
+    #[test]
+    fn running_reports_the_operation_a_background_fetch_must_yield_to() {
+        let repo = TestRepo::new();
+        let registry = RemoteOpRegistry::default();
+
+        assert_eq!(registry.running(&repo.path), None);
+        let _push = registry.acquire(&repo.path, RemoteOp::Push).unwrap();
+        assert_eq!(registry.running(&repo.path), Some(RemoteOp::Push));
+    }
+
+    /// A background refresh takes no slot, so it can never refuse a user action.
+    #[tokio::test]
+    async fn run_holding_without_a_slot_leaves_the_repository_free() {
+        let repo = TestRepo::new();
+        let registry = RemoteOpRegistry::default();
+        let (finish_tx, finish_rx) = mpsc::channel::<()>();
+
+        let background = tokio::spawn(run_holding(None, RemoteOp::Fetch, move || {
+            let _ = finish_rx.recv();
+            Ok(())
+        }));
+
+        // The user can still push while it runs.
+        let user_push = registry.acquire(&repo.path, RemoteOp::Push);
+        assert!(
+            user_push.is_ok(),
+            "a background fetch must not hold the repository against a push"
+        );
+
+        finish_tx.send(()).unwrap();
+        background.await.unwrap().unwrap();
+    }
+
+    #[tokio::test]
+    async fn run_holding_releases_when_the_blocking_task_finishes() {
+        let repo = TestRepo::new();
+        let registry = RemoteOpRegistry::default();
+
+        let slot = registry.acquire(&repo.path, RemoteOp::Push).unwrap();
+        let value = run_holding(Some(slot), RemoteOp::Push, || Ok(7))
+            .await
+            .unwrap();
+
+        assert_eq!(value, 7);
+        assert_eq!(registry.running(&repo.path), None);
+    }
+
+    /// The bug this module exists for: a push that timed out is still live.
+    ///
+    /// `tokio::time::timeout` drops the caller's future but cannot cancel the
+    /// `spawn_blocking` task, so the slot must stay claimed until that task
+    /// returns. Holding the guard anywhere other than inside the closure
+    /// (in `run_holding`'s own body, or in the command's future) frees it the
+    /// instant the timeout fires — and the retry races the original push.
+    #[tokio::test]
+    async fn a_timed_out_operation_keeps_its_slot_until_the_work_really_ends() {
+        let repo = TestRepo::new();
+        let registry = RemoteOpRegistry::default();
+        let (finish_tx, finish_rx) = mpsc::channel::<()>();
+
+        // Exactly what `push` does: claim, then hand the claim to the task.
+        let slot = registry.acquire(&repo.path, RemoteOp::Push).unwrap();
+        let slow_push = run_holding(Some(slot), RemoteOp::Push, move || {
+            // Stands in for git2's push against an unreachable remote:
+            // blocking, and with no abort point.
+            let _ = finish_rx.recv();
+            Ok(())
+        });
+
+        // The caller gives up, exactly as the network timeout does.
+        assert!(
+            tokio::time::timeout(Duration::from_millis(100), slow_push)
+                .await
+                .is_err(),
+            "the slow push should have outlived the timeout"
+        );
+
+        // ... but the abandoned task is still pushing, so a retry is refused.
+        assert_eq!(
+            registry.running(&repo.path),
+            Some(RemoteOp::Push),
+            "the timed-out push must still hold the slot"
+        );
+        assert!(
+            registry.acquire(&repo.path, RemoteOp::Push).is_err(),
+            "a retry after a timeout must not overlap the push that is still running"
+        );
+
+        // Once the real work ends the repository is usable again.
+        finish_tx.send(()).unwrap();
+        wait_until(|| registry.running(&repo.path).is_none()).await;
+        assert!(registry.acquire(&repo.path, RemoteOp::Push).is_ok());
+    }
+}

--- a/src/services/__tests__/error-suggestion.service.test.ts
+++ b/src/services/__tests__/error-suggestion.service.test.ts
@@ -70,6 +70,38 @@ describe('error-suggestion.service', () => {
       expect(result!.action).to.be.undefined;
     });
 
+    // A repository that already has a remote operation in flight. The backend
+    // refuses with LeviathanError::RemoteOperationInFlight; its message is
+    // already user-facing and explains that a timed-out operation can still be
+    // running, so the suggestion service must pass it through UNCHANGED rather
+    // than let a later rule rewrite it.
+    const inFlightMessage =
+      'A push is already running for this repository. Wait for it to finish and try again — an operation that timed out can still be finishing in the background.';
+
+    it('should keep the in-flight refusal verbatim instead of calling it a timeout', () => {
+      const result = getErrorSuggestion(inFlightMessage, { operation: 'push' });
+      expect(result).to.not.be.null;
+      expect(result!.message).to.equal(inFlightMessage);
+      // The timeout rule would otherwise claim it (the message says "timed
+      // out") and offer Open Settings, which fixes nothing here.
+      expect(result!.action).to.be.undefined;
+    });
+
+    it('should recognise the in-flight refusal by its error code', () => {
+      const result = getErrorSuggestion('REMOTE_OPERATION_IN_FLIGHT: a pull is already running');
+      expect(result).to.not.be.null;
+      expect(result!.message).to.include('already running');
+      expect(result!.action).to.be.undefined;
+    });
+
+    it('should not mistake the in-flight refusal for a stuck lock file', () => {
+      const result = getErrorSuggestion(
+        'A fetch is already running for this repository. Wait for it to finish and try again.'
+      );
+      expect(result).to.not.be.null;
+      expect(result!.message).to.not.include('lock file');
+    });
+
     it('should return suggestion for operation timeout', () => {
       const result = getErrorSuggestion('The operation timed out after 300 seconds');
       expect(result).to.not.be.null;

--- a/src/services/error-suggestion.service.ts
+++ b/src/services/error-suggestion.service.ts
@@ -31,6 +31,22 @@ export function getErrorSuggestion(
 
   const msg = errorMessage.toLowerCase();
 
+  // The backend refused because this repository already has a fetch, pull or
+  // push in flight (LeviathanError::RemoteOperationInFlight).
+  //
+  // Kept VERBATIM, and checked FIRST. The backend's wording already names
+  // which operation holds the repository and says to retry — and it mentions
+  // that an operation which timed out can still be finishing, which is the
+  // part the user cannot deduce, because the app's own push/ref locks were
+  // released the moment the timeout fired and everything looks idle. Two
+  // rules below would otherwise claim it and replace that with something
+  // wrong: the timeout rule ("increase the timeout in Settings") and the
+  // repository-lock rule ("remove the lock file").
+  if (msg.includes('already running for this repository') ||
+      msg.includes('remote_operation_in_flight')) {
+    return { message: errorMessage };
+  }
+
   // A push the remote refused. libgit2 emits TWO different messages here
   // (push.c:345 and :356) that share no substring, and they mean opposite
   // things:


### PR DESCRIPTION
Closes #449

## The problem

`runRefExclusive` / `runPushExclusive` (`src/app-shell.ts`) release their slot in a `finally` as soon as `invoke` returns — and `invoke` returns **early** when the network timeout fires. `tokio::time::timeout` only drops the command's future; it cannot cancel the `spawn_blocking` task underneath, and git2 push has no abort point at all. So after a push to a slow remote timed out, the frontend lock was free while the original push was still live against the remote, and the user's retry ran alongside it.

## What was built

**`src-tauri/src/services/remote_ops.rs` (new)** — a `RemoteOpRegistry` of repositories with a remote operation in flight (`Mutex<HashMap<PathBuf, RemoteOp>>`), registered as Tauri managed state in `lib.rs`.

- `acquire()` claims a repository's slot and returns an RAII `RemoteOpGuard`; a claim on a busy repository is refused with the new `LeviathanError::RemoteOperationInFlight` (code `REMOTE_OPERATION_IN_FLIGHT`). It is refused, not queued — waiting silently behind a push to an unreachable remote is indistinguishable from a hang.
- `run_holding()` is the piece that matters: it moves the guard **into** the closure it hands to `spawn_blocking`, so the slot is released when the blocking work really ends, not when the caller's future is dropped. Holding it anywhere else frees it the instant the timeout fires, which is the bug.
- Repositories are keyed by resolved path, so `/repo` and `/repo/.` cannot hand out two slots for one working tree.

**`fetch`, `pull`, `push` (`src-tauri/src/commands/remote.rs`)** now take `State<'_, RemoteOpRegistry>`, claim on entry and run their existing blocking body through `run_holding`. The "`<Op>` task failed" join errors are preserved byte-for-byte.

**Background fetch** — the window-focus fetch (`quiet: true`) *yields* to the slot but never takes one: it skips the round when the user has something running, and can never refuse the user's next push. Its timer twin in `autofetch_service.rs` has always run alongside whatever the user is doing, so making this one exclusive would break a working flow rather than fix the racing retry.

**Frontend** — the refusal message is user-facing as written ("A push is already running for this repository. Wait for it to finish and try again — an operation that timed out can still be finishing in the background"). That last clause is the part a user cannot deduce, because every spinner and lock the app shows was released when the timeout fired. `error-suggestion.service.ts` passes the refusal through **verbatim**, checked first, so the timeout rule ("increase the timeout in Settings") and the repository-lock rule ("remove the lock file") cannot rewrite it into advice that does not apply. The existing frontend locks stay as the fast path; the registry is the actual guarantee.

## Tests

| Test | File | Covers |
| --- | --- | --- |
| `a_timed_out_operation_keeps_its_slot_until_the_work_really_ends` | `src-tauri/src/services/remote_ops.rs` | **The reported bug.** A `timeout` abandons the caller; the slot must stay claimed until the blocking task returns, and be freed once it does. |
| `second_operation_on_the_same_repository_is_refused` | same | Two claims on one repo |
| `refusal_names_the_running_operation_and_carries_its_own_code` | same | Message names the running op, says the timeout part, and serializes as `REMOTE_OPERATION_IN_FLIGHT` |
| `releasing_the_guard_frees_the_repository` | same | RAII release |
| `separate_repositories_do_not_block_each_other` | same | Per-repo keying |
| `the_same_repository_spelled_differently_shares_one_slot` | same | Path normalization edge case |
| `running_reports_the_operation_a_background_fetch_must_yield_to` | same | Yield check the quiet fetch uses |
| `run_holding_without_a_slot_leaves_the_repository_free` | same | A background fetch cannot block a user push |
| `run_holding_releases_when_the_blocking_task_finishes` | same | Happy path |
| `should keep the in-flight refusal verbatim instead of calling it a timeout` | `src/services/__tests__/error-suggestion.service.test.ts` | The timeout rule must not claim it |
| `should recognise the in-flight refusal by its error code` | same | Code-form input |
| `should not mistake the in-flight refusal for a stuck lock file` | same | The lock rule must not claim it |
| `push refused while the repository is busy says so and keeps the badge` | `e2e/tests/remote-operations.spec.ts` | User-visible flow: error toast carries the real message, no "Open Settings" action, ahead badge survives, Push button stays enabled for the retry |

### Verified to fail without the change

- Reverting `run_holding` to drop the guard in its own body instead of inside the `spawn_blocking` closure:
  `assertion left == right failed: the timed-out push must still hold the slot / left: None` — `a_timed_out_operation_keeps_its_slot_until_the_work_really_ends` fails, the other 8 still pass.
- Removing the in-flight rule from `error-suggestion.service.ts`:
  - `expected 'Operation timed out. You can increase the timeout in Settings > Behavior.' to equal 'A push is already running for this repository. …'`
  - `expected null not to be null` (×2)
  - E2E: `expect(locator).toContainText(/already running for this repository/i) failed`

### Gate

`npm run lint`, `npm run typecheck`, `npm test`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, `cargo test --lib` all green; `e2e/tests/remote-operations.spec.ts` 37 passed.

## Notes / decisions

- **Scope.** Only `fetch`, `pull` and `push` participate, as the issue specifies. `push_to_multiple_remotes`, `fetch_all_remotes` and `push_tag` are untouched — adding them is a separate call about which operations should exclude each other.
- **`HashMap` rather than `HashSet`.** The issue suggested a set; storing which operation holds the slot costs nothing and lets the refusal name it, which is most of what makes the message actionable.
- **Command wiring is not unit-tested.** Calling the commands directly needs `tauri`'s `test` feature (`mock_app`), which is not enabled in this repo; the mechanism is tested directly and the wiring is three lines per command covered by the type checker and the E2E flow.
- No git CLI output is parsed or matched by this change, so the git 2.43/2.55 output-quoting skew does not apply.


---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_