### PR TITLE
fix: protect staged work during cherry-pick and revert

### DIFF
--- a/src-tauri/src/commands/rewrite.rs
+++ b/src-tauri/src/commands/rewrite.rs
@@ -24,15 +24,32 @@ const CHERRY_PICK_SEQUENCE: &str = "CHERRY_PICK_SEQUENCE";
 /// picks on the branch.
 const CHERRY_PICK_SEQUENCE_HEAD: &str = "CHERRY_PICK_SEQUENCE_HEAD";
 
+/// Refuse to start an index-rewriting operation while the index holds staged
+/// work the operation — or a later abort of it — would destroy.
 fn ensure_index_matches_head(repo: &git2::Repository) -> Result<()> {
     let head_tree = repo.head()?.peel_to_commit()?.tree()?;
     let mut index = repo.index()?;
+
+    // write_tree fails outright on an index with unmerged entries, and that
+    // state is reachable while `state()` is still Clean — a conflicted stash
+    // apply leaves it — so answer it before writing rather than leaking a raw
+    // libgit2 error. The wording deliberately avoids the word "conflict": the
+    // cherry-pick dialog routes any message containing it to the
+    // conflict-resolution flow, which has no operation to resolve here.
+    if index.has_conflicts() {
+        return Err(LeviathanError::OperationFailed(
+            "The index has unmerged files. Resolve them before starting this operation."
+                .to_string(),
+        ));
+    }
+
     if index.write_tree()? != head_tree.id() {
         return Err(LeviathanError::OperationFailed(
             "The index has staged changes. Commit or stash them before starting this operation."
                 .to_string(),
         ));
     }
+
     Ok(())
 }
 
@@ -3774,6 +3791,125 @@ mod tests {
                 .unwrap()
                 .id,
             staged_oid
+        );
+    }
+
+    /// A `no_commit` pick leaves its work staged with `state()` back to Clean,
+    /// so the next pick meets the guard. libgit2's merge preflight refuses that
+    /// index regardless (it rejects any index that differs from HEAD, even a
+    /// pure addition), so the guard is not what makes chaining impossible — it
+    /// only replaces libgit2's "uncommitted changes would be overwritten by
+    /// merge" with something the user can act on. The first pick's work must
+    /// survive intact either way.
+    #[tokio::test]
+    async fn test_no_commit_cherry_pick_chain_reports_actionable_error() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let first = test_repo.create_commit("First", &[("first.txt", "first")]);
+        let second = test_repo.create_commit("Second", &[("second.txt", "second")]);
+        test_repo.checkout_branch("main");
+
+        cherry_pick(test_repo.path_str(), first.to_string(), Some(true), None)
+            .await
+            .expect("first no_commit pick should succeed");
+
+        let err = cherry_pick(test_repo.path_str(), second.to_string(), Some(true), None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("index has staged changes"),
+            "expected an actionable message, got: {err}"
+        );
+
+        let repo = test_repo.repo();
+        assert_eq!(repo.state(), git2::RepositoryState::Clean);
+        assert!(repo
+            .index()
+            .unwrap()
+            .get_path(std::path::Path::new("first.txt"), 0)
+            .is_some());
+    }
+
+    /// A staged deletion of a path HEAD tracks is work the operation could
+    /// destroy just as surely as a staged edit, so it must still be refused.
+    #[tokio::test]
+    async fn test_cherry_pick_refuses_staged_deletion() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_commit("Add unrelated", &[("unrelated.txt", "original")]);
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let feature_oid = test_repo.create_commit("Feature commit", &[("feature.txt", "feature")]);
+        test_repo.checkout_branch("main");
+
+        let repo = test_repo.repo();
+        let mut index = repo.index().unwrap();
+        index
+            .remove_path(std::path::Path::new("unrelated.txt"))
+            .unwrap();
+        index.write().unwrap();
+
+        let result = cherry_pick(test_repo.path_str(), feature_oid.to_string(), None, None).await;
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("index has staged changes"));
+    }
+
+    /// A conflicted stash apply leaves unmerged entries in the index while
+    /// `state()` stays Clean. Diffing (or writing) a tree fails outright there,
+    /// so the guard must recognise it rather than leak a raw libgit2 error.
+    fn leave_conflicted_index(test_repo: &TestRepo) {
+        test_repo.create_commit("Base", &[("conflict.txt", "base")]);
+        {
+            let mut repo = test_repo.repo();
+            std::fs::write(test_repo.path.join("conflict.txt"), "stashed").unwrap();
+            let signature = repo.signature().unwrap();
+            repo.stash_save(&signature, "wip", None).unwrap();
+        }
+        test_repo.create_commit("Diverge", &[("conflict.txt", "other")]);
+
+        // Re-open: a Repository handle caches its index, so the one that saved
+        // the stash would apply against a stale snapshot.
+        let mut repo = test_repo.repo();
+        repo.stash_apply(0, None).unwrap();
+        assert!(repo.index().unwrap().has_conflicts());
+        assert_eq!(repo.state(), git2::RepositoryState::Clean);
+    }
+
+    #[tokio::test]
+    async fn test_revert_refuses_unmerged_index() {
+        let test_repo = TestRepo::with_initial_commit();
+        let revert_oid = test_repo.create_commit("Add file", &[("file.txt", "content")]);
+        leave_conflicted_index(&test_repo);
+
+        let err = revert(test_repo.path_str(), revert_oid.to_string(), None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("index has unmerged files"),
+            "expected an actionable message, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cherry_pick_refuses_unmerged_index() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let feature_oid = test_repo.create_commit("Feature commit", &[("feature.txt", "feature")]);
+        test_repo.checkout_branch("main");
+        leave_conflicted_index(&test_repo);
+
+        let err = cherry_pick(test_repo.path_str(), feature_oid.to_string(), None, None)
+            .await
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains("index has unmerged files"),
+            "expected an actionable message, got: {err}"
         );
     }
 

--- a/src-tauri/src/commands/rewrite.rs
+++ b/src-tauri/src/commands/rewrite.rs
@@ -24,6 +24,18 @@ const CHERRY_PICK_SEQUENCE: &str = "CHERRY_PICK_SEQUENCE";
 /// picks on the branch.
 const CHERRY_PICK_SEQUENCE_HEAD: &str = "CHERRY_PICK_SEQUENCE_HEAD";
 
+fn ensure_index_matches_head(repo: &git2::Repository) -> Result<()> {
+    let head_tree = repo.head()?.peel_to_commit()?.tree()?;
+    let mut index = repo.index()?;
+    if index.write_tree()? != head_tree.id() {
+        return Err(LeviathanError::OperationFailed(
+            "The index has staged changes. Commit or stash them before starting this operation."
+                .to_string(),
+        ));
+    }
+    Ok(())
+}
+
 /// Interpret a git path (raw bytes) as a filesystem path.
 ///
 /// git stores paths as bytes, and on unix a name that is not valid UTF-8 is
@@ -405,6 +417,7 @@ pub async fn cherry_pick(
             }
         }
     }
+    ensure_index_matches_head(&repo)?;
 
     // Find the commit to cherry-pick
     let oid = git2::Oid::from_str(&commit_oid)
@@ -675,6 +688,7 @@ pub async fn revert(path: String, commit_oid: String, mainline: Option<u32>) -> 
             "Another operation is in progress".to_string(),
         ));
     }
+    ensure_index_matches_head(&repo)?;
 
     // Find the commit to revert
     let oid = git2::Oid::from_str(&commit_oid)
@@ -912,6 +926,7 @@ pub async fn cherry_pick_range(path: String, commit_oids: Vec<String>) -> Result
             "Another operation is in progress".to_string(),
         ));
     }
+    ensure_index_matches_head(&repo)?;
 
     if commit_oids.is_empty() {
         return Err(LeviathanError::OperationFailed(
@@ -1716,6 +1731,7 @@ pub async fn cherry_pick_from_branch(
             }
         }
     }
+    ensure_index_matches_head(&repo)?;
 
     let count = count.unwrap_or(1);
     if count == 0 {
@@ -3591,6 +3607,175 @@ mod tests {
     }
 
     // ---- Finding 40: aborting must preserve unrelated uncommitted work ----
+
+    fn stage_file(test_repo: &TestRepo, path: &str, content: &str) -> git2::Oid {
+        std::fs::write(test_repo.path.join(path), content).unwrap();
+        let repo = test_repo.repo();
+        let mut index = repo.index().unwrap();
+        index.add_path(std::path::Path::new(path)).unwrap();
+        index.write().unwrap();
+        index.get_path(std::path::Path::new(path), 0).unwrap().id
+    }
+
+    #[tokio::test]
+    async fn test_cherry_pick_refuses_preexisting_staged_changes() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_commit("Add unrelated", &[("unrelated.txt", "original")]);
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let feature_oid = test_repo.create_commit("Feature commit", &[("feature.txt", "feature")]);
+        test_repo.checkout_branch("main");
+
+        let staged_oid = stage_file(&test_repo, "unrelated.txt", "STAGED WORK");
+        let result = cherry_pick(test_repo.path_str(), feature_oid.to_string(), None, None).await;
+
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("index has staged changes"));
+        assert_eq!(test_repo.repo().state(), git2::RepositoryState::Clean);
+        assert_eq!(
+            test_repo
+                .repo()
+                .index()
+                .unwrap()
+                .get_path(std::path::Path::new("unrelated.txt"), 0)
+                .unwrap()
+                .id,
+            staged_oid
+        );
+    }
+
+    #[tokio::test]
+    async fn test_revert_refuses_preexisting_staged_changes() {
+        let test_repo = TestRepo::with_initial_commit();
+        let revert_oid = test_repo.create_commit("Add file", &[("file.txt", "content")]);
+        test_repo.create_commit("Add unrelated", &[("unrelated.txt", "original")]);
+
+        let staged_oid = stage_file(&test_repo, "unrelated.txt", "STAGED WORK");
+        let result = revert(test_repo.path_str(), revert_oid.to_string(), None).await;
+
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("index has staged changes"));
+        assert_eq!(test_repo.repo().state(), git2::RepositoryState::Clean);
+        assert_eq!(
+            test_repo
+                .repo()
+                .index()
+                .unwrap()
+                .get_path(std::path::Path::new("unrelated.txt"), 0)
+                .unwrap()
+                .id,
+            staged_oid
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cherry_pick_range_refuses_preexisting_staged_changes() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_commit("Add unrelated", &[("unrelated.txt", "original")]);
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        let feature_oid = test_repo.create_commit("Feature commit", &[("feature.txt", "feature")]);
+        test_repo.checkout_branch("main");
+
+        let staged_oid = stage_file(&test_repo, "unrelated.txt", "STAGED WORK");
+        let result = cherry_pick_range(test_repo.path_str(), vec![feature_oid.to_string()]).await;
+
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("index has staged changes"));
+        assert_eq!(test_repo.repo().state(), git2::RepositoryState::Clean);
+        assert_eq!(
+            test_repo
+                .repo()
+                .index()
+                .unwrap()
+                .get_path(std::path::Path::new("unrelated.txt"), 0)
+                .unwrap()
+                .id,
+            staged_oid
+        );
+    }
+
+    #[tokio::test]
+    async fn test_cherry_pick_from_branch_refuses_preexisting_staged_changes() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_commit("Add unrelated", &[("unrelated.txt", "original")]);
+        test_repo.create_branch("feature");
+        test_repo.checkout_branch("feature");
+        test_repo.create_commit("Feature commit", &[("feature.txt", "feature")]);
+        test_repo.checkout_branch("main");
+
+        let staged_oid = stage_file(&test_repo, "unrelated.txt", "STAGED WORK");
+        let result =
+            cherry_pick_from_branch(test_repo.path_str(), "feature".to_string(), None).await;
+
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("index has staged changes"));
+        assert_eq!(test_repo.repo().state(), git2::RepositoryState::Clean);
+        assert_eq!(
+            test_repo
+                .repo()
+                .index()
+                .unwrap()
+                .get_path(std::path::Path::new("unrelated.txt"), 0)
+                .unwrap()
+                .id,
+            staged_oid
+        );
+    }
+
+    #[tokio::test]
+    async fn test_no_commit_cherry_pick_refuses_preexisting_staged_changes() {
+        let test_repo = TestRepo::with_initial_commit();
+        test_repo.create_commit(
+            "Add files",
+            &[("conflict.txt", "base"), ("unrelated.txt", "original")],
+        );
+        let repo = test_repo.repo();
+        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
+        let parent = head_commit.parent(0).unwrap();
+        repo.branch("feature", &parent, false).unwrap();
+        test_repo.checkout_branch("feature");
+        let feature_oid =
+            test_repo.create_commit("Feature conflict", &[("conflict.txt", "feature")]);
+        test_repo.checkout_branch("main");
+        test_repo.create_commit("Main conflict", &[("conflict.txt", "main")]);
+
+        let staged_oid = stage_file(&test_repo, "unrelated.txt", "PRECIOUS STAGED WORK");
+        let result = cherry_pick(
+            test_repo.path_str(),
+            feature_oid.to_string(),
+            Some(true),
+            None,
+        )
+        .await;
+        assert!(result
+            .unwrap_err()
+            .to_string()
+            .contains("index has staged changes"));
+
+        let repo = test_repo.repo();
+        assert_eq!(repo.state(), git2::RepositoryState::Clean);
+        assert_eq!(
+            std::fs::read_to_string(test_repo.path.join("unrelated.txt")).unwrap(),
+            "PRECIOUS STAGED WORK"
+        );
+        assert_eq!(
+            repo.index()
+                .unwrap()
+                .get_path(std::path::Path::new("unrelated.txt"), 0)
+                .unwrap()
+                .id,
+            staged_oid
+        );
+    }
 
     #[tokio::test]
     async fn test_abort_cherry_pick_preserves_unrelated_changes() {

--- a/src/__tests__/app-shell-revert-precondition.test.ts
+++ b/src/__tests__/app-shell-revert-precondition.test.ts
@@ -1,0 +1,125 @@
+/**
+ * Revert precondition failures in app-shell.
+ *
+ * The backend refuses a revert whose index holds staged work it would destroy
+ * (staged changes, or unmerged entries left by a conflicted stash apply). Those
+ * are precondition failures with nothing to resolve, so the graph's Revert
+ * gesture must surface them as an error toast and leave the conflict-resolution
+ * dialog shut — opening it would offer Resolve/Abort over a repository with no
+ * operation in progress.
+ */
+
+const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
+const mockResponses: Record<string, (args: Record<string, unknown>) => unknown> = {};
+const mockErrors: Record<string, { code: string; message: string }> = {};
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCallArgs.push({ command, args: args || {} });
+    if (mockErrors[command]) return Promise.reject(mockErrors[command]);
+    const handler = mockResponses[command];
+    return Promise.resolve(handler ? handler(args || {}) : null);
+  },
+  transformCallback: () => cbId++,
+};
+
+import { expect } from '@open-wc/testing';
+import type { AppShell } from '../app-shell.ts';
+import '../app-shell.ts';
+import { uiStore, repositoryStore } from '../stores/index.ts';
+import type { Repository } from '../types/git.types.ts';
+import { resetRefOpLocks } from '../utils/ref-lock.ts';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+const STAGED_CHANGES_MSG =
+  'The index has staged changes. Commit or stash them before starting this operation.';
+const UNMERGED_MSG = 'The index has unmerged files. Resolve them before starting this operation.';
+
+function mockRepo(): Repository {
+  return {
+    path: '/repo/one',
+    name: 'one',
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    detachedHeadOid: null,
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  } as Repository;
+}
+
+describe('app-shell revert precondition failures', () => {
+  beforeEach(() => {
+    resetRefOpLocks();
+    invokeCallArgs.length = 0;
+    for (const k of Object.keys(mockResponses)) delete mockResponses[k];
+    for (const k of Object.keys(mockErrors)) delete mockErrors[k];
+    uiStore.setState({ toasts: [] });
+    repositoryStore.getState().reset();
+    // The revert gesture confirms first. plugin-dialog's confirm() routes
+    // through the 'message' command and reads the clicked button's label back.
+    mockResponses['plugin:dialog|message'] = () => 'Ok';
+  });
+
+  afterEach(() => {
+    repositoryStore.getState().reset();
+  });
+
+  for (const { name, message } of [
+    { name: 'staged changes', message: STAGED_CHANGES_MSG },
+    { name: 'unmerged files', message: UNMERGED_MSG },
+  ]) {
+    it(`toasts a ${name} refusal without opening the conflict dialog`, async () => {
+      mockErrors['revert'] = { code: 'OPERATION_FAILED', message };
+
+      const el = document.createElement('lv-app-shell') as AppShell;
+      (el as any).activeRepository = { repository: mockRepo() };
+      (el as any).contextMenu = {
+        visible: true,
+        x: 0,
+        y: 0,
+        commit: { oid: 'abc1234deadbeef', summary: 's', body: null, parentIds: ['p1'] },
+      };
+
+      await (el as any).revertCommit();
+
+      expect(
+        invokeCallArgs.some((c) => c.command === 'revert'),
+        'the revert was actually attempted',
+      ).to.equal(true);
+      expect(
+        uiStore.getState().toasts.some((t) => t.type === 'error' && t.message.includes(message)),
+        `the refusal must reach the user; toasts were ${JSON.stringify(
+          uiStore.getState().toasts.map((t) => t.message),
+        )}`,
+      ).to.equal(true);
+      expect(
+        (el as any).showConflictDialog,
+        'nothing is in progress, so there is no conflict to resolve',
+      ).to.not.equal(true);
+    });
+  }
+
+  it('still routes a genuine revert conflict to the conflict dialog', async () => {
+    mockErrors['revert'] = { code: 'REVERT_CONFLICT', message: 'Revert conflict' };
+
+    const repo = mockRepo();
+    const el = document.createElement('lv-app-shell') as AppShell;
+    (el as any).activeRepository = { repository: repo };
+    (el as any).contextMenu = {
+      visible: true,
+      x: 0,
+      y: 0,
+      commit: { oid: 'abc1234deadbeef', summary: 's', body: null, parentIds: ['p1'] },
+    };
+
+    await (el as any).revertCommit();
+
+    expect((el as any).showConflictDialog).to.equal(true);
+    expect((el as any).conflictOperationType).to.equal('revert');
+  });
+});

--- a/src/components/dialogs/__tests__/lv-cherry-pick-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-cherry-pick-dialog.test.ts
@@ -12,6 +12,7 @@ import type { Commit } from '../../../types/git.types.ts';
 
 let lastInvokedCommand: string | null = null;
 let lastInvokedArgs: Record<string, unknown> | null = null;
+let cherryPickError: { code: string; message: string } | null = null;
 let cbId = 0;
 
 type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
@@ -21,6 +22,7 @@ const mockInvoke: MockInvoke = async (command: string, args?: unknown) => {
   lastInvokedCommand = command;
   lastInvokedArgs = (args as Record<string, unknown>) ?? null;
   if (command === 'cherry_pick') {
+    if (cherryPickError) throw cherryPickError;
     // Mimic a successful cherry-pick returning the new commit.
     return {
       oid: 'newcommit0000',
@@ -65,6 +67,7 @@ describe('lv-cherry-pick-dialog', () => {
   beforeEach(() => {
     lastInvokedCommand = null;
     lastInvokedArgs = null;
+    cherryPickError = null;
   });
 
   it('shows a mainline selector only for merge commits', async () => {
@@ -206,4 +209,50 @@ describe('lv-cherry-pick-dialog', () => {
     ).to.contain('main');
     expect(el.shadowRoot!.querySelector('.target-branch')?.textContent).to.not.contain('develop');
   });
+
+  // The backend refuses a cherry-pick whose index would destroy staged work.
+  // That is a precondition failure with nothing to resolve, so it must land
+  // inline in the dialog — routing it to the conflict-resolution flow would
+  // open a resolve/abort UI over a repository with no operation in progress.
+  // The routing at handleCherryPick() falls back to a substring match on
+  // "conflict", so these also pin the wording of both refusal messages.
+  for (const { name, message } of [
+    {
+      name: 'staged changes',
+      message:
+        'The index has staged changes. Commit or stash them before starting this operation.',
+    },
+    {
+      name: 'unmerged files',
+      message: 'The index has unmerged files. Resolve them before starting this operation.',
+    },
+  ]) {
+    it(`reports a ${name} refusal inline instead of opening the conflict dialog`, async () => {
+      cherryPickError = { code: 'OPERATION_FAILED', message };
+
+      const el = await fixture<LvCherryPickDialog>(
+        html`<lv-cherry-pick-dialog .repositoryPath=${'/test/repo'}></lv-cherry-pick-dialog>`,
+      );
+      el.open(makeCommit(['p1']));
+      await el.updateComplete;
+
+      let conflictFired = false;
+      el.addEventListener('cherry-pick-conflict', () => {
+        conflictFired = true;
+      });
+
+      const btn = Array.from(el.shadowRoot!.querySelectorAll('button')).find((b) =>
+        /cherry-pick/i.test(b.textContent ?? ''),
+      ) as HTMLButtonElement;
+      btn.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      expect(conflictFired, 'must not route a precondition failure to the conflict dialog').to.be
+        .false;
+      expect(el.shadowRoot!.querySelector('.error-message')?.textContent).to.contain(message);
+      // The dialog stays open so the user can act and retry.
+      expect(el.shadowRoot!.querySelector('lv-modal')?.hasAttribute('open')).to.be.true;
+    });
+  }
 });


### PR DESCRIPTION
## Summary
- refuse cherry-pick and revert operations when the index already contains staged changes
- cover single, range, branch-based, and no-commit cherry-pick entry points
- preserve existing support for unrelated unstaged work and clean-index no-commit operations

## Why
Abort previously identified operation-owned paths by diffing HEAD against the current index. Pre-existing staged paths therefore looked operation-owned and could be overwritten during abort. Rejecting the operation before mutation prevents that data loss and matches normal Git safety behavior.

## Validation
- 89 rewrite command tests pass
- lint and typecheck pass
- three independent large-model reviews found no issues
- full frontend suite remains blocked by 190 pre-existing dialog-mock failures
- cargo fmt --check remains blocked by pre-existing untracked checkout scratch tests
- clippy remains blocked by missing local NASM support for aws-lc-sys