### PR TITLE
Fix graph tag checkout ref collisions

### DIFF
--- a/src/__tests__/app-shell-ref-context-menu.integration.test.ts
+++ b/src/__tests__/app-shell-ref-context-menu.integration.test.ts
@@ -77,10 +77,11 @@ function commandIndex(name: string): number {
 /** Make every showConfirm() in the run resolve to "declined". */
 function declineConfirms(): void {
   const previous = mockInvoke;
-  mockInvoke = (command: string, args?: unknown) =>
-    command === 'plugin:dialog|message'
-      ? Promise.resolve('Cancel')
-      : previous(command, args);
+  mockInvoke = (command: string, args?: unknown) => {
+    if (command === 'plugin:dialog|confirm') return Promise.resolve(false);
+    if (command === 'plugin:dialog|message') return Promise.resolve('Cancel');
+    return previous(command, args);
+  };
 }
 
 function setupDefaultMocks(): void {
@@ -91,6 +92,8 @@ function setupDefaultMocks(): void {
       // their sidebar counterparts.
       case 'plugin:dialog|message':
         return 'Ok';
+      case 'plugin:dialog|confirm':
+        return true;
       case 'checkout_with_autostash':
         return { success: true, stashed: false, stashApplied: false, stashConflict: false, message: 'ok' };
       case 'open_repository':
@@ -129,14 +132,19 @@ function createAppShell(): AppShell {
   return el;
 }
 
-function setRefContextMenu(el: AppShell, refName: string, refType: 'localBranch' | 'remoteBranch' | 'tag' = 'localBranch'): void {
+function setRefContextMenu(
+  el: AppShell,
+  refName: string,
+  refType: 'localBranch' | 'remoteBranch' | 'tag' = 'localBranch',
+  fullName = refName,
+): void {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   (el as any).refContextMenu = {
     visible: true,
     x: 100,
     y: 100,
     refName,
-    fullName: refName,
+    fullName,
     refType,
   };
 }
@@ -162,6 +170,21 @@ describe('app-shell ref context menu handlers (integration)', () => {
       expect(calls[0].args).to.deep.include({
         path: REPO_PATH,
         refName: 'feature-branch',
+      });
+    });
+
+    it('uses the qualified tag ref when a branch has the same short name', async () => {
+      const el = createAppShell();
+      setRefContextMenu(el, 'release', 'tag', 'refs/tags/release');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRefCheckout();
+
+      const calls = findCommands('checkout_with_autostash');
+      expect(calls).to.have.length(1);
+      expect(calls[0].args).to.deep.include({
+        path: REPO_PATH,
+        refName: 'refs/tags/release',
       });
     });
 
@@ -686,4 +709,3 @@ describe('app-shell force-delete toast action (integration)', () => {
       .to.be.true;
   });
 });
-

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2194,6 +2194,10 @@ export class AppShell extends LitElement {
     // per-repo lock in the backend. The sidebar has always guarded its own
     // checkout with the flag it shares with merge/rebase/rename.
     const refName = this.refContextMenu.refName;
+    const checkoutRef =
+      this.refContextMenu.refType === 'tag'
+        ? this.refContextMenu.fullName || `refs/tags/${refName}`
+        : refName;
     const repoPath = this.activeRepository.repository.path;
     if (!this.claimRefOperation(repoPath)) return;
     const refType = this.refContextMenu.refType;
@@ -2216,7 +2220,7 @@ export class AppShell extends LitElement {
     }
 
     try {
-      const result = await gitService.checkoutWithAutoStash(repoPath, refName);
+      const result = await gitService.checkoutWithAutoStash(repoPath, checkoutRef);
 
       if (result.success && result.data?.success) {
         this.handleAutoStashToast(result.data, refName, repoPath);


### PR DESCRIPTION
## Summary
- send fully-qualified tag refs from graph context-menu checkout
- preserve existing local and remote branch checkout behavior
- add regression coverage for a tag and branch sharing the same short name

## Tests
- new tag collision regression passed
- integration file: 30 passed; 2 pre-existing merge/rebase confirm-mock failures outside this change
- TypeScript typecheck passed
- targeted ESLint passed with one pre-existing warning