### PR TITLE
chore(release): bump version to 0.8.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "leviathan",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "leviathan",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "dependencies": {
         "@lit-labs/context": "^0.5.0",
         "@tauri-apps/api": "^2.11.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "leviathan",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "A fully-featured, open-source, cross-platform Git GUI client",
   "type": "module",
   "scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -2974,7 +2974,7 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "leviathan"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "anyhow",
  "async-trait",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leviathan"
-version = "0.7.0"
+version = "0.8.0"
 description = "A fully-featured, open-source, cross-platform Git GUI client"
 authors = ["Leviathan Contributors"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Leviathan",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "identifier": "io.github.hegsie.leviathan",
   "build": {
     "beforeBuildCommand": "npm run build",


### PR DESCRIPTION
Bumps the application version to 0.8.0 across the npm, Cargo, and Tauri manifests so the release workflow can create v0.8.0.