### PR TITLE
fix: prevent stale diff actions after selection changes

### DIFF
--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -1308,6 +1308,86 @@ describe('lv-diff-view', () => {
       const writes = invokeHistory.filter((c) => c.command === 'write_file_content');
       expect(writes.length, "B.ts is never written with A's content").to.equal(0);
     });
+
+    it('closes the editor when the file being edited becomes conflicted', async () => {
+      // A merge run elsewhere turns the open file conflicted; app-shell swaps in
+      // the fresh status entry. The path still matches, so nothing else closes
+      // the editor — and the conflict notice hides the textarea, parking the
+      // pre-conflict buffer out of sight instead of reporting it.
+      setupDefaultMocks({ fileContent: 'contents of main' });
+      const el = await renderDiffView({ file: makeStatusEntry({ path: 'src/main.ts' }) });
+
+      (el.shadowRoot!.querySelector('.edit-btn') as HTMLElement).click();
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const textarea = el.shadowRoot!.querySelector('.editor-textarea') as HTMLTextAreaElement;
+      textarea.value = 'pre-conflict text';
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+
+      uiStore.setState({ toasts: [] });
+      el.file = makeStatusEntry({ path: 'src/main.ts', isConflicted: true, status: 'conflicted' });
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const view = el as unknown as { editMode: boolean; editContent: string };
+      expect(view.editMode, 'the editor closes on the conflicted transition').to.be.false;
+      expect(view.editContent).to.equal('');
+      const warnings = uiStore.getState().toasts.filter((t) => t.type === 'warning');
+      expect(
+        warnings.some((t) => t.message.includes('src/main.ts')),
+        'the dropped text is reported, not silently parked behind the conflict notice',
+      ).to.be.true;
+
+      // Resolving the conflict swaps the entry back — the editor must not
+      // reappear holding text from before the merge.
+      el.file = makeStatusEntry({ path: 'src/main.ts', isConflicted: false });
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      expect(
+        el.shadowRoot!.querySelector('.editor-textarea'),
+        'the pre-conflict buffer does not come back over the resolved file',
+      ).to.be.null;
+      expect(view.editContent).to.equal('');
+    });
+
+    it('does not report a save in flight as unsaved edits', async () => {
+      // app-shell's teardowns (the x button, Escape, a repository tab switch)
+      // read hasUnsavedEdits to warn. A write already on its way to disk is not
+      // lost text — saveEdit reports its own failure.
+      const write = deferred<unknown>();
+      setupDefaultMocks({ fileContent: 'contents of main' });
+      const el = await renderDiffView({ file: makeStatusEntry({ path: 'src/main.ts' }) });
+
+      (el.shadowRoot!.querySelector('.edit-btn') as HTMLElement).click();
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const textarea = el.shadowRoot!.querySelector('.editor-textarea') as HTMLTextAreaElement;
+      textarea.value = 'edited text';
+      textarea.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      expect(el.hasUnsavedEdits, 'typed text with no save started is unsaved').to.be.true;
+
+      mockInvoke = async (command: string) => {
+        if (command === 'write_file_content') return write.promise;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const save = (el as unknown as { saveEdit: () => Promise<void> }).saveEdit();
+      await el.updateComplete;
+      expect(el.hasUnsavedEdits, 'a write in flight is not discarded text').to.be.false;
+
+      write.reject({ code: 'COMMAND_ERROR', message: 'permission denied' });
+      await save;
+      await el.updateComplete;
+
+      expect(el.hasUnsavedEdits, 'a failed write leaves the text unsaved again').to.be.true;
+    });
   });
 
   // ── Conflicted files ──────────────────────────────────────────────────

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -697,6 +697,152 @@ describe('lv-diff-view', () => {
       await el.updateComplete;
     });
 
+    it('disables the context-menu stage items while a stage is in flight', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: false }) });
+      const stage = deferred<unknown>();
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      clearHistory();
+      (el.shadowRoot!.querySelector('.stage-btn.stage') as HTMLButtonElement).click();
+      await el.updateComplete;
+
+      // A contextmenu event never reaches the document click handler, so the
+      // menu still opens while the stage is in flight.
+      (el.shadowRoot!.querySelector('.line.code-addition') as HTMLElement).dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+      );
+      await el.updateComplete;
+
+      const menuItem = (label: string): HTMLButtonElement => {
+        const item = Array.from(el.shadowRoot!.querySelectorAll('.context-menu-item')).find(
+          (b) => (b.textContent ?? '').includes(label)
+        ) as HTMLButtonElement | undefined;
+        expect(item, `the "${label}" context-menu item renders`).to.not.be.undefined;
+        return item!;
+      };
+
+      expect(
+        menuItem('Stage hunk').disabled,
+        'the in-flight stage is visible on the context menu instead of the click being dropped'
+      ).to.be.true;
+      expect(
+        menuItem('Stage line').disabled,
+        'the in-flight stage is visible on the context menu instead of the click being dropped'
+      ).to.be.true;
+      expect(menuItem('Copy line').disabled, 'copy stays usable during a stage').to.be.false;
+
+      stage.resolve(undefined);
+      await flushAsyncUpdates(el);
+      await el.updateComplete;
+
+      expect(menuItem('Stage hunk').disabled, 're-enabled once the stage completes').to.be.false;
+      expect(menuItem('Stage line').disabled, 're-enabled once the stage completes').to.be.false;
+    });
+
+    it('disables the context-menu unstage items while an unstage is in flight', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: true }) });
+      const unstage = deferred<unknown>();
+      mockInvoke = async (command: string) => {
+        if (command === 'unstage_hunk') return unstage.promise;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      clearHistory();
+      (el.shadowRoot!.querySelector('.stage-btn.unstage') as HTMLButtonElement).click();
+      await el.updateComplete;
+
+      (el.shadowRoot!.querySelector('.line.code-addition') as HTMLElement).dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, cancelable: true })
+      );
+      await el.updateComplete;
+
+      const menuItem = (label: string): HTMLButtonElement => {
+        const item = Array.from(el.shadowRoot!.querySelectorAll('.context-menu-item')).find(
+          (b) => (b.textContent ?? '').includes(label)
+        ) as HTMLButtonElement | undefined;
+        expect(item, `the "${label}" context-menu item renders`).to.not.be.undefined;
+        return item!;
+      };
+
+      expect(
+        menuItem('Unstage hunk').disabled,
+        'the in-flight unstage is visible on the context menu'
+      ).to.be.true;
+      expect(
+        menuItem('Unstage line').disabled,
+        'the in-flight unstage is visible on the context menu'
+      ).to.be.true;
+
+      unstage.reject(new Error('patch does not apply'));
+      await flushAsyncUpdates(el);
+      await el.updateComplete;
+
+      expect(
+        menuItem('Unstage hunk').disabled,
+        'a failed unstage leaves the context-menu item usable again'
+      ).to.be.false;
+    });
+
+    it('does not clear a newly selected file when a superseded reload reports "not found in diff"', async () => {
+      const el = await renderDiffView({
+        file: makeStatusEntry({ path: 'src/main.ts', isStaged: false }),
+      });
+      const view = el as unknown as {
+        diff: DiffFile;
+        error: string | null;
+        initCodeLanguage: (path: string) => Promise<void>;
+        handleStageHunk: (hunk: DiffHunk, event: Event) => Promise<void>;
+      };
+      view.initCodeLanguage = async () => {};
+      const hunk = view.diff.hunks[0];
+
+      const reloadOfStagedFile = deferred<DiffFile>();
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'stage_hunk') return null;
+        if (command === 'get_file_diff') {
+          const filePath = (args as { filePath: string }).filePath;
+          if (filePath === 'src/main.ts') return reloadOfStagedFile.promise;
+          // The file the user switches to has nothing left to show on its own.
+          throw {
+            code: 'COMMAND_ERROR',
+            message: "File 'src/next.ts' not found in diff. Staged: false.",
+          };
+        }
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      let cleared = 0;
+      el.addEventListener('file-cleared', () => cleared++);
+
+      const operation = view.handleStageHunk(hunk, new Event('click'));
+      // Let stage_hunk settle so the reload of src/main.ts is in flight.
+      await flushAsyncUpdates(el);
+
+      el.file = makeStatusEntry({ path: 'src/next.ts', isStaged: false });
+      await flushAsyncUpdates(el);
+      expect(view.error, 'the newly selected file reported its own load error').to.contain(
+        'not found in diff'
+      );
+
+      reloadOfStagedFile.resolve(makeDiffFile({ path: 'src/main.ts' }));
+      await operation;
+      await el.updateComplete;
+
+      expect(
+        el.file?.path,
+        'the superseded reload cleared the file the user had switched to'
+      ).to.equal('src/next.ts');
+      expect(cleared, 'file-cleared was dispatched for a file that was never staged').to.equal(0);
+    });
+
     it('disables every editor exit and input while saving', async () => {
       const el = await renderDiffView();
       (el.shadowRoot!.querySelector('.edit-btn') as HTMLElement).click();

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -588,6 +588,115 @@ describe('lv-diff-view', () => {
       await Promise.all([first, second]);
     });
 
+    it('disables the hunk Stage button while its stage is in flight', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: false }) });
+      const stage = deferred<unknown>();
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      clearHistory();
+      const stageBtn = el.shadowRoot!.querySelector('.stage-btn.stage') as HTMLButtonElement;
+      expect(stageBtn, 'the hunk Stage button renders').to.not.be.null;
+      expect(stageBtn.disabled, 'enabled before any mutation').to.be.false;
+
+      stageBtn.click();
+      await el.updateComplete;
+
+      expect(
+        (el.shadowRoot!.querySelector('.stage-btn.stage') as HTMLButtonElement).disabled,
+        'the in-flight stage is visible on the button instead of being silently swallowed'
+      ).to.be.true;
+
+      // A second click on the now-disabled button cannot reach the handler.
+      (el.shadowRoot!.querySelector('.stage-btn.stage') as HTMLButtonElement).click();
+      expect(findCommands('stage_hunk').length).to.equal(1);
+
+      stage.resolve(undefined);
+      await flushAsyncUpdates(el);
+      await el.updateComplete;
+
+      expect(
+        (el.shadowRoot!.querySelector('.stage-btn.stage') as HTMLButtonElement).disabled,
+        're-enabled once the stage completes'
+      ).to.be.false;
+    });
+
+    it('re-enables the hunk Unstage button after its unstage fails', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: true }) });
+      const unstage = deferred<unknown>();
+      mockInvoke = async (command: string) => {
+        if (command === 'unstage_hunk') return unstage.promise;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const unstageBtn = el.shadowRoot!.querySelector('.stage-btn.unstage') as HTMLButtonElement;
+      expect(unstageBtn, 'the hunk Unstage button renders').to.not.be.null;
+      unstageBtn.click();
+      await el.updateComplete;
+
+      expect(
+        (el.shadowRoot!.querySelector('.stage-btn.unstage') as HTMLButtonElement).disabled,
+        'disabled while the unstage is in flight'
+      ).to.be.true;
+
+      unstage.reject(new Error('patch does not apply'));
+      await flushAsyncUpdates(el);
+      await el.updateComplete;
+
+      expect(
+        (el.shadowRoot!.querySelector('.stage-btn.unstage') as HTMLButtonElement).disabled,
+        'a failed unstage leaves the button usable again'
+      ).to.be.false;
+    });
+
+    it('disables Stage Selected while the bulk stage is in flight', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: false }) });
+      const selectionBtn = (): HTMLButtonElement =>
+        el.shadowRoot!.querySelector('.selection-actions .selection-btn.primary') as HTMLButtonElement;
+
+      const toggle = Array.from(el.shadowRoot!.querySelectorAll('.view-btn')).find(
+        (b) => b.getAttribute('title') === 'Toggle line selection mode for staging individual lines'
+      ) as HTMLElement;
+      expect(toggle, 'the line-selection toggle renders').to.not.be.undefined;
+      toggle.click();
+      await el.updateComplete;
+
+      (el.shadowRoot!.querySelector('.line.code-addition') as HTMLElement).click();
+      await el.updateComplete;
+      expect(selectionBtn(), 'the bulk selection bar renders').to.not.be.null;
+      expect(selectionBtn().disabled, 'enabled before any mutation').to.be.false;
+
+      const stage = deferred<unknown>();
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      clearHistory();
+      selectionBtn().click();
+      await el.updateComplete;
+
+      expect(
+        selectionBtn().disabled,
+        'the in-flight bulk stage is visible on the button'
+      ).to.be.true;
+
+      selectionBtn().click();
+      expect(findCommands('stage_hunk').length).to.equal(1);
+
+      stage.resolve(undefined);
+      await flushAsyncUpdates(el);
+      await el.updateComplete;
+    });
+
     it('disables every editor exit and input while saving', async () => {
       const el = await renderDiffView();
       (el.shadowRoot!.querySelector('.edit-btn') as HTMLElement).click();

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -593,8 +593,10 @@ describe('lv-diff-view', () => {
       // context, but the pane still shows the file the stage was applied to.
       const full = view.handleLoadFullDiff();
       stage.resolve(undefined);
-      expect(await apply, 'the stage was applied').to.be.true;
+      // The apply now re-fetches once it lands, so the reload has to be able to
+      // answer that request too.
       reload.resolve(makeDiffFile());
+      expect(await apply, 'the stage was applied').to.be.true;
       await full;
       await flushAsyncUpdates(el);
 
@@ -626,8 +628,8 @@ describe('lv-diff-view', () => {
       const apply = view.handleStageHunk(view.diff.hunks[0], new Event('click'));
       const full = view.handleLoadFullDiff();
       stage.resolve(undefined);
-      await apply;
       reload.resolve(makeDiffFile());
+      await apply;
       await full;
       await flushAsyncUpdates(el);
 
@@ -635,6 +637,104 @@ describe('lv-diff-view', () => {
         view.selectedLines.size,
         'line indexes invalidated by the hunk stage survived into the renumbered diff',
       ).to.equal(0);
+    });
+
+    it('re-fetches after a hunk stage that raced a same-file reload', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: false }) });
+      const view = el as unknown as {
+        diff: DiffFile | null;
+        handleStageHunk: (hunk: DiffHunk, event: Event) => Promise<void>;
+        handleLoadFullDiff: () => Promise<void>;
+      };
+      const stage = deferred<unknown>();
+      const staleReload = deferred<DiffFile>();
+      const staleRequested = deferred<void>();
+      const preApply = makeDiffFile({ hunks: [makeDiffHunk({ header: '@@ pre-apply @@' })] });
+      const postApply = makeDiffFile({ hunks: [makeDiffHunk({ header: '@@ post-apply @@' })] });
+      let diffCalls = 0;
+
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') {
+          diffCalls++;
+          // The first reload asked for the diff before the stage landed, so it
+          // can only answer with the pre-apply content.
+          if (diffCalls === 1) {
+            staleRequested.resolve(undefined);
+            return staleReload.promise;
+          }
+          return postApply;
+        }
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const hunk = view.diff!.hunks[0];
+      const apply = view.handleStageHunk(hunk, new Event('click'));
+      const full = view.handleLoadFullDiff();
+      await staleRequested.promise;
+      stage.resolve(undefined);
+      await apply;
+      staleReload.resolve(preApply);
+      await full;
+      await settleAsyncUpdates(el);
+
+      expect(
+        view.diff?.hunks[0]?.header,
+        'the pre-apply diff a racing reload had already asked for was left in the pane',
+      ).to.equal('@@ post-apply @@');
+    });
+
+    it('clears the pane when a stage that raced a same-file reload emptied the file', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: false }) });
+      const view = el as unknown as {
+        diff: DiffFile | null;
+        handleStageHunk: (hunk: DiffHunk, event: Event) => Promise<void>;
+        handleLoadFullDiff: () => Promise<void>;
+      };
+      const stage = deferred<unknown>();
+      const staleReload = deferred<DiffFile>();
+      const staleRequested = deferred<void>();
+      let cleared = 0;
+      el.addEventListener('file-cleared', () => cleared++);
+      let diffCalls = 0;
+
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') {
+          diffCalls++;
+          if (diffCalls === 1) {
+            staleRequested.resolve(undefined);
+            return staleReload.promise;
+          }
+          // The stage took the file's last unstaged hunk, so there is no
+          // unstaged diff left for the backend to answer with.
+          throw {
+            code: 'COMMAND_ERROR',
+            message: "File 'src/main.ts' not found in diff. Staged: false. Found 0 files: []",
+          };
+        }
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const hunk = view.diff!.hunks[0];
+      const apply = view.handleStageHunk(hunk, new Event('click'));
+      const full = view.handleLoadFullDiff();
+      await staleRequested.promise;
+      stage.resolve(undefined);
+      await apply;
+      staleReload.resolve(makeDiffFile());
+      await full;
+      await settleAsyncUpdates(el);
+
+      expect(cleared, 'a fully applied file left the pane bound after a racing reload').to.equal(1);
+      expect(el.file, 'the fully applied file stayed bound to the pane').to.be.null;
+      expect(view.diff, 'the emptied diff stayed painted in the pane').to.be.null;
+      expect(
+        el.shadowRoot!.textContent,
+        'the backend\'s "not found in diff" text was painted into the pane',
+      ).to.not.contain('not found in diff');
     });
 
     it('keeps a selection made in another file after an apply to the previous one', async () => {

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -153,8 +153,7 @@ function setupDefaultMocks(opts: {
         return undefined;
       case 'get_diff_tool':
         return opts.diffToolConfig ?? { tool: null };
-      case 'plugin:dialog|confirm':
-        return confirmAnswer === 'Ok';
+      // showConfirm() resolves to (this result === okLabel); default ok is 'Ok'.
       case 'plugin:dialog|message':
         return confirmAnswer;
       default:
@@ -568,6 +567,104 @@ describe('lv-diff-view', () => {
       await view.handleStageHunk(view.diff.hunks[0], new Event('click'));
 
       expect(view.selectedLines.size).to.equal(0);
+    });
+
+    it('clears positional selections when a same-file reload starts mid-apply', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: false }) });
+      const view = el as unknown as {
+        selectedLines: Set<string>;
+        stageSelectedLines: () => Promise<boolean>;
+        handleLoadFullDiff: () => Promise<void>;
+      };
+      const stage = deferred<unknown>();
+      const reload = deferred<DiffFile>();
+      view.selectedLines = new Set(['0-2']);
+
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') return reload.promise;
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const apply = view.stageSelectedLines();
+      // "Load full diff" is not disabled while a mutation is in flight, so it
+      // can start a reload of the SAME file mid-apply. That leaves no loaded
+      // context, but the pane still shows the file the stage was applied to.
+      const full = view.handleLoadFullDiff();
+      stage.resolve(undefined);
+      expect(await apply, 'the stage was applied').to.be.true;
+      reload.resolve(makeDiffFile());
+      await full;
+      await flushAsyncUpdates(el);
+
+      expect(
+        view.selectedLines.size,
+        'line indexes invalidated by the apply survived into the renumbered diff',
+      ).to.equal(0);
+    });
+
+    it('clears positional selections when a same-file reload starts mid hunk stage', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: false }) });
+      const view = el as unknown as {
+        diff: DiffFile;
+        selectedLines: Set<string>;
+        handleStageHunk: (hunk: DiffHunk, event: Event) => Promise<void>;
+        handleLoadFullDiff: () => Promise<void>;
+      };
+      const stage = deferred<unknown>();
+      const reload = deferred<DiffFile>();
+      view.selectedLines = new Set(['0-2']);
+
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') return reload.promise;
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const apply = view.handleStageHunk(view.diff.hunks[0], new Event('click'));
+      const full = view.handleLoadFullDiff();
+      stage.resolve(undefined);
+      await apply;
+      reload.resolve(makeDiffFile());
+      await full;
+      await flushAsyncUpdates(el);
+
+      expect(
+        view.selectedLines.size,
+        'line indexes invalidated by the hunk stage survived into the renumbered diff',
+      ).to.equal(0);
+    });
+
+    it('keeps a selection made in another file after an apply to the previous one', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: false }) });
+      const view = el as unknown as {
+        selectedLines: Set<string>;
+        stageSelectedLines: () => Promise<boolean>;
+      };
+      const stage = deferred<unknown>();
+      view.selectedLines = new Set(['0-2']);
+
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') return makeDiffFile({ path: 'src/next.ts' });
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const apply = view.stageSelectedLines();
+      el.file = makeStatusEntry({ path: 'src/next.ts' });
+      await flushAsyncUpdates(el);
+      view.selectedLines = new Set(['0-1']);
+      stage.resolve(undefined);
+      await apply;
+      await flushAsyncUpdates(el);
+
+      expect(
+        [...view.selectedLines],
+        'an apply to the previous file cleared a selection made in the new one',
+      ).to.deep.equal(['0-1']);
     });
 
     it('serializes overlapping hunk staging operations', async () => {

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -101,6 +101,26 @@ function clearHistory(): void {
   invokeHistory.length = 0;
 }
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flushAsyncUpdates(el: LvDiffView): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0));
+  await el.updateComplete;
+  await new Promise((resolve) => setTimeout(resolve, 0));
+}
+
 function findCommands(name: string): Array<{ command: string; args?: unknown }> {
   return invokeHistory.filter((h) => h.command === name);
 }
@@ -128,7 +148,8 @@ function setupDefaultMocks(opts: {
         return undefined;
       case 'get_diff_tool':
         return opts.diffToolConfig ?? { tool: null };
-      // showConfirm() resolves to (this result === okLabel); default ok is 'Ok'.
+      case 'plugin:dialog|confirm':
+        return confirmAnswer === 'Ok';
       case 'plugin:dialog|message':
         return confirmAnswer;
       default:
@@ -194,6 +215,393 @@ describe('lv-diff-view', () => {
     // Word wrap is a shared setting now — start every test from a known off.
     settingsStore.getState().setWordWrap(false);
     localStorage.removeItem('leviathan-diff-word-wrap');
+  });
+
+  describe('async diff context pinning', () => {
+    it('ignores a working diff response for a file that is no longer selected', async () => {
+      const el = document.createElement('lv-diff-view') as LvDiffView;
+      const first = deferred<DiffFile>();
+      const second = deferred<DiffFile>();
+
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_file_diff') {
+          const filePath = (args as { filePath: string }).filePath;
+          return filePath === 'src/first.ts' ? first.promise : second.promise;
+        }
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      el.repositoryPath = REPO_PATH;
+      (el as unknown as { initCodeLanguage: () => Promise<void> }).initCodeLanguage =
+        async () => {};
+      el.file = makeStatusEntry({ path: 'src/first.ts' });
+      const firstLoad = (
+        el as unknown as { loadWorkingDiff: () => Promise<void> }
+      ).loadWorkingDiff();
+      el.file = makeStatusEntry({ path: 'src/second.ts' });
+      const secondLoad = (
+        el as unknown as { loadWorkingDiff: () => Promise<void> }
+      ).loadWorkingDiff();
+
+      second.resolve(makeDiffFile({ path: 'src/second.ts' }));
+      first.resolve(makeDiffFile({ path: 'src/first.ts' }));
+      await Promise.all([firstLoad, secondLoad]);
+      expect(
+        (el as unknown as { diff: DiffFile }).diff.path,
+        'the older response replaced the selected file diff',
+      ).to.equal('src/second.ts');
+    });
+
+    it('ignores a commit diff response for a commit file that is no longer selected', async () => {
+      const el = document.createElement('lv-diff-view') as LvDiffView;
+      const first = deferred<DiffFile>();
+      const second = deferred<DiffFile>();
+
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'get_commit_file_diff') {
+          const filePath = (args as { filePath: string }).filePath;
+          return filePath === 'src/first.ts' ? first.promise : second.promise;
+        }
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      el.repositoryPath = REPO_PATH;
+      (el as unknown as { initCodeLanguage: () => Promise<void> }).initCodeLanguage =
+        async () => {};
+      el.commitFile = { commitOid: 'first', filePath: 'src/first.ts' };
+      const firstLoad = (
+        el as unknown as { loadCommitDiff: () => Promise<void> }
+      ).loadCommitDiff();
+      el.commitFile = { commitOid: 'second', filePath: 'src/second.ts' };
+      const secondLoad = (
+        el as unknown as { loadCommitDiff: () => Promise<void> }
+      ).loadCommitDiff();
+
+      second.resolve(makeDiffFile({ path: 'src/second.ts' }));
+      first.resolve(makeDiffFile({ path: 'src/first.ts' }));
+      await Promise.all([firstLoad, secondLoad]);
+
+      expect(
+        (el as unknown as { diff: DiffFile }).diff.path,
+        'the older commit response replaced the selected commit file diff',
+      ).to.equal('src/second.ts');
+    });
+
+    it('does not stage a displayed hunk after the selection changes', async () => {
+      const el = await renderDiffView();
+      const oldDiff = (el as unknown as { diff: DiffFile }).diff;
+
+      mockInvoke = async (command: string) => {
+        if (command === 'get_file_diff') return makeDiffFile({ path: 'src/next.ts' });
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      el.file = makeStatusEntry({ path: 'src/next.ts' });
+      clearHistory();
+
+      await (
+        el as unknown as {
+          handleStageHunk: (hunk: DiffHunk, event: Event) => Promise<void>;
+        }
+      ).handleStageHunk(oldDiff.hunks[0], new Event('click'));
+
+      expect(
+        findCommands('stage_hunk').length,
+        'a hunk from the previous file was staged against the new selection',
+      ).to.equal(0);
+      await flushAsyncUpdates(el);
+    });
+
+    it('clears positional line selections before the replacement diff can use them', async () => {
+      const el = await renderDiffView();
+      (el as unknown as { selectedLines: Set<string> }).selectedLines = new Set(['0-1']);
+
+      mockInvoke = async (command: string) => {
+        if (command === 'get_file_diff') return makeDiffFile({ path: 'src/next.ts' });
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      el.file = makeStatusEntry({ path: 'src/next.ts' });
+      await flushAsyncUpdates(el);
+
+      clearHistory();
+      await (
+        el as unknown as { stageSelectedLines: () => Promise<boolean> }
+      ).stageSelectedLines();
+
+      expect(
+        findCommands('stage_hunk').length,
+        'line indexes selected in the previous file were applied to the new diff',
+      ).to.equal(0);
+    });
+
+    it('does not let an older file read replace a newer edit buffer', async () => {
+      const el = document.createElement('lv-diff-view') as LvDiffView;
+      const first = deferred<string>();
+      const second = deferred<string>();
+      let reads = 0;
+
+      mockInvoke = async (command: string) => {
+        if (command === 'read_file_content') {
+          reads++;
+          return reads === 1 ? first.promise : second.promise;
+        }
+        return null;
+      };
+
+      el.repositoryPath = REPO_PATH;
+      el.file = makeStatusEntry({ path: 'src/main.ts' });
+      const view = el as unknown as {
+        loadFileContent: () => Promise<void>;
+        editContent: string;
+      };
+      const firstLoad = view.loadFileContent();
+      const secondLoad = view.loadFileContent();
+
+      second.resolve('newer content');
+      await secondLoad;
+      view.editContent = 'typed after newer load';
+      first.resolve('older content');
+      await firstLoad;
+
+      expect(view.editContent).to.equal('typed after newer load');
+    });
+
+    it('keeps an edit load valid across a same-file status refresh', async () => {
+      const el = await renderDiffView();
+      const read = deferred<string>();
+      mockInvoke = async (command: string) => {
+        if (command === 'read_file_content') return read.promise;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const view = el as unknown as {
+        loadFileContent: () => Promise<void>;
+        editMode: boolean;
+        editContent: string;
+      };
+      const load = view.loadFileContent();
+      el.file = makeStatusEntry({ path: 'src/main.ts', status: 'modified' });
+      await flushAsyncUpdates(el);
+      read.resolve('loaded content');
+      await load;
+
+      expect(view.editMode).to.be.true;
+      expect(view.editContent).to.equal('loaded content');
+    });
+
+    it('invalidates an edit load when the same file becomes conflicted', async () => {
+      const el = await renderDiffView();
+      const read = deferred<string>();
+      mockInvoke = async (command: string) => {
+        if (command === 'read_file_content') return read.promise;
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const view = el as unknown as {
+        loadFileContent: () => Promise<void>;
+        editMode: boolean;
+      };
+      const load = view.loadFileContent();
+      el.file = makeStatusEntry({ path: 'src/main.ts', isConflicted: true });
+      await flushAsyncUpdates(el);
+      read.resolve('stale content');
+      await load;
+
+      expect(view.editMode).to.be.false;
+    });
+
+    it('does not restore an old selection when context-menu staging fails after a file switch', async () => {
+      const el = await renderDiffView();
+      const view = el as unknown as {
+        diff: DiffFile;
+        selectedLines: Set<string>;
+        contextMenu: {
+          visible: boolean;
+          x: number;
+          y: number;
+          line: DiffLine | null;
+          hunk: DiffHunk | null;
+        };
+        handleContextStageLine: () => Promise<void>;
+      };
+      const oldHunk = view.diff.hunks[0];
+      const stage = deferred<unknown>();
+      view.selectedLines = new Set(['0-2']);
+      view.contextMenu = {
+        visible: true,
+        x: 0,
+        y: 0,
+        line: oldHunk.lines[1],
+        hunk: oldHunk,
+      };
+
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') return makeDiffFile({ path: 'src/next.ts' });
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const operation = view.handleContextStageLine();
+      el.file = makeStatusEntry({ path: 'src/next.ts' });
+      await flushAsyncUpdates(el);
+      view.selectedLines = new Set(['0-1']);
+      stage.reject({ code: 'COMMAND_ERROR', message: 'patch does not apply' });
+      await operation;
+
+      expect([...view.selectedLines]).to.deep.equal(['0-1']);
+    });
+
+    it('does not let an older save completion discard a newer edit buffer', async () => {
+      const el = document.createElement('lv-diff-view') as LvDiffView;
+      const write = deferred<unknown>();
+      mockInvoke = async (command: string) => {
+        if (command === 'write_file_content') return write.promise;
+        return null;
+      };
+
+      el.repositoryPath = REPO_PATH;
+      el.file = makeStatusEntry({ path: 'src/a.ts' });
+      const view = el as unknown as {
+        editMode: boolean;
+        editPath: string | null;
+        editRepositoryPath: string | null;
+        editRequestId: number;
+        editContent: string;
+        originalContent: string;
+        saveEdit: () => Promise<void>;
+      };
+      view.editMode = true;
+      view.editPath = 'src/a.ts';
+      view.editRepositoryPath = REPO_PATH;
+      view.editContent = 'save A';
+      view.originalContent = 'old A';
+      let editedEvents = 0;
+      el.addEventListener('file-edited', () => editedEvents++);
+
+      const save = view.saveEdit();
+      view.editRequestId++;
+      el.file = makeStatusEntry({ path: 'src/b.ts' });
+      view.editPath = 'src/b.ts';
+      view.editRepositoryPath = REPO_PATH;
+      view.editContent = 'unsaved B';
+      view.originalContent = 'old B';
+      write.resolve(undefined);
+      await save;
+
+      expect(view.editMode).to.be.true;
+      expect(view.editContent).to.equal('unsaved B');
+      expect(view.editPath).to.equal('src/b.ts');
+      expect(editedEvents, 'a successful write must still refresh repository status').to.equal(1);
+    });
+
+    it('does not restore old line indexes after a same-file diff reload', async () => {
+      const el = await renderDiffView();
+      const view = el as unknown as {
+        diff: DiffFile;
+        selectedLines: Set<string>;
+        contextMenu: {
+          visible: boolean;
+          x: number;
+          y: number;
+          line: DiffLine | null;
+          hunk: DiffHunk | null;
+        };
+        handleContextStageLine: () => Promise<void>;
+        loadWorkingDiff: () => Promise<void>;
+      };
+      const oldHunk = view.diff.hunks[0];
+      const stage = deferred<unknown>();
+      view.selectedLines = new Set(['0-2']);
+      view.contextMenu = {
+        visible: true,
+        x: 0,
+        y: 0,
+        line: oldHunk.lines[1],
+        hunk: oldHunk,
+      };
+
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      const operation = view.handleContextStageLine();
+      await view.loadWorkingDiff();
+      view.selectedLines = new Set(['0-1']);
+      stage.reject({ code: 'COMMAND_ERROR', message: 'patch does not apply' });
+      await operation;
+
+      expect([...view.selectedLines]).to.deep.equal(['0-1']);
+    });
+
+    it('clears positional selections when staging a whole hunk reloads the diff', async () => {
+      const el = await renderDiffView();
+      const view = el as unknown as {
+        diff: DiffFile;
+        selectedLines: Set<string>;
+        handleStageHunk: (hunk: DiffHunk, event: Event) => Promise<void>;
+      };
+      view.selectedLines = new Set(['0-1']);
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return null;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      await view.handleStageHunk(view.diff.hunks[0], new Event('click'));
+
+      expect(view.selectedLines.size).to.equal(0);
+    });
+
+    it('serializes overlapping hunk staging operations', async () => {
+      const el = await renderDiffView();
+      const stage = deferred<unknown>();
+      const view = el as unknown as {
+        diff: DiffFile;
+        handleStageHunk: (hunk: DiffHunk, event: Event) => Promise<void>;
+      };
+      mockInvoke = async (command: string) => {
+        if (command === 'stage_hunk') return stage.promise;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      clearHistory();
+      const first = view.handleStageHunk(view.diff.hunks[0], new Event('click'));
+      const second = view.handleStageHunk(view.diff.hunks[0], new Event('click'));
+      expect(findCommands('stage_hunk').length).to.equal(1);
+
+      stage.resolve(undefined);
+      await Promise.all([first, second]);
+    });
+
+    it('disables every editor exit and input while saving', async () => {
+      const el = await renderDiffView();
+      (el.shadowRoot!.querySelector('.edit-btn') as HTMLElement).click();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      await el.updateComplete;
+
+      (el as unknown as { saving: boolean }).saving = true;
+      el.requestUpdate();
+      await el.updateComplete;
+
+      expect((el.shadowRoot!.querySelector('.edit-btn.active') as HTMLButtonElement).disabled).to.be.true;
+      expect((el.shadowRoot!.querySelector('.cancel-btn') as HTMLButtonElement).disabled).to.be.true;
+      expect((el.shadowRoot!.querySelector('.editor-textarea') as HTMLTextAreaElement).disabled).to.be.true;
+    });
   });
 
   // ── Rendering ──────────────────────────────────────────────────────────
@@ -544,6 +952,26 @@ describe('lv-diff-view', () => {
         'nothing is at stake, so nothing is asked',
       ).to.equal(false);
       expect(el.shadowRoot!.querySelector('.editor-textarea')).to.be.null;
+    });
+
+    it('switching repositories closes the editor even when the file path is unchanged', async () => {
+      setupDefaultMocks({ fileContent: 'contents from repository A' });
+      const el = await renderDiffView({
+        file: makeStatusEntry({ path: 'src/main.ts' }),
+      });
+
+      (el.shadowRoot!.querySelector('.edit-btn') as HTMLElement).click();
+      await new Promise((r) => setTimeout(r, 100));
+      await el.updateComplete;
+      expect(el.shadowRoot!.querySelector('.editor-textarea')).to.not.be.null;
+
+      el.repositoryPath = '/test/other-repo';
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      expect(
+        el.shadowRoot!.querySelector('.editor-textarea'),
+        'the buffer from repository A remained writable in repository B',
+      ).to.be.null;
     });
 
     it('cancel restores to diff view and discards edits', async () => {
@@ -1343,11 +1771,24 @@ describe('lv-diff-view', () => {
 
     async function viewWithMixedHunk(): Promise<LvDiffView> {
       const el = await bareView();
+      (el as unknown as { repositoryPath: string }).repositoryPath = REPO_PATH;
       (el as unknown as { file: unknown }).file = makeStatusEntry({ path: 'f.txt' });
+      await el.updateComplete;
       (el as unknown as { diff: unknown }).diff = makeDiffFile({
         path: 'f.txt',
         hunks: [mixedHunk()],
       });
+      (el as unknown as {
+        loadedWorkingDiffContext: {
+          repositoryPath: string;
+          filePath: string;
+          isStaged: boolean;
+        };
+      }).loadedWorkingDiffContext = {
+        repositoryPath: REPO_PATH,
+        filePath: 'f.txt',
+        isStaged: false,
+      };
       // Select the deletion at index 1 and the addition at index 3.
       (el as unknown as { selectedLines: Set<string> }).selectedLines = new Set(['0-1', '0-3']);
       return el;

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -1544,7 +1544,8 @@ describe('lv-diff-view', () => {
       expect(el.shadowRoot!.querySelector('.editor-textarea')).to.not.be.null;
 
       el.repositoryPath = '/test/other-repo';
-      await new Promise((resolve) => setTimeout(resolve, 50));
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
 
       expect(
         el.shadowRoot!.querySelector('.editor-textarea'),

--- a/src/components/panels/__tests__/lv-diff-view.test.ts
+++ b/src/components/panels/__tests__/lv-diff-view.test.ts
@@ -121,6 +121,11 @@ async function flushAsyncUpdates(el: LvDiffView): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 0));
 }
 
+/** Flush repeatedly so a chain of awaited invokes settles before asserting. */
+async function settleAsyncUpdates(el: LvDiffView, times = 5): Promise<void> {
+  for (let i = 0; i < times; i++) await flushAsyncUpdates(el);
+}
+
 function findCommands(name: string): Array<{ command: string; args?: unknown }> {
   return invokeHistory.filter((h) => h.command === name);
 }
@@ -841,6 +846,127 @@ describe('lv-diff-view', () => {
         'the superseded reload cleared the file the user had switched to'
       ).to.equal('src/next.ts');
       expect(cleared, 'file-cleared was dispatched for a file that was never staged').to.equal(0);
+    });
+
+    it('clears the pane when unstaging the last staged hunk empties the staged diff', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: true }) });
+      (el as unknown as { initCodeLanguage: (path: string) => Promise<void> }).initCodeLanguage =
+        async () => {};
+
+      let unstaged = false;
+      mockInvoke = async (command: string) => {
+        if (command === 'unstage_hunk') {
+          unstaged = true;
+          return null;
+        }
+        if (command === 'get_file_diff') {
+          // Nothing is staged for this file any more, so the backend has no
+          // staged diff to return.
+          if (unstaged) {
+            throw {
+              code: 'COMMAND_ERROR',
+              message:
+                "File 'src/main.ts' not found in diff. Staged: true. Found 1 files: [src/other.ts]",
+            };
+          }
+          return makeDiffFile();
+        }
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      let cleared = 0;
+      el.addEventListener('file-cleared', () => cleared++);
+
+      (el.shadowRoot!.querySelector('.stage-btn.unstage') as HTMLButtonElement).click();
+      await settleAsyncUpdates(el);
+
+      expect(
+        el.shadowRoot!.textContent,
+        'the backend\'s "not found in diff" text was painted into the pane',
+      ).to.not.contain('not found in diff');
+      expect(el.file, 'the emptied file stayed bound to the pane').to.be.null;
+      expect(
+        el.shadowRoot!.querySelector('.empty')?.textContent,
+        'the pane should fall back to its empty state',
+      ).to.contain('No file selected');
+      expect(cleared, 'file-cleared closes the diff in app-shell').to.equal(1);
+    });
+
+    it('keeps the diff open when unstaging leaves other staged hunks', async () => {
+      const el = await renderDiffView({ file: makeStatusEntry({ isStaged: true }) });
+      (el as unknown as { initCodeLanguage: (path: string) => Promise<void> }).initCodeLanguage =
+        async () => {};
+
+      mockInvoke = async (command: string) => {
+        if (command === 'unstage_hunk') return null;
+        if (command === 'get_file_diff') return makeDiffFile();
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      let cleared = 0;
+      el.addEventListener('file-cleared', () => cleared++);
+
+      (el.shadowRoot!.querySelector('.stage-btn.unstage') as HTMLButtonElement).click();
+      await settleAsyncUpdates(el);
+
+      expect(el.file?.path, 'a partial unstage must keep the file selected').to.equal('src/main.ts');
+      expect(cleared, 'file-cleared was dispatched while hunks were still staged').to.equal(0);
+      expect(el.shadowRoot!.querySelectorAll('.line.code-addition').length).to.be.greaterThan(0);
+    });
+
+    it('does not clear a newly selected file when a superseded unstage reload reports "not found in diff"', async () => {
+      const el = await renderDiffView({
+        file: makeStatusEntry({ path: 'src/main.ts', isStaged: true }),
+      });
+      const view = el as unknown as {
+        diff: DiffFile;
+        error: string | null;
+        initCodeLanguage: (path: string) => Promise<void>;
+        handleUnstageHunk: (hunk: DiffHunk, event: Event) => Promise<void>;
+      };
+      view.initCodeLanguage = async () => {};
+      const hunk = view.diff.hunks[0];
+
+      const reloadOfUnstagedFile = deferred<DiffFile>();
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'unstage_hunk') return null;
+        if (command === 'get_file_diff') {
+          const filePath = (args as { filePath: string }).filePath;
+          if (filePath === 'src/main.ts') return reloadOfUnstagedFile.promise;
+          // The file the user switches to has nothing left to show on its own.
+          throw {
+            code: 'COMMAND_ERROR',
+            message: "File 'src/next.ts' not found in diff. Staged: true.",
+          };
+        }
+        if (command === 'get_diff_tool') return { tool: null };
+        return null;
+      };
+
+      let cleared = 0;
+      el.addEventListener('file-cleared', () => cleared++);
+
+      const operation = view.handleUnstageHunk(hunk, new Event('click'));
+      // Let unstage_hunk settle so the reload of src/main.ts is in flight.
+      await flushAsyncUpdates(el);
+
+      el.file = makeStatusEntry({ path: 'src/next.ts', isStaged: true });
+      await flushAsyncUpdates(el);
+      expect(view.error, 'the newly selected file reported its own load error').to.contain(
+        'not found in diff'
+      );
+
+      reloadOfUnstagedFile.resolve(makeDiffFile({ path: 'src/main.ts' }));
+      await operation;
+      await el.updateComplete;
+
+      expect(
+        el.file?.path,
+        'the superseded reload cleared the file the user had switched to'
+      ).to.equal('src/next.ts');
+      expect(cleared, 'file-cleared was dispatched for a file that was never unstaged').to.equal(0);
     });
 
     it('disables every editor exit and input while saving', async () => {
@@ -2559,7 +2685,7 @@ describe('lv-diff-view', () => {
      * '0-4') and the context menu open on a third line.
      */
     async function viewWithOpenContextMenu(
-      opts: { isStaged?: boolean; hunkFails?: boolean } = {},
+      opts: { isStaged?: boolean; hunkFails?: boolean; emptyAfterApply?: boolean } = {},
     ): Promise<LvDiffView> {
       const original = makeDiffFile({ hunks: [stageableHunk()] });
       const reloaded = makeDiffFile({ hunks: [reloadedHunk()] });
@@ -2568,6 +2694,14 @@ describe('lv-diff-view', () => {
       mockInvoke = async (command: string) => {
         switch (command) {
           case 'get_file_diff':
+            if (applied && opts.emptyAfterApply) {
+              // The apply took the file's last change on this side, so the
+              // backend has no diff left to return for it.
+              throw {
+                code: 'COMMAND_ERROR',
+                message: `File 'src/main.ts' not found in diff. Staged: ${opts.isStaged ?? false}. Found 0 files: []`,
+              };
+            }
             return applied ? reloaded : original;
           case 'get_diff_tool':
             return { tool: null };
@@ -2625,6 +2759,38 @@ describe('lv-diff-view', () => {
       ).to.equal(0);
       expect(el.shadowRoot!.querySelector('.selection-actions')).to.be.null;
       expect(el.shadowRoot!.querySelectorAll('.line.selected').length).to.equal(0);
+    });
+
+    it('clears the pane when a context-menu stage takes the file\'s last unstaged line', async () => {
+      const el = await viewWithOpenContextMenu({ emptyAfterApply: true });
+      let cleared = 0;
+      el.addEventListener('file-cleared', () => cleared++);
+
+      await (el as unknown as Handlers).handleContextStageLine();
+      await el.updateComplete;
+
+      expect(
+        el.shadowRoot!.textContent,
+        'the backend\'s "not found in diff" text was painted into the pane',
+      ).to.not.contain('not found in diff');
+      expect(el.file, 'the emptied file stayed bound to the pane').to.be.null;
+      expect(cleared, 'file-cleared closes the diff in app-shell').to.equal(1);
+    });
+
+    it('clears the pane when a context-menu unstage takes the file\'s last staged line', async () => {
+      const el = await viewWithOpenContextMenu({ isStaged: true, emptyAfterApply: true });
+      let cleared = 0;
+      el.addEventListener('file-cleared', () => cleared++);
+
+      await (el as unknown as Handlers).handleContextUnstageLine();
+      await el.updateComplete;
+
+      expect(
+        el.shadowRoot!.textContent,
+        'the backend\'s "not found in diff" text was painted into the pane',
+      ).to.not.contain('not found in diff');
+      expect(el.file, 'the emptied file stayed bound to the pane').to.be.null;
+      expect(cleared, 'file-cleared closes the diff in app-shell').to.equal(1);
     });
 
     it('does not let a follow-up Stage Selected act on stale keys', async () => {

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -1185,6 +1185,43 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     }
   }
 
+  /**
+   * Clear the pane when the reload that followed an apply found nothing left.
+   *
+   * Staging the last unstaged hunk (or unstaging the last staged one) empties
+   * this side of the index for the file, and the backend answers that reload
+   * with a "not found in diff" error — which would otherwise be painted into
+   * the pane as raw text. The shell cannot rescue it either: the surviving
+   * entry for the other side has the same path and status, so it never swaps
+   * the bound file. Clear and let the shell close the diff instead.
+   *
+   * A reload for another file can win the request race while the apply is
+   * still awaiting, leaving `error`/`file` describing that other file, so the
+   * selection has to still be the file we applied to.
+   * `isSameWorkingDiffContext` cannot be used for that: a "not found in diff"
+   * reload leaves no loaded context, which is exactly the case handled here.
+   */
+  private clearIfFullyApplied(context: {
+    repositoryPath: string;
+    filePath: string;
+    isStaged: boolean;
+  }): void {
+    if (
+      this.commitFile ||
+      this.repositoryPath !== context.repositoryPath ||
+      this.file?.path !== context.filePath ||
+      this.file?.isStaged !== context.isStaged
+    ) return;
+    if (!this.error?.includes('not found in diff')) return;
+    this.error = null;
+    this.diff = null;
+    this.file = null;
+    this.dispatchEvent(new CustomEvent('file-cleared', {
+      bubbles: true,
+      composed: true,
+    }));
+  }
+
   private async loadWorkingDiff(): Promise<void> {
     if (!this.repositoryPath || !this.file) return;
     const requestId = ++this.diffRequestId;
@@ -1944,6 +1981,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         if (this.isSameWorkingDiffContext(context)) {
           this.selectedLines = new Set();
           await this.loadWorkingDiff();
+          this.clearIfFullyApplied(context);
         }
         return true;
       }
@@ -1983,6 +2021,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         if (this.isSameWorkingDiffContext(context)) {
           this.selectedLines = new Set();
           await this.loadWorkingDiff();
+          this.clearIfFullyApplied(context);
         }
         return true;
       }
@@ -2021,27 +2060,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         if (!this.isSameWorkingDiffContext(context)) return;
         this.selectedLines = new Set();
         await this.loadWorkingDiff();
-        // A reload for another file can win the request race while this one is
-        // still awaiting, leaving `error`/`file` describing that other file. Do
-        // not read them unless the selection is still the file we just staged.
-        // `isSameWorkingDiffContext` cannot be used here: a "not found in diff"
-        // reload leaves no loaded context, which is exactly the case below.
-        if (
-          this.commitFile ||
-          this.repositoryPath !== context.repositoryPath ||
-          this.file?.path !== context.filePath ||
-          this.file?.isStaged !== context.isStaged
-        ) return;
-        // Check if we got a "not found" error (file fully staged)
-        if (this.error?.includes('not found in diff')) {
-          this.error = null;
-          this.diff = null;
-          this.file = null;
-          this.dispatchEvent(new CustomEvent('file-cleared', {
-            bubbles: true,
-            composed: true,
-          }));
-        }
+        this.clearIfFullyApplied(context);
       } else {
         console.error('Failed to stage hunk:', result.error);
         showToast(`Failed to stage hunk: ${result.error?.message ?? 'Unknown error'}`, 'error');
@@ -2074,10 +2093,11 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           bubbles: true,
           composed: true,
         }));
-        // Reload diff to show updated state
+        // Reload diff - if nothing is left staged for this file, clear the view
         if (this.isSameWorkingDiffContext(context)) {
           this.selectedLines = new Set();
           await this.loadWorkingDiff();
+          this.clearIfFullyApplied(context);
         }
       } else {
         console.error('Failed to unstage hunk:', result.error);

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -881,6 +881,13 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         background: var(--color-bg-hover);
       }
 
+      .context-menu-item:disabled,
+      .context-menu-item:disabled:hover {
+        opacity: 0.6;
+        cursor: not-allowed;
+        background: none;
+      }
+
       .context-menu-item svg {
         width: 14px;
         height: 14px;
@@ -2003,6 +2010,17 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         if (!this.isSameWorkingDiffContext(context)) return;
         this.selectedLines = new Set();
         await this.loadWorkingDiff();
+        // A reload for another file can win the request race while this one is
+        // still awaiting, leaving `error`/`file` describing that other file. Do
+        // not read them unless the selection is still the file we just staged.
+        // `isSameWorkingDiffContext` cannot be used here: a "not found in diff"
+        // reload leaves no loaded context, which is exactly the case below.
+        if (
+          this.commitFile ||
+          this.repositoryPath !== context.repositoryPath ||
+          this.file?.path !== context.filePath ||
+          this.file?.isStaged !== context.isStaged
+        ) return;
         // Check if we got a "not found" error (file fully staged)
         if (this.error?.includes('not found in diff')) {
           this.error = null;
@@ -2947,14 +2965,22 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         ${showStageButton && isChangeableLine ? html`
           <div class="context-menu-divider"></div>
           ${isStaged ? html`
-            <button class="context-menu-item" @click=${this.handleContextUnstageLine}>
+            <button
+              class="context-menu-item"
+              @click=${this.handleContextUnstageLine}
+              ?disabled=${this.diffMutationInProgress}
+            >
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <line x1="5" y1="12" x2="19" y2="12"></line>
               </svg>
               Unstage line
             </button>
           ` : html`
-            <button class="context-menu-item" @click=${this.handleContextStageLine}>
+            <button
+              class="context-menu-item"
+              @click=${this.handleContextStageLine}
+              ?disabled=${this.diffMutationInProgress}
+            >
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <line x1="12" y1="5" x2="12" y2="19"></line>
                 <line x1="5" y1="12" x2="19" y2="12"></line>
@@ -2966,14 +2992,22 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         ${showStageButton ? html`
           <div class="context-menu-divider"></div>
           ${isStaged ? html`
-            <button class="context-menu-item" @click=${this.handleContextUnstageHunk}>
+            <button
+              class="context-menu-item"
+              @click=${this.handleContextUnstageHunk}
+              ?disabled=${this.diffMutationInProgress}
+            >
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <line x1="5" y1="12" x2="19" y2="12"></line>
               </svg>
               Unstage hunk
             </button>
           ` : html`
-            <button class="context-menu-item" @click=${this.handleContextStageHunk}>
+            <button
+              class="context-menu-item"
+              @click=${this.handleContextStageHunk}
+              ?disabled=${this.diffMutationInProgress}
+            >
               <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                 <line x1="12" y1="5" x2="12" y2="19"></line>
                 <line x1="5" y1="12" x2="19" y2="12"></line>

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -1186,6 +1186,29 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   }
 
   /**
+   * True while the pane still shows the file an apply was made against.
+   *
+   * Deliberately weaker than `isSameWorkingDiffContext`: it ignores the loaded
+   * diff, so it stays true while a reload for the SAME file is still in flight
+   * (the "Load full diff" link can start one mid-apply, and it leaves no loaded
+   * context behind). The apply itself invalidated every positional
+   * `${hunkIndex}-${lineIndex}` key, so the selection must be dropped in that
+   * case too - whichever diff lands renumbers them.
+   */
+  private isStillOnAppliedFile(context: {
+    repositoryPath: string;
+    filePath: string;
+    isStaged: boolean;
+  }): boolean {
+    return (
+      !this.commitFile &&
+      this.repositoryPath === context.repositoryPath &&
+      this.file?.path === context.filePath &&
+      this.file?.isStaged === context.isStaged
+    );
+  }
+
+  /**
    * Clear the pane when the reload that followed an apply found nothing left.
    *
    * Staging the last unstaged hunk (or unstaging the last staged one) empties
@@ -1206,12 +1229,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     filePath: string;
     isStaged: boolean;
   }): void {
-    if (
-      this.commitFile ||
-      this.repositoryPath !== context.repositoryPath ||
-      this.file?.path !== context.filePath ||
-      this.file?.isStaged !== context.isStaged
-    ) return;
+    if (!this.isStillOnAppliedFile(context)) return;
     if (!this.error?.includes('not found in diff')) return;
     this.error = null;
     this.diff = null;
@@ -1978,8 +1996,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           bubbles: true,
           composed: true,
         }));
+        if (this.isStillOnAppliedFile(context)) this.selectedLines = new Set();
         if (this.isSameWorkingDiffContext(context)) {
-          this.selectedLines = new Set();
           await this.loadWorkingDiff();
           this.clearIfFullyApplied(context);
         }
@@ -2018,8 +2036,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           bubbles: true,
           composed: true,
         }));
+        if (this.isStillOnAppliedFile(context)) this.selectedLines = new Set();
         if (this.isSameWorkingDiffContext(context)) {
-          this.selectedLines = new Set();
           await this.loadWorkingDiff();
           this.clearIfFullyApplied(context);
         }
@@ -2057,10 +2075,11 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           composed: true,
         }));
         // Reload diff - if file is fully staged, clear the view
-        if (!this.isSameWorkingDiffContext(context)) return;
-        this.selectedLines = new Set();
-        await this.loadWorkingDiff();
-        this.clearIfFullyApplied(context);
+        if (this.isStillOnAppliedFile(context)) this.selectedLines = new Set();
+        if (this.isSameWorkingDiffContext(context)) {
+          await this.loadWorkingDiff();
+          this.clearIfFullyApplied(context);
+        }
       } else {
         console.error('Failed to stage hunk:', result.error);
         showToast(`Failed to stage hunk: ${result.error?.message ?? 'Unknown error'}`, 'error');
@@ -2094,8 +2113,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           composed: true,
         }));
         // Reload diff - if nothing is left staged for this file, clear the view
+        if (this.isStillOnAppliedFile(context)) this.selectedLines = new Set();
         if (this.isSameWorkingDiffContext(context)) {
-          this.selectedLines = new Set();
           await this.loadWorkingDiff();
           this.clearIfFullyApplied(context);
         }

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -1485,9 +1485,13 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    * `showDiff = false` in app-shell. Every teardown the component CAN see
    * already guards (Cancel confirms, a file change warns); the host needs this
    * to close the gap for the ones it owns.
+   *
+   * A save in flight is NOT unsaved: the write is already on its way to disk
+   * and `saveEdit` reports its own failure, so counting it here would tell the
+   * user their edits were discarded moments before they land.
    */
   public get hasUnsavedEdits(): boolean {
-    return this.editMode && this.hasChanges;
+    return this.editMode && this.hasChanges && !this.saving;
   }
 
   /** The file the unsaved buffer belongs to, for a message naming it. */
@@ -1510,11 +1514,18 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    * A confirm is not possible here — the property has already changed by the
    * time `updated()` runs, so there is nothing left to cancel. Unsaved text is
    * therefore reported rather than silently dropped.
+   *
+   * The same file turning conflicted closes the editor too, matching the
+   * invalidation `updated()` already applies to an in-flight load. `render()`
+   * hides the textarea behind the conflict notice, so the buffer would survive
+   * unreachable — and reappear over the merge the user then resolved, with
+   * Save writing pre-conflict text over the resolution.
    */
   private exitEditModeOnFileChange(): void {
     if (!this.editMode) return;
     if (
       !this.commitFile &&
+      !this.file?.isConflicted &&
       this.editPath &&
       this.file?.path === this.editPath &&
       this.editRepositoryPath === this.repositoryPath

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -979,7 +979,10 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    * buffer and the Save target could name two different files.
    */
   private editPath: string | null = null;
+  private editRepositoryPath: string | null = null;
+  private editRequestId = 0;
   @state() private saving = false;
+  private saveContextChanged = false;
   @state() private contextMenu: DiffContextMenuState = { visible: false, x: 0, y: 0, line: null, hunk: null };
   @state() private selectedLines: Set<LineKey> = new Set();
   @state() private lineSelectionMode = false;
@@ -993,6 +996,13 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   private virtualScrollManager = new DiffVirtualScrollManager();
   private flatLines: FlatDiffItem[] = [];
   private diffScrollTop = 0;
+  private diffRequestId = 0;
+  private diffMutationInProgress = false;
+  private loadedWorkingDiffContext: {
+    repositoryPath: string;
+    filePath: string;
+    isStaged: boolean;
+  } | null = null;
 
   private handleDocumentClick = (): void => {
     if (this.contextMenu.visible) {
@@ -1054,7 +1064,11 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   async updated(changedProperties: Map<string, unknown>): Promise<void> {
     // A different file/commit resets the "show full diff" opt-in so large diffs
     // are re-truncated by default.
-    if (changedProperties.has('file') || changedProperties.has('commitFile')) {
+    if (
+      changedProperties.has('file') ||
+      changedProperties.has('commitFile') ||
+      changedProperties.has('repositoryPath')
+    ) {
       this.showFullDiff = false;
       // The editor does NOT follow the selection. This pane is one reused
       // element, so selecting another file while the editor was open left the
@@ -1063,12 +1077,43 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
       // the previous file's content over the newly selected file, destroying
       // its uncommitted changes with no git object and no reflog entry.
       this.exitEditModeOnFileChange();
-    }
-    if (changedProperties.has('file') && this.file) {
-      await this.loadWorkingDiff();
-    }
-    if (changedProperties.has('commitFile') && this.commitFile) {
-      await this.loadCommitDiff();
+      const previousFile = changedProperties.get('file') as StatusEntry | null | undefined;
+      const previousCommitFile = changedProperties.get('commitFile') as
+        | { commitOid: string; filePath: string }
+        | null
+        | undefined;
+      const editContextChanged =
+        (changedProperties.has('repositoryPath') &&
+          changedProperties.get('repositoryPath') !== this.repositoryPath) ||
+        (changedProperties.has('file') &&
+          (previousFile?.path !== this.file?.path ||
+            previousFile?.isConflicted !== this.file?.isConflicted)) ||
+        (changedProperties.has('commitFile') &&
+          (previousCommitFile?.commitOid !== this.commitFile?.commitOid ||
+            previousCommitFile?.filePath !== this.commitFile?.filePath));
+      if (editContextChanged) this.editRequestId++;
+
+      const replacedExistingContext =
+        (changedProperties.has('file') && changedProperties.get('file') !== null) ||
+        (changedProperties.has('commitFile') && changedProperties.get('commitFile') !== null) ||
+        (changedProperties.has('repositoryPath') && !!changedProperties.get('repositoryPath'));
+      if (replacedExistingContext) {
+        this.selectedLines = new Set();
+        this.contextMenu = { ...this.contextMenu, visible: false, line: null, hunk: null };
+        this.currentHunkIndex = 0;
+      }
+
+      if (this.commitFile) {
+        await this.loadCommitDiff();
+      } else if (this.file) {
+        await this.loadWorkingDiff();
+      } else {
+        this.diffRequestId++;
+        this.loadedWorkingDiffContext = null;
+        this.diff = null;
+        this.error = null;
+        this.loading = false;
+      }
     }
     if (changedProperties.has('repositoryPath') && this.repositoryPath) {
       await this.checkDiffToolAvailability();
@@ -1113,9 +1158,19 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
 
   private async loadWorkingDiff(): Promise<void> {
     if (!this.repositoryPath || !this.file) return;
+    const requestId = ++this.diffRequestId;
+    const repositoryPath = this.repositoryPath;
+    const filePath = this.file.path;
+    const isStaged = this.file.isStaged;
+    this.loadedWorkingDiffContext = null;
     // Conflicted files render a redirect to the merge editor — don't load the
     // marker-laden diff at all.
-    if (this.isConflicted) return;
+    if (this.isConflicted) {
+      this.loading = false;
+      this.error = null;
+      this.diff = null;
+      return;
+    }
 
     this.loading = true;
     this.error = null;
@@ -1125,29 +1180,37 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
 
     try {
       // Initialize highlighter and detect language
-      await this.initCodeLanguage(this.file.path);
+      await this.initCodeLanguage(filePath);
 
       const result = await gitService.getFileDiff(
-        this.repositoryPath,
-        this.file.path,
-        this.file.isStaged,
+        repositoryPath,
+        filePath,
+        isStaged,
         this.showFullDiff ? undefined : DEFAULT_MAX_DIFF_LINES
       );
 
+      if (requestId !== this.diffRequestId) return;
       if (result.success) {
         this.diff = result.data!;
+        this.loadedWorkingDiffContext = { repositoryPath, filePath, isStaged };
       } else {
         this.error = result.error?.message ?? 'Failed to load diff';
       }
     } catch (err) {
+      if (requestId !== this.diffRequestId) return;
       this.error = err instanceof Error ? err.message : 'Unknown error';
     } finally {
-      this.loading = false;
+      if (requestId === this.diffRequestId) this.loading = false;
     }
   }
 
   private async loadCommitDiff(): Promise<void> {
     if (!this.repositoryPath || !this.commitFile) return;
+    const requestId = ++this.diffRequestId;
+    const repositoryPath = this.repositoryPath;
+    const commitOid = this.commitFile.commitOid;
+    const filePath = this.commitFile.filePath;
+    this.loadedWorkingDiffContext = null;
 
     this.loading = true;
     this.error = null;
@@ -1157,25 +1220,57 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
 
     try {
       // Initialize highlighter and detect language
-      await this.initCodeLanguage(this.commitFile.filePath);
+      await this.initCodeLanguage(filePath);
 
       const result = await gitService.getCommitFileDiff(
-        this.repositoryPath,
-        this.commitFile.commitOid,
-        this.commitFile.filePath,
+        repositoryPath,
+        commitOid,
+        filePath,
         this.showFullDiff ? undefined : DEFAULT_MAX_DIFF_LINES
       );
 
+      if (requestId !== this.diffRequestId) return;
       if (result.success) {
         this.diff = result.data!;
       } else {
         this.error = result.error?.message ?? 'Failed to load diff';
       }
     } catch (err) {
+      if (requestId !== this.diffRequestId) return;
       this.error = err instanceof Error ? err.message : 'Unknown error';
     } finally {
-      this.loading = false;
+      if (requestId === this.diffRequestId) this.loading = false;
     }
+  }
+
+  private currentWorkingDiffContext(): {
+    repositoryPath: string;
+    filePath: string;
+    isStaged: boolean;
+  } | null {
+    if (
+      this.commitFile ||
+      !this.file ||
+      !this.loadedWorkingDiffContext ||
+      this.loadedWorkingDiffContext.repositoryPath !== this.repositoryPath ||
+      this.loadedWorkingDiffContext.filePath !== this.file.path ||
+      this.loadedWorkingDiffContext.isStaged !== this.file.isStaged
+    ) return null;
+    return this.loadedWorkingDiffContext;
+  }
+
+  private isSameWorkingDiffContext(context: {
+    repositoryPath: string;
+    filePath: string;
+    isStaged: boolean;
+  }): boolean {
+    const current = this.currentWorkingDiffContext();
+    return !!(
+      current &&
+      current.repositoryPath === context.repositoryPath &&
+      current.filePath === context.filePath &&
+      current.isStaged === context.isStaged
+    );
   }
 
   private setViewMode(mode: DiffViewMode): void {
@@ -1194,13 +1289,20 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   private get canEdit(): boolean {
     // Conflicted files must not be free-text edited here — their working-tree
     // content is git's conflict-marker text.
-    return this.file !== null && this.commitFile === null && !this.diff?.isBinary && !this.isConflicted;
+    return (
+      !this.saving &&
+      this.file !== null &&
+      this.commitFile === null &&
+      !this.diff?.isBinary &&
+      !this.isConflicted
+    );
   }
 
   /**
    * Toggle edit mode
    */
   private async toggleEditMode(): Promise<void> {
+    if (this.saving) return;
     if (!this.canEdit) return;
 
     if (!this.editMode) {
@@ -1218,17 +1320,28 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    */
   private async loadFileContent(): Promise<void> {
     if (!this.repositoryPath || !this.file) return;
+    const requestId = ++this.editRequestId;
+    const repositoryPath = this.repositoryPath;
+    const filePath = this.file.path;
 
     const result = await gitService.readFileContent(
-      this.repositoryPath,
-      this.file.path,
+      repositoryPath,
+      filePath,
       false // Read from working directory
     );
+
+    if (
+      requestId !== this.editRequestId ||
+      this.repositoryPath !== repositoryPath ||
+      this.file?.path !== filePath ||
+      this.commitFile
+    ) return;
 
     if (result.success && result.data !== undefined) {
       this.originalContent = result.data;
       this.editContent = result.data;
-      this.editPath = this.file.path;
+      this.editPath = filePath;
+      this.editRepositoryPath = repositoryPath;
       this.editMode = true;
       return;
     }
@@ -1242,7 +1355,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     // separate codes because they are presented very differently.
     showToast(
       result.error?.code === 'FILE_NOT_FOUND'
-        ? `${this.file.path} is no longer on disk — refresh to see its current state`
+        ? `${filePath} is no longer on disk — refresh to see its current state`
         : result.error?.message ?? 'Could not open this file for editing',
       'error'
     );
@@ -1287,34 +1400,51 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     if (!this.editMode || !this.repositoryPath || !this.file || this.saving) return;
     // Identity, not just existence: the buffer must belong to the file it is
     // about to be written to.
-    if (this.editPath && this.editPath !== this.file.path) {
+    if (
+      (this.editPath && this.editPath !== this.file.path) ||
+      (this.editRepositoryPath && this.editRepositoryPath !== this.repositoryPath)
+    ) {
       showToast('The editor no longer matches the selected file', 'error');
       return;
     }
 
+    const requestId = this.editRequestId;
+    const repositoryPath = this.repositoryPath;
+    const filePath = this.file.path;
+    const content = this.editContent;
+    this.saveContextChanged = false;
     this.saving = true;
 
     const result = await gitService.writeFileContent(
-      this.repositoryPath,
-      this.file.path,
-      this.editContent,
+      repositoryPath,
+      filePath,
+      content,
       false // Don't auto-stage
     );
 
     this.saving = false;
 
     if (result.success) {
-      this.discardEditBuffer();
-      // Reload the diff to show updated changes
-      await this.loadWorkingDiff();
-      // Dispatch event to notify parent to refresh status
       this.dispatchEvent(new CustomEvent('file-edited', {
         bubbles: true,
         composed: true,
-        detail: { path: this.file.path }
+        detail: { path: filePath, repositoryPath }
       }));
+      if (
+        requestId !== this.editRequestId ||
+        this.editRepositoryPath !== repositoryPath ||
+        this.editPath !== filePath
+      ) return;
+      this.discardEditBuffer();
+      // Reload the diff to show updated changes
+      await this.loadWorkingDiff();
     } else {
-      showToast(`Failed to save file: ${result.error?.message ?? 'Unknown error'}`, 'error');
+      showToast(
+        this.saveContextChanged
+          ? `Failed to save ${filePath}; its unsaved edits were discarded when the selection changed`
+          : `Failed to save file: ${result.error?.message ?? 'Unknown error'}`,
+        'error'
+      );
     }
   }
 
@@ -1342,6 +1472,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     this.editContent = '';
     this.originalContent = '';
     this.editPath = null;
+    this.editRepositoryPath = null;
   }
 
   /**
@@ -1353,8 +1484,14 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    */
   private exitEditModeOnFileChange(): void {
     if (!this.editMode) return;
-    if (this.editPath && this.file?.path === this.editPath) return;
-    const lost = this.hasChanges ? this.editPath : null;
+    if (
+      !this.commitFile &&
+      this.editPath &&
+      this.file?.path === this.editPath &&
+      this.editRepositoryPath === this.repositoryPath
+    ) return;
+    if (this.saving) this.saveContextChanged = true;
+    const lost = this.hasChanges && !this.saving ? this.editPath : null;
     this.discardEditBuffer();
     if (lost) {
       showToast(`Unsaved edits to ${lost} were discarded`, 'warning');
@@ -1369,6 +1506,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    * bound app-wide to "close diff" — so it gets pressed reflexively.
    */
   private async cancelEdit(): Promise<void> {
+    if (this.saving) return;
     if (this.hasChanges) {
       const confirmed = await showConfirm(
         'Discard edits?',
@@ -1744,25 +1882,29 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   /**
    * Stage selected lines
    *
-   * Resolves to true only when the stage was applied and the diff reloaded.
-   * The reload renumbers hunks and lines, so every positional
+   * Resolves to true only when the stage was applied. A same-context reload
+   * renumbers hunks and lines, so every positional
    * `${hunkIndex}-${lineIndex}` key a caller saved is stale after that.
    */
   private async stageSelectedLines(): Promise<boolean> {
-    if (!this.repositoryPath || !this.file || this.selectedLines.size === 0) return false;
+    const context = this.currentWorkingDiffContext();
+    if (!context || this.diffMutationInProgress || this.selectedLines.size === 0) return false;
 
     const patch = this.buildSelectedLinesPatch();
     if (!patch) return false;
 
+    this.diffMutationInProgress = true;
     try {
-      const result = await gitService.stageHunk(this.repositoryPath, patch);
+      const result = await gitService.stageHunk(context.repositoryPath, patch);
       if (result.success) {
-        this.selectedLines = new Set();
         this.dispatchEvent(new CustomEvent('status-changed', {
           bubbles: true,
           composed: true,
         }));
-        await this.loadWorkingDiff();
+        if (this.isSameWorkingDiffContext(context)) {
+          this.selectedLines = new Set();
+          await this.loadWorkingDiff();
+        }
         return true;
       }
       console.error('Failed to stage selected lines:', result.error);
@@ -1770,6 +1912,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     } catch (err) {
       console.error('Failed to stage selected lines:', err);
       showToast(`Failed to stage lines: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error');
+    } finally {
+      this.diffMutationInProgress = false;
     }
     return false;
   }
@@ -1777,25 +1921,29 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   /**
    * Unstage selected lines
    *
-   * Resolves to true only when the unstage was applied and the diff reloaded.
-   * The reload renumbers hunks and lines, so every positional
+   * Resolves to true only when the unstage was applied. A same-context reload
+   * renumbers hunks and lines, so every positional
    * `${hunkIndex}-${lineIndex}` key a caller saved is stale after that.
    */
   private async unstageSelectedLines(): Promise<boolean> {
-    if (!this.repositoryPath || !this.file || this.selectedLines.size === 0) return false;
+    const context = this.currentWorkingDiffContext();
+    if (!context || this.diffMutationInProgress || this.selectedLines.size === 0) return false;
 
     const patch = this.buildSelectedLinesPatch('unstage');
     if (!patch) return false;
 
+    this.diffMutationInProgress = true;
     try {
-      const result = await gitService.unstageHunk(this.repositoryPath, patch);
+      const result = await gitService.unstageHunk(context.repositoryPath, patch);
       if (result.success) {
-        this.selectedLines = new Set();
         this.dispatchEvent(new CustomEvent('status-changed', {
           bubbles: true,
           composed: true,
         }));
-        await this.loadWorkingDiff();
+        if (this.isSameWorkingDiffContext(context)) {
+          this.selectedLines = new Set();
+          await this.loadWorkingDiff();
+        }
         return true;
       }
       console.error('Failed to unstage selected lines:', result.error);
@@ -1803,6 +1951,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     } catch (err) {
       console.error('Failed to unstage selected lines:', err);
       showToast(`Failed to unstage lines: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error');
+    } finally {
+      this.diffMutationInProgress = false;
     }
     return false;
   }
@@ -1812,13 +1962,15 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    */
   private async handleStageHunk(hunk: DiffHunk, e: Event): Promise<void> {
     e.stopPropagation();
-    if (!this.repositoryPath || !this.file) return;
+    const context = this.currentWorkingDiffContext();
+    if (!context || this.diffMutationInProgress) return;
 
     const patch = this.buildHunkPatch(hunk);
     if (!patch) return;
 
+    this.diffMutationInProgress = true;
     try {
-      const result = await gitService.stageHunk(this.repositoryPath, patch);
+      const result = await gitService.stageHunk(context.repositoryPath, patch);
       if (result.success) {
         // Dispatch event to refresh status
         this.dispatchEvent(new CustomEvent('status-changed', {
@@ -1826,6 +1978,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           composed: true,
         }));
         // Reload diff - if file is fully staged, clear the view
+        if (!this.isSameWorkingDiffContext(context)) return;
+        this.selectedLines = new Set();
         await this.loadWorkingDiff();
         // Check if we got a "not found" error (file fully staged)
         if (this.error?.includes('not found in diff')) {
@@ -1844,6 +1998,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     } catch (err) {
       console.error('Failed to stage hunk:', err);
       showToast(`Failed to stage hunk: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error');
+    } finally {
+      this.diffMutationInProgress = false;
     }
   }
 
@@ -1852,13 +2008,15 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    */
   private async handleUnstageHunk(hunk: DiffHunk, e: Event): Promise<void> {
     e.stopPropagation();
-    if (!this.repositoryPath || !this.file) return;
+    const context = this.currentWorkingDiffContext();
+    if (!context || this.diffMutationInProgress) return;
 
     const patch = this.buildHunkPatch(hunk);
     if (!patch) return;
 
+    this.diffMutationInProgress = true;
     try {
-      const result = await gitService.unstageHunk(this.repositoryPath, patch);
+      const result = await gitService.unstageHunk(context.repositoryPath, patch);
       if (result.success) {
         // Dispatch event to refresh status
         this.dispatchEvent(new CustomEvent('status-changed', {
@@ -1866,7 +2024,10 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           composed: true,
         }));
         // Reload diff to show updated state
-        await this.loadWorkingDiff();
+        if (this.isSameWorkingDiffContext(context)) {
+          this.selectedLines = new Set();
+          await this.loadWorkingDiff();
+        }
       } else {
         console.error('Failed to unstage hunk:', result.error);
         showToast(`Failed to unstage hunk: ${result.error?.message ?? 'Unknown error'}`, 'error');
@@ -1874,6 +2035,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     } catch (err) {
       console.error('Failed to unstage hunk:', err);
       showToast(`Failed to unstage hunk: ${err instanceof Error ? err.message : 'Unknown error'}`, 'error');
+    } finally {
+      this.diffMutationInProgress = false;
     }
   }
 
@@ -2060,7 +2223,9 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   private async handleContextStageLine(): Promise<void> {
     const line = this.contextMenu.line;
     const hunk = this.contextMenu.hunk;
-    if (!line || !hunk || !this.diff) return;
+    const context = this.currentWorkingDiffContext();
+    if (!line || !hunk || !this.diff || !context) return;
+    const requestId = this.diffRequestId;
 
     // Find hunk and line indices
     const hunkIndex = this.diff.hunks.indexOf(hunk);
@@ -2075,7 +2240,11 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     // A successful stage reloads the diff, which renumbers hunks and lines, so
     // the saved `${hunkIndex}-${lineIndex}` keys would point at different code.
     // Put the previous selection back only when nothing was applied.
-    if (!(await this.stageSelectedLines())) {
+    if (
+      !(await this.stageSelectedLines()) &&
+      requestId === this.diffRequestId &&
+      this.isSameWorkingDiffContext(context)
+    ) {
       this.selectedLines = prevSelected;
     }
   }
@@ -2086,7 +2255,9 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   private async handleContextUnstageLine(): Promise<void> {
     const line = this.contextMenu.line;
     const hunk = this.contextMenu.hunk;
-    if (!line || !hunk || !this.diff) return;
+    const context = this.currentWorkingDiffContext();
+    if (!line || !hunk || !this.diff || !context) return;
+    const requestId = this.diffRequestId;
 
     // Find hunk and line indices
     const hunkIndex = this.diff.hunks.indexOf(hunk);
@@ -2101,7 +2272,11 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
     // A successful unstage reloads the diff, which renumbers hunks and lines,
     // so the saved `${hunkIndex}-${lineIndex}` keys would point at different
     // code. Put the previous selection back only when nothing was applied.
-    if (!(await this.unstageSelectedLines())) {
+    if (
+      !(await this.unstageSelectedLines()) &&
+      requestId === this.diffRequestId &&
+      this.isSameWorkingDiffContext(context)
+    ) {
       this.selectedLines = prevSelected;
     }
   }
@@ -2833,6 +3008,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           <button
             class="edit-btn active"
             @click=${() => void this.toggleEditMode()}
+            ?disabled=${this.saving}
             title="Exit edit mode"
           >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -2847,7 +3023,13 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           : nothing}
         <div class="editor-container">
           <div class="editor-toolbar">
-            <button class="cancel-btn" @click=${() => void this.cancelEdit()}>Cancel</button>
+            <button
+              class="cancel-btn"
+              @click=${() => void this.cancelEdit()}
+              ?disabled=${this.saving}
+            >
+              Cancel
+            </button>
             <button
               class="save-btn"
               @click=${this.saveEdit}
@@ -2861,6 +3043,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
             .value=${this.editContent}
             @input=${this.handleEditorChange}
             @keydown=${this.handleEditorKeydown}
+            ?disabled=${this.saving}
             spellcheck="false"
           ></textarea>
         </div>

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -1190,10 +1190,15 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
    *
    * Deliberately weaker than `isSameWorkingDiffContext`: it ignores the loaded
    * diff, so it stays true while a reload for the SAME file is still in flight
-   * (the "Load full diff" link can start one mid-apply, and it leaves no loaded
-   * context behind). The apply itself invalidated every positional
-   * `${hunkIndex}-${lineIndex}` key, so the selection must be dropped in that
-   * case too - whichever diff lands renumbers them.
+   * (the "Load full diff" link is not disabled during an apply, so it can start
+   * one mid-apply, and it leaves no loaded context behind). That in-flight
+   * reload asked for the diff BEFORE the apply landed, so gating on the loaded
+   * context would both keep the invalidated positional
+   * `${hunkIndex}-${lineIndex}` keys and let the pre-apply content settle with
+   * nothing left to correct it - `status-changed` only re-binds the file when
+   * its status or conflicted flag changed, which a partial apply does not do.
+   * Re-running `loadWorkingDiff()` bumps `diffRequestId`, so the newer fetch
+   * discards the superseded one.
    */
   private isStillOnAppliedFile(context: {
     repositoryPath: string;
@@ -1996,8 +2001,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           bubbles: true,
           composed: true,
         }));
-        if (this.isStillOnAppliedFile(context)) this.selectedLines = new Set();
-        if (this.isSameWorkingDiffContext(context)) {
+        if (this.isStillOnAppliedFile(context)) {
+          this.selectedLines = new Set();
           await this.loadWorkingDiff();
           this.clearIfFullyApplied(context);
         }
@@ -2036,8 +2041,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           bubbles: true,
           composed: true,
         }));
-        if (this.isStillOnAppliedFile(context)) this.selectedLines = new Set();
-        if (this.isSameWorkingDiffContext(context)) {
+        if (this.isStillOnAppliedFile(context)) {
+          this.selectedLines = new Set();
           await this.loadWorkingDiff();
           this.clearIfFullyApplied(context);
         }
@@ -2075,8 +2080,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           composed: true,
         }));
         // Reload diff - if file is fully staged, clear the view
-        if (this.isStillOnAppliedFile(context)) this.selectedLines = new Set();
-        if (this.isSameWorkingDiffContext(context)) {
+        if (this.isStillOnAppliedFile(context)) {
+          this.selectedLines = new Set();
           await this.loadWorkingDiff();
           this.clearIfFullyApplied(context);
         }
@@ -2113,8 +2118,8 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           composed: true,
         }));
         // Reload diff - if nothing is left staged for this file, clear the view
-        if (this.isStillOnAppliedFile(context)) this.selectedLines = new Set();
-        if (this.isSameWorkingDiffContext(context)) {
+        if (this.isStillOnAppliedFile(context)) {
+          this.selectedLines = new Set();
           await this.loadWorkingDiff();
           this.clearIfFullyApplied(context);
         }

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -384,6 +384,18 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         border-color: var(--color-warning);
       }
 
+      /* The .stage-btn.stage:hover / .stage-btn.unstage:hover rules above are
+         restated here so a disabled button does not still light up on hover. */
+      .stage-btn:disabled,
+      .stage-btn.stage:disabled:hover,
+      .stage-btn.unstage:disabled:hover {
+        opacity: 0.6;
+        cursor: not-allowed;
+        background: var(--color-bg-primary);
+        color: var(--color-text-secondary);
+        border-color: var(--color-border);
+      }
+
       .stage-btn svg {
         width: 12px;
         height: 12px;
@@ -806,6 +818,13 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         filter: brightness(1.1);
       }
 
+      .selection-btn:disabled,
+      .selection-btn:disabled:hover {
+        opacity: 0.6;
+        cursor: not-allowed;
+        filter: none;
+      }
+
       .selection-btn svg {
         width: 12px;
         height: 12px;
@@ -997,7 +1016,10 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
   private flatLines: FlatDiffItem[] = [];
   private diffScrollTop = 0;
   private diffRequestId = 0;
-  private diffMutationInProgress = false;
+  // Reactive: the stage/unstage buttons bind `?disabled` to it, so a second
+  // click while a mutation is in flight is visibly refused rather than
+  // silently dropped by the guards in the handlers below.
+  @state() private diffMutationInProgress = false;
   private loadedWorkingDiffContext: {
     repositoryPath: string;
     filePath: string;
@@ -2569,6 +2591,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         <button
           class="stage-btn unstage"
           @click=${(e: Event) => this.handleUnstageHunk(hunk, e)}
+          ?disabled=${this.diffMutationInProgress}
           title="Unstage this hunk"
         >
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -2580,6 +2603,7 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         <button
           class="stage-btn stage"
           @click=${(e: Event) => this.handleStageHunk(hunk, e)}
+          ?disabled=${this.diffMutationInProgress}
           title="Stage this hunk"
         >
           <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
@@ -2852,14 +2876,22 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
           Clear
         </button>
         ${isStaged ? html`
-          <button class="selection-btn primary" @click=${this.unstageSelectedLines}>
+          <button
+            class="selection-btn primary"
+            @click=${this.unstageSelectedLines}
+            ?disabled=${this.diffMutationInProgress}
+          >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="5" y1="12" x2="19" y2="12"></line>
             </svg>
             Unstage Selected
           </button>
         ` : html`
-          <button class="selection-btn primary" @click=${this.stageSelectedLines}>
+          <button
+            class="selection-btn primary"
+            @click=${this.stageSelectedLines}
+            ?disabled=${this.diffMutationInProgress}
+          >
             <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
               <line x1="12" y1="5" x2="12" y2="19"></line>
               <line x1="5" y1="12" x2="19" y2="12"></line>


### PR DESCRIPTION
## Summary
- ignore superseded working-tree and commit diff responses
- pin staging and unstaging to the repository, file, and staged state that produced the diff
- clear positional selections when a replacement diff invalidates them
- protect editor loads and saves across repository and file changes
- serialize diff mutations so overlapping actions cannot leave stale content

## Validation
- 96 diff-view tests pass
- lint and typecheck pass
- three independent frontier-model reviewers converged on no issues