### PR TITLE
Name and pin tag push destinations

### DIFF
--- a/e2e/fixtures/tauri-mock.ts
+++ b/e2e/fixtures/tauri-mock.ts
@@ -483,6 +483,9 @@ function createMockHandler(mocks: typeof defaultMockData) {
         return null;
       }
       case 'push_tag':
+        return null;
+      case 'get_push_remote':
+        return (args?.remote as string) ?? mocks.remotes[0]?.name ?? 'origin';
       // Deleting a tag offers to delete the remote copy too — the local
       // delete leaves it behind and the tag fetch refspec restores it.
       case 'delete_remote_tag':
@@ -1061,6 +1064,13 @@ export async function setupTauriMocks(
             return null;
           }
           case 'push_tag':
+            return null;
+          case 'get_push_remote':
+            return (
+              (args as { remote?: string })?.remote ??
+              state.remotes[0]?.name ??
+              'origin'
+            );
           // See the other builder's switch — tag delete offers the remote too.
           case 'delete_remote_tag':
             return null;

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -563,6 +563,7 @@ pub(crate) fn resolve_push_remote(repo: &git2::Repository, requested: Option<Str
     if let Some(r) = requested {
         return r;
     }
+
     let head_branch = repo
         .head()
         .ok()
@@ -594,6 +595,15 @@ pub(crate) fn resolve_push_remote(repo: &git2::Repository, requested: Option<Str
         }
         _ => "origin".to_string(),
     }
+}
+
+#[tauri::command]
+pub async fn get_push_remote(path: String, remote: Option<String>) -> Result<String> {
+    let repo = git2::Repository::open(Path::new(&path))?;
+    let remote_name = resolve_push_remote(&repo, remote);
+    repo.find_remote(&remote_name)
+        .map_err(|_| LeviathanError::RemoteNotFound(remote_name.clone()))?;
+    Ok(remote_name)
 }
 
 /// The merge-and-commit body of a non-fast-forward `pull`.
@@ -2583,6 +2593,7 @@ mod tests {
             )
             .unwrap();
         }
+
         assert_eq!(
             resolve_push_remote(&repo, None),
             "upstream",
@@ -2617,6 +2628,18 @@ mod tests {
             "chosen",
             "an explicit remote still wins over everything"
         );
+    }
+
+    #[tokio::test]
+    async fn test_get_push_remote_returns_the_resolved_destination() {
+        let repo_dir = TestRepo::with_initial_commit();
+        repo_dir.add_remote("upstream", "https://example.test/repo.git");
+
+        let remote = get_push_remote(repo_dir.path_str(), None)
+            .await
+            .expect("the sole remote should resolve");
+
+        assert_eq!(remote, "upstream");
     }
 
     /// Pull must follow the branch's CONFIGURED upstream, not "origin/<name>".

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -2642,6 +2642,48 @@ mod tests {
         assert_eq!(remote, "upstream");
     }
 
+    /// A repo with NO remotes resolves to the "origin" default, which does not
+    /// exist. Returning it anyway would send the UI on to push_tag and surface
+    /// "Remote not found: origin" from the push instead of from the lookup the
+    /// callers gate on.
+    #[tokio::test]
+    async fn test_get_push_remote_errors_when_the_repo_has_no_remotes() {
+        let repo_dir = TestRepo::with_initial_commit();
+
+        let err = get_push_remote(repo_dir.path_str(), None)
+            .await
+            .expect_err("a repo with no remotes has no push destination");
+
+        assert!(
+            matches!(err, LeviathanError::RemoteNotFound(ref name) if name == "origin"),
+            "the missing destination is named: {err:?}"
+        );
+    }
+
+    /// remote.pushDefault can outlive the remote it names (renamed, removed).
+    /// The resolver happily returns the stale name, so the existence check is
+    /// the only thing standing between the user and a confirm dialog naming a
+    /// remote that is not there.
+    #[tokio::test]
+    async fn test_get_push_remote_errors_when_the_configured_default_is_gone() {
+        let repo_dir = TestRepo::with_initial_commit();
+        repo_dir.add_remote("origin", "https://example.test/repo.git");
+        {
+            let repo = git2::Repository::open(&repo_dir.path).unwrap();
+            let mut cfg = repo.config().unwrap();
+            cfg.set_str("remote.pushDefault", "nope").unwrap();
+        }
+
+        let err = get_push_remote(repo_dir.path_str(), None)
+            .await
+            .expect_err("a pushDefault naming a missing remote must not resolve");
+
+        assert!(
+            matches!(err, LeviathanError::RemoteNotFound(ref name) if name == "nope"),
+            "the missing destination is named: {err:?}"
+        );
+    }
+
     /// Pull must follow the branch's CONFIGURED upstream, not "origin/<name>".
     ///
     /// In the standard fork workflow (origin = your fork, upstream = canonical,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -334,6 +334,7 @@ pub fn run() {
             commands::staging::strip_trailing_whitespace,
             commands::staging::get_sorted_file_status,
             commands::remote::get_remotes,
+            commands::remote::get_push_remote,
             commands::remote::add_remote,
             commands::remote::remove_remote,
             commands::remote::rename_remote,

--- a/src/__tests__/app-shell-ref-context-menu.integration.test.ts
+++ b/src/__tests__/app-shell-ref-context-menu.integration.test.ts
@@ -557,6 +557,29 @@ describe('app-shell ref context menu handlers (integration)', () => {
         remote: 'origin',
       });
     });
+
+    it('reports an unresolvable destination instead of pushing blind', async () => {
+      // The toast and the Force Push Tag suggestion both name the destination,
+      // so a push that could not resolve one must stop rather than let the
+      // backend pick a remote the user is never told about.
+      const previous = mockInvoke;
+      mockInvoke = (command: string, args?: unknown) =>
+        command === 'get_push_remote'
+          ? Promise.reject({ code: 'REMOTE_NOT_FOUND', message: 'Remote not found: origin' })
+          : previous(command, args);
+
+      const el = createAppShell();
+      setRefContextMenu(el, 'v2.0.0', 'tag');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRefPushTag();
+
+      const errors = uiStore.getState().toasts.filter((t) => t.type === 'error');
+      expect(errors.length, 'the user is told why nothing happened').to.equal(1);
+      expect(errors[0].message).to.contain('Could not determine the tag destination');
+      expect(errors[0].message).to.contain('Remote not found: origin');
+      expect(findCommands('push_tag').length, 'and nothing is pushed').to.equal(0);
+    });
   });
 
   describe('handleRefresh ordering (regression test for checkout bug)', () => {

--- a/src/__tests__/app-shell-ref-context-menu.integration.test.ts
+++ b/src/__tests__/app-shell-ref-context-menu.integration.test.ts
@@ -563,10 +563,73 @@ describe('app-shell ref context menu handlers (integration)', () => {
       // so a push that could not resolve one must stop rather than let the
       // backend pick a remote the user is never told about.
       const previous = mockInvoke;
-      mockInvoke = (command: string, args?: unknown) =>
-        command === 'get_push_remote'
-          ? Promise.reject({ code: 'REMOTE_NOT_FOUND', message: 'Remote not found: origin' })
-          : previous(command, args);
+      mockInvoke = (command: string, args?: unknown) => {
+        if (command === 'get_push_remote') {
+          return Promise.reject({ code: 'REMOTE_NOT_FOUND', message: 'Remote not found: upstream' });
+        }
+        // Remotes exist — the configured push remote just is not one of them.
+        if (command === 'get_remotes') {
+          return Promise.resolve([
+            { name: 'origin', url: 'https://example.test/r.git', pushUrl: null },
+          ]);
+        }
+        return previous(command, args);
+      };
+
+      const el = createAppShell();
+      setRefContextMenu(el, 'v2.0.0', 'tag');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRefPushTag();
+
+      const errors = uiStore.getState().toasts.filter((t) => t.type === 'error');
+      expect(errors.length, 'the user is told why nothing happened').to.equal(1);
+      expect(errors[0].message).to.contain('Could not determine the tag destination');
+      expect(errors[0].message).to.contain('Remote not found: upstream');
+      expect(findCommands('push_tag').length, 'and nothing is pushed').to.equal(0);
+    });
+
+    it('names missing setup, not a phantom remote, when the repo has none', async () => {
+      // The resolver falls back to the literal `origin`, so a fresh `git init`
+      // repo fails with "Remote not found: origin" — a remote the user never
+      // configured. The tag list translates that into setup guidance; this
+      // surface must say the same thing rather than read as a bug.
+      const previous = mockInvoke;
+      mockInvoke = (command: string, args?: unknown) => {
+        if (command === 'get_push_remote') {
+          return Promise.reject({ code: 'REMOTE_NOT_FOUND', message: 'Remote not found: origin' });
+        }
+        if (command === 'get_remotes') return Promise.resolve([]);
+        return previous(command, args);
+      };
+
+      const el = createAppShell();
+      setRefContextMenu(el, 'v2.0.0', 'tag');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRefPushTag();
+
+      const errors = uiStore.getState().toasts.filter((t) => t.type === 'error');
+      expect(errors.length, 'the user is told why nothing happened').to.equal(1);
+      expect(errors[0].message).to.equal(
+        'No remotes configured. Add a remote before pushing tags.',
+      );
+      expect(findCommands('push_tag').length, 'and nothing is pushed').to.equal(0);
+    });
+
+    it('falls back to the resolver error when the remote list cannot be read', async () => {
+      // No answer about the remote count means no basis for the setup wording;
+      // the resolver's own message is still better than silence.
+      const previous = mockInvoke;
+      mockInvoke = (command: string, args?: unknown) => {
+        if (command === 'get_push_remote') {
+          return Promise.reject({ code: 'REMOTE_NOT_FOUND', message: 'Remote not found: origin' });
+        }
+        if (command === 'get_remotes') {
+          return Promise.reject({ code: 'GIT_ERROR', message: 'could not read config' });
+        }
+        return previous(command, args);
+      };
 
       const el = createAppShell();
       setRefContextMenu(el, 'v2.0.0', 'tag');

--- a/src/__tests__/app-shell-ref-context-menu.integration.test.ts
+++ b/src/__tests__/app-shell-ref-context-menu.integration.test.ts
@@ -105,6 +105,8 @@ function setupDefaultMocks(): void {
         return null;
       case 'push_tag':
         return null;
+      case 'get_push_remote':
+        return 'origin';
       case 'get_branches':
         return [];
       case 'get_remotes':
@@ -552,6 +554,7 @@ describe('app-shell ref context menu handlers (integration)', () => {
       expect(calls[0].args).to.deep.include({
         path: REPO_PATH,
         name: 'v2.0.0',
+        remote: 'origin',
       });
     });
   });
@@ -686,4 +689,3 @@ describe('app-shell force-delete toast action (integration)', () => {
       .to.be.true;
   });
 });
-

--- a/src/__tests__/app-shell-remote-feedback.test.ts
+++ b/src/__tests__/app-shell-remote-feedback.test.ts
@@ -455,6 +455,37 @@ describe('app-shell remote-operation feedback', () => {
       ).to.equal(true);
     });
 
+    it('an unresolvable destination stops the force push before the confirm', async () => {
+      // Without the destination there is nothing honest to name in the "this
+      // moves the remote tag" confirm, and pushing anyway force-moves the tag
+      // on whatever the backend picks — a destructive write to a remote the
+      // user never aimed at.
+      mockResponses['plugin:dialog|confirm'] = () => 'Ok';
+      mockResponses['plugin:dialog|message'] = () => 'Ok';
+      failures['get_push_remote'] = {
+        code: 'REMOTE_NOT_FOUND',
+        message: 'Remote not found: origin',
+      };
+      const el = shellWithStoreRepo();
+
+      await (el as any).forcePushTag('v1.2.0', '/repo/one');
+
+      const errors = uiStore.getState().toasts.filter((t) => t.type === 'error');
+      expect(errors.length, 'the user is told why nothing happened').to.equal(1);
+      expect(errors[0].message).to.contain('Could not determine the tag destination');
+      expect(errors[0].message).to.contain('Remote not found: origin');
+      expect(
+        invokeCallArgs.some(
+          (c) => c.command === 'plugin:dialog|confirm' || c.command === 'plugin:dialog|message',
+        ),
+        'no confirm for a push that cannot happen',
+      ).to.equal(false);
+      expect(
+        invokeCallArgs.some((c) => c.command === 'push_tag'),
+        'and nothing is pushed',
+      ).to.equal(false);
+    });
+
     it('the force-push-tag event carries the remote through to the push', async () => {
       // The suggestion service dispatches on `window`; the remote has to
       // survive the hop or the retry re-resolves the destination anyway.

--- a/src/__tests__/app-shell-remote-feedback.test.ts
+++ b/src/__tests__/app-shell-remote-feedback.test.ts
@@ -65,6 +65,7 @@ describe('app-shell remote-operation feedback', () => {
     invokeCallArgs.length = 0;
     for (const k of Object.keys(mockResponses)) delete mockResponses[k];
     for (const k of Object.keys(failures)) delete failures[k];
+    mockResponses['get_push_remote'] = (args) => args.remote ?? 'origin';
     uiStore.setState({ toasts: [] });
     repositoryStore.getState().reset();
   });
@@ -409,6 +410,11 @@ describe('app-shell remote-operation feedback', () => {
 
       await (el as any).forcePushTag('v1.2.0', '/repo/one');
 
+      const confirm = invokeCallArgs.find(
+        (c) => c.command === 'plugin:dialog|confirm' || c.command === 'plugin:dialog|message',
+      );
+      expect(confirm, 'the force push asks for confirmation').to.not.be.undefined;
+      expect(String(confirm!.args.message)).to.contain('"origin"');
       const pushTag = invokeCallArgs.find((c) => c.command === 'push_tag');
       expect(pushTag).to.not.be.undefined;
       expect(pushTag!.args.name).to.equal('v1.2.0');
@@ -435,9 +441,7 @@ describe('app-shell remote-operation feedback', () => {
       ).to.equal(true);
     });
 
-    it('a tag force push with no chosen remote still leaves the key off', async () => {
-      // The graph ref menu names no remote; the backend resolver has to keep
-      // running, so the key must be absent rather than undefined.
+    it('a tag force push resolves and names the destination when none was chosen', async () => {
       mockResponses['plugin:dialog|confirm'] = () => 'Ok';
       mockResponses['plugin:dialog|message'] = () => 'Ok';
       const el = shellWithStoreRepo();
@@ -445,7 +449,10 @@ describe('app-shell remote-operation feedback', () => {
       await (el as any).forcePushTag('v1.2.0', '/repo/one');
 
       const pushTag = invokeCallArgs.find((c) => c.command === 'push_tag');
-      expect('remote' in pushTag!.args, 'no remote key at all').to.equal(false);
+      expect(pushTag!.args.remote).to.equal('origin');
+      expect(
+        uiStore.getState().toasts.some((t) => t.message === 'Force pushed tag v1.2.0 to origin'),
+      ).to.equal(true);
     });
 
     it('the force-push-tag event carries the remote through to the push', async () => {

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2473,8 +2473,16 @@ export class AppShell extends LitElement {
     try {
       const remoteResult = await gitService.getPushRemote(repoPath);
       if (!remoteResult.success || !remoteResult.data) {
+        // A repo with no remote cannot push a tag anywhere. The resolver falls
+        // back to the literal `origin`, so its answer — "Remote not found:
+        // origin" — names a remote the user never configured, which reads as a
+        // bug rather than as missing setup. Translated exactly as the tag list
+        // translates it, so both tag-push surfaces say the same thing.
+        const remotes = await gitService.getRemotes(repoPath);
         showToast(
-          `Could not determine the tag destination: ${remoteResult.error?.message ?? 'Unknown error'}`,
+          remotes.success && (remotes.data?.length ?? 0) === 0
+            ? 'No remotes configured. Add a remote before pushing tags.'
+            : `Could not determine the tag destination: ${remoteResult.error?.message ?? 'Unknown error'}`,
           'error',
         );
         return;

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2471,11 +2471,20 @@ export class AppShell extends LitElement {
     this.refContextMenu = { ...this.refContextMenu, visible: false };
 
     try {
-      const result = await gitService.pushTag({ path: repoPath, name: tagName });
+      const remoteResult = await gitService.getPushRemote(repoPath);
+      if (!remoteResult.success || !remoteResult.data) {
+        showToast(
+          `Could not determine the tag destination: ${remoteResult.error?.message ?? 'Unknown error'}`,
+          'error',
+        );
+        return;
+      }
+      const remote = remoteResult.data;
+      const result = await gitService.pushTag({ path: repoPath, name: tagName, remote });
 
       if (result.success) {
         this.refreshConflictDialogRepo(repoPath);
-        showToast(`Pushed tag ${tagName}`, 'success');
+        showToast(`Pushed tag ${tagName} to ${remote}`, 'success');
       } else if (!gitService.isNetworkGateRefusal(result.error)) {
         log.error('Push tag failed:', result.error);
         showErrorWithSuggestion(result.error?.message || '', 'Push tag failed', {
@@ -2483,6 +2492,7 @@ export class AppShell extends LitElement {
           // Carries the tag through to the Force Push Tag suggestion action.
           branchName: tagName,
           repoPath,
+          remote,
         });
       }
     } finally {
@@ -3140,9 +3150,19 @@ export class AppShell extends LitElement {
       .openRepositories.find((r) => r.repository.path === repoPath);
     if (!repo) return;
 
+    const remoteResult = await gitService.getPushRemote(repoPath, remote);
+    if (!remoteResult.success || !remoteResult.data) {
+      showToast(
+        `Could not determine the tag destination: ${remoteResult.error?.message ?? 'Unknown error'}`,
+        'error',
+      );
+      return;
+    }
+    const destination = remoteResult.data;
+
     const confirmed = await showConfirm(
       'Force Push Tag',
-      `This moves the tag "${tagName}" on ${remote ?? 'the remote'} in ` +
+      `This moves the tag "${tagName}" on "${destination}" in ` +
         `${repo.repository.name} to your local commit. Anyone who already fetched ` +
         `the tag keeps the old one until they delete it locally.`,
       'error'
@@ -3155,11 +3175,11 @@ export class AppShell extends LitElement {
       force: true,
       // Omitted, not undefined: the backend resolver only runs when the key is
       // absent, and git.service's allowlist/token lookups key off it too.
-      ...(remote ? { remote } : {}),
+      remote: destination,
     });
     if (result.success) {
       showToast(
-        remote ? `Force pushed tag ${tagName} to ${remote}` : `Force pushed tag ${tagName}`,
+        `Force pushed tag ${tagName} to ${destination}`,
         'success',
       );
       this.refreshConflictDialogRepo(repoPath);

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -3173,8 +3173,9 @@ export class AppShell extends LitElement {
       path: repoPath,
       name: tagName,
       force: true,
-      // Omitted, not undefined: the backend resolver only runs when the key is
-      // absent, and git.service's allowlist/token lookups key off it too.
+      // Always explicit: the destination was resolved above, so the confirm,
+      // the toast and git.service's allowlist/token lookups all name the same
+      // remote.
       remote: destination,
     });
     if (result.success) {

--- a/src/components/sidebar/__tests__/lv-tag-list-feedback.test.ts
+++ b/src/components/sidebar/__tests__/lv-tag-list-feedback.test.ts
@@ -51,6 +51,7 @@ function deleteFlowMock(options: {
   answers?: string[];
   deleteRemoteTag?: () => Promise<unknown>;
   getRemotes?: () => Promise<unknown>;
+  getPushRemote?: () => Promise<unknown>;
 }) {
   const dialogMessages: string[] = [];
   const invokes: Array<{ command: string; args?: unknown }> = [];
@@ -65,6 +66,9 @@ function deleteFlowMock(options: {
     }
     if (command === 'get_remotes') {
       return options.getRemotes ? options.getRemotes() : Promise.resolve(options.remotes ?? []);
+    }
+    if (command === 'get_push_remote' && options.getPushRemote) {
+      return options.getPushRemote();
     }
     if (command === 'delete_tag') return Promise.resolve(null);
     if (command === 'delete_remote_tag') {
@@ -268,6 +272,30 @@ describe('lv-tag-list feedback', () => {
     expect(warning, 'the user is told the remote copy may survive').to.not.be.undefined;
     expect(warning!.message).to.contain('v3.0.0');
     expect(warning!.message).to.contain('remote');
+    expect(flow.invokes.filter((i) => i.command === 'delete_remote_tag')).to.have.length(0);
+  });
+
+  it('an unresolvable push destination warns instead of skipping the follow-up', async () => {
+    // Same hazard as an unreadable remote list: the local delete already
+    // toasted success, so returning silently tells the user the tag is gone
+    // while the remote copy survives and the next fetch restores it.
+    const el = await createComponent();
+    const flow = deleteFlowMock({
+      remotes: ORIGIN,
+      // Both dialogs answered, so a missing guard would actually reach the
+      // remote delete rather than stall on an unanswered confirm.
+      answers: ['Ok', 'Ok'],
+      getPushRemote: () =>
+        Promise.reject({ code: 'REMOTE_NOT_FOUND', message: 'Remote not found: origin' }),
+    });
+    mockInvoke = flow.mock;
+
+    await runDeleteTag(el, 'v4.0.0');
+
+    const warning = uiStore.getState().toasts.find((t) => t.type === 'warning');
+    expect(warning, 'the user is told the remote copy may survive').to.not.be.undefined;
+    expect(warning!.message).to.contain('v4.0.0');
+    expect(warning!.message).to.contain('push destination could not be resolved');
     expect(flow.invokes.filter((i) => i.command === 'delete_remote_tag')).to.have.length(0);
   });
 

--- a/src/components/sidebar/__tests__/lv-tag-list-feedback.test.ts
+++ b/src/components/sidebar/__tests__/lv-tag-list-feedback.test.ts
@@ -33,6 +33,7 @@ function makeTag(name = 'v1.0.0') {
 function defaultMockInvoke(command: string): Promise<unknown> {
   if (command === 'get_tags') return Promise.resolve([]);
   if (command === 'get_tag_sort_mode') return Promise.resolve('name');
+  if (command === 'get_push_remote') return Promise.resolve('origin');
   // Confirmation dialogs return the clicked button label; 'Ok' = confirmed.
   if (command === 'plugin:dialog|message') return Promise.resolve('Ok');
   return Promise.resolve(null);
@@ -140,7 +141,7 @@ describe('lv-tag-list feedback', () => {
 
     const successToast = uiStore.getState().toasts.find(t => t.type === 'success');
     expect(successToast, 'a success toast should be shown').to.not.be.undefined;
-    expect(successToast!.message).to.equal('Pushed tag v2.0.0 to remote');
+    expect(successToast!.message).to.equal('Pushed tag v2.0.0 to origin');
   });
 
   it('deleting a tag confirms the destructive operation happened', async () => {

--- a/src/components/sidebar/__tests__/lv-tag-list-feedback.test.ts
+++ b/src/components/sidebar/__tests__/lv-tag-list-feedback.test.ts
@@ -275,28 +275,53 @@ describe('lv-tag-list feedback', () => {
     expect(flow.invokes.filter((i) => i.command === 'delete_remote_tag')).to.have.length(0);
   });
 
-  it('an unresolvable push destination warns instead of skipping the follow-up', async () => {
-    // Same hazard as an unreadable remote list: the local delete already
-    // toasted success, so returning silently tells the user the tag is gone
-    // while the remote copy survives and the next fetch restores it.
+  it('an unresolvable push destination still offers the follow-up on a known remote', async () => {
+    // `resolve_push_remote` answers from config and falls back to the literal
+    // "origin", so a stale `remote.pushDefault` fails `get_push_remote` on a
+    // repo that plainly has remotes. The remote list was read a moment ago —
+    // dropping the follow-up would leave NO surface for deleting the remote
+    // tag, and the next fetch would restore it.
     const el = await createComponent();
     const flow = deleteFlowMock({
       remotes: ORIGIN,
-      // Both dialogs answered, so a missing guard would actually reach the
-      // remote delete rather than stall on an unanswered confirm.
+      answers: ['Ok', 'Ok'],
+      getPushRemote: () =>
+        Promise.reject({ code: 'REMOTE_NOT_FOUND', message: 'Remote not found: gone' }),
+    });
+    mockInvoke = flow.mock;
+
+    await runDeleteTag(el, 'v4.0.0');
+
+    const remoteDeletes = flow.invokes.filter((i) => i.command === 'delete_remote_tag');
+    expect(remoteDeletes, 'the remote copy is still deletable').to.have.length(1);
+    expect((remoteDeletes[0].args as { remote: string }).remote).to.equal('origin');
+    expect(flow.dialogMessages[1], 'and the confirm names where it goes').to.contain('origin');
+    expect(uiStore.getState().toasts.find((t) => t.type === 'warning'), 'no dead end').to.be
+      .undefined;
+  });
+
+  it('falls back to the first remote when none is named origin', async () => {
+    // Two remotes, no `origin`, and a detached HEAD (which checking out a tag
+    // puts you in) leaves `resolve_push_remote` guessing "origin" — a name
+    // `find_remote` rejects. The first configured remote is the same pick this
+    // followed before `get_push_remote` existed.
+    const el = await createComponent();
+    const flow = deleteFlowMock({
+      remotes: [
+        { name: 'upstream', url: 'https://example.test/u.git', pushUrl: null },
+        { name: 'fork', url: 'https://example.test/f.git', pushUrl: null },
+      ],
       answers: ['Ok', 'Ok'],
       getPushRemote: () =>
         Promise.reject({ code: 'REMOTE_NOT_FOUND', message: 'Remote not found: origin' }),
     });
     mockInvoke = flow.mock;
 
-    await runDeleteTag(el, 'v4.0.0');
+    await runDeleteTag(el, 'v5.0.0');
 
-    const warning = uiStore.getState().toasts.find((t) => t.type === 'warning');
-    expect(warning, 'the user is told the remote copy may survive').to.not.be.undefined;
-    expect(warning!.message).to.contain('v4.0.0');
-    expect(warning!.message).to.contain('push destination could not be resolved');
-    expect(flow.invokes.filter((i) => i.command === 'delete_remote_tag')).to.have.length(0);
+    const remoteDeletes = flow.invokes.filter((i) => i.command === 'delete_remote_tag');
+    expect(remoteDeletes).to.have.length(1);
+    expect((remoteDeletes[0].args as { remote: string }).remote).to.equal('upstream');
   });
 
   it('a failed remote delete is reported to the user', async () => {

--- a/src/components/sidebar/__tests__/lv-tag-list-guards.test.ts
+++ b/src/components/sidebar/__tests__/lv-tag-list-guards.test.ts
@@ -78,6 +78,9 @@ function defaultMockInvoke(command: string): Promise<unknown> {
   if (command === 'get_tag_sort_mode') {
     return Promise.resolve('name');
   }
+  if (command === 'get_push_remote') {
+    return Promise.resolve('origin');
+  }
   return Promise.resolve(null);
 }
 

--- a/src/components/sidebar/__tests__/lv-tag-list-push-remote.test.ts
+++ b/src/components/sidebar/__tests__/lv-tag-list-push-remote.test.ts
@@ -68,6 +68,7 @@ async function createComponent(remotes: ReturnType<typeof remote>[] | 'fail'): P
           : Promise.resolve(remotes);
       return remotesCall;
     }
+    if (command === 'get_push_remote') return Promise.resolve('origin');
     if (command === 'push_tag') {
       pushCalls.push(args as PushCall);
       if (pushFailure) return Promise.reject(pushFailure);
@@ -204,9 +205,7 @@ describe('lv-tag-list push destination', () => {
     expect(isRefOpRunning(REPO_PATH), 'the working-tree lock is not held').to.equal(false);
   });
 
-  it('an unreadable remote list still pushes the way it always did', async () => {
-    // remotes === null: the destination is unknown, so the arg is left off
-    // entirely and the backend resolves it.
+  it('an unreadable remote list resolves and names the backend destination', async () => {
     const el = await createComponent('fail');
     await openMenu(el);
     expect(pushLabel(el)).to.equal('Push to Remote');
@@ -215,15 +214,14 @@ describe('lv-tag-list push destination', () => {
     await waitUntil(() => pushCalls.length === 1, 'push_tag to be invoked');
 
     expect(pushCalls[0].name).to.equal('v1.0.0');
-    expect('remote' in pushCalls[0], 'no remote key at all, so the backend resolver runs')
-      .to.equal(false);
+    expect(pushCalls[0].remote).to.equal('origin');
 
     await waitUntil(
       () => uiStore.getState().toasts.some((t) => t.type === 'success'),
       'the success toast'
     );
     const toast = uiStore.getState().toasts.find((t) => t.type === 'success');
-    expect(toast!.message).to.equal('Pushed tag v1.0.0 to remote');
+    expect(toast!.message).to.equal('Pushed tag v1.0.0 to origin');
   });
 
   it('a push clicked before the remote read lands still asks which remote', async () => {
@@ -233,14 +231,20 @@ describe('lv-tag-list push destination', () => {
     // was about to render is never offered.
     pushCalls = [];
     let landRemotes: (value: unknown) => void = () => undefined;
+    let remoteReads = 0;
     mockInvoke = (command: string, args?: unknown) => {
       if (command === 'get_tags') return Promise.resolve([TAG]);
       if (command === 'get_tag_sort_mode') return Promise.resolve('name');
       if (command === 'get_remotes') {
+        remoteReads++;
+        if (remoteReads > 1) {
+          return Promise.resolve([remote('origin'), remote('upstream')]);
+        }
         return new Promise((resolvePending) => {
           landRemotes = resolvePending;
         });
       }
+      if (command === 'get_push_remote') return Promise.resolve('origin');
       if (command === 'push_tag') {
         pushCalls.push(args as PushCall);
         return Promise.resolve(null);

--- a/src/components/sidebar/__tests__/lv-tag-list-push-remote.test.ts
+++ b/src/components/sidebar/__tests__/lv-tag-list-push-remote.test.ts
@@ -50,6 +50,8 @@ interface PushCall {
 let pushCalls: PushCall[] = [];
 /** When set, push_tag rejects with this instead of succeeding. */
 let pushFailure: { code: string; message: string } | null = null;
+/** When set, get_push_remote rejects with this instead of resolving. */
+let pushRemoteFailure: { code: string; message: string } | null = null;
 /** The in-flight get_remotes call for the most recent context-menu open. */
 let remotesCall: Promise<unknown> | null = null;
 
@@ -68,7 +70,10 @@ async function createComponent(remotes: ReturnType<typeof remote>[] | 'fail'): P
           : Promise.resolve(remotes);
       return remotesCall;
     }
-    if (command === 'get_push_remote') return Promise.resolve('origin');
+    if (command === 'get_push_remote') {
+      if (pushRemoteFailure) return Promise.reject(pushRemoteFailure);
+      return Promise.resolve('origin');
+    }
     if (command === 'push_tag') {
       pushCalls.push(args as PushCall);
       if (pushFailure) return Promise.reject(pushFailure);
@@ -127,6 +132,7 @@ describe('lv-tag-list push destination', () => {
     const state = uiStore.getState();
     state.toasts.forEach((t) => state.removeToast(t.id));
     pushFailure = null;
+    pushRemoteFailure = null;
   });
 
   it('names the sole remote in the menu and pushes to it', async () => {
@@ -222,6 +228,28 @@ describe('lv-tag-list push destination', () => {
     );
     const toast = uiStore.getState().toasts.find((t) => t.type === 'success');
     expect(toast!.message).to.equal('Pushed tag v1.0.0 to origin');
+  });
+
+  it('an unresolvable destination is reported instead of pushing blind', async () => {
+    // The unreadable-remote-list path leans entirely on the backend resolver.
+    // When that fails too there is no destination to name in the toast or to
+    // hand the Force Push Tag retry, so nothing may be pushed.
+    pushRemoteFailure = { code: 'REMOTE_NOT_FOUND', message: 'Remote not found: origin' };
+    const el = await createComponent('fail');
+    await openMenu(el);
+
+    pushItem(el)!.click();
+    await waitUntil(
+      () => uiStore.getState().toasts.some((t) => t.type === 'error'),
+      'the error toast'
+    );
+
+    const toast = uiStore.getState().toasts.find((t) => t.type === 'error');
+    expect(toast!.message).to.contain('Could not determine the tag destination');
+    expect(toast!.message).to.contain('Remote not found: origin');
+    expect(pushCalls, 'nothing is pushed to a destination nobody could name').to.have.length(0);
+    // The early return must leak no lock.
+    await waitUntil(() => !isRefOpRunning(REPO_PATH), 'the working-tree lock to be released');
   });
 
   it('a push clicked before the remote read lands still asks which remote', async () => {

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -850,8 +850,9 @@ export class LvTagList extends LitElement {
    * Push the right-clicked tag.
    *
    * `remote` is the destination the user picked in the menu. When it is
-   * undefined the arg is left off the command entirely so the backend resolves
-   * the destination the same way `push` does.
+   * undefined the destination is resolved up front via `get_push_remote`, so
+   * the success toast and the force-push retry can both name where the tag
+   * actually went.
    */
   private async handlePushTag(remote?: string): Promise<void> {
     const tag = this.contextMenu.tag;
@@ -920,8 +921,9 @@ export class LvTagList extends LitElement {
       const result = await gitService.pushTag({
         path: repoPath,
         name: tag.name,
-        // Omitted, not undefined: the backend resolver only runs when the key
-        // is absent, and git.service's allowlist/token lookups key off it too.
+        // Always explicit: the destination was resolved above, so the toast,
+        // the force retry and git.service's allowlist/token lookups all key off
+        // the same remote.
         remote: destination,
       });
 

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -906,20 +906,29 @@ export class LvTagList extends LitElement {
     // slow) network push, which rebinds this.repositoryPath.
     const repoPath = this.repositoryPath;
     try {
+      if (!destination) {
+        const remoteResult = await gitService.getPushRemote(repoPath);
+        if (!remoteResult.success || !remoteResult.data) {
+          showToast(
+            `Could not determine the tag destination: ${remoteResult.error?.message ?? 'Unknown error'}`,
+            'error',
+          );
+          return;
+        }
+        destination = remoteResult.data;
+      }
       const result = await gitService.pushTag({
         path: repoPath,
         name: tag.name,
         // Omitted, not undefined: the backend resolver only runs when the key
         // is absent, and git.service's allowlist/token lookups key off it too.
-        ...(destination ? { remote: destination } : {}),
+        remote: destination,
       });
 
       if (result.success) {
         await this.loadTags();
         showToast(
-          destination
-            ? `Pushed tag ${tag.name} to ${destination}`
-            : `Pushed tag ${tag.name} to remote`,
+          `Pushed tag ${tag.name} to ${destination}`,
           'success',
         );
         this.dispatchEvent(new CustomEvent('tags-changed', {

--- a/src/services/__tests__/git.service.tag-push-token.test.ts
+++ b/src/services/__tests__/git.service.tag-push-token.test.ts
@@ -34,6 +34,10 @@ const REPO = '/test/repo';
 const ORIGIN_URL = 'https://github.com/acme/app.git';
 /** The user's own fork. Same host, different account. */
 const FORK_URL = 'https://github.com/me/app.git';
+/** A self-hosted intranet remote: plaintext transport, but where this repo lives. */
+const INTRANET_ORIGIN_URL = 'http://git.corp/acme/app.git';
+/** A second remote on the same intranet host, which the detectors never report. */
+const INTRANET_BACKUP_URL = 'http://git.corp/acme/backup.git';
 
 const keyring = new Map<string, string>();
 let pushTagToken: string | undefined;
@@ -149,6 +153,44 @@ describe('git.service - tag push credential scoping', () => {
     );
   });
 
+  it('authenticates a plaintext remote the name filter matched', async () => {
+    // A self-hosted `http://` remote. The remote-name lookup matched the very
+    // remote being pushed to, so the token is the one `push`, `fetch` and
+    // `pull` already send over this transport with no check of their own —
+    // withholding it here fails the push with "No valid credentials found"
+    // while the toolbar Push on the same repo keeps working.
+    const { personal } = setupTwoGitHubAccounts();
+    installMock({
+      remotes: [{ name: 'origin', url: INTRANET_ORIGIN_URL, pushUrl: null }],
+      accountForUrl: () => personal,
+    });
+
+    await pushTag({ path: REPO, name: 'v1.0.0', remote: 'origin' });
+
+    expect(pushTagToken, 'an intranet tag push authenticates like the toolbar push').to.equal(
+      'personal-tok',
+    );
+  });
+
+  it('still withholds the token from a plaintext remote the filter did not match', async () => {
+    // The unfiltered fallback lends a token resolved for a DIFFERENT remote, so
+    // it must not be the thing that first puts a credential on a cleartext
+    // wire: nothing pushed to `backup` today.
+    const { personal } = setupTwoGitHubAccounts();
+    installMock({
+      remotes: [
+        { name: 'origin', url: INTRANET_ORIGIN_URL, pushUrl: null },
+        { name: 'backup', url: INTRANET_BACKUP_URL, pushUrl: null },
+      ],
+      accountForUrl: () => personal,
+    });
+
+    await pushTag({ path: REPO, name: 'v1.0.0', remote: 'backup' });
+
+    expect(pushTagCalled, 'the push still happens').to.equal(true);
+    expect(pushTagToken, 'a borrowed token stays off a cleartext transport').to.be.undefined;
+  });
+
   it('applies the same two rules to a remote tag delete', async () => {
     const { personal, work } = setupTwoGitHubAccounts();
     installMock({ accountForUrl: (url) => (url === FORK_URL ? personal : work) });
@@ -159,5 +201,15 @@ describe('git.service - tag push credential scoping', () => {
     installMock({ remotes: 'fail', accountForUrl: () => personal });
     await deleteRemoteTag({ path: REPO, name: 'v1.0.0', remote: 'origin' });
     expect(deleteRemoteTagToken, 'and the same credential fallback').to.equal('personal-tok');
+
+    deleteRemoteTagToken = undefined;
+    installMock({
+      remotes: [{ name: 'origin', url: INTRANET_ORIGIN_URL, pushUrl: null }],
+      accountForUrl: () => personal,
+    });
+    await deleteRemoteTag({ path: REPO, name: 'v1.0.0', remote: 'origin' });
+    expect(deleteRemoteTagToken, 'and the same intranet remote still authenticates').to.equal(
+      'personal-tok',
+    );
   });
 });

--- a/src/services/__tests__/git.service.tag-push-token.test.ts
+++ b/src/services/__tests__/git.service.tag-push-token.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Which identity a tag push authenticates as.
+ *
+ * `pushTag`/`deleteRemoteTag` scope the credential to the remote the tag is
+ * actually going to. Two things have to hold for that to be safe:
+ *
+ * - the remote-name lookup misses on any remote the provider detectors did not
+ *   report first, so an unfiltered retry rescues those pushes — but it resolves
+ *   the account for a DIFFERENT remote, and two github.com remotes routinely
+ *   belong to different accounts;
+ * - and when the push URL cannot be read at all, the credential must degrade to
+ *   the remote-scoped lookup rather than disappear.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as unknown as { __TAURI_INTERNALS__: { invoke: MockInvoke } }).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect } from '@open-wc/testing';
+import { pushTag, deleteRemoteTag } from '../git.service.ts';
+import { unifiedProfileStore } from '../../stores/unified-profile.store.ts';
+import { createEmptyIntegrationAccount } from '../../types/unified-profile.types.ts';
+import type { IntegrationAccount } from '../../types/unified-profile.types.ts';
+
+// ── Fixtures ───────────────────────────────────────────────────────────────
+const REPO = '/test/repo';
+/** The company repo. Detected first, and matched to the work account. */
+const ORIGIN_URL = 'https://github.com/acme/app.git';
+/** The user's own fork. Same host, different account. */
+const FORK_URL = 'https://github.com/me/app.git';
+
+const keyring = new Map<string, string>();
+let pushTagToken: string | undefined;
+let deleteRemoteTagToken: string | undefined;
+let pushTagCalled = false;
+
+interface MockOptions {
+  /** get_remotes result, or 'fail' to reject it. */
+  remotes?: Array<{ name: string; url: string; pushUrl: string | null }> | 'fail';
+  /** Which account the backend resolver returns for a given repo URL. */
+  accountForUrl?: (url: string | null) => IntegrationAccount | null;
+}
+
+function installMock(opts: MockOptions) {
+  mockInvoke = async (command: string, args?: unknown) => {
+    const a = args as Record<string, unknown> | undefined;
+    if (command === 'detect_github_repo') {
+      // The detector reports the FIRST GitHub remote it finds, whatever the
+      // caller asked about.
+      return { owner: 'acme', repo: 'app', remoteName: 'origin' };
+    }
+    if (command === 'detect_ado_repo' || command === 'detect_gitlab_repo') return null;
+    if (command === 'get_remotes') {
+      if (opts.remotes === 'fail') throw new Error('could not read remote config');
+      return (
+        opts.remotes ?? [
+          { name: 'origin', url: ORIGIN_URL, pushUrl: null },
+          { name: 'personal-fork', url: FORK_URL, pushUrl: null },
+        ]
+      );
+    }
+    if (command === 'get_assigned_unified_profile') return null;
+    if (command === 'get_repository_preferred_account') {
+      return opts.accountForUrl?.((a?.repoUrl as string | null) ?? null) ?? null;
+    }
+    if (command === 'get_keyring_token') return keyring.get(a!.key as string) ?? null;
+    if (command === 'push_tag') {
+      pushTagCalled = true;
+      pushTagToken = a?.token as string | undefined;
+      return null;
+    }
+    if (command === 'delete_remote_tag') {
+      deleteRemoteTagToken = a?.token as string | undefined;
+      return null;
+    }
+    return null;
+  };
+}
+
+function account(id: string, isDefault: boolean): IntegrationAccount {
+  return { ...createEmptyIntegrationAccount('github'), id, name: id, isDefault };
+}
+
+/** Work is only reachable via URL-pattern matching; personal is the global default. */
+function setupTwoGitHubAccounts() {
+  const personal = account('gh-personal', true);
+  const work = account('gh-work', false);
+  unifiedProfileStore.getState().setAccounts([personal, work]);
+  keyring.clear();
+  keyring.set('github_token_gh-personal', 'personal-tok');
+  keyring.set('github_token_gh-work', 'work-tok');
+  return { personal, work };
+}
+
+describe('git.service - tag push credential scoping', () => {
+  beforeEach(() => {
+    pushTagToken = undefined;
+    deleteRemoteTagToken = undefined;
+    pushTagCalled = false;
+  });
+
+  afterEach(() => {
+    unifiedProfileStore.getState().reset();
+    mockInvoke = () => Promise.resolve(null);
+  });
+
+  it("does not lend one account's token to another account's remote", async () => {
+    // The detectors report `origin` first, so the remote-scoped lookup finds
+    // nothing for `personal-fork` and the unfiltered retry resolves the WORK
+    // account. Both remotes are on github.com, so host equality alone would
+    // hand the work token to a push aimed at the user's own fork.
+    const { personal, work } = setupTwoGitHubAccounts();
+    installMock({ accountForUrl: (url) => (url === FORK_URL ? personal : work) });
+
+    await pushTag({ path: REPO, name: 'v1.0.0', remote: 'personal-fork' });
+
+    expect(pushTagCalled, 'the push still happens').to.equal(true);
+    expect(pushTagToken, 'the work account must not authenticate a fork push').to.be.undefined;
+  });
+
+  it('still lends the token when the same account owns the push URL', async () => {
+    // The single-account fork case the unfiltered retry exists for: nothing
+    // repo-specific matches, so both URLs resolve to the same account.
+    const { personal } = setupTwoGitHubAccounts();
+    installMock({ accountForUrl: () => personal });
+
+    await pushTag({ path: REPO, name: 'v1.0.0', remote: 'personal-fork' });
+
+    expect(pushTagToken, 'a fork push still authenticates').to.equal('personal-tok');
+  });
+
+  it('keeps the credential when the push URL cannot be read', async () => {
+    // get_remotes failing leaves no push URL to scope against. Dropping the
+    // token here fails the push with "No valid credentials found" on exactly
+    // the token-authenticated HTTPS remotes this plumbing exists for.
+    const { personal } = setupTwoGitHubAccounts();
+    installMock({ remotes: 'fail', accountForUrl: () => personal });
+
+    await pushTag({ path: REPO, name: 'v1.0.0', remote: 'origin' });
+
+    expect(pushTagToken, 'a transient remote-list failure must not cost the token').to.equal(
+      'personal-tok',
+    );
+  });
+
+  it('applies the same two rules to a remote tag delete', async () => {
+    const { personal, work } = setupTwoGitHubAccounts();
+    installMock({ accountForUrl: (url) => (url === FORK_URL ? personal : work) });
+
+    await deleteRemoteTag({ path: REPO, name: 'v1.0.0', remote: 'personal-fork' });
+    expect(deleteRemoteTagToken, 'no borrowed identity on the delete either').to.be.undefined;
+
+    installMock({ remotes: 'fail', accountForUrl: () => personal });
+    await deleteRemoteTag({ path: REPO, name: 'v1.0.0', remote: 'origin' });
+    expect(deleteRemoteTagToken, 'and the same credential fallback').to.equal('personal-tok');
+  });
+});

--- a/src/services/__tests__/tags.service.test.ts
+++ b/src/services/__tests__/tags.service.test.ts
@@ -22,6 +22,7 @@ import {
   deleteTag,
   deleteRemoteTag,
   pushTag,
+  getPushRemote,
   getTagDetails,
   editTagMessage,
 } from '../git.service.ts';
@@ -310,6 +311,18 @@ describe('git.service - Tag operations', () => {
       expect(args.path).to.equal('/test/repo');
       expect(args.name).to.equal('v1.0.0');
       expect(result.success).to.be.true;
+    });
+
+    describe('getPushRemote', () => {
+      it('invokes get_push_remote without an undefined remote key', async () => {
+        mockInvoke = () => Promise.resolve('upstream');
+
+        const result = await getPushRemote('/test/repo');
+
+        expect(lastInvokedCommand).to.equal('get_push_remote');
+        expect(lastInvokedArgs).to.deep.equal({ path: '/test/repo' });
+        expect(result.data).to.equal('upstream');
+      });
     });
 
     it('invokes push_tag with remote specified', async () => {

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -1651,7 +1651,19 @@ async function getPushUrlToken(
   const fetchUrl = await resolveRemoteUrl(repoPath, resolved.remoteName);
   const fetchHost = fetchUrl ? cloneUrlHost(fetchUrl) : null;
   const pushHost = cloneUrlHost(pushUrl);
-  if (!fetchHost || !pushHost || fetchHost !== pushHost || !cloneUrlIsCredentialSafe(pushUrl)) {
+  // The plaintext gate applies to the UNFILTERED answer only. A remote-name
+  // match resolved the token for the very remote being pushed to, which is
+  // exactly what `push`, `fetch` and `pull` do with no transport check — gating
+  // it here would break Push Tag and Delete tag on remote on a self-hosted
+  // `http://` remote while the toolbar Push kept working, with nothing telling
+  // the user why. The unfiltered fallback lends a token resolved for a
+  // DIFFERENT remote, so it stays off cleartext transports.
+  if (
+    !fetchHost ||
+    !pushHost ||
+    fetchHost !== pushHost ||
+    (unfiltered && !cloneUrlIsCredentialSafe(pushUrl))
+  ) {
     return undefined;
   }
   if (

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -1436,6 +1436,12 @@ interface ResolvedRepoToken {
   token?: string;
   remoteName?: string;
   refused?: boolean;
+  /**
+   * The account the token belongs to, when one resolved it. Absent for the
+   * legacy single-token fallbacks, which have no account to speak of.
+   */
+  accountId?: string;
+  integrationType?: IntegrationType;
 }
 
 /**
@@ -1467,7 +1473,14 @@ async function resolveRepoToken(
       );
       if (account) {
         const token = await AccountCredentials.getToken("github", account.id);
-        if (token) return { token, remoteName: resolvedRemote };
+        if (token) {
+          return {
+            token,
+            remoteName: resolvedRemote,
+            accountId: account.id,
+            integrationType: "github",
+          };
+        }
         // This repo resolves to THIS account, but its keyring entry is gone. Every
         // fallback below re-resolves the global default, so continuing would push
         // as a different identity. Fail instead and let the user reconnect it.
@@ -1509,7 +1522,12 @@ async function resolveRepoToken(
           if (accountOrg && accountOrg === adoRepoResult.data.organization) {
             await syncAdoGitCredentials(adoRepoResult.data.organization, token);
           }
-          return { token, remoteName: resolvedRemote };
+          return {
+            token,
+            remoteName: resolvedRemote,
+            accountId: account.id,
+            integrationType: "azure-devops",
+          };
         }
         // See the GitHub branch: a repo-specific account with no usable token
         // must not silently borrow the global default's.
@@ -1537,7 +1555,14 @@ async function resolveRepoToken(
       );
       if (account) {
         const token = await AccountCredentials.getToken("gitlab", account.id);
-        if (token) return { token, remoteName: resolvedRemote };
+        if (token) {
+          return {
+            token,
+            remoteName: resolvedRemote,
+            accountId: account.id,
+            integrationType: "gitlab",
+          };
+        }
         // See the GitHub branch: a repo-specific account with no usable token
         // must not silently borrow the global default's.
         if (repoSpecific) return { refused: true };
@@ -1568,26 +1593,81 @@ async function getRepoToken(
   return (await resolveRepoToken(repoPath, remoteName)).token;
 }
 
+/**
+ * Does the account an UNFILTERED lookup landed on also own `pushUrl`?
+ *
+ * The unfiltered fallback resolves the account for whichever remote the
+ * provider detectors found first, which is routinely NOT the remote being
+ * pushed to. Same host is not the same identity: two github.com remotes
+ * (`origin` = the company repo, `personal-fork` = your own) belong to
+ * different accounts, and an account's `urlPatterns` are matched per URL. So
+ * ask the resolver who owns the push URL and only lend the token when the
+ * answer is the same account.
+ *
+ * A lookup that cannot answer withholds the token, which is exactly what the
+ * remote-scoped lookup did before this fallback existed.
+ */
+async function fallbackAccountOwnsPushUrl(
+  repoPath: string,
+  integrationType: IntegrationType,
+  accountId: string,
+  pushUrl: string,
+): Promise<boolean> {
+  try {
+    // Dynamic import for the same cycle reason as resolveRepoAccount's.
+    const { getAssignedUnifiedProfile, fetchRepositoryPreferredAccount } = await import(
+      "./unified-profile.service.ts"
+    );
+    const profile = await getAssignedUnifiedProfile(repoPath).catch(() => null);
+    const account = await fetchRepositoryPreferredAccount(
+      profile?.id ?? "",
+      integrationType,
+      pushUrl,
+    );
+    return !!account && account.id === accountId;
+  } catch (err) {
+    console.error("Failed to resolve the push URL's account:", err);
+    return false;
+  }
+}
+
 async function getPushUrlToken(
   repoPath: string,
   remoteName: string,
   pushUrl: string,
 ): Promise<string | undefined> {
   let resolved = await resolveRepoToken(repoPath, remoteName);
+  // The provider detectors report the FIRST remote they recognise, so a push to
+  // any other remote never matches the name filter and resolves nothing. Retry
+  // unfiltered so those pushes still get a credential — guarded below, because
+  // an unfiltered answer is about a different remote.
+  let unfiltered = false;
   if (!resolved.token && !resolved.refused) {
     resolved = await resolveRepoToken(repoPath);
+    unfiltered = true;
   }
   if (!resolved.token || resolved.refused || !resolved.remoteName) return undefined;
 
   const fetchUrl = await resolveRemoteUrl(repoPath, resolved.remoteName);
   const fetchHost = fetchUrl ? cloneUrlHost(fetchUrl) : null;
   const pushHost = cloneUrlHost(pushUrl);
-  return fetchHost &&
-    pushHost &&
-    fetchHost === pushHost &&
-    cloneUrlIsCredentialSafe(pushUrl)
-    ? resolved.token
-    : undefined;
+  if (!fetchHost || !pushHost || fetchHost !== pushHost || !cloneUrlIsCredentialSafe(pushUrl)) {
+    return undefined;
+  }
+  if (
+    unfiltered &&
+    resolved.accountId &&
+    resolved.integrationType &&
+    !(await fallbackAccountOwnsPushUrl(
+      repoPath,
+      resolved.integrationType,
+      resolved.accountId,
+      pushUrl,
+    ))
+  ) {
+    return undefined;
+  }
+  return resolved.token;
 }
 
 /**
@@ -2011,8 +2091,12 @@ export async function pushTag(
     let token: string | undefined;
     if (args.remote && pushUrl) {
       token = await getPushUrlToken(args.path, args.remote, pushUrl);
-    } else if (!args.remote) {
-      token = await getRepoToken(args.path);
+    } else {
+      // No push URL to scope against — `get_remotes` failed, or the remote is
+      // not in the list. Dropping the credential here would fail the push with
+      // "No valid credentials found"; fall back to the remote-scoped lookup,
+      // which never needed the URL to reach a token.
+      token = await getRepoToken(args.path, args.remote);
     }
     if (token) {
       args.token = token;
@@ -2053,8 +2137,12 @@ export async function deleteRemoteTag(
     let token: string | undefined;
     if (args.remote && pushUrl) {
       token = await getPushUrlToken(args.path, args.remote, pushUrl);
-    } else if (!args.remote) {
-      token = await getRepoToken(args.path);
+    } else {
+      // No push URL to scope against — `get_remotes` failed, or the remote is
+      // not in the list. Dropping the credential here would fail the push with
+      // "No valid credentials found"; fall back to the remote-scoped lookup,
+      // which never needed the URL to reach a token.
+      token = await getRepoToken(args.path, args.remote);
     }
     if (token) {
       args.token = token;

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -37,6 +37,19 @@ async function resolveRemoteUrl(repoPath: string, remote?: string): Promise<stri
   return match?.url ?? null;
 }
 
+async function resolveRemotePushUrl(repoPath: string, remote?: string): Promise<string | null> {
+  if (remote && /^([a-z][a-z0-9+.-]*:\/\/|[^@/]+@[^:/]+:|ssh:\/\/)/i.test(remote)) {
+    return remote;
+  }
+  const result = await invokeCommand<Remote[]>("get_remotes", { path: repoPath });
+  if (!result.success || !result.data) return null;
+  const wanted = remote ?? 'origin';
+  const match =
+    result.data.find((r) => r.name === wanted) ??
+    (remote === undefined ? result.data[0] : undefined);
+  return match?.pushUrl ?? match?.url ?? null;
+}
+
 /**
  * Hard blocks only: offline mode and the remote allowlist. No confirm prompt.
  *
@@ -55,6 +68,7 @@ async function checkNetworkAllowed(
    * "Offline mode is enabled" on the user for every commit, stage and
    * checkout. The refusal still happens — it just doesn't shout. */
   silent = false,
+  resolvedUrl?: string | null,
 ): Promise<NetworkBlockReason | null> {
   const settings = settingsStore.getState();
 
@@ -70,7 +84,8 @@ async function checkNetworkAllowed(
   // An allowlist that cannot see the URL must refuse, not wave the operation
   // through: silently allowing is the failure mode that made this setting
   // decorative.
-  const url = repoPath ? await resolveRemoteUrl(repoPath, remote) : (remote ?? null);
+  const url =
+    resolvedUrl ?? (repoPath ? await resolveRemoteUrl(repoPath, remote) : (remote ?? null));
   const allowed =
     !!url &&
     settings.remoteAllowlist.some((domain) => url.toLowerCase().includes(domain.toLowerCase()));
@@ -126,8 +141,9 @@ async function checkNetworkPermission(
   operation: string,
   repoPath: string | null,
   remote?: string,
+  resolvedUrl?: string | null,
 ): Promise<boolean> {
-  if (await checkNetworkAllowed(repoPath, remote)) return false;
+  if (await checkNetworkAllowed(repoPath, remote, false, resolvedUrl)) return false;
 
   if (settingsStore.getState().confirmNetworkOps) {
     // A declined confirm is the user's own decision, not a failure — callers
@@ -1419,6 +1435,7 @@ async function resolveRepoAccount(
 interface ResolvedRepoToken {
   token?: string;
   remoteName?: string;
+  refused?: boolean;
 }
 
 /**
@@ -1454,7 +1471,7 @@ async function resolveRepoToken(
         // This repo resolves to THIS account, but its keyring entry is gone. Every
         // fallback below re-resolves the global default, so continuing would push
         // as a different identity. Fail instead and let the user reconnect it.
-        if (repoSpecific) return {};
+        if (repoSpecific) return { refused: true };
       }
       // Legacy fallback for GitHub
       const tokenResult = await getGitHubToken();
@@ -1496,7 +1513,7 @@ async function resolveRepoToken(
         }
         // See the GitHub branch: a repo-specific account with no usable token
         // must not silently borrow the global default's.
-        if (repoSpecific) return {};
+        if (repoSpecific) return { refused: true };
       }
       // Legacy fallback for Azure DevOps
       const tokenResult = await getAdoToken();
@@ -1523,7 +1540,7 @@ async function resolveRepoToken(
         if (token) return { token, remoteName: resolvedRemote };
         // See the GitHub branch: a repo-specific account with no usable token
         // must not silently borrow the global default's.
-        if (repoSpecific) return {};
+        if (repoSpecific) return { refused: true };
       }
       // Legacy fallback for GitLab
       const tokenResult = await getGitLabToken();
@@ -1549,6 +1566,28 @@ async function getRepoToken(
   remoteName?: string,
 ): Promise<string | undefined> {
   return (await resolveRepoToken(repoPath, remoteName)).token;
+}
+
+async function getPushUrlToken(
+  repoPath: string,
+  remoteName: string,
+  pushUrl: string,
+): Promise<string | undefined> {
+  let resolved = await resolveRepoToken(repoPath, remoteName);
+  if (!resolved.token && !resolved.refused) {
+    resolved = await resolveRepoToken(repoPath);
+  }
+  if (!resolved.token || resolved.refused || !resolved.remoteName) return undefined;
+
+  const fetchUrl = await resolveRemoteUrl(repoPath, resolved.remoteName);
+  const fetchHost = fetchUrl ? cloneUrlHost(fetchUrl) : null;
+  const pushHost = cloneUrlHost(pushUrl);
+  return fetchHost &&
+    pushHost &&
+    fetchHost === pushHost &&
+    cloneUrlIsCredentialSafe(pushUrl)
+    ? resolved.token
+    : undefined;
 }
 
 /**
@@ -1959,7 +1998,8 @@ export async function deleteTag(
 export async function pushTag(
   args: PushTagCommand,
 ): Promise<CommandResult<void>> {
-  if (!await checkNetworkPermission('push tag', args.path, args.remote)) {
+  const pushUrl = args.remote ? await resolveRemotePushUrl(args.path, args.remote) : null;
+  if (!await checkNetworkPermission('push tag', args.path, args.remote, pushUrl)) {
     return blockedResult();
   }
 
@@ -1968,13 +2008,28 @@ export async function pushTag(
   // remote the toolbar Push worked and "Push tag" failed with "No valid
   // credentials found".
   if (!args.token) {
-    const token = await getRepoToken(args.path, args.remote);
+    let token: string | undefined;
+    if (args.remote && pushUrl) {
+      token = await getPushUrlToken(args.path, args.remote, pushUrl);
+    } else if (!args.remote) {
+      token = await getRepoToken(args.path);
+    }
     if (token) {
       args.token = token;
     }
   }
 
   return invokeCommand<void>("push_tag", args);
+}
+
+export async function getPushRemote(
+  path: string,
+  remote?: string,
+): Promise<CommandResult<string>> {
+  return invokeCommand<string>("get_push_remote", {
+    path,
+    ...(remote ? { remote } : {}),
+  });
 }
 
 /**
@@ -1987,14 +2042,20 @@ export async function pushTag(
 export async function deleteRemoteTag(
   args: DeleteRemoteTagCommand,
 ): Promise<CommandResult<void>> {
-  if (!await checkNetworkPermission('delete remote tag', args.path, args.remote)) {
+  const pushUrl = args.remote ? await resolveRemotePushUrl(args.path, args.remote) : null;
+  if (!await checkNetworkPermission('delete remote tag', args.path, args.remote, pushUrl)) {
     return blockedResult();
   }
 
   // Same credential plumbing push_tag needs: without a token this fails with
   // "No valid credentials found" on a token-authenticated HTTPS remote.
   if (!args.token) {
-    const token = await getRepoToken(args.path, args.remote);
+    let token: string | undefined;
+    if (args.remote && pushUrl) {
+      token = await getPushUrlToken(args.path, args.remote, pushUrl);
+    } else if (!args.remote) {
+      token = await getRepoToken(args.path);
+    }
     if (token) {
       args.token = token;
     }

--- a/src/utils/tag-delete.ts
+++ b/src/utils/tag-delete.ts
@@ -49,7 +49,15 @@ export async function offerRemoteTagDelete(repoPath: string, tagName: string): P
   const remotes = remotesResult.data ?? [];
   if (remotes.length === 0) return;
   // The remote push_tag targets by default, named so the confirm can say it.
-  const remote = (remotes.find((r) => r.name === 'origin') ?? remotes[0]).name;
+  const remoteResult = await gitService.getPushRemote(repoPath);
+  if (!remoteResult.success || !remoteResult.data) {
+    showToast(
+      `Deleted tag ${tagName} locally, but its push destination could not be resolved — it may still exist remotely`,
+      'warning',
+    );
+    return;
+  }
+  const remote = remoteResult.data;
 
   // The SHARED tag-push key: this pushes a refspec for the same ref Push Tag
   // and Force Push Tag push, and it is held across the confirm so neither can

--- a/src/utils/tag-delete.ts
+++ b/src/utils/tag-delete.ts
@@ -49,15 +49,20 @@ export async function offerRemoteTagDelete(repoPath: string, tagName: string): P
   const remotes = remotesResult.data ?? [];
   if (remotes.length === 0) return;
   // The remote push_tag targets by default, named so the confirm can say it.
+  //
+  // A failed resolve is NOT a dead end here: `resolve_push_remote` answers from
+  // config and falls back to the literal "origin", so a stale
+  // `remote.pushDefault`, or two remotes with no `origin` among them and no
+  // push/upstream config, makes `get_push_remote` fail on a repo that plainly
+  // has remotes. `remotes` was just read successfully, so fall back to the same
+  // local pick this used before — dropping the follow-up would leave the user
+  // with no surface at all for deleting the remote tag, and the next fetch
+  // would restore it.
   const remoteResult = await gitService.getPushRemote(repoPath);
-  if (!remoteResult.success || !remoteResult.data) {
-    showToast(
-      `Deleted tag ${tagName} locally, but its push destination could not be resolved — it may still exist remotely`,
-      'warning',
-    );
-    return;
-  }
-  const remote = remoteResult.data;
+  const remote =
+    remoteResult.success && remoteResult.data
+      ? remoteResult.data
+      : (remotes.find((r) => r.name === 'origin') ?? remotes[0]).name;
 
   // The SHARED tag-push key: this pushes a refspec for the same ref Push Tag
   // and Force Push Tag push, and it is held across the confirm so neither can


### PR DESCRIPTION
## Summary
- resolve tag destinations with Git's real push-remote precedence
- name the destination in force-push confirmations and push feedback
- reuse the resolved destination for retries and remote tag deletion
- gate and scope credentials against the actual push URL, including pushurl

## Tests
- tag push guard, destination, and service suites: 52 passed
- network/tag combined suites: 87 passed; 1 pre-existing dialog-confirm mock failure
- Rust get_push_remote test passed
- TypeScript typecheck passed
- changed Rust files pass rustfmt check