### PR TITLE
Fix graph context menus after repository switches

### DIFF
--- a/e2e/tests/context-menus.spec.ts
+++ b/e2e/tests/context-menus.spec.ts
@@ -282,6 +282,10 @@ test.describe('Context Menus - repository switch', () => {
       '/work/other-repo'
     );
 
+    // The switch reloads the list, and while `loading` is true the whole body
+    // — menu included — is swapped for a placeholder. Wait for the rows back
+    // first, so an absent menu means it was disarmed and not just unrendered.
+    await expect(branchRow).toBeVisible();
     await expect(contextMenu).not.toBeVisible();
   });
 });

--- a/e2e/tests/context-menus.spec.ts
+++ b/e2e/tests/context-menus.spec.ts
@@ -166,6 +166,106 @@ test.describe('Commit Context Menu', () => {
 // 2. Using visual regression testing
 // 3. Testing at the component/unit level instead of E2E
 
+/**
+ * Add a second repository tab without activating it, mirroring how the
+ * welcome/restore flows populate the store.
+ */
+async function addBackgroundRepo(
+  page: import('@playwright/test').Page,
+  path: string,
+  name: string
+): Promise<void> {
+  await page.evaluate(
+    ({ path, name }) => {
+      const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as {
+        repositoryStore: {
+          getState: () => {
+            addRepository: (repo: unknown, options?: { activate?: boolean }) => void;
+          };
+        };
+      };
+      stores.repositoryStore.getState().addRepository(
+        {
+          path,
+          name,
+          isValid: true,
+          isBare: false,
+          headRef: 'main',
+          state: 'clean',
+          isShallow: false,
+          isPartialClone: false,
+          cloneFilter: null,
+        },
+        { activate: false }
+      );
+    },
+    { path, name }
+  );
+}
+
+/**
+ * A context menu targets a commit/ref in ONE repository. Switching tabs by
+ * keyboard never produces a document click, so the menu would otherwise stay
+ * on screen and its next action would resolve against the newly active repo.
+ */
+test.describe('Context Menus - repository switch', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+    await addBackgroundRepo(page, '/work/other-repo', 'other-repo');
+    await expect(page.locator('lv-toolbar .tab')).toHaveCount(2);
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveAttribute('title', '/tmp/test-repo');
+  });
+
+  test('Ctrl+digit tab switch closes an open commit context menu', async ({ page }) => {
+    await rightClickOnCommitRow(page, 0);
+
+    const contextMenu = page.locator('.context-menu');
+    await expect(contextMenu).toBeVisible({ timeout: 3000 });
+
+    // Keyboard switch — no click, so handleDocumentClick never runs.
+    await page.keyboard.press('Control+2');
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveAttribute(
+      'title',
+      '/work/other-repo'
+    );
+
+    await expect(contextMenu).not.toBeVisible();
+  });
+
+  test('Ctrl+digit tab switch closes an open ref context menu', async ({ page }) => {
+    // Ref labels live on the canvas, so drive the real component event the
+    // graph dispatches on a ref-label right-click rather than guessing pixels.
+    const graphHandle = await page.locator('lv-graph-canvas').elementHandle();
+    await page.evaluate((el) => {
+      el!.dispatchEvent(
+        new CustomEvent('ref-context-menu', {
+          detail: {
+            refName: 'main',
+            fullName: 'refs/heads/main',
+            refType: 'localBranch',
+            isHead: true,
+            position: { x: 120, y: 120 },
+          },
+          bubbles: true,
+          composed: true,
+        })
+      );
+    }, graphHandle);
+
+    const contextMenu = page.locator('.context-menu');
+    await expect(contextMenu).toBeVisible({ timeout: 3000 });
+    await expect(contextMenu.locator('.context-menu-summary')).toHaveText('main');
+
+    await page.keyboard.press('Control+2');
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveAttribute(
+      'title',
+      '/work/other-repo'
+    );
+
+    await expect(contextMenu).not.toBeVisible();
+  });
+});
+
 test.describe('Operation Banner', () => {
   let app: AppPage;
 

--- a/e2e/tests/context-menus.spec.ts
+++ b/e2e/tests/context-menus.spec.ts
@@ -264,6 +264,26 @@ test.describe('Context Menus - repository switch', () => {
 
     await expect(contextMenu).not.toBeVisible();
   });
+
+  test('Ctrl+digit tab switch closes an open sidebar branch context menu', async ({ page }) => {
+    // lv-left-panel keeps ONE lv-branch-list across tabs and only rebinds
+    // `.repositoryPath`, so a leaked menu ends up over the NEW repo's rows
+    // while Delete/Rename still resolve the repo at click time.
+    const branchRow = page.locator('lv-branch-list .branch-item').first();
+    await expect(branchRow).toBeVisible();
+    await branchRow.click({ button: 'right' });
+
+    const contextMenu = page.locator('lv-branch-list .context-menu');
+    await expect(contextMenu).toBeVisible();
+
+    await page.keyboard.press('Control+2');
+    await expect(page.locator('lv-toolbar .tab.active')).toHaveAttribute(
+      'title',
+      '/work/other-repo'
+    );
+
+    await expect(contextMenu).not.toBeVisible();
+  });
 });
 
 test.describe('Operation Banner', () => {

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1713,13 +1713,21 @@ describe('app-shell multi-repo behavior', () => {
 
   describe('context-menu operation pinning', () => {
     it('closes commit and ref context menus when the active repository changes', async () => {
-      repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
-      repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
-
+      // Append BEFORE adding repos so connectedCallback's restore pass sees an
+      // empty persistedOpenRepos and returns early — otherwise its async prune
+      // writes drive the store subscription and land the element on /repo/b
+      // before the switch below, making it a no-op.
       const el = createAppShell();
       document.body.appendChild(el);
       try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+        repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+        // addRepository activates by default, so /repo/b is active here; pin
+        // back to /repo/a so the switch below is a real A -> B transition.
+        repositoryStore.getState().setActiveByPath('/repo/a');
         await el.updateComplete;
+        expect((el as any).activeRepository?.repository.path).to.equal('/repo/a');
+
         (el as any).contextMenu = {
           visible: true,
           x: 0,
@@ -1762,12 +1770,13 @@ describe('app-shell multi-repo behavior', () => {
       };
 
       let resolveConfirm: (v: unknown) => void = () => {};
-      const deferredConfirm = () =>
+      // showConfirm() goes through @tauri-apps/plugin-dialog's confirm(), which
+      // is a wrapper over the message command — there is no dedicated
+      // `plugin:dialog|confirm` IPC command to mock.
+      mockResponses['plugin:dialog|message'] = () =>
         new Promise((res) => {
           resolveConfirm = res;
         });
-      mockResponses['plugin:dialog|confirm'] = deferredConfirm;
-      mockResponses['plugin:dialog|message'] = deferredConfirm;
 
       const promise = (el as any).handleResetToCommit('hard');
       await new Promise((r) => setTimeout(r, 0));

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -1712,6 +1712,40 @@ describe('app-shell multi-repo behavior', () => {
   });
 
   describe('context-menu operation pinning', () => {
+    it('closes commit and ref context menus when the active repository changes', async () => {
+      repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
+      repositoryStore.getState().addRepository(mockRepo('/repo/b', 'b'));
+
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        await el.updateComplete;
+        (el as any).contextMenu = {
+          visible: true,
+          x: 0,
+          y: 0,
+          commit: { oid: 'commit-from-a', summary: 'A commit', shortId: 'commit-f' },
+        };
+        (el as any).refContextMenu = {
+          visible: true,
+          x: 0,
+          y: 0,
+          refName: 'branch-from-a',
+          fullName: 'refs/heads/branch-from-a',
+          refType: 'localBranch',
+          isHead: false,
+        };
+
+        repositoryStore.getState().setActiveByPath('/repo/b');
+        await el.updateComplete;
+
+        expect((el as any).contextMenu.visible).to.be.false;
+        expect((el as any).refContextMenu.visible).to.be.false;
+      } finally {
+        el.remove();
+      }
+    });
+
     it('handleResetToCommit hard-resets the origin repo, not the tab switched to during the confirm', async () => {
       // A hard reset discards uncommitted work — it must never run against a
       // repo the user did not confirm. The confirm await yields; a mid-confirm
@@ -1728,10 +1762,12 @@ describe('app-shell multi-repo behavior', () => {
       };
 
       let resolveConfirm: (v: unknown) => void = () => {};
-      mockResponses['plugin:dialog|message'] = () =>
+      const deferredConfirm = () =>
         new Promise((res) => {
           resolveConfirm = res;
         });
+      mockResponses['plugin:dialog|confirm'] = deferredConfirm;
+      mockResponses['plugin:dialog|message'] = deferredConfirm;
 
       const promise = (el as any).handleResetToCommit('hard');
       await new Promise((r) => setTimeout(r, 0));
@@ -2132,5 +2168,4 @@ describe('the toolbar command-palette button loads the active repo', () => {
     el.remove();
   });
 });
-
 

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1673,6 +1673,12 @@ export class AppShell extends LitElement {
         this.showFileHistory = false;
         this.fileHistoryPath = null;
 
+        // Graph context-menu entries are scoped to the repository that
+        // produced their commit/ref. Leaving either menu open across a tab
+        // switch lets a subsequent click resolve against the new active repo.
+        this.contextMenu = { ...this.contextMenu, visible: false };
+        this.refContextMenu = { ...this.refContextMenu, visible: false };
+
         // Clear search filter
         this.searchFilter = null;
 

--- a/src/components/panels/__tests__/lv-commit-details.test.ts
+++ b/src/components/panels/__tests__/lv-commit-details.test.ts
@@ -311,4 +311,103 @@ describe('lv-commit-details', () => {
       }
     });
   });
+
+  /**
+   * lv-right-panel keeps ONE lv-commit-details across tabs and only rebinds
+   * `.repositoryPath`/`.commit`. A Ctrl+digit switch produces no document
+   * click, and app-shell clears the selected commit — so the panel falls back
+   * to its empty state and the menu merely LOOKS closed while still armed with
+   * repo A's file. Selecting any commit in repo B brought it straight back, and
+   * Restore/Open then joined repo B's path with repo A's file.
+   */
+  describe('file context menu across a repository switch', () => {
+    const otherCommit: Commit = { ...mockCommit, oid: 'fed987cba654', shortId: 'fed987c' };
+
+    /** Let the un-awaited work `updated()` kicks off settle. */
+    async function flush(el: LvCommitDetails): Promise<void> {
+      for (let i = 0; i < 5; i++) {
+        await el.updateComplete;
+        await new Promise((r) => setTimeout(r, 0));
+      }
+      await el.updateComplete;
+    }
+
+    function menuCount(el: LvCommitDetails): number {
+      return el.shadowRoot!.querySelectorAll('.context-menu').length;
+    }
+
+    /** The state the menu entries actually read at click time. */
+    function menuState(el: LvCommitDetails): { visible: boolean; file: { path: string } | null } {
+      return (el as unknown as { contextMenu: { visible: boolean; file: { path: string } | null } })
+        .contextMenu;
+    }
+
+    async function mountedWithOpenMenu(): Promise<LvCommitDetails> {
+      mockFiles = [{ path: 'src/main.ts', status: 'modified', additions: 2, deletions: 1 }];
+      const el = await fixture<LvCommitDetails>(
+        html`<lv-commit-details
+          .repositoryPath=${'/repo/a'}
+          .commit=${mockCommit}
+        ></lv-commit-details>`,
+      );
+      await flush(el);
+
+      const row = el.shadowRoot!.querySelector('.file-item[title="src/main.ts"]');
+      expect(row, 'no file row to right-click').to.not.be.null;
+      row!.dispatchEvent(new MouseEvent('contextmenu', { bubbles: true, cancelable: true }));
+      await el.updateComplete;
+
+      expect(menuCount(el), 'the menu opens on right-click').to.equal(1);
+      expect(menuState(el).visible).to.be.true;
+      return el;
+    }
+
+    it('disarms the menu on the switch, so selecting a commit in the new repo does not bring it back', async () => {
+      const el = await mountedWithOpenMenu();
+
+      // Exactly what a Ctrl+digit switch does: app-shell clears the selection
+      // and lv-right-panel rebinds the path on the SAME element. No click.
+      el.commit = null;
+      el.repositoryPath = '/repo/b';
+      await flush(el);
+
+      // The empty state hides the menu node either way, so assert on the state
+      // the entries read — that is what tells the two cases apart.
+      expect(menuState(el).visible, 'the switch disarms the menu').to.be.false;
+
+      // Selecting a commit in the new repo re-renders the full panel.
+      el.commit = otherCommit;
+      await flush(el);
+
+      expect(menuCount(el), "repo A's menu must not return over repo B").to.equal(0);
+    });
+
+    it('leaves the menu alone on a re-render that does not change the repository', async () => {
+      const el = await mountedWithOpenMenu();
+
+      // A real re-render with `changedProperties.has('repositoryPath')` false:
+      // the guard must key off a repo CHANGE, not off any update cycle, or a
+      // routine refresh yanks the menu out from under the user's click.
+      el.githubOwner = 'hegsie';
+      await flush(el);
+
+      expect(menuCount(el), 'an unrelated re-render keeps the menu').to.equal(1);
+      expect(menuState(el).visible).to.be.true;
+      expect(menuState(el).file?.path).to.equal('src/main.ts');
+    });
+
+    it('disarms the menu even when the new repository fails to load its files', async () => {
+      const el = await mountedWithOpenMenu();
+
+      // The close must land before any await, or a failed load leaves the menu
+      // armed behind an error state and it reappears on the next good render.
+      failingCommands.add('get_commit_files');
+      el.commit = otherCommit;
+      el.repositoryPath = '/repo/b';
+      await flush(el);
+
+      expect(menuState(el).visible, 'a failed load still disarms the menu').to.be.false;
+      expect(menuCount(el), 'no menu is rendered over the error state').to.equal(0);
+    });
+  });
 });

--- a/src/components/panels/lv-commit-details.ts
+++ b/src/components/panels/lv-commit-details.ts
@@ -709,6 +709,13 @@ export class LvCommitDetails extends LitElement {
     const repositoryChanged =
       changedProperties.has('repositoryPath') && this.repositoryPath !== '';
     if (repositoryChanged) {
+      // The file menu acts on the entry it was opened over but resolves the
+      // repo from `this.repositoryPath` at click time. A keyboard tab switch
+      // produces no document click, and the panel merely renders its empty
+      // state while `commit` is null — so an armed menu would come back over
+      // the NEW repo the moment a commit is selected, and Restore/Open would
+      // join repo B's path with repo A's file.
+      this.contextMenu = { ...this.contextMenu, visible: false };
       this.resetNotesState();
       this.refreshNotes();
     }

--- a/src/components/sidebar/__tests__/lv-sidebar-context-menu-repo-switch.test.ts
+++ b/src/components/sidebar/__tests__/lv-sidebar-context-menu-repo-switch.test.ts
@@ -34,10 +34,13 @@ type Loadable = HTMLElement & { repositoryPath: string; updateComplete: Promise<
 let rows: Record<string, Record<string, unknown[]>> = {};
 /** Commands whose next call must reject, simulating a failed load. */
 let failing = new Set<string>();
+/** Every invoke, so a test can assert WHICH paths an operation actually hit. */
+let calls: Array<{ command: string; args: Record<string, unknown> }> = [];
 
 function installMock(): void {
   mockInvoke = (command, args) => {
     const path = String((args as { path?: string })?.path ?? '');
+    calls.push({ command, args: (args ?? {}) as Record<string, unknown> });
     if (failing.has(command)) {
       return Promise.reject({ code: 'COMMAND_ERROR', message: 'repository is locked' });
     }
@@ -151,6 +154,7 @@ describe('sidebar context menus across a repository switch', () => {
   beforeEach(() => {
     rows = {};
     failing = new Set();
+    calls = [];
     installMock();
   });
 
@@ -229,4 +233,126 @@ describe('sidebar context menus across a repository switch', () => {
       });
     });
   }
+});
+
+/**
+ * The multi-file selection must not survive a repository switch either.
+ *
+ * `selectedFiles` holds PATHS, and the row buttons redirect to the batch
+ * handlers whenever the clicked file is in it. Several worktrees of one project
+ * open as tabs share paths by construction, so a selection carried across the
+ * rebind silently re-selects the new repo's same-named files — and the × on one
+ * row then discards every one of them.
+ */
+describe('lv-file-status selection across a repository switch', () => {
+  beforeEach(() => {
+    rows = {};
+    failing = new Set();
+    calls = [];
+    installMock();
+  });
+
+  const entries = [makeEntry('src/main.ts'), makeEntry('README.md')];
+
+  /** Ctrl+click a row by path, as a user building a multi-selection would. */
+  function ctrlClickRow(el: HTMLElement, path: string): void {
+    const row = el.shadowRoot!.querySelector(`.file-item[title="${path}"]`);
+    if (!row) throw new Error(`no row for ${path}`);
+    row.dispatchEvent(new MouseEvent('click', { bubbles: true, composed: true, ctrlKey: true }));
+  }
+
+  function selectedPaths(el: HTMLElement): string[] {
+    return Array.from((el as unknown as { selectedFiles: Set<string> }).selectedFiles).sort();
+  }
+
+  function selectedRowCount(el: HTMLElement): number {
+    return el.shadowRoot!.querySelectorAll('.file-item.selected').length;
+  }
+
+  /** Mounted on /repo/a with both files selected; /repo/b has the same paths. */
+  async function twoSelectedInRepoA(): Promise<Loadable> {
+    rows['/repo/a'] = { get_status: [...entries] };
+    rows['/repo/b'] = { get_status: [...entries] };
+    const el = await fixture<Loadable>('<lv-file-status></lv-file-status>');
+    el.repositoryPath = '/repo/a';
+    await flush(el);
+
+    ctrlClickRow(el, 'src/main.ts');
+    ctrlClickRow(el, 'README.md');
+    await el.updateComplete;
+
+    expect(selectedPaths(el), 'both rows are selected in repo A').to.deep.equal([
+      'README.md',
+      'src/main.ts',
+    ]);
+    expect(selectedRowCount(el), 'both rows render selected').to.equal(2);
+    return el;
+  }
+
+  it('clears the selection when the tab switch rebinds the repository', async () => {
+    const el = await twoSelectedInRepoA();
+
+    el.repositoryPath = '/repo/b';
+    await flush(el);
+
+    expect(selectedPaths(el), 'no selection survives into the new repository').to.deep.equal([]);
+    expect(selectedRowCount(el), 'no row in the new repository renders selected').to.equal(0);
+    expect(
+      (el as unknown as { lastSelectedFile: string | null }).lastSelectedFile,
+      'the shift-range anchor is dropped with the selection'
+    ).to.equal(null);
+  });
+
+  it('keeps a single-file stage single-file after the switch', async () => {
+    // The user-visible failure: handleStageFile redirects to the BATCH handler
+    // whenever the clicked file is in a >1 selection, so a leaked selection
+    // turns one row's + button into an operation over files never selected here.
+    const el = await twoSelectedInRepoA();
+
+    el.repositoryPath = '/repo/b';
+    await flush(el);
+
+    calls = [];
+    const stage = el.shadowRoot!.querySelector<HTMLButtonElement>(
+      'button[aria-label="Stage main.ts"]'
+    );
+    expect(stage, 'the row keeps its stage button').to.not.equal(null);
+    stage!.click();
+    await flush(el);
+
+    const staged = calls.filter((c) => c.command === 'stage_files');
+    expect(staged.length, 'exactly one stage command runs').to.equal(1);
+    expect(staged[0].args.path, 'it targets the repository on screen').to.equal('/repo/b');
+    expect(staged[0].args.paths, 'it stages only the clicked file').to.deep.equal([
+      'src/main.ts',
+    ]);
+  });
+
+  it('keeps the selection across a refresh of the same repository', async () => {
+    // The guard keys off a repo CHANGE, not any re-render: a watcher-driven
+    // refresh must not wipe a selection the user is still building.
+    const el = await twoSelectedInRepoA();
+
+    await (el as unknown as { refresh: () => unknown }).refresh();
+    (el as unknown as { requestUpdate: () => void }).requestUpdate();
+    await flush(el);
+
+    expect(selectedPaths(el), 'a same-repo refresh leaves the selection alone').to.deep.equal([
+      'README.md',
+      'src/main.ts',
+    ]);
+  });
+
+  it('clears the selection even when the new repository fails to load', async () => {
+    // The clear must happen BEFORE the reload await, or a failing load leaves
+    // repo A's paths armed behind the error state — ready to fire the moment a
+    // later refresh succeeds.
+    const el = await twoSelectedInRepoA();
+
+    failing.add('get_status');
+    el.repositoryPath = '/repo/b';
+    await flush(el);
+
+    expect(selectedPaths(el), 'a failed load still drops the selection').to.deep.equal([]);
+  });
 });

--- a/src/components/sidebar/__tests__/lv-sidebar-context-menu-repo-switch.test.ts
+++ b/src/components/sidebar/__tests__/lv-sidebar-context-menu-repo-switch.test.ts
@@ -181,18 +181,29 @@ describe('sidebar context menus across a repository switch', () => {
         expect(menuCount(el), 'no menu survives into the new repository').to.equal(0);
       });
 
-      it('keeps the menu open when the same repository is rebound', async () => {
-        // The guard must be a repo CHANGE, not any re-render: a refresh that
-        // re-sets the same path must not yank the menu out from under a click.
+      it('keeps the menu open across a refresh of the same repository', async () => {
+        // The guard must key off a repo CHANGE, not any re-render: a refresh
+        // must not yank the menu out from under the user's click. Re-assigning
+        // the SAME path would prove nothing — `repositoryPath` is a plain
+        // @property, so Lit's `!==` check requests no update at all. Drive the
+        // component's own refresh instead, which re-renders with
+        // `changedProperties.has('repositoryPath')` false.
         const el = await mounted();
         rightClickRow(el, c.row);
         await el.updateComplete;
         expect(menuCount(el), 'the menu opens on right-click').to.equal(1);
 
-        el.repositoryPath = '/repo/a';
+        await (el as unknown as { refresh: () => unknown }).refresh();
+        // A load that happens to produce identical state re-renders nothing, so
+        // force one update cycle to guarantee `updated()` actually runs.
+        (el as unknown as { requestUpdate: () => void }).requestUpdate();
         await flush(el);
 
-        expect(menuCount(el), 'an unchanged repository leaves the menu alone').to.equal(1);
+        expect(menuCount(el), 'a same-repo refresh leaves the menu alone').to.equal(1);
+        expect(
+          (el as unknown as { contextMenu: { visible: boolean } }).contextMenu.visible,
+          'a same-repo refresh leaves the menu armed'
+        ).to.equal(true);
       });
 
       it('closes the menu even when the new repository fails to load', async () => {

--- a/src/components/sidebar/__tests__/lv-sidebar-context-menu-repo-switch.test.ts
+++ b/src/components/sidebar/__tests__/lv-sidebar-context-menu-repo-switch.test.ts
@@ -1,0 +1,221 @@
+/**
+ * Sidebar context menus must not survive a repository switch.
+ *
+ * lv-left-panel keeps ONE instance of each list across tabs and only rebinds
+ * `.repositoryPath`. The only close paths a menu has are a document click and
+ * Escape, and a Ctrl+digit / Ctrl+Tab switch produces neither — so an open menu
+ * stayed on screen over the new repo's rows while its entries still resolved
+ * the repo from `this.repositoryPath` at click time. Right-click `v1.0.0` in
+ * repo A, Ctrl+2, click Delete, and the irreversible operation ran against
+ * repo B — which routinely has a tag by the same name.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: Record<string, unknown>) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture } from '@open-wc/testing';
+import '../lv-branch-list.ts';
+import '../lv-file-status.ts';
+import '../lv-stash-list.ts';
+import '../lv-tag-list.ts';
+
+type Loadable = HTMLElement & { repositoryPath: string; updateComplete: Promise<unknown> };
+
+/** Rows loaded per repo path, keyed by the command that fetches them. */
+let rows: Record<string, Record<string, unknown[]>> = {};
+/** Commands whose next call must reject, simulating a failed load. */
+let failing = new Set<string>();
+
+function installMock(): void {
+  mockInvoke = (command, args) => {
+    const path = String((args as { path?: string })?.path ?? '');
+    if (failing.has(command)) {
+      return Promise.reject({ code: 'COMMAND_ERROR', message: 'repository is locked' });
+    }
+    const forCommand = rows[path]?.[command];
+    if (forCommand) return Promise.resolve(forCommand);
+    if (command === 'get_tag_sort_mode') return Promise.resolve('name');
+    return Promise.resolve(null);
+  };
+}
+
+/** Let an un-awaited async `updated()`/load settle. */
+async function flush(el: Loadable): Promise<void> {
+  for (let i = 0; i < 5; i++) {
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  await el.updateComplete;
+}
+
+/** Right-click the first row matching `selector`, as a user would. */
+function rightClickRow(el: HTMLElement, selector: string): void {
+  const row = el.shadowRoot!.querySelector(selector);
+  if (!row) throw new Error(`no ${selector} row to right-click`);
+  row.dispatchEvent(
+    new MouseEvent('contextmenu', { bubbles: true, composed: true, clientX: 40, clientY: 60 })
+  );
+}
+
+function menuOf(el: HTMLElement): Element | null {
+  return el.shadowRoot!.querySelector('.context-menu');
+}
+
+/** Asserted on instead of the element itself: a failed `.to.be.null` on a DOM
+ * node makes chai deep-inspect the whole menu subtree, which drowns the
+ * reporter and turns a one-line failure into a runner timeout. */
+function menuCount(el: HTMLElement): number {
+  return el.shadowRoot!.querySelectorAll('.context-menu').length;
+}
+
+function makeTag(name: string) {
+  return { name, targetOid: `oid-${name}`, message: null, tagger: null, isAnnotated: false };
+}
+
+function makeBranch(name: string) {
+  return {
+    name,
+    shorthand: name,
+    isHead: false,
+    isRemote: false,
+    upstream: null,
+    targetOid: `oid-${name}`,
+    isStale: false,
+  };
+}
+
+function makeStash(index: number, message: string) {
+  return { index, message, oid: `oid-${index}`, branch: 'main', timestamp: 0 };
+}
+
+function makeEntry(path: string) {
+  return { path, status: 'modified', isStaged: false, isConflicted: false };
+}
+
+/**
+ * One table-driven case per list: how to seed its rows, which row to
+ * right-click, and the label the menu carries so the assertions are about the
+ * REAL menu and not some other node.
+ */
+const cases = [
+  {
+    name: 'lv-tag-list',
+    tag: 'lv-tag-list',
+    command: 'get_tags',
+    row: '.tag-item',
+    menuLabel: 'Tag actions',
+    // The same name in both repos: the exact collision that makes a leaked
+    // menu destructive rather than merely confusing.
+    a: [makeTag('v1.0.0')],
+    b: [makeTag('v1.0.0')],
+  },
+  {
+    name: 'lv-branch-list',
+    tag: 'lv-branch-list',
+    command: 'get_branches',
+    row: '.branch-item',
+    menuLabel: 'Branch actions',
+    a: [makeBranch('develop')],
+    b: [makeBranch('develop')],
+  },
+  {
+    name: 'lv-stash-list',
+    tag: 'lv-stash-list',
+    command: 'get_stashes',
+    row: '.stash-item',
+    menuLabel: 'Stash actions',
+    a: [makeStash(0, 'WIP on develop')],
+    b: [makeStash(0, 'WIP on develop')],
+  },
+  {
+    name: 'lv-file-status',
+    tag: 'lv-file-status',
+    command: 'get_status',
+    row: '.file-item',
+    menuLabel: 'File actions',
+    a: [makeEntry('src/main.ts')],
+    b: [makeEntry('src/main.ts')],
+  },
+] as const;
+
+describe('sidebar context menus across a repository switch', () => {
+  beforeEach(() => {
+    rows = {};
+    failing = new Set();
+    installMock();
+  });
+
+  for (const c of cases) {
+    describe(c.name, () => {
+      async function mounted(): Promise<Loadable> {
+        rows['/repo/a'] = { [c.command]: [...c.a] };
+        rows['/repo/b'] = { [c.command]: [...c.b] };
+        const list = await fixture<Loadable>(`<${c.tag}></${c.tag}>`);
+        list.repositoryPath = '/repo/a';
+        await flush(list);
+        return list;
+      }
+
+      it('closes an open menu when the tab switch rebinds the repository', async () => {
+        const el = await mounted();
+        rightClickRow(el, c.row);
+        await el.updateComplete;
+
+        expect(menuCount(el), 'the menu opens on right-click').to.equal(1);
+        expect(menuOf(el)!.getAttribute('aria-label')).to.equal(c.menuLabel);
+
+        // Exactly what a Ctrl+digit switch does: lv-left-panel rebinds the
+        // property on the SAME element. No click, no Escape.
+        el.repositoryPath = '/repo/b';
+        await flush(el);
+
+        expect(menuCount(el), 'no menu survives into the new repository').to.equal(0);
+      });
+
+      it('keeps the menu open when the same repository is rebound', async () => {
+        // The guard must be a repo CHANGE, not any re-render: a refresh that
+        // re-sets the same path must not yank the menu out from under a click.
+        const el = await mounted();
+        rightClickRow(el, c.row);
+        await el.updateComplete;
+        expect(menuCount(el), 'the menu opens on right-click').to.equal(1);
+
+        el.repositoryPath = '/repo/a';
+        await flush(el);
+
+        expect(menuCount(el), 'an unchanged repository leaves the menu alone').to.equal(1);
+      });
+
+      it('closes the menu even when the new repository fails to load', async () => {
+        // The close must happen BEFORE the reload await, or a failing load
+        // leaves the menu armed: lv-branch-list and lv-file-status swap the
+        // whole body for an error state, so the node is merely hidden and comes
+        // straight back — still holding repo A's row — the moment a later
+        // refresh succeeds. Hence the assertion is on the state the entries
+        // actually read, not on the DOM, which cannot tell the two apart.
+        const el = await mounted();
+        rightClickRow(el, c.row);
+        await el.updateComplete;
+        expect(menuCount(el), 'the menu opens on right-click').to.equal(1);
+
+        failing.add(c.command);
+        el.repositoryPath = '/repo/b';
+        await flush(el);
+
+        expect(
+          (el as unknown as { contextMenu: { visible: boolean } }).contextMenu.visible,
+          'a failed load still disarms the menu'
+        ).to.equal(false);
+      });
+    });
+  }
+});

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -766,6 +766,11 @@ export class LvBranchList extends LitElement {
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     if (changedProperties.has('repositoryPath') && this.repositoryPath) {
+      // A menu entry acts on the branch it was opened over, but resolves the
+      // repo from `this.repositoryPath` at click time — and a keyboard tab
+      // switch produces neither a document click nor Escape, so the menu would
+      // survive the rebind and delete repo A's branch inside repo B.
+      this.contextMenu = { ...this.contextMenu, visible: false };
       this.loadHiddenBranches();
       await this.loadBranches();
     }

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -1141,6 +1141,14 @@ export class LvFileStatus extends LitElement {
       // produces neither a document click nor Escape, so the menu would survive
       // the rebind and discard/stage repo A's file inside repo B.
       this.contextMenu = { ...this.contextMenu, visible: false };
+      // The multi-file selection is a set of PATHS, and the row buttons and the
+      // s/u shortcuts redirect to the batch handlers whenever the clicked file
+      // is in it — so a selection carried across the rebind re-selects
+      // same-named files in the new repo (guaranteed with several worktrees of
+      // one project open as tabs) and turns a single-file discard into a batch
+      // discard of files never selected here.
+      this.selectedFiles = new Set();
+      this.lastSelectedFile = null;
       // Reset for new repository so we show loading on first load
       this.hasInitiallyLoaded = false;
       this.statusDirtySeq++;

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -1136,6 +1136,11 @@ export class LvFileStatus extends LitElement {
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     if (changedProperties.has("repositoryPath") && this.repositoryPath) {
+      // A menu entry acts on the file it was opened over, but resolves the repo
+      // from `this.repositoryPath` at click time — and a keyboard tab switch
+      // produces neither a document click nor Escape, so the menu would survive
+      // the rebind and discard/stage repo A's file inside repo B.
+      this.contextMenu = { ...this.contextMenu, visible: false };
       // Reset for new repository so we show loading on first load
       this.hasInitiallyLoaded = false;
       this.statusDirtySeq++;

--- a/src/components/sidebar/lv-stash-list.ts
+++ b/src/components/sidebar/lv-stash-list.ts
@@ -410,6 +410,11 @@ export class LvStashList extends LitElement {
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     if (changedProperties.has('repositoryPath') && this.repositoryPath) {
+      // A menu entry acts on the stash it was opened over, but resolves the
+      // repo from `this.repositoryPath` at click time — and a keyboard tab
+      // switch produces neither a document click nor Escape, so the menu would
+      // survive the rebind and drop repo A's stash inside repo B.
+      this.contextMenu = { ...this.contextMenu, visible: false };
       // A preview belongs to the repo it was opened in.
       this.collapseDetails();
       await this.loadStashes();

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -499,6 +499,11 @@ export class LvTagList extends LitElement {
 
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     if (changedProperties.has('repositoryPath') && this.repositoryPath) {
+      // A menu entry acts on the tag it was opened over, but resolves the repo
+      // from `this.repositoryPath` at click time — and a keyboard tab switch
+      // produces neither a document click nor Escape, so the menu would survive
+      // the rebind and delete repo A's `v1.0.0` inside repo B.
+      this.contextMenu = { ...this.contextMenu, visible: false };
       // Drop the previous repo's remotes before the reload: they must never
       // label the new repo's menu.
       this.remotes = null;


### PR DESCRIPTION
## Summary
- close commit and ref context menus whenever the active repository changes
- prevent stale graph actions from being executed against a newly selected repository
- add multi-repository regression coverage
- update the deferred confirmation mock to cover the current Tauri dialog command

## Validation
- npm run lint -- --quiet
- npm run typecheck
- npm test -- --files src/__tests__/app-shell-multi-repo.test.ts
- Tauri API naming sweep: no snake_case invoke argument objects found

## Environment blockers
- full npm test currently has 189 unrelated dialog-mock failures on main
- cargo fmt --check is blocked by pre-existing untracked src-tauri/tests/checkout*.rs scratch files
- cargo clippy --all-targets -- -D warnings is blocked locally by aws-lc-sys requiring NASM