### PR TITLE
Fix main: set detachedHeadOid on the palette test's repository fixture

### DIFF
--- a/src/__tests__/app-shell-palette-open-file.test.ts
+++ b/src/__tests__/app-shell-palette-open-file.test.ts
@@ -40,6 +40,7 @@ function mockRepo(path: string, name: string): Repository {
     isValid: true,
     isBare: false,
     headRef: 'main',
+    detachedHeadOid: null,
     state: 'clean',
     isShallow: false,
     isPartialClone: false,


### PR DESCRIPTION
## What was broken

`main` is currently red on `npm run typecheck`:

```
src/__tests__/app-shell-palette-open-file.test.ts(37,3): error TS2741:
Property 'detachedHeadOid' is missing in type '{ path: string; ... }'
but required in type 'Repository'.
```

This is a **semantic merge conflict** between two pull requests that were each green in isolation:

| PR | What it did |
|----|-------------|
| #414 (detached-HEAD indicator) | Added the required field `detachedHeadOid: string \| null` to the `Repository` interface in `src/types/git.types.ts` |
| #393 (palette open-file errors) | Added `app-shell-palette-open-file.test.ts`, which builds a `Repository` object literal |

Neither diff touched the other's file, so git merged both cleanly and CI passed on each branch. The break only exists in the combination.

## The fix

Add `detachedHeadOid: null` to the fixture. The fixture describes a repository sitting on the `main` branch (`headRef: 'main'`), so HEAD is not detached and `null` is what the backend would return.

## Verification

| Check | Result |
|-------|--------|
| `npm run lint` | pass |
| `npm run typecheck` | pass (was failing before this change) |
| `npm test` | pass |

The typecheck failure above reproduces on `origin/main` at `9ad8c4e` and is resolved by this commit — that is the assertion this change is verified against.

## Note for the remaining queue

There are still open pull requests waiting to merge that were branched before `detachedHeadOid` existed. Any of them that construct a `Repository` literal will hit the same error once merged, so `typecheck` is worth re-running against `main` after each batch rather than trusting per-branch CI alone.

---
_Generated by [Claude Code](https://claude.ai/code/session_01NAj55piiETwW7MrYtgbp3c)_