### PR TITLE
Fix fetch remote selection

### DIFF
--- a/e2e/fixtures/tauri-mock.ts
+++ b/e2e/fixtures/tauri-mock.ts
@@ -519,6 +519,15 @@ function createMockHandler(mocks: typeof defaultMockData) {
       case 'get_remotes':
         return mocks.remotes;
 
+      // The remote a fetch/pull/push resolves to before the network gate runs.
+      // Unmocked these fell through to the default arm's `null`, so every
+      // remote operation silently ran the "could not resolve" fallback and no
+      // test ever saw the remote the app actually picked.
+      case 'get_fetch_remote':
+      case 'get_pull_remote':
+      case 'get_push_remote':
+        return mocks.remotes[0]?.name ?? 'origin';
+
       case 'fetch':
         return null;
       case 'push': {
@@ -841,6 +850,10 @@ export async function setupTauriMocks(
             return state.tags;
           case 'get_remotes':
             return state.remotes;
+          case 'get_fetch_remote':
+          case 'get_pull_remote':
+          case 'get_push_remote':
+            return state.remotes[0]?.name ?? 'origin';
           case 'get_profiles':
             return [
               { id: 'default', name: 'Default', gitName: 'Test User', gitEmail: 'test@example.com' },

--- a/e2e/fixtures/tauri-mock.ts
+++ b/e2e/fixtures/tauri-mock.ts
@@ -484,8 +484,6 @@ function createMockHandler(mocks: typeof defaultMockData) {
       }
       case 'push_tag':
         return null;
-      case 'get_push_remote':
-        return (args?.remote as string) ?? mocks.remotes[0]?.name ?? 'origin';
       // Deleting a tag offers to delete the remote copy too — the local
       // delete leaves it behind and the tag fetch refspec restores it.
       case 'delete_remote_tag':
@@ -526,10 +524,17 @@ function createMockHandler(mocks: typeof defaultMockData) {
       // Unmocked these fell through to the default arm's `null`, so every
       // remote operation silently ran the "could not resolve" fallback and no
       // test ever saw the remote the app actually picked.
+      //
+      // An explicit `remote` wins, mirroring the backend's resolve_*_remote,
+      // which hands back the requested remote untouched. The tag force-push
+      // retry re-resolves the destination the rejected push was aimed at, so
+      // ignoring the argument here answered `origin` for a push aimed at
+      // `upstream`. This must stay the ONLY arm for these three commands —
+      // a second `case 'get_push_remote'` later in the switch is unreachable.
       case 'get_fetch_remote':
       case 'get_pull_remote':
       case 'get_push_remote':
-        return mocks.remotes[0]?.name ?? 'origin';
+        return (args?.remote as string) ?? mocks.remotes[0]?.name ?? 'origin';
 
       case 'fetch':
         return null;
@@ -853,10 +858,16 @@ export async function setupTauriMocks(
             return state.tags;
           case 'get_remotes':
             return state.remotes;
+          // See the other builder's switch: an explicit `remote` wins, and
+          // this is the ONLY arm for these three commands.
           case 'get_fetch_remote':
           case 'get_pull_remote':
           case 'get_push_remote':
-            return state.remotes[0]?.name ?? 'origin';
+            return (
+              (args as { remote?: string })?.remote ??
+              state.remotes[0]?.name ??
+              'origin'
+            );
           case 'get_profiles':
             return [
               { id: 'default', name: 'Default', gitName: 'Test User', gitEmail: 'test@example.com' },
@@ -1078,12 +1089,6 @@ export async function setupTauriMocks(
           }
           case 'push_tag':
             return null;
-          case 'get_push_remote':
-            return (
-              (args as { remote?: string })?.remote ??
-              state.remotes[0]?.name ??
-              'origin'
-            );
           // See the other builder's switch — tag delete offers the remote too.
           case 'delete_remote_tag':
             return null;

--- a/e2e/tests/remote-operations.spec.ts
+++ b/e2e/tests/remote-operations.spec.ts
@@ -11,7 +11,7 @@
 import { test, expect } from '@playwright/test';
 import { setupOpenRepository, defaultMockData, withConflicts } from '../fixtures/tauri-mock';
 import { AppPage } from '../pages/app.page';
-import { startCommandCapture, findCommand, injectCommandError, waitForCommand } from '../fixtures/test-helpers';
+import { startCommandCapture, startCommandCaptureWithMocks, findCommand, injectCommandError, waitForCommand } from '../fixtures/test-helpers';
 
 // ============================================================================
 // Helper function to create branches with ahead/behind status
@@ -391,6 +391,10 @@ test.describe('Fetch Operation', () => {
 
     const fetchCommands = await findCommand(page, 'fetch');
     expect(fetchCommands.length).toBeGreaterThan(0);
+    // Whatever the repo resolved is what the backend must be told to fetch —
+    // an unresolved remote leaves the backend to guess a second time, against
+    // config the network gate never saw.
+    expect((fetchCommands[0].args as { remote?: string }).remote).toBe('origin');
 
     // After fetch completes, the app should refresh remote status to update badges
     await waitForCommand(page, 'get_remote_status');
@@ -411,6 +415,82 @@ test.describe('Fetch Operation', () => {
     await expect(toast).toContainText(/error|fail|unable/i);
 
     // Fetch button should be re-enabled so user can retry
+    await expect(fetchButton).toBeEnabled();
+  });
+});
+
+// ============================================================================
+// Remote selection — fetch/pull/push must target the remote the repo resolves,
+// not a hard-coded "origin". In the ordinary fork layout (origin = your fork,
+// the branch tracking a canonical remote elsewhere) those are different hosts.
+// ============================================================================
+
+test.describe('Remote selection for fetch/pull/push', () => {
+  /** origin is the fork; the checked-out branch tracks `upstream`. */
+  const forkRemotes = {
+    remotes: [
+      { name: 'origin', url: 'https://github.com/me/repo.git', pushUrl: null },
+      { name: 'upstream', url: 'https://gitlab.example.test/acme/repo.git', pushUrl: null },
+    ],
+  } as Partial<typeof defaultMockData>;
+
+  test('fetch targets the branch upstream, not origin', async ({ page }) => {
+    await setupOpenRepository(page, forkRemotes);
+    await startCommandCaptureWithMocks(page, { get_fetch_remote: 'upstream', fetch: null });
+
+    const fetchButton = page.getByRole('button', { name: /Fetch/i });
+    await fetchButton.click();
+    await waitForCommand(page, 'fetch');
+
+    const [call] = await findCommand(page, 'fetch');
+    expect((call.args as { remote?: string }).remote).toBe('upstream');
+
+    // And the operation completes visibly: status is re-read and the button
+    // comes back, rather than the app hanging on a remote it never resolved.
+    await waitForCommand(page, 'get_remote_status');
+    await expect(fetchButton).toBeEnabled();
+  });
+
+  test('pull targets the branch upstream, not origin', async ({ page }) => {
+    await setupOpenRepository(page, forkRemotes);
+    await startCommandCaptureWithMocks(page, { get_pull_remote: 'upstream', pull: null });
+
+    const pullButton = page.getByRole('button', { name: /Pull/i });
+    await pullButton.click();
+    await waitForCommand(page, 'pull');
+
+    const [call] = await findCommand(page, 'pull');
+    expect((call.args as { remote?: string }).remote).toBe('upstream');
+    await expect(pullButton).toBeEnabled();
+  });
+
+  test('push targets the resolved push remote, not origin', async ({ page }) => {
+    await setupOpenRepository(page, forkRemotes);
+    await startCommandCaptureWithMocks(page, { get_push_remote: 'upstream', push: null });
+
+    const pushButton = page.getByRole('button', { name: /^Push/i });
+    await pushButton.click();
+    await waitForCommand(page, 'push');
+
+    const [call] = await findCommand(page, 'push');
+    expect((call.args as { remote?: string }).remote).toBe('upstream');
+    await expect(pushButton).toBeEnabled();
+  });
+
+  test('a fetch whose remote cannot be resolved still runs and reports', async ({ page }) => {
+    // A detached HEAD, or a repo with no remote at all: resolution fails. The
+    // fetch must still reach the backend so the REAL error is what the user
+    // sees — not a silent no-op here.
+    await setupOpenRepository(page, forkRemotes);
+    await startCommandCapture(page);
+    await injectCommandError(page, 'get_fetch_remote', 'Remote not found: origin');
+
+    const fetchButton = page.getByRole('button', { name: /Fetch/i });
+    await fetchButton.click();
+    await waitForCommand(page, 'fetch');
+
+    const [call] = await findCommand(page, 'fetch');
+    expect((call.args as { remote?: string }).remote).toBeUndefined();
     await expect(fetchButton).toBeEnabled();
   });
 });

--- a/src-tauri/src/commands/autofetch.rs
+++ b/src-tauri/src/commands/autofetch.rs
@@ -11,6 +11,8 @@ pub async fn start_auto_fetch(
     state: State<'_, AutoFetchState>,
     path: String,
     interval_minutes: u32,
+    remote: String,
+    remote_url: String,
     token: Option<String>,
 ) -> Result<()> {
     if interval_minutes == 0 {
@@ -20,8 +22,20 @@ pub async fn start_auto_fetch(
     }
 
     let mut service = state.write().await;
-    service.start(path, interval_minutes, token, app);
+    service.start(path, interval_minutes, remote, remote_url, token, app);
     Ok(())
+}
+
+#[command]
+pub async fn trigger_auto_fetch(state: State<'_, AutoFetchState>, path: String) -> Result<()> {
+    let service = state.read().await;
+    if service.trigger(&path) {
+        Ok(())
+    } else {
+        Err(LeviathanError::OperationFailed(
+            "Auto-fetch is not running for this repository".to_string(),
+        ))
+    }
 }
 
 /// Stop auto-fetching for a repository

--- a/src-tauri/src/commands/azure_devops.rs
+++ b/src-tauri/src/commands/azure_devops.rs
@@ -306,7 +306,10 @@ pub async fn check_ado_connection(
 
 /// Detect Azure DevOps repository from git remotes
 #[command]
-pub async fn detect_ado_repo(path: String) -> Result<Option<DetectedAdoRepo>> {
+pub async fn detect_ado_repo(
+    path: String,
+    remote_name: Option<String>,
+) -> Result<Option<DetectedAdoRepo>> {
     let repo = git2::Repository::open(&path).map_err(|e| {
         LeviathanError::OperationFailed(format!("Failed to open repository: {}", e))
     })?;
@@ -315,15 +318,21 @@ pub async fn detect_ado_repo(path: String) -> Result<Option<DetectedAdoRepo>> {
         .remotes()
         .map_err(|e| LeviathanError::OperationFailed(format!("Failed to get remotes: {}", e)))?;
 
-    for remote_name in remotes.iter().flatten().flatten() {
-        if let Ok(remote) = repo.find_remote(remote_name) {
+    for candidate in remotes.iter().flatten().flatten() {
+        if remote_name
+            .as_deref()
+            .is_some_and(|wanted| wanted != candidate)
+        {
+            continue;
+        }
+        if let Ok(remote) = repo.find_remote(candidate) {
             if let Ok(url) = remote.url() {
                 if let Some(repo_info) = parse_ado_url(url) {
                     return Ok(Some(DetectedAdoRepo {
                         organization: repo_info.0,
                         project: repo_info.1,
                         repository: repo_info.2,
-                        remote_name: remote_name.to_string(),
+                        remote_name: candidate.to_string(),
                     }));
                 }
             }

--- a/src-tauri/src/commands/azure_devops.rs
+++ b/src-tauri/src/commands/azure_devops.rs
@@ -1469,6 +1469,33 @@ mod tests {
         assert_eq!(ado_pr_status_param(None), None);
     }
 
+    /// Credential selection is scoped to the remote the operation actually
+    /// targets, so detection must answer for THAT remote — not for whichever
+    /// one happens to sort first. Without the filter a fetch of `upstream`
+    /// resolved `origin`'s organization, and with it the wrong account.
+    #[tokio::test]
+    async fn test_detect_ado_repo_targets_requested_remote() {
+        use crate::test_utils::TestRepo;
+
+        let repo = TestRepo::with_initial_commit();
+        repo.add_remote(
+            "origin",
+            "https://dev.azure.com/personalorg/Proj/_git/frontend",
+        );
+        repo.add_remote(
+            "upstream",
+            "https://dev.azure.com/workorg/Proj/_git/frontend",
+        );
+
+        let detected = detect_ado_repo(repo.path_str(), Some("upstream".to_string()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(detected.organization, "workorg");
+        assert_eq!(detected.remote_name, "upstream");
+    }
+
     #[test]
     fn test_parse_ado_url_https_standard() {
         let url = "https://dev.azure.com/mycompany/MyProject/_git/frontend";

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -329,19 +329,28 @@ pub async fn check_github_connection(token: Option<String>) -> Result<GitHubConn
 
 /// Detect GitHub repository from git remotes
 #[command]
-pub async fn detect_github_repo(path: String) -> Result<Option<DetectedGitHubRepo>> {
+pub async fn detect_github_repo(
+    path: String,
+    remote_name: Option<String>,
+) -> Result<Option<DetectedGitHubRepo>> {
     let repo = git2::Repository::open(&path)
         .map_err(|e| LeviathanError::RepositoryNotFound(e.to_string()))?;
 
     // Check all remotes for GitHub URLs
-    for remote_name in repo.remotes()?.iter().flatten().flatten() {
-        if let Ok(remote) = repo.find_remote(remote_name) {
+    for candidate in repo.remotes()?.iter().flatten().flatten() {
+        if remote_name
+            .as_deref()
+            .is_some_and(|wanted| wanted != candidate)
+        {
+            continue;
+        }
+        if let Ok(remote) = repo.find_remote(candidate) {
             if let Ok(url) = remote.url() {
                 if let Some(parsed) = parse_github_url(url) {
                     return Ok(Some(DetectedGitHubRepo {
                         owner: parsed.0,
                         repo: parsed.1,
-                        remote_name: remote_name.to_string(),
+                        remote_name: candidate.to_string(),
                     }));
                 }
             }

--- a/src-tauri/src/commands/github.rs
+++ b/src-tauri/src/commands/github.rs
@@ -2579,6 +2579,27 @@ mod tests {
         );
     }
 
+    /// Credential selection is scoped to the remote the operation actually
+    /// targets, so detection must answer for THAT remote — not for whichever
+    /// one happens to sort first. Without the filter a fetch of `upstream`
+    /// resolved `origin`'s account.
+    #[tokio::test]
+    async fn test_detect_github_repo_targets_requested_remote() {
+        use crate::test_utils::TestRepo;
+
+        let repo = TestRepo::with_initial_commit();
+        repo.add_remote("origin", "https://github.com/personal/repo.git");
+        repo.add_remote("upstream", "https://github.com/work/repo.git");
+
+        let detected = detect_github_repo(repo.path_str(), Some("upstream".to_string()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(detected.owner, "work");
+        assert_eq!(detected.remote_name, "upstream");
+    }
+
     // ========================================================================
     // GitHub URL Parsing Tests
     // ========================================================================

--- a/src-tauri/src/commands/gitlab.rs
+++ b/src-tauri/src/commands/gitlab.rs
@@ -294,7 +294,10 @@ pub async fn check_gitlab_connection(
 
 /// Detect GitLab repository from git remotes
 #[command]
-pub async fn detect_gitlab_repo(path: String) -> Result<Option<DetectedGitLabRepo>> {
+pub async fn detect_gitlab_repo(
+    path: String,
+    remote_name: Option<String>,
+) -> Result<Option<DetectedGitLabRepo>> {
     let repo = git2::Repository::open(&path).map_err(|e| {
         LeviathanError::OperationFailed(format!("Failed to open repository: {}", e))
     })?;
@@ -303,14 +306,20 @@ pub async fn detect_gitlab_repo(path: String) -> Result<Option<DetectedGitLabRep
         .remotes()
         .map_err(|e| LeviathanError::OperationFailed(format!("Failed to get remotes: {}", e)))?;
 
-    for remote_name in remotes.iter().flatten().flatten() {
-        if let Ok(remote) = repo.find_remote(remote_name) {
+    for candidate in remotes.iter().flatten().flatten() {
+        if remote_name
+            .as_deref()
+            .is_some_and(|wanted| wanted != candidate)
+        {
+            continue;
+        }
+        if let Ok(remote) = repo.find_remote(candidate) {
             if let Ok(url) = remote.url() {
                 if let Some(repo_info) = parse_gitlab_url(url) {
                     return Ok(Some(DetectedGitLabRepo {
                         instance_url: repo_info.0,
                         project_path: repo_info.1,
-                        remote_name: remote_name.to_string(),
+                        remote_name: candidate.to_string(),
                     }));
                 }
             }
@@ -1051,7 +1060,7 @@ mod tests {
         // Add a non-GitLab remote
         repo.add_remote("origin", "https://github.com/user/repo.git");
 
-        let result = detect_gitlab_repo(repo.path_str()).await;
+        let result = detect_gitlab_repo(repo.path_str(), None).await;
         assert!(result.is_ok());
         assert!(result.unwrap().is_none());
     }
@@ -1062,7 +1071,7 @@ mod tests {
         // Add a GitLab remote
         repo.add_remote("origin", "https://gitlab.com/user/repo.git");
 
-        let result = detect_gitlab_repo(repo.path_str()).await;
+        let result = detect_gitlab_repo(repo.path_str(), None).await;
         assert!(result.is_ok());
         let detected = result.unwrap();
         assert!(detected.is_some());
@@ -1074,12 +1083,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_detect_gitlab_repo_targets_requested_remote() {
+        let repo = TestRepo::with_initial_commit();
+        repo.add_remote("origin", "https://gitlab.com/personal/repo.git");
+        repo.add_remote("upstream", "https://gitlab.com/work/repo.git");
+
+        let detected = detect_gitlab_repo(repo.path_str(), Some("upstream".to_string()))
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(detected.project_path, "work/repo");
+        assert_eq!(detected.remote_name, "upstream");
+    }
+
+    #[tokio::test]
     async fn test_detect_gitlab_repo_with_ssh_remote() {
         let repo = TestRepo::with_initial_commit();
         // Add a GitLab SSH remote
         repo.add_remote("origin", "git@gitlab.com:user/repo.git");
 
-        let result = detect_gitlab_repo(repo.path_str()).await;
+        let result = detect_gitlab_repo(repo.path_str(), None).await;
         assert!(result.is_ok());
         let detected = result.unwrap();
         assert!(detected.is_some());

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -550,6 +550,87 @@ fn pull_should_rebase(repo: &git2::Repository, branch_name: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// The branch a pull will merge into, and its full refname.
+///
+/// On a detached HEAD, shorthand() is the literal "HEAD" — so this used to
+/// resolve origin/HEAD (a symref that DOES exist in a normal clone),
+/// fast-forward-check-out its tree, and only then fail looking up
+/// "refs/heads/HEAD". The tree ended up holding origin/main's content while
+/// HEAD still pointed at the tag, so every diverging file showed as an
+/// uncommitted change. git refuses to pull with no upstream; so do we. merge()
+/// gets this right by using head.name() rather than rebuilding it.
+///
+/// Shared with `get_pull_remote` so the remote the frontend's network gate is
+/// evaluated against comes from exactly the ref the pull itself will use.
+pub(crate) fn resolve_pull_branch(
+    repo: &git2::Repository,
+    branch_for_task: Option<&str>,
+) -> Result<(String, String)> {
+    if let Some(b) = branch_for_task {
+        return Ok((b.to_string(), format!("refs/heads/{}", b)));
+    }
+    let head = repo.head()?;
+    if !head.is_branch() {
+        return Err(LeviathanError::OperationFailed(
+            "You are not currently on a branch. Check out a branch before \
+             pulling, or say which branch to pull."
+                .to_string(),
+        ));
+    }
+    let refname = head
+        .name()
+        .map_err(|_| LeviathanError::InvalidReference)?
+        .to_string();
+    Ok((head.shorthand().unwrap_or("main").to_string(), refname))
+}
+
+/// Which remote a pull will contact when the caller named none.
+///
+/// The remote half of `resolve_pull_target`, split out so `get_pull_remote` can
+/// answer the same question WITHOUT touching the network. The frontend's
+/// offline/allowlist gate and its credential scoping both need the remote a
+/// pull will actually reach: assuming "origin" evaluated the allowlist against
+/// the wrong host and offered origin's token to an unrelated one.
+pub(crate) fn resolve_pull_remote(
+    repo: &git2::Repository,
+    requested_remote: Option<String>,
+    head_refname: &str,
+) -> String {
+    match requested_remote {
+        Some(r) => r,
+        None => repo
+            .branch_upstream_remote(head_refname)
+            .ok()
+            .and_then(|b| b.as_str().ok().map(|s| s.to_string()))
+            .unwrap_or_else(|| "origin".to_string()),
+    }
+}
+
+/// The remote a pull would contact, without performing it.
+#[tauri::command]
+pub async fn get_pull_remote(
+    path: String,
+    remote: Option<String>,
+    branch: Option<String>,
+) -> Result<String> {
+    let repo = git2::Repository::open(Path::new(&path))?;
+    let (_, head_refname) = resolve_pull_branch(&repo, branch.as_deref())?;
+    let remote_name = resolve_pull_remote(&repo, remote, &head_refname);
+    repo.find_remote(&remote_name)
+        .map_err(|_| LeviathanError::RemoteNotFound(remote_name.clone()))?;
+    Ok(remote_name)
+}
+
+/// The remote a push would target, without performing it.
+#[tauri::command]
+pub async fn get_push_remote(path: String, remote: Option<String>) -> Result<String> {
+    let repo = git2::Repository::open(Path::new(&path))?;
+    let remote_name = resolve_push_remote(&repo, remote);
+    repo.find_remote(&remote_name)
+        .map_err(|_| LeviathanError::RemoteNotFound(remote_name.clone()))?;
+    Ok(remote_name)
+}
+
 /// Which remote to fetch, and which remote-tracking ref to merge, for a pull.
 ///
 /// Asks git rather than rebuilding "<remote>/<shorthand>". The rebuilt form was
@@ -571,14 +652,7 @@ pub(crate) fn resolve_pull_target(
         .and_then(|b| b.upstream().ok())
         .and_then(|u| u.get().name().ok().map(|n| n.to_string()));
 
-    let remote = match requested_remote {
-        Some(r) => r,
-        None => repo
-            .branch_upstream_remote(head_refname)
-            .ok()
-            .and_then(|b| b.as_str().ok().map(|s| s.to_string()))
-            .unwrap_or_else(|| "origin".to_string()),
-    };
+    let remote = resolve_pull_remote(repo, requested_remote, head_refname);
 
     let remote_ref = upstream_ref
         .as_deref()
@@ -744,31 +818,7 @@ pub(crate) fn pull_branch(
 
     let repo = git2::Repository::open(Path::new(path_for_task))?;
 
-    // On a detached HEAD, shorthand() is the literal "HEAD" — so
-    // this used to resolve origin/HEAD (a symref that DOES exist in
-    // a normal clone), fast-forward-check-out its tree, and only
-    // then fail looking up "refs/heads/HEAD". The tree ended up
-    // holding origin/main's content while HEAD still pointed at the
-    // tag, so every diverging file showed as an uncommitted change.
-    // git refuses to pull with no upstream; so do we. merge() gets
-    // this right by using head.name() rather than rebuilding it.
-    let (branch_name, head_refname) = if let Some(ref b) = branch_for_task {
-        (b.clone(), format!("refs/heads/{}", b))
-    } else {
-        let head = repo.head()?;
-        if !head.is_branch() {
-            return Err(LeviathanError::OperationFailed(
-                "You are not currently on a branch. Check out a branch before \
-                 pulling, or say which branch to pull."
-                    .to_string(),
-            ));
-        }
-        let refname = head
-            .name()
-            .map_err(|_| LeviathanError::InvalidReference)?
-            .to_string();
-        (head.shorthand().unwrap_or("main").to_string(), refname)
-    };
+    let (branch_name, head_refname) = resolve_pull_branch(&repo, branch_for_task.as_deref())?;
 
     // Honour the repository's own pull strategy when the caller
     // did not force one. Defaulting to merge meant a user with
@@ -2788,6 +2838,147 @@ mod tests {
             &format!("refs/heads/{}", branch),
         );
         assert_eq!(remote, "chosen");
+    }
+
+    // ---- get_pull_remote / get_push_remote ----
+    //
+    // The frontend's offline/allowlist gate and its credential scoping both
+    // have to know which remote an operation will REACH before it runs. They
+    // used to assume "origin"; in the ordinary fork layout that checked the
+    // allowlist against the fork's host and offered the fork's token to the
+    // upstream's. These commands answer the same question the pull/push paths
+    // answer, without touching the network.
+
+    /// A repo with two remotes whose branch tracks the NON-origin one.
+    #[cfg(unix)]
+    fn repo_tracking_upstream() -> (TestRepo, String) {
+        let repo_dir = TestRepo::with_initial_commit();
+        repo_dir.add_remote("origin", "https://github.com/me/app.git");
+        repo_dir.add_remote("upstream", "https://gitlab.example.test/acme/app.git");
+        let branch = repo_dir.current_branch();
+        let mut config = repo_dir.repo().config().unwrap();
+        config
+            .set_str(&format!("branch.{branch}.remote"), "upstream")
+            .unwrap();
+        config
+            .set_str(
+                &format!("branch.{branch}.merge"),
+                &format!("refs/heads/{branch}"),
+            )
+            .unwrap();
+        drop(config);
+        (repo_dir, branch)
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_get_pull_remote_follows_the_branch_upstream() {
+        let (repo_dir, _) = repo_tracking_upstream();
+        let remote = get_pull_remote(repo_dir.path.to_string_lossy().to_string(), None, None)
+            .await
+            .unwrap();
+        assert_eq!(remote, "upstream", "a pull follows the branch's upstream");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_get_pull_remote_falls_back_to_origin() {
+        let repo_dir = TestRepo::with_initial_commit();
+        repo_dir.add_remote("origin", "https://github.com/me/app.git");
+        let remote = get_pull_remote(repo_dir.path.to_string_lossy().to_string(), None, None)
+            .await
+            .unwrap();
+        assert_eq!(remote, "origin");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_get_pull_remote_honours_an_explicit_remote() {
+        let (repo_dir, _) = repo_tracking_upstream();
+        let remote = get_pull_remote(
+            repo_dir.path.to_string_lossy().to_string(),
+            Some("origin".to_string()),
+            None,
+        )
+        .await
+        .unwrap();
+        assert_eq!(remote, "origin");
+    }
+
+    /// A configured upstream whose remote was deleted must be reported, not
+    /// silently downgraded to origin — the gate would then approve a host the
+    /// pull is never going to reach anyway.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_get_pull_remote_rejects_a_missing_remote() {
+        let repo_dir = TestRepo::with_initial_commit();
+        repo_dir.add_remote("origin", "https://github.com/me/app.git");
+        let branch = repo_dir.current_branch();
+        let mut config = repo_dir.repo().config().unwrap();
+        config
+            .set_str(&format!("branch.{branch}.remote"), "deleted")
+            .unwrap();
+        drop(config);
+
+        let err = get_pull_remote(repo_dir.path.to_string_lossy().to_string(), None, None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LeviathanError::RemoteNotFound(name) if name == "deleted"));
+    }
+
+    /// Detached HEAD: `pull_branch` refuses outright, so this must too rather
+    /// than inventing a remote for an operation that cannot run.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_get_pull_remote_refuses_a_detached_head() {
+        let repo_dir = TestRepo::with_initial_commit();
+        repo_dir.add_remote("origin", "https://github.com/me/app.git");
+        let oid = repo_dir.head_oid();
+        repo_dir.repo().set_head_detached(oid).unwrap();
+
+        assert!(
+            get_pull_remote(repo_dir.path.to_string_lossy().to_string(), None, None)
+                .await
+                .is_err()
+        );
+    }
+
+    /// Push follows remote.pushDefault ahead of the branch's upstream — the
+    /// fork case where a pull and a push reach DIFFERENT hosts.
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_get_push_remote_honours_push_default() {
+        let (repo_dir, _) = repo_tracking_upstream();
+        let mut config = repo_dir.repo().config().unwrap();
+        config.set_str("remote.pushDefault", "origin").unwrap();
+        drop(config);
+
+        let path = repo_dir.path.to_string_lossy().to_string();
+        assert_eq!(
+            get_push_remote(path.clone(), None).await.unwrap(),
+            "origin",
+            "a push follows pushDefault"
+        );
+        assert_eq!(
+            get_pull_remote(path, None, None).await.unwrap(),
+            "upstream",
+            "while the pull still follows the upstream"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_get_push_remote_rejects_a_missing_remote() {
+        let repo_dir = TestRepo::with_initial_commit();
+        repo_dir.add_remote("origin", "https://github.com/me/app.git");
+        let mut config = repo_dir.repo().config().unwrap();
+        config.set_str("remote.pushDefault", "gone").unwrap();
+        drop(config);
+
+        let err = get_push_remote(repo_dir.path.to_string_lossy().to_string(), None)
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LeviathanError::RemoteNotFound(name) if name == "gone"));
     }
 
     // ---- pull's normal-merge arm (merge_fetched_commit) ----

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -193,11 +193,16 @@ pub async fn fetch(
         Some(remote_ops_registry.acquire(Path::new(&path), RemoteOp::Fetch)?)
     };
 
+    let repo = git2::Repository::open(Path::new(&path))?;
+    let remote_name_owned = resolve_fetch_remote(&repo, remote);
+    repo.find_remote(&remote_name_owned)
+        .map_err(|_| LeviathanError::RemoteNotFound(remote_name_owned.clone()))?;
+    drop(repo);
+
     let repo_path = path.clone();
     let deadline = network_deadline(timeout_secs);
     let path_clone = path.clone();
     let prune_val = prune.unwrap_or(false);
-    let remote_name_owned = remote.unwrap_or_else(|| "origin".to_string());
     let remote_name_for_event = remote_name_owned.clone();
 
     // git2 fetch is blocking network I/O; offload to a blocking thread so
@@ -277,6 +282,38 @@ pub async fn fetch(
     }
 
     Ok(())
+}
+
+pub(crate) fn resolve_fetch_remote(repo: &git2::Repository, requested: Option<String>) -> String {
+    if let Some(remote) = requested {
+        return remote;
+    }
+    let from_upstream = repo
+        .head()
+        .ok()
+        .filter(|head| head.is_branch())
+        .and_then(|head| head.name().ok().map(str::to_owned))
+        .and_then(|refname| repo.branch_upstream_remote(&refname).ok())
+        .and_then(|name| name.as_str().ok().map(str::to_owned))
+        .filter(|name| name != "." && repo.find_remote(name).is_ok());
+    if let Some(remote) = from_upstream {
+        return remote;
+    }
+    match repo.remotes() {
+        Ok(names) if names.len() == 1 => {
+            names.get(0).ok().flatten().unwrap_or("origin").to_string()
+        }
+        _ => "origin".to_string(),
+    }
+}
+
+#[tauri::command]
+pub async fn get_fetch_remote(path: String, remote: Option<String>) -> Result<String> {
+    let repo = git2::Repository::open(Path::new(&path))?;
+    let remote_name = resolve_fetch_remote(&repo, remote);
+    repo.find_remote(&remote_name)
+        .map_err(|_| LeviathanError::RemoteNotFound(remote_name.clone()))?;
+    Ok(remote_name)
 }
 
 /// The message and IPC error code for a failure reported through an EVENT
@@ -2617,6 +2654,67 @@ mod tests {
             "chosen",
             "an explicit remote still wins over everything"
         );
+    }
+
+    #[test]
+    fn test_resolve_fetch_remote_uses_the_checked_out_branch_upstream() {
+        let repo_dir = TestRepo::with_initial_commit();
+        let branch = repo_dir.current_branch();
+        repo_dir.add_remote("origin", "https://example.test/origin.git");
+        repo_dir.add_remote("upstream", "https://example.test/upstream.git");
+        let repo = repo_dir.repo();
+        let mut config = repo.config().unwrap();
+        config
+            .set_str(&format!("branch.{}.remote", branch), "upstream")
+            .unwrap();
+        config
+            .set_str(
+                &format!("branch.{}.merge", branch),
+                &format!("refs/heads/{}", branch),
+            )
+            .unwrap();
+
+        assert_eq!(resolve_fetch_remote(&repo, None), "upstream");
+    }
+
+    #[test]
+    fn test_resolve_fetch_remote_uses_the_only_configured_remote() {
+        let repo_dir = TestRepo::with_initial_commit();
+        repo_dir.add_remote("mirror", "https://example.test/mirror.git");
+
+        assert_eq!(resolve_fetch_remote(&repo_dir.repo(), None), "mirror");
+    }
+
+    #[test]
+    fn test_resolve_fetch_remote_ignores_local_branch_upstream() {
+        let repo_dir = TestRepo::with_initial_commit();
+        repo_dir.add_remote("origin", "https://example.test/origin.git");
+        let branch = repo_dir.current_branch();
+        let mut config = repo_dir.repo().config().unwrap();
+        config
+            .set_str(&format!("branch.{branch}.remote"), ".")
+            .unwrap();
+        config
+            .set_str(&format!("branch.{branch}.merge"), "refs/heads/main")
+            .unwrap();
+
+        assert_eq!(resolve_fetch_remote(&repo_dir.repo(), None), "origin");
+    }
+
+    #[test]
+    fn test_resolve_fetch_remote_ignores_missing_upstream_remote() {
+        let repo_dir = TestRepo::with_initial_commit();
+        repo_dir.add_remote("mirror", "https://example.test/mirror.git");
+        let branch = repo_dir.current_branch();
+        let mut config = repo_dir.repo().config().unwrap();
+        config
+            .set_str(&format!("branch.{branch}.remote"), "deleted")
+            .unwrap();
+        config
+            .set_str(&format!("branch.{branch}.merge"), "refs/heads/main")
+            .unwrap();
+
+        assert_eq!(resolve_fetch_remote(&repo_dir.repo(), None), "mirror");
     }
 
     /// Pull must follow the branch's CONFIGURED upstream, not "origin/<name>".

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -335,6 +335,8 @@ pub fn run() {
             commands::staging::get_sorted_file_status,
             commands::remote::get_remotes,
             commands::remote::get_fetch_remote,
+            commands::remote::get_pull_remote,
+            commands::remote::get_push_remote,
             commands::remote::add_remote,
             commands::remote::remove_remote,
             commands::remote::rename_remote,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -334,6 +334,7 @@ pub fn run() {
             commands::staging::strip_trailing_whitespace,
             commands::staging::get_sorted_file_status,
             commands::remote::get_remotes,
+            commands::remote::get_fetch_remote,
             commands::remote::add_remote,
             commands::remote::remove_remote,
             commands::remote::rename_remote,
@@ -630,6 +631,7 @@ pub fn run() {
             commands::issue_templates::get_issue_template_content,
             // Auto-fetch
             commands::autofetch::start_auto_fetch,
+            commands::autofetch::trigger_auto_fetch,
             commands::autofetch::stop_auto_fetch,
             commands::autofetch::is_auto_fetch_running,
             commands::autofetch::get_remote_status,

--- a/src-tauri/src/services/autofetch_service.rs
+++ b/src-tauri/src/services/autofetch_service.rs
@@ -410,6 +410,44 @@ mod tests {
         assert_eq!(error, FETCH_REMOTE_CHANGED);
     }
 
+    /// The frontend restarts the loop after a fetch-remote change and then
+    /// triggers it, so the badge refreshes now instead of a full interval
+    /// later. A trigger for a repo with no loop must report that rather than
+    /// pretend it worked — the command turns that `false` into the error the
+    /// caller logs.
+    #[tokio::test]
+    async fn test_trigger_wakes_a_parked_loop_and_reports_unknown_repos() {
+        let mut service = AutoFetchService::new();
+        assert!(
+            !service.trigger("/repo/one"),
+            "a repo with no loop has nothing to wake"
+        );
+
+        let trigger = Arc::new(Notify::new());
+        let waiter = Arc::clone(&trigger);
+        // Stands in for the loop's `select!` arm: parked until the trigger fires.
+        let task = tokio::spawn(async move { waiter.notified().await });
+        service
+            .repos
+            .insert("/repo/one".to_string(), RepoFetchState { task, trigger });
+
+        assert!(service.trigger("/repo/one"), "a running loop is woken");
+
+        // `notify_one` stores a permit when nobody is waiting yet, so a trigger
+        // issued right after `start` — before the task has reached its first
+        // await — is not lost.
+        let state = service.repos.remove("/repo/one").unwrap();
+        tokio::time::timeout(Duration::from_secs(5), state.task)
+            .await
+            .expect("the parked loop must wake on a trigger")
+            .expect("the loop task must not panic");
+
+        assert!(
+            !service.trigger("/repo/one"),
+            "a stopped loop is no longer triggerable"
+        );
+    }
+
     #[test]
     fn test_stagger_offset_is_deterministic() {
         let interval = Duration::from_secs(300);

--- a/src-tauri/src/services/autofetch_service.rs
+++ b/src-tauri/src/services/autofetch_service.rs
@@ -4,12 +4,16 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use tauri::Emitter;
+use tokio::sync::Notify;
 use tokio::sync::RwLock;
 use tokio::task::JoinHandle;
+
+const FETCH_REMOTE_CHANGED: &str = "FETCH_REMOTE_CHANGED";
 
 /// Auto-fetch state for a single repository
 struct RepoFetchState {
     task: JoinHandle<()>,
+    trigger: Arc<Notify>,
 }
 
 /// Global auto-fetch service state
@@ -35,6 +39,8 @@ impl AutoFetchService {
         &mut self,
         repo_path: String,
         interval_minutes: u32,
+        remote: String,
+        remote_url: String,
         token: Option<String>,
         app_handle: tauri::AppHandle,
     ) {
@@ -44,17 +50,22 @@ impl AutoFetchService {
         let path = repo_path.clone();
         let interval = Duration::from_secs(interval_minutes as u64 * 60);
         let initial_delay = interval + stagger_offset(&repo_path, interval);
+        let trigger = Arc::new(Notify::new());
+        let task_trigger = Arc::clone(&trigger);
 
         let task = tokio::spawn(async move {
             // The first tick is staggered per repo so that many open repos
             // don't all fetch at the same instant (thundering herd on every
             // interval boundary); afterwards each repo keeps its own cadence.
-            tokio::time::sleep(initial_delay).await;
+            tokio::select! {
+                _ = tokio::time::sleep(initial_delay) => {}
+                _ = task_trigger.notified() => {}
+            }
             loop {
                 // Perform fetch
                 tracing::info!("Auto-fetching repository: {}", path);
 
-                match perform_fetch(&path, token.clone()).await {
+                match perform_fetch(&path, &remote, &remote_url, token.clone()).await {
                     Ok(status) => {
                         tracing::info!("Auto-fetch complete for {}: {:?}", path, status);
 
@@ -98,11 +109,23 @@ impl AutoFetchService {
                     }
                 }
 
-                tokio::time::sleep(interval).await;
+                tokio::select! {
+                    _ = tokio::time::sleep(interval) => {}
+                    _ = task_trigger.notified() => {}
+                }
             }
         });
 
-        self.repos.insert(repo_path, RepoFetchState { task });
+        self.repos
+            .insert(repo_path, RepoFetchState { task, trigger });
+    }
+
+    pub fn trigger(&self, repo_path: &str) -> bool {
+        let Some(state) = self.repos.get(repo_path) else {
+            return false;
+        };
+        state.trigger.notify_one();
+        true
     }
 
     /// Stop auto-fetching for a repository
@@ -172,30 +195,34 @@ fn stagger_offset(repo_path: &str, interval: Duration) -> Duration {
 }
 
 /// Perform a fetch operation
-async fn perform_fetch(repo_path: &str, token: Option<String>) -> Result<RemoteStatus, String> {
+async fn perform_fetch(
+    repo_path: &str,
+    remote_name: &str,
+    expected_remote_url: &str,
+    token: Option<String>,
+) -> Result<RemoteStatus, String> {
     let path = repo_path.to_string();
+    let remote_name = remote_name.to_string();
+    let expected_remote_url = expected_remote_url.to_string();
 
     tokio::task::spawn_blocking(move || {
         let repo =
             git2::Repository::open(&path).map_err(|e| format!("Failed to open repo: {}", e))?;
 
-        // Fetch the remote the CURRENT BRANCH tracks, not a hard-coded "origin".
-        //
-        // remote.rs's resolve_pull_target exists precisely because "origin" is
-        // an assumption: `git clone -o upstream`, Gerrit checkouts, and remotes
-        // renamed through this app's own Remote dialog all break it, and every
-        // cycle then failed with a persistent "auto-fetch failed" warning.
-        //
-        // The quieter failure mattered more. In the fork workflow — origin is
-        // your fork, the branch tracks upstream/main — fetching origin and then
-        // computing ahead/behind against the never-updated upstream tracking ref
-        // reported SUCCESS, so the badge and the "remote has N new commits"
-        // toast were stale while looking fresh.
-        let remote_name = tracked_remote(&repo);
+        // A branch switch can change the fetch destination. Stop before using
+        // credentials authorized for the previous remote; the frontend will
+        // restart this loop after re-running permission and token resolution.
+        let current_remote = crate::commands::remote::resolve_fetch_remote(&repo, None);
+        if current_remote != remote_name {
+            return Err(FETCH_REMOTE_CHANGED.to_string());
+        }
 
         let mut remote = repo
             .find_remote(&remote_name)
             .map_err(|e| format!("Failed to find remote: {}", e))?;
+        if remote.url().ok() != Some(expected_remote_url.as_str()) {
+            return Err(FETCH_REMOTE_CHANGED.to_string());
+        }
 
         // Use the shared credentials helper (reads from OS keyring via `security` CLI
         // on macOS, avoiding Keychain authorization dialogs)
@@ -215,32 +242,6 @@ async fn perform_fetch(repo_path: &str, token: Option<String>) -> Result<RemoteS
     })
     .await
     .map_err(|e| format!("Task failed: {}", e))?
-}
-
-/// The remote the current branch tracks, falling back to "origin".
-///
-/// Mirrors what resolve_pull_target does for an explicit pull, so the
-/// background loop fetches the same remote the foreground would.
-fn tracked_remote(repo: &git2::Repository) -> String {
-    const DEFAULT_REMOTE: &str = "origin";
-
-    let Ok(head) = repo.head() else {
-        return DEFAULT_REMOTE.to_string();
-    };
-
-    if !head.is_branch() {
-        return DEFAULT_REMOTE.to_string();
-    }
-
-    let Ok(refname) = head.name() else {
-        return DEFAULT_REMOTE.to_string();
-    };
-
-    repo.branch_upstream_remote(refname)
-        .ok()
-        .and_then(|buf| buf.as_str().ok().map(|s| s.to_string()))
-        .filter(|name| !name.is_empty())
-        .unwrap_or_else(|| DEFAULT_REMOTE.to_string())
 }
 
 /// Get remote status (ahead/behind counts)
@@ -340,104 +341,73 @@ mod tests {
         assert!(status.upstream_name.is_none());
     }
 
-    /// Auto-fetch must follow the branch's own upstream, the way an explicit
-    /// pull does. Hard-coding "origin" broke `git clone -o upstream` and
-    /// renamed remotes outright, and silently reported stale counts in the fork
-    /// workflow (origin = your fork, branch tracks upstream/main).
-    #[test]
-    fn test_tracked_remote_follows_the_branch_upstream() {
-        let test_repo = TestRepo::with_initial_commit();
-        let repo = test_repo.repo();
-        let branch = test_repo.current_branch();
-
-        // Two remotes; the branch tracks the one that is NOT origin.
-        repo.remote("origin", "https://example.com/fork.git")
-            .unwrap();
-        repo.remote("upstream", "https://example.com/canonical.git")
-            .unwrap();
-
-        let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
-        repo.reference(
-            &format!("refs/remotes/upstream/{}", branch),
-            head_commit.id(),
-            true,
-            "test",
-        )
-        .unwrap();
-
-        let mut local = repo.find_branch(&branch, git2::BranchType::Local).unwrap();
-        local
-            .set_upstream(Some(&format!("upstream/{}", branch)))
-            .unwrap();
-
-        assert_eq!(tracked_remote(&repo), "upstream");
-    }
-
-    /// The call site must USE the tracked remote, not just be able to compute
-    /// it: testing tracked_remote() alone leaves perform_fetch's one-line
-    /// substitution unverified.
-    ///
-    /// Uses a local path as the remote, so this exercises the real fetch with no
-    /// network. The repository deliberately has NO "origin": with the remote
-    /// hard-coded, find_remote("origin") fails and the fetch errors.
+    /// The timer must use the remote resolved by the frontend for its permission
+    /// check and token selection.
     #[tokio::test]
-    async fn test_perform_fetch_uses_the_tracked_remote_not_origin() {
+    async fn test_perform_fetch_uses_the_resolved_remote() {
         let upstream = TestRepo::with_initial_commit();
         let consumer = TestRepo::with_initial_commit();
-        let branch = consumer.current_branch();
 
         {
             let repo = consumer.repo();
-            // Only "upstream" exists — no "origin" anywhere.
             repo.remote("upstream", &upstream.path.to_string_lossy())
                 .unwrap();
             assert!(repo.find_remote("origin").is_err(), "origin must not exist");
-
-            let head_commit = repo.head().unwrap().peel_to_commit().unwrap();
-            repo.reference(
-                &format!("refs/remotes/upstream/{}", branch),
-                head_commit.id(),
-                true,
-                "test",
-            )
-            .unwrap();
-
-            let mut local = repo.find_branch(&branch, git2::BranchType::Local).unwrap();
-            local
-                .set_upstream(Some(&format!("upstream/{}", branch)))
-                .unwrap();
         }
 
-        let result = perform_fetch(&consumer.path_str(), None).await;
+        let result = perform_fetch(
+            &consumer.path_str(),
+            "upstream",
+            &upstream.path.to_string_lossy(),
+            None,
+        )
+        .await;
 
         assert!(
             result.is_ok(),
-            "auto-fetch must follow the branch's upstream remote, got: {:?}",
+            "auto-fetch must use the resolved remote, got: {:?}",
             result.err()
         );
     }
 
-    /// With no upstream configured, "origin" remains the sensible default.
-    #[test]
-    fn test_tracked_remote_falls_back_to_origin() {
+    #[tokio::test]
+    async fn test_perform_fetch_rejects_a_changed_remote() {
         let test_repo = TestRepo::with_initial_commit();
-        let repo = test_repo.repo();
-        repo.remote("origin", "https://example.com/repo.git")
+        test_repo
+            .repo()
+            .remote("upstream", "https://example.com/repo.git")
             .unwrap();
 
-        assert_eq!(tracked_remote(&repo), "origin");
+        let error = perform_fetch(
+            &test_repo.path_str(),
+            "origin",
+            "https://example.com/repo.git",
+            None,
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error, FETCH_REMOTE_CHANGED);
     }
 
-    /// A detached HEAD has no upstream to consult, so the default applies
-    /// rather than a panic or an empty remote name.
-    #[test]
-    fn test_tracked_remote_on_detached_head_falls_back_to_origin() {
+    #[tokio::test]
+    async fn test_perform_fetch_rejects_a_changed_remote_url() {
         let test_repo = TestRepo::with_initial_commit();
-        let repo = test_repo.repo();
-        let head_oid = repo.head().unwrap().peel_to_commit().unwrap().id();
-        repo.set_head_detached(head_oid).unwrap();
+        test_repo
+            .repo()
+            .remote("origin", "https://attacker.example/repo.git")
+            .unwrap();
 
-        assert_eq!(tracked_remote(&repo), "origin");
+        let error = perform_fetch(
+            &test_repo.path_str(),
+            "origin",
+            "https://github.com/example/repo.git",
+            Some("secret".to_string()),
+        )
+        .await
+        .unwrap_err();
+
+        assert_eq!(error, FETCH_REMOTE_CHANGED);
     }
 
     #[test]

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -216,10 +216,13 @@ describe('app-shell multi-repo behavior', () => {
   /** start_auto_fetch now resolves a credential token first, so the invoke
    * lands a microtask later than a bare `setTimeout(0)` observes. */
   const waitForCommand = async (command: string): Promise<{ command: string; args: any } | undefined> => {
-    for (let i = 0; i < 50; i++) {
+    // Generous, because it returns the instant the call lands: the whole
+    // budget is only ever spent on a genuine failure. A tight one flaked when
+    // the full suite ran the browser under load.
+    for (let i = 0; i < 200; i++) {
       const call = invokeCallArgs.find((c) => c.command === command);
       if (call) return call;
-      await new Promise((r) => setTimeout(r, 5));
+      await new Promise((r) => setTimeout(r, 10));
     }
     return undefined;
   };
@@ -336,19 +339,180 @@ describe('app-shell multi-repo behavior', () => {
       try {
         repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
         repositoryStore.getState().addRepository(mockRepo('/repo/two', 'two'));
-        await new Promise((r) => setTimeout(r, 0));
+        // Wait for the START to land, not a fixed macrotask: stops are queued
+        // behind the in-flight start for the same repo, and that start resolves
+        // a remote, a URL and a credential first. A `setTimeout(0)` here beat
+        // the stop to the assertion whenever the machine was loaded.
+        await waitForCommand('start_auto_fetch');
         invokeCallArgs.length = 0;
 
         repositoryStore.getState().removeRepository('/repo/one');
-        await new Promise((r) => setTimeout(r, 0));
 
-        const stopCall = invokeCallArgs.find((c) => c.command === 'stop_auto_fetch');
+        const stopCall = await waitForCommand('stop_auto_fetch');
         expect(stopCall).to.not.be.undefined;
         expect(stopCall!.args.path).to.equal('/repo/one');
       } finally {
         el.remove();
         settingsStore.setState({ autoFetchInterval: 0 });
       }
+    });
+
+    /** Lifecycle commands in the order the backend saw them. */
+    const lifecycleOrder = () =>
+      invokeCallArgs
+        .filter((c) =>
+          ['start_auto_fetch', 'stop_auto_fetch', 'trigger_auto_fetch'].includes(c.command)
+        )
+        .map((c) => c.command);
+
+    it('restarts every open repo when the remote allowlist changes', async () => {
+      // The allowlist decides which remotes the loop may reach, and the loop
+      // is a Tokio task with no re-check — so a running loop must be torn down
+      // and re-approved, not left running under the old decision.
+      settingsStore.setState({ autoFetchInterval: 5, remoteAllowlist: [] });
+      const el = createAppShell();
+      document.body.appendChild(el);
+      try {
+        repositoryStore.getState().addRepository(mockRepo('/repo/one', 'one'));
+        await waitForCommand('start_auto_fetch');
+        invokeCallArgs.length = 0;
+
+        settingsStore.setState({ remoteAllowlist: ['github.com'] });
+        await waitForCommand('start_auto_fetch');
+
+        expect(lifecycleOrder()).to.deep.equal(['stop_auto_fetch', 'start_auto_fetch']);
+      } finally {
+        el.remove();
+        settingsStore.setState({ autoFetchInterval: 0, remoteAllowlist: [] });
+      }
+    });
+
+    it('restarts and immediately triggers a fetch when the fetch remote changed', async () => {
+      // A branch switch can move the fetch destination. The backend refuses to
+      // reuse credentials authorized for the old remote and reports
+      // FETCH_REMOTE_CHANGED; the frontend must re-run permission and token
+      // resolution and then fetch NOW, or the badge stays stale for a full
+      // interval.
+      settingsStore.setState({ autoFetchInterval: 5 });
+      const el = createAppShell();
+      seedRepo('/repo/one', 'one');
+      try {
+        (el as any).handleAutoFetchCompleted({
+          repoPath: '/repo/one',
+          success: false,
+          ahead: 0,
+          behind: 0,
+          message: 'FETCH_REMOTE_CHANGED',
+        });
+
+        const trigger = await waitForCommand('trigger_auto_fetch');
+        expect(trigger!.args.path).to.equal('/repo/one');
+        expect(lifecycleOrder()).to.deep.equal(['start_auto_fetch', 'trigger_auto_fetch']);
+        expect(uiStore.getState().toasts, 'a remote change is not a failure to report').to.have
+          .length(0);
+      } finally {
+        settingsStore.setState({ autoFetchInterval: 0 });
+      }
+    });
+
+    it('reports and clears the loop when the fetch-remote restart fails', async () => {
+      // The backend keeps its loop parked on the timer after
+      // FETCH_REMOTE_CHANGED. If the restart cannot re-approve it — here the
+      // branch's upstream remote is gone — the old loop would re-report the
+      // same change every interval, forever, with the badge frozen and nothing
+      // shown to the user.
+      settingsStore.setState({ autoFetchInterval: 5 });
+      mockResponses.get_remotes = () => [];
+      const el = createAppShell();
+      seedRepo('/repo/one', 'one');
+      try {
+        (el as any).handleAutoFetchCompleted({
+          repoPath: '/repo/one',
+          success: false,
+          ahead: 0,
+          behind: 0,
+          message: 'FETCH_REMOTE_CHANGED',
+        });
+
+        const stopCall = await waitForCommand('stop_auto_fetch');
+        expect(stopCall, 'the loop that cannot be restarted is torn down').to.not.be.undefined;
+        expect(stopCall!.args.path).to.equal('/repo/one');
+        expect(
+          invokeCallArgs.find((c) => c.command === 'start_auto_fetch'),
+          'the refused start never reached the backend'
+        ).to.be.undefined;
+
+        const toast = uiStore.getState().toasts.find((t) => t.message.includes('auto-fetch failed'));
+        expect(toast, 'the user is told the ahead/behind counts are stale').to.not.be.undefined;
+        expect(toast!.message).to.contain('one');
+      } finally {
+        settingsStore.setState({ autoFetchInterval: 0 });
+      }
+    });
+
+    it('does not restart a fetch-remote change for a repo that is no longer open', async () => {
+      settingsStore.setState({ autoFetchInterval: 5 });
+      const el = createAppShell();
+      try {
+        (el as any).handleAutoFetchCompleted({
+          repoPath: '/repo/closed',
+          success: false,
+          ahead: 0,
+          behind: 0,
+          message: 'FETCH_REMOTE_CHANGED',
+        });
+        await new Promise((r) => setTimeout(r, 20));
+
+        expect(lifecycleOrder(), 'a closed repo has no loop to revive').to.deep.equal([]);
+      } finally {
+        settingsStore.setState({ autoFetchInterval: 0 });
+      }
+    });
+
+    it('does not restart a fetch-remote change while offline, or with no interval', async () => {
+      const el = createAppShell();
+      seedRepo('/repo/one', 'one');
+      const event = {
+        repoPath: '/repo/one',
+        success: false,
+        ahead: 0,
+        behind: 0,
+        message: 'FETCH_REMOTE_CHANGED',
+      };
+      try {
+        settingsStore.setState({ autoFetchInterval: 5, offlineMode: true });
+        (el as any).handleAutoFetchCompleted(event);
+        await new Promise((r) => setTimeout(r, 20));
+        expect(lifecycleOrder(), 'offline mode must not start a fetch loop').to.deep.equal([]);
+
+        settingsStore.setState({ autoFetchInterval: 0, offlineMode: false });
+        (el as any).handleAutoFetchCompleted(event);
+        await new Promise((r) => setTimeout(r, 20));
+        expect(lifecycleOrder(), 'auto-fetch turned off must stay off').to.deep.equal([]);
+      } finally {
+        settingsStore.setState({ autoFetchInterval: 0, offlineMode: false });
+      }
+    });
+
+    it('a stop issued before a start resolves leaves the repo stopped', async () => {
+      // `startAutoFetch` resolves the remote, its URL and a credential before
+      // it reaches the backend. A stop that lands inside that window — closing
+      // a tab, or going offline — must supersede it, not be overtaken by a
+      // start that was already obsolete when it was issued.
+      const el = createAppShell();
+      seedRepo('/repo/one', 'one');
+
+      (el as any).startAutoFetchLogged('/repo/one', 5);
+      (el as any).stopAutoFetchLogged('/repo/one');
+
+      await waitForCommand('stop_auto_fetch');
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(
+        invokeCallArgs.find((c) => c.command === 'start_auto_fetch'),
+        'the superseded start must never reach the backend'
+      ).to.be.undefined;
+      expect(lifecycleOrder()).to.deep.equal(['stop_auto_fetch']);
     });
   });
 

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -514,6 +514,43 @@ describe('app-shell multi-repo behavior', () => {
       ).to.be.undefined;
       expect(lifecycleOrder()).to.deep.equal(['stop_auto_fetch']);
     });
+
+    it('stays quiet when a superseded fetch-remote restart fails', async () => {
+      // The restart's own resolution is several IPC round trips long, and the
+      // user can close the tab (or a newer start can be issued) inside that
+      // window. Reporting the failure then toasts about a repo that is already
+      // gone and tears down a loop the supersession owns — so the failure
+      // branch has to check the sequence exactly as the success branch does.
+      settingsStore.setState({ autoFetchInterval: 5 });
+      const el = createAppShell();
+      seedRepo('/repo/one', 'one');
+      try {
+        // The supersession has to land WHILE the restart is resolving, which
+        // is the only window that can go wrong: `get_remotes` is one of the
+        // round trips `startAutoFetch` makes before it reaches the backend.
+        // Returning nothing then fails that restart.
+        mockResponses.get_remotes = () => {
+          (el as any).stopAutoFetchLogged('/repo/one');
+          return [];
+        };
+
+        (el as any).startAutoFetchLogged('/repo/one', 5, true);
+
+        await waitForCommand('stop_auto_fetch');
+        await new Promise((r) => setTimeout(r, 20));
+
+        expect(
+          uiStore.getState().toasts.filter((t) => t.message.includes('auto-fetch failed')),
+          'a superseded restart must not report its failure'
+        ).to.have.length(0);
+        expect(
+          lifecycleOrder(),
+          'only the supersession stops the loop — the dead restart must not stop it again'
+        ).to.deep.equal(['stop_auto_fetch']);
+      } finally {
+        settingsStore.setState({ autoFetchInterval: 0 });
+      }
+    });
   });
 
   describe('background autofetch results update tab badge data', () => {

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -123,6 +123,10 @@ describe('app-shell multi-repo behavior', () => {
     for (const key of Object.keys(mockResponses)) {
       delete mockResponses[key];
     }
+    mockResponses.get_fetch_remote = () => 'origin';
+    mockResponses.get_remotes = () => [
+      { name: 'origin', url: 'https://github.com/example/repo.git', pushUrl: null },
+    ];
     uiStore.setState({ toasts: [] });
     repositoryStore.getState().reset();
     searchIndexService.invalidate();
@@ -2132,5 +2136,3 @@ describe('the toolbar command-palette button loads the active repo', () => {
     el.remove();
   });
 });
-
-

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1120,6 +1120,16 @@ export class AppShell extends LitElement {
         const r = await gitService.startAutoFetch(path, intervalMinutes);
         if (!r.success) {
           log.warn('Failed to start auto-fetch for', path, r.error?.message);
+          // `immediate` means this is the restart after the backend reported
+          // FETCH_REMOTE_CHANGED. That loop is still alive and still parked on
+          // its timer, so a failed restart leaves it re-reporting the same
+          // change every interval while the ahead/behind badge stays frozen —
+          // and, without this, saying nothing at all. Clear the dead loop and
+          // tell the user their counts are stale.
+          if (immediate) {
+            this.reportAutoFetchFailure(path, r.error?.message);
+            await gitService.stopAutoFetch(path);
+          }
           return;
         }
         if (this.autoFetchStartSeq.get(path) !== sequence) {

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -967,6 +967,7 @@ export class AppShell extends LitElement {
   }
   private lastOfflineMode = false;
   private lastAutoFetchInterval = 0;
+  private lastRemoteAllowlistKey = '';
   private refsChangedDebounceTimer?: ReturnType<typeof setTimeout>;
   private updateUnlisteners: UnlistenFn[] = [];
   private shownIntegrationSuggestions: Set<string> = new Set();
@@ -1068,6 +1069,8 @@ export class AppShell extends LitElement {
   // Per-path monotonic sequence for badge hydration: a superseded hydration
   // (an older watcher tick's) must not overwrite a newer one's store write.
   private badgeHydrationSeq = new Map<string, number>();
+  private autoFetchStartSeq = new Map<string, number>();
+  private autoFetchOperationChains = new Map<string, Promise<void>>();
 
   /**
    * Tear down every per-repo backend service and client-side cache for a
@@ -1102,22 +1105,75 @@ export class AppShell extends LitElement {
   // Auto-fetch start/stop are fire-and-forget, but a failure must not be
   // fully silent — log it (matching the watcher-start error handling) so a
   // repo silently not auto-fetching is diagnosable.
-  private startAutoFetchLogged(path: string, intervalMinutes: number): void {
-    gitService
-      .startAutoFetch(path, intervalMinutes)
-      .then((r) => {
-        if (!r.success) log.warn('Failed to start auto-fetch for', path, r.error?.message);
+  private startAutoFetchLogged(
+    path: string,
+    intervalMinutes: number,
+    immediate = false,
+  ): void {
+    const sequence = (this.autoFetchStartSeq.get(path) ?? 0) + 1;
+    this.autoFetchStartSeq.set(path, sequence);
+    const previous = this.autoFetchOperationChains.get(path) ?? Promise.resolve();
+    const operation = previous
+      .catch(() => undefined)
+      .then(async () => {
+        if (this.autoFetchStartSeq.get(path) !== sequence) return;
+        const r = await gitService.startAutoFetch(path, intervalMinutes);
+        if (!r.success) {
+          log.warn('Failed to start auto-fetch for', path, r.error?.message);
+          return;
+        }
+        if (this.autoFetchStartSeq.get(path) !== sequence) {
+          await gitService.stopAutoFetch(path);
+        } else if (immediate) {
+          const triggered = await gitService.triggerAutoFetch(path);
+          if (!triggered.success) {
+            log.warn('Failed to trigger auto-fetch for', path, triggered.error?.message);
+          }
+        }
       })
-      .catch((err) => log.warn('Failed to start auto-fetch for', path, err));
+      .catch((err) => log.warn('Failed to start auto-fetch for', path, err))
+      .finally(() => {
+        if (this.autoFetchOperationChains.get(path) === operation) {
+          this.autoFetchOperationChains.delete(path);
+        }
+      });
+    this.autoFetchOperationChains.set(path, operation);
   }
 
   private stopAutoFetchLogged(path: string): void {
-    gitService
-      .stopAutoFetch(path)
-      .then((r) => {
+    this.autoFetchStartSeq.set(path, (this.autoFetchStartSeq.get(path) ?? 0) + 1);
+    const previous = this.autoFetchOperationChains.get(path) ?? Promise.resolve();
+    const operation = previous
+      .catch(() => undefined)
+      .then(async () => {
+        const r = await gitService.stopAutoFetch(path);
         if (!r.success) log.warn('Failed to stop auto-fetch for', path, r.error?.message);
       })
-      .catch((err) => log.warn('Failed to stop auto-fetch for', path, err));
+      .catch((err) => log.warn('Failed to stop auto-fetch for', path, err))
+      .finally(() => {
+        if (this.autoFetchOperationChains.get(path) === operation) {
+          this.autoFetchOperationChains.delete(path);
+        }
+      });
+    this.autoFetchOperationChains.set(path, operation);
+  }
+
+  private async ensureAutoFetchRunning(path: string): Promise<void> {
+    const initialSettings = settingsStore.getState();
+    if (initialSettings.autoFetchInterval <= 0 || initialSettings.offlineMode) return;
+    const running = await gitService.isAutoFetchRunning(path);
+    const settings = settingsStore.getState();
+    if (
+      running.success &&
+      running.data === false &&
+      settings.autoFetchInterval > 0 &&
+      !settings.offlineMode &&
+      repositoryStore
+        .getState()
+        .openRepositories.some((repo) => repo.repository.path === path)
+    ) {
+      this.startAutoFetchLogged(path, settings.autoFetchInterval);
+    }
   }
 
   /**
@@ -3891,13 +3947,14 @@ export class AppShell extends LitElement {
       return;
     }
     this.refreshInFlight = true;
+    let refreshingPath: string | null = null;
     try {
       // Refresh the repository state (e.g., after cherry-pick, merge, rebase)
       if (this.activeRepository) {
         // Capture the path before awaiting: if the user switches tabs during the
         // IPC round-trip, updateActiveRepository would otherwise write repo A's
         // data into repo B's (now-active) tab slot, corrupting its identity.
-        const refreshingPath = this.activeRepository.repository.path;
+        refreshingPath = this.activeRepository.repository.path;
         const result = await gitService.openRepository({ path: refreshingPath });
         if (result.success && result.data) {
           if (
@@ -3922,6 +3979,9 @@ export class AppShell extends LitElement {
       window.dispatchEvent(
         new CustomEvent('repository-refresh', { detail: { source: 'app-shell' } }),
       );
+      if (refreshingPath) {
+        await this.ensureAutoFetchRunning(refreshingPath);
+      }
     } finally {
       this.refreshInFlight = false;
     }
@@ -4729,6 +4789,7 @@ export class AppShell extends LitElement {
     // reacting to unrelated changes would defer fetches indefinitely.
     this.lastAutoFetchInterval = settings.autoFetchInterval;
     this.lastOfflineMode = settings.offlineMode;
+    this.lastRemoteAllowlistKey = settings.remoteAllowlist.join('\0');
     this.autoFetchUnsubscribe = settingsStore.subscribe((state) => {
       // Offline mode gates the START call, but the loop it started is a Tokio
       // task with no re-check: turning offline mode on left it fetching every
@@ -4736,12 +4797,24 @@ export class AppShell extends LitElement {
       // start had been refused. Treat an offline-mode flip like an interval
       // change.
       const offlineChanged = state.offlineMode !== this.lastOfflineMode;
-      if (state.autoFetchInterval !== this.lastAutoFetchInterval || offlineChanged) {
+      const allowlistKey = state.remoteAllowlist.join('\0');
+      const allowlistChanged = allowlistKey !== this.lastRemoteAllowlistKey;
+      if (
+        state.autoFetchInterval !== this.lastAutoFetchInterval ||
+        offlineChanged ||
+        allowlistChanged
+      ) {
         this.lastAutoFetchInterval = state.autoFetchInterval;
         this.lastOfflineMode = state.offlineMode;
+        this.lastRemoteAllowlistKey = allowlistKey;
         const paths = repositoryStore
           .getState()
           .openRepositories.map((r) => r.repository.path);
+        if (allowlistChanged) {
+          for (const path of paths) {
+            this.stopAutoFetchLogged(path);
+          }
+        }
         if (state.autoFetchInterval > 0 && !state.offlineMode) {
           for (const path of paths) {
             this.startAutoFetchLogged(path, state.autoFetchInterval);
@@ -4824,6 +4897,16 @@ export class AppShell extends LitElement {
     message?: string;
   }): void => {
     if (!event.success) {
+      if (event.message === 'FETCH_REMOTE_CHANGED') {
+        const settings = settingsStore.getState();
+        const isOpen = repositoryStore
+          .getState()
+          .openRepositories.some((repo) => repo.repository.path === event.repoPath);
+        if (isOpen && settings.autoFetchInterval > 0 && !settings.offlineMode) {
+          this.startAutoFetchLogged(event.repoPath, settings.autoFetchInterval, true);
+        }
+        return;
+      }
       this.reportAutoFetchFailure(event.repoPath, event.message);
       return;
     }

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1126,7 +1126,14 @@ export class AppShell extends LitElement {
           // change every interval while the ahead/behind badge stays frozen —
           // and, without this, saying nothing at all. Clear the dead loop and
           // tell the user their counts are stale.
-          if (immediate) {
+          //
+          // Only while this restart is still the current one, the same guard
+          // the success path below applies: `startAutoFetch` is several IPC
+          // round trips, and the repo can be closed — or the loop legitimately
+          // restarted — while they are in flight. Reporting a superseded
+          // restart's failure toasts about a repo the user has already shut,
+          // and stops a loop somebody else just started.
+          if (immediate && this.autoFetchStartSeq.get(path) === sequence) {
             this.reportAutoFetchFailure(path, r.error?.message);
             await gitService.stopAutoFetch(path);
           }

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -543,6 +543,7 @@ describe('git.service - getRepoToken repo-aware account resolution', () => {
     detectAdo?: unknown;
     detectGitLab?: unknown;
     remoteUrl?: string;
+    remotes?: Array<{ name: string; url: string; pushUrl: string | null }>;
     /** null → no profile assigned; 'throw' → the profile lookup fails. */
     assignedProfile?: { id: string } | null | 'throw';
     /** What the backend resolver returns; 'throw' → the command fails. */
@@ -556,7 +557,7 @@ describe('git.service - getRepoToken repo-aware account resolution', () => {
       if (command === 'detect_ado_repo') return opts.detectAdo ?? null;
       if (command === 'detect_gitlab_repo') return opts.detectGitLab ?? null;
       if (command === 'get_remotes') {
-        return [{ name: 'origin', url: opts.remoteUrl ?? GH_URL, pushUrl: null }];
+        return opts.remotes ?? [{ name: 'origin', url: opts.remoteUrl ?? GH_URL, pushUrl: null }];
       }
       if (command === 'get_assigned_unified_profile') {
         if (opts.assignedProfile === 'throw') throw new Error('profile lookup failed');
@@ -635,6 +636,38 @@ describe('git.service - getRepoToken repo-aware account resolution', () => {
       integrationType: 'github',
       repoUrl: GH_URL,
     });
+  });
+
+  it('scopes provider detection and account resolution to the requested remote', async () => {
+    const { work } = setupGitHubAccounts();
+    const upstreamUrl = 'https://github.com/acme/upstream.git';
+    let detectedRemote: unknown;
+    installMock({
+      detectGitHub: { owner: 'acme', repo: 'upstream', remoteName: 'upstream' },
+      remotes: [
+        { name: 'origin', url: GH_URL, pushUrl: null },
+        { name: 'upstream', url: upstreamUrl, pushUrl: null },
+      ],
+      assignedProfile: { id: 'profile-work' },
+      preferredAccount: work,
+    });
+    const baseInvoke = mockInvoke;
+    mockInvoke = async (command: string, args?: unknown) => {
+      if (command === 'detect_github_repo') {
+        detectedRemote = (args as Record<string, unknown>).remoteName;
+      }
+      return baseInvoke(command, args);
+    };
+
+    await gitFetch({ path: '/repo', remote: 'upstream', silent: true });
+
+    expect(detectedRemote).to.equal('upstream');
+    expect(resolverArgs).to.deep.equal({
+      profileId: 'profile-work',
+      integrationType: 'github',
+      repoUrl: upstreamUrl,
+    });
+    expect(fetchToken).to.equal('work-tok');
   });
 
   it('still resolves by account URL patterns when the profile lookup fails', async () => {

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -548,11 +548,18 @@ describe('git.service - getRepoToken repo-aware account resolution', () => {
     assignedProfile?: { id: string } | null | 'throw';
     /** What the backend resolver returns; 'throw' → the command fails. */
     preferredAccount?: IntegrationAccount | null | 'throw';
+    /** The remote `fetch` resolves when the caller names none. */
+    fetchRemote?: string;
   }
 
   function installMock(opts: MockOptions) {
     mockInvoke = async (command: string, args?: unknown) => {
       const a = args as Record<string, unknown> | undefined;
+      // `fetch` resolves the repo's fetch remote before picking a credential,
+      // and only takes the remote-scoped token path when it has one. Leaving
+      // this unmocked sent every assertion below down a branch the real
+      // toolbar and background fetches no longer use.
+      if (command === 'get_fetch_remote') return opts.fetchRemote ?? 'origin';
       if (command === 'detect_github_repo') return opts.detectGitHub ?? null;
       if (command === 'detect_ado_repo') return opts.detectAdo ?? null;
       if (command === 'detect_gitlab_repo') return opts.detectGitLab ?? null;
@@ -668,6 +675,54 @@ describe('git.service - getRepoToken repo-aware account resolution', () => {
       repoUrl: upstreamUrl,
     });
     expect(fetchToken).to.equal('work-tok');
+  });
+
+  it("withholds the token when the fetch remote is on a different host from the account's", async () => {
+    // A fork setup: `origin` is the GitHub repo the account belongs to,
+    // `upstream` lives somewhere else entirely. Nothing about `upstream`
+    // resolves to an account, so the lookup falls back to the repo's default
+    // remote — and that token must not follow the fetch to another host.
+    setupGitHubAccounts();
+    installMock({
+      detectGitHub: GH_REPO, // matches `origin` only
+      remotes: [
+        { name: 'origin', url: GH_URL, pushUrl: null },
+        { name: 'upstream', url: 'https://git.other.test/acme/app.git', pushUrl: null },
+      ],
+      assignedProfile: null,
+      preferredAccount: null,
+    });
+
+    await gitFetch({ path: '/repo', remote: 'upstream', silent: true });
+
+    expect(fetchToken, "origin's token must not authenticate to another host").to.be.undefined;
+  });
+
+  it('withholds a host-agnostic token too when the fetch remote host differs', async () => {
+    // The Azure DevOps branch resolves no credential host, so only the
+    // source-host === target-host comparison stands between an ADO token and
+    // an unrelated remote.
+    const work: IntegrationAccount = {
+      ...createEmptyIntegrationAccount('azure-devops', 'workorg'),
+      id: 'ado-work',
+      isDefault: true,
+    };
+    unifiedProfileStore.getState().setAccounts([work]);
+    keyring.clear();
+    seedToken('azure-devops', 'ado-work', 'ado-tok');
+    installMock({
+      detectAdo: { organization: 'workorg', project: 'p', repository: 'repo', remoteName: 'origin' },
+      remotes: [
+        { name: 'origin', url: 'https://dev.azure.com/workorg/p/_git/repo', pushUrl: null },
+        { name: 'upstream', url: 'https://github.com/acme/app.git', pushUrl: null },
+      ],
+      assignedProfile: null,
+      preferredAccount: null,
+    });
+
+    await gitFetch({ path: '/repo', remote: 'upstream', silent: true });
+
+    expect(fetchToken, 'an ADO token must not be offered to github.com').to.be.undefined;
   });
 
   it('still resolves by account URL patterns when the profile lookup fails', async () => {

--- a/src/services/__tests__/git.service.test.ts
+++ b/src/services/__tests__/git.service.test.ts
@@ -4,6 +4,8 @@ import {
   isClosingKeyword,
   getAdoToken,
   fetch as gitFetch,
+  pull as gitPull,
+  push as gitPush,
   resetAdoGitCredentialSyncCache,
 } from '../git.service.ts';
 import { unifiedProfileStore } from '../../stores/unified-profile.store.ts';
@@ -511,7 +513,7 @@ describe('git.service - getRepoToken keyring sync (via fetch)', () => {
 
 describe('git.service - getRepoToken repo-aware account resolution', () => {
   const keyring = new Map<string, string>();
-  /** The token `fetch` actually sent to the backend — i.e. the one that authenticates. */
+  /** The token fetch/pull/push actually sent to the backend — i.e. the one that authenticates. */
   let fetchToken: string | undefined;
   /** Args the backend resolver was invoked with, or null when it was never called. */
   let resolverArgs: Record<string, unknown> | null;
@@ -550,6 +552,9 @@ describe('git.service - getRepoToken repo-aware account resolution', () => {
     preferredAccount?: IntegrationAccount | null | 'throw';
     /** The remote `fetch` resolves when the caller names none. */
     fetchRemote?: string;
+    /** The remote `pull` / `push` resolve when the caller names none. */
+    pullRemote?: string;
+    pushRemote?: string;
   }
 
   function installMock(opts: MockOptions) {
@@ -560,6 +565,8 @@ describe('git.service - getRepoToken repo-aware account resolution', () => {
       // this unmocked sent every assertion below down a branch the real
       // toolbar and background fetches no longer use.
       if (command === 'get_fetch_remote') return opts.fetchRemote ?? 'origin';
+      if (command === 'get_pull_remote') return opts.pullRemote ?? 'origin';
+      if (command === 'get_push_remote') return opts.pushRemote ?? 'origin';
       if (command === 'detect_github_repo') return opts.detectGitHub ?? null;
       if (command === 'detect_ado_repo') return opts.detectAdo ?? null;
       if (command === 'detect_gitlab_repo') return opts.detectGitLab ?? null;
@@ -578,7 +585,10 @@ describe('git.service - getRepoToken repo-aware account resolution', () => {
       if (command === 'get_keyring_token') return keyring.get(a!.key as string) ?? null;
       if (command === 'store_keyring_token') { keyring.set(a!.key as string, a!.value as string); return null; }
       if (command === 'store_git_credentials') { credWrites.push(a!.url as string); return null; }
-      if (command === 'fetch') { fetchToken = a?.token as string | undefined; return null; }
+      if (command === 'fetch' || command === 'pull' || command === 'push') {
+        fetchToken = a?.token as string | undefined;
+        return null;
+      }
       return null;
     };
   }
@@ -723,6 +733,67 @@ describe('git.service - getRepoToken repo-aware account resolution', () => {
     await gitFetch({ path: '/repo', remote: 'upstream', silent: true });
 
     expect(fetchToken, 'an ADO token must not be offered to github.com').to.be.undefined;
+  });
+
+  /**
+   * The fork layout the app cannot avoid: `origin` is your GitHub fork, the
+   * branch tracks `upstream` on an unrelated host. Neither pull nor push has a
+   * remote selector, so both resolve the remote themselves — and the token
+   * must follow that remote, not origin.
+   */
+  const FORK_REMOTES = [
+    { name: 'origin', url: GH_URL, pushUrl: null },
+    { name: 'upstream', url: 'https://git.other.test/acme/app.git', pushUrl: null },
+  ];
+
+  it("withholds origin's token from a pull that follows the branch's upstream", async () => {
+    setupGitHubAccounts();
+    installMock({
+      detectGitHub: GH_REPO, // matches `origin` only
+      remotes: FORK_REMOTES,
+      pullRemote: 'upstream',
+      assignedProfile: null,
+      preferredAccount: null,
+    });
+
+    await gitPull({ path: '/repo', silent: true });
+
+    expect(fetchToken, "a GitHub PAT must not be sent to git.other.test").to.be.undefined;
+  });
+
+  it("withholds origin's token from a push aimed at another host", async () => {
+    setupGitHubAccounts();
+    installMock({
+      detectGitHub: GH_REPO,
+      remotes: FORK_REMOTES,
+      pushRemote: 'upstream',
+      assignedProfile: null,
+      preferredAccount: null,
+    });
+
+    await gitPush({ path: '/repo', silent: true });
+
+    expect(fetchToken, "a GitHub PAT must not be sent to git.other.test").to.be.undefined;
+  });
+
+  it('still authenticates a pull to the resolved remote on the same host', async () => {
+    const { work } = setupGitHubAccounts();
+    installMock({
+      detectGitHub: { owner: 'acme', repo: 'upstream', remoteName: 'upstream' },
+      remotes: [
+        { name: 'origin', url: GH_URL, pushUrl: null },
+        { name: 'upstream', url: 'https://github.com/acme/upstream.git', pushUrl: null },
+      ],
+      pullRemote: 'upstream',
+      assignedProfile: { id: 'profile-work' },
+      preferredAccount: work,
+    });
+
+    await gitPull({ path: '/repo', silent: true });
+
+    expect(fetchToken, 'scoping must not cost the credential its legitimate use').to.equal(
+      'work-tok',
+    );
   });
 
   it('still resolves by account URL patterns when the profile lookup fails', async () => {

--- a/src/services/__tests__/network-gate.test.ts
+++ b/src/services/__tests__/network-gate.test.ts
@@ -96,11 +96,25 @@ const NETWORK_OPERATIONS: Array<{ name: string; command: string; run: () => Prom
   },
 ];
 
+/** A plain https remote, so nothing is refused for a reason other than the gate. */
+const ALLOWED_URL = 'https://github.com/example/repo.git';
+
 describe('network security gate', () => {
   beforeEach(() => {
     invokeHistory.length = 0;
+    // Enough for every gated operation to REACH the gate. `startAutoFetch`
+    // resolves the fetch remote and then its URL before checking anything; a
+    // mock that answers only `get_fetch_remote` makes it bail with
+    // REMOTE_NOT_FOUND first, which passes the assertions below with the gate
+    // deleted.
     mockInvoke = (command) =>
-      Promise.resolve(command === 'get_fetch_remote' ? 'origin' : null);
+      Promise.resolve(
+        command === 'get_fetch_remote'
+          ? 'origin'
+          : command === 'get_remotes'
+            ? [{ name: 'origin', url: ALLOWED_URL, fetchUrl: ALLOWED_URL, pushUrl: ALLOWED_URL }]
+            : null,
+      );
     settingsStore.setState({ offlineMode: false, confirmNetworkOps: false, remoteAllowlist: [] });
   });
 
@@ -113,9 +127,13 @@ describe('network security gate', () => {
       it(`blocks ${op.name}`, async () => {
         settingsStore.setState({ offlineMode: true });
 
-        const result = (await op.run()) as { success: boolean };
+        const result = (await op.run()) as { success: boolean; error?: { code?: string } };
 
         expect(result.success, `${op.name} should be refused`).to.equal(false);
+        // Not just "some failure": the refusal must be the GATE's. Without
+        // this an unrelated early return (a remote that cannot be resolved,
+        // say) satisfies the test while offline mode goes unchecked.
+        expect(result.error?.code, `${op.name} must be refused BY THE GATE`).to.equal('BLOCKED');
         expect(
           invokeHistory.some((c) => c.command === op.command),
           `${op.name} must not reach ${op.command}`,

--- a/src/services/__tests__/network-gate.test.ts
+++ b/src/services/__tests__/network-gate.test.ts
@@ -353,6 +353,113 @@ describe('network security gate', () => {
     });
   });
 
+  /**
+   * No pull or push surface in the app names a remote, and the backend does
+   * NOT default to origin: a pull follows the branch's upstream, and a push
+   * follows pushRemote/pushDefault/branch.<n>.remote. Gating on origin's URL
+   * therefore checked the allowlist against a host the operation never
+   * contacts — the bypass this suite exists to prevent.
+   */
+  describe('the allowlist follows the remote the operation will really contact', () => {
+    /** The ordinary fork layout: origin is your fork, the branch tracks elsewhere. */
+    const installForkLayout = (resolved: string) => {
+      mockInvoke = (command) =>
+        Promise.resolve(
+          command === 'get_pull_remote' || command === 'get_push_remote'
+            ? resolved
+            : command === 'get_remotes'
+              ? [
+                  { name: 'origin', url: 'https://github.com/me/app.git', pushUrl: null },
+                  { name: 'upstream', url: 'https://gitlab.example.com/acme/app.git', pushUrl: null },
+                ]
+              : null,
+        );
+    };
+
+    it('blocks a pull whose upstream remote is off the list', async () => {
+      installForkLayout('upstream');
+      settingsStore.setState({ remoteAllowlist: ['github.com'] });
+
+      const result = await pull({ path: '/repo', silent: true });
+
+      expect(result.success, 'allowlisting github.com must not permit gitlab.example.com').to.equal(
+        false,
+      );
+      expect(invokeHistory.some((c) => c.command === 'pull')).to.equal(false);
+    });
+
+    it('blocks a push whose push remote is off the list', async () => {
+      installForkLayout('upstream');
+      settingsStore.setState({ remoteAllowlist: ['github.com'] });
+
+      const result = await push({ path: '/repo', silent: true });
+
+      expect(result.success).to.equal(false);
+      expect(invokeHistory.some((c) => c.command === 'push')).to.equal(false);
+    });
+
+    it('allows — and names — a pull to the resolved remote when it is on the list', async () => {
+      installForkLayout('origin');
+      settingsStore.setState({ remoteAllowlist: ['github.com'] });
+
+      const result = await pull({ path: '/repo', silent: true });
+
+      expect(result.success).to.equal(true);
+      const call = invokeHistory.find((c) => c.command === 'pull');
+      expect(call, 'pull reaches the backend').to.not.be.undefined;
+      // Passed on rather than dropped: the backend must act on the same remote
+      // the gate just approved, not re-resolve and possibly pick another.
+      expect((call!.args as Record<string, unknown>).remote).to.equal('origin');
+    });
+
+    it('allows — and names — a push to the resolved remote when it is on the list', async () => {
+      installForkLayout('origin');
+      settingsStore.setState({ remoteAllowlist: ['github.com'] });
+
+      const result = await push({ path: '/repo', silent: true });
+
+      expect(result.success).to.equal(true);
+      const call = invokeHistory.find((c) => c.command === 'push');
+      expect(call, 'push reaches the backend').to.not.be.undefined;
+      expect((call!.args as Record<string, unknown>).remote).to.equal('origin');
+    });
+
+    it('leaves an explicitly named remote alone', async () => {
+      installForkLayout('upstream');
+      settingsStore.setState({ remoteAllowlist: [] });
+
+      await push({ path: '/repo', remote: 'origin', silent: true });
+
+      expect(
+        invokeHistory.some((c) => c.command === 'get_push_remote'),
+        'a caller that already knows the remote must not be second-guessed',
+      ).to.equal(false);
+      const call = invokeHistory.find((c) => c.command === 'push');
+      expect((call!.args as Record<string, unknown>).remote).to.equal('origin');
+    });
+
+    it('falls back to the old behaviour when the remote cannot be resolved', async () => {
+      // A detached HEAD, or a repo git cannot open: the resolve command fails.
+      // The operation must still run (the backend reports the real problem) —
+      // it must not be silently swallowed here.
+      mockInvoke = (command) => {
+        if (command === 'get_pull_remote') return Promise.reject(new Error('not on a branch'));
+        if (command === 'get_remotes') {
+          return Promise.resolve([{ name: 'origin', url: ALLOWED_URL, pushUrl: null }]);
+        }
+        return Promise.resolve(null);
+      };
+      settingsStore.setState({ remoteAllowlist: [] });
+
+      const result = await pull({ path: '/repo', silent: true });
+
+      expect(result.success).to.equal(true);
+      const call = invokeHistory.find((c) => c.command === 'pull');
+      expect(call, 'pull still runs').to.not.be.undefined;
+      expect((call!.args as Record<string, unknown>).remote).to.equal(undefined);
+    });
+  });
+
   describe('credentials reach the operations that need them', () => {
     it('pushTag forwards a resolved token, like push does', async () => {
       mockInvoke = (command: string) => {

--- a/src/services/__tests__/network-gate.test.ts
+++ b/src/services/__tests__/network-gate.test.ts
@@ -99,7 +99,8 @@ const NETWORK_OPERATIONS: Array<{ name: string; command: string; run: () => Prom
 describe('network security gate', () => {
   beforeEach(() => {
     invokeHistory.length = 0;
-    mockInvoke = () => Promise.resolve(null);
+    mockInvoke = (command) =>
+      Promise.resolve(command === 'get_fetch_remote' ? 'origin' : null);
     settingsStore.setState({ offlineMode: false, confirmNetworkOps: false, remoteAllowlist: [] });
   });
 
@@ -304,6 +305,18 @@ describe('network security gate', () => {
       expect(invokeHistory.some((c) => c.command === 'push_tag')).to.equal(false);
     });
 
+    it('does not allow a look-alike hostname containing an allowed domain', async () => {
+      settingsStore.setState({ remoteAllowlist: ['github.com'] });
+
+      const result = await fetch({
+        path: '/repo',
+        remote: 'https://github.com.attacker.test/repo.git',
+      });
+
+      expect(result.success).to.equal(false);
+      expect(invokeHistory.some((c) => c.command === 'fetch')).to.equal(false);
+    });
+
     it('allows a push tag to a remote on the list', async () => {
       settingsStore.setState({ remoteAllowlist: ['github.com'] });
 
@@ -343,6 +356,12 @@ describe('network security gate', () => {
 
     it('startAutoFetch forwards a token so the background loop can authenticate', async () => {
       mockInvoke = (command: string) => {
+        if (command === 'get_fetch_remote') return Promise.resolve('upstream');
+        if (command === 'get_remotes') {
+          return Promise.resolve([
+            { name: 'upstream', url: 'https://github.com/acme/repo.git', pushUrl: null },
+          ]);
+        }
         if (command === 'get_repo_token') return Promise.resolve('tok_abc');
         return Promise.resolve(null);
       };
@@ -355,6 +374,7 @@ describe('network security gate', () => {
         Object.prototype.hasOwnProperty.call(call!.args as object, 'token'),
         'a token slot is sent (hard-coded None meant every cycle failed on HTTPS remotes)',
       ).to.equal(true);
+      expect((call!.args as Record<string, unknown>).remote).to.equal('upstream');
     });
   });
 });

--- a/src/services/__tests__/remote.service.test.ts
+++ b/src/services/__tests__/remote.service.test.ts
@@ -270,18 +270,30 @@ describe('git.service - Remote operations', () => {
       expect(args.remote).to.equal('upstream');
     });
 
+    it('resolves an omitted remote before fetching', async () => {
+      mockInvoke = (command) =>
+        Promise.resolve(command === 'get_fetch_remote' ? 'upstream' : null);
+
+      await fetch({ path: '/test/repo', silent: true });
+
+      expect(lastInvokedCommand).to.equal('fetch');
+      expect((lastInvokedArgs as Record<string, unknown>).remote).to.equal('upstream');
+    });
+
     // The window-focus refresh runs this same backend command, and the
     // backend's success event is toasted by setupRemoteOperationListeners. So
     // with fetch-on-focus enabled, "Fetched from origin" appeared every single
     // time the user alt-tabbed back into the app — exactly the noise the
     // background fetch is documented to avoid.
     it('marks a background fetch quiet so it does not toast', async () => {
-      mockInvoke = () => Promise.resolve(null);
+      mockInvoke = (command) =>
+        Promise.resolve(command === 'get_fetch_remote' ? 'upstream' : null);
 
       await fetchInBackground('/test/repo');
       expect(lastInvokedCommand).to.equal('fetch');
       const args = lastInvokedArgs as Record<string, unknown>;
       expect(args.quiet, 'the background fetch must suppress the success event').to.be.true;
+      expect(args.remote).to.equal('upstream');
     });
 
     it('leaves a user-initiated fetch loud', async () => {
@@ -648,17 +660,35 @@ describe('git.service - Remote operations', () => {
 
   describe('startAutoFetch', () => {
     it('invokes start_auto_fetch command with correct arguments', async () => {
-      mockInvoke = () => Promise.resolve(null);
+      mockInvoke = (command) => {
+        if (command === 'get_fetch_remote') return Promise.resolve('upstream');
+        if (command === 'get_remotes') {
+          return Promise.resolve([
+            { name: 'upstream', url: 'https://github.com/acme/repo.git', pushUrl: null },
+          ]);
+        }
+        return Promise.resolve(null);
+      };
 
       await startAutoFetch('/test/repo', 5);
       expect(lastInvokedCommand).to.equal('start_auto_fetch');
       const args = lastInvokedArgs as Record<string, unknown>;
       expect(args.path).to.equal('/test/repo');
       expect(args.intervalMinutes).to.equal(5);
+      expect(args.remote).to.equal('upstream');
+      expect(args.remoteUrl).to.equal('https://github.com/acme/repo.git');
     });
 
     it('returns success when auto-fetch is started', async () => {
-      mockInvoke = () => Promise.resolve(null);
+      mockInvoke = (command) => {
+        if (command === 'get_fetch_remote') return Promise.resolve('origin');
+        if (command === 'get_remotes') {
+          return Promise.resolve([
+            { name: 'origin', url: 'https://github.com/acme/repo.git', pushUrl: null },
+          ]);
+        }
+        return Promise.resolve(null);
+      };
 
       const result = await startAutoFetch('/test/repo', 10);
       expect(result.success).to.be.true;

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -71,9 +71,18 @@ async function checkNetworkAllowed(
   // through: silently allowing is the failure mode that made this setting
   // decorative.
   const url = repoPath ? await resolveRemoteUrl(repoPath, remote) : (remote ?? null);
+  const host = url
+    ? cloneUrlHost(url.includes("://") || url.includes("@") ? url : `https://${url}`)
+    : null;
   const allowed =
-    !!url &&
-    settings.remoteAllowlist.some((domain) => url.toLowerCase().includes(domain.toLowerCase()));
+    !!host &&
+    settings.remoteAllowlist.some((entry) => {
+      const normalized = entry.trim().toLowerCase().replace(/^\*\./, "");
+      const allowedHost =
+        cloneUrlHost(normalized.includes("://") ? normalized : `https://${normalized}`) ??
+        normalized;
+      return host === allowedHost || host.endsWith(`.${allowedHost}`);
+    });
   if (!allowed) {
     if (!silent) {
       showToast(
@@ -97,10 +106,15 @@ async function checkNetworkAllowed(
 export async function fetchInBackground(
   repoPath: string,
 ): Promise<CommandResult<void>> {
-  if (await checkNetworkAllowed(repoPath, undefined, true)) {
+  const resolved = await invokeCommand<string>('get_fetch_remote', { path: repoPath });
+  if (!resolved.success || !resolved.data) {
+    return { success: false, error: resolved.error };
+  }
+  const remote = resolved.data;
+  if (await checkNetworkAllowed(repoPath, remote, true)) {
     return blockedResult();
   }
-  const token = await getRepoToken(repoPath);
+  const token = await getRemoteToken(repoPath, remote);
 
   // Same timeout its sibling `fetch` applies. Without it the backend's
   // `timeout_secs: None` branch awaits forever, so a hung remote left one
@@ -109,6 +123,7 @@ export async function fetchInBackground(
   const timeoutSecs = settingsStore.getState().networkOperationTimeout;
   return invokeCommand<void>("fetch", {
     path: repoPath,
+    remote,
     token,
     // Suppresses the backend's success event, which
     // setupRemoteOperationListeners toasts. Without it this "silent" fetch
@@ -1133,13 +1148,21 @@ export async function setRemoteUrl(
 export async function fetch(
   args?: FetchCommand & { silent?: boolean },
 ): Promise<CommandResult<void>> {
+  if (args?.path && !args.remote) {
+    const resolved = await invokeCommand<string>('get_fetch_remote', { path: args.path });
+    if (resolved.success && resolved.data) {
+      args.remote = resolved.data;
+    }
+  }
   if (!await checkNetworkPermission('fetch', args?.path ?? null, args?.remote)) {
     return blockedResult();
   }
 
   // If no token is provided, try to find one for the repository
   if (args && !args.token) {
-    const token = await getRepoToken(args.path, args.remote);
+    const token = args.remote
+      ? await getRemoteToken(args.path, args.remote)
+      : await getRepoToken(args.path);
     if (token) {
       args.token = token;
     }
@@ -1419,6 +1442,8 @@ async function resolveRepoAccount(
 interface ResolvedRepoToken {
   token?: string;
   remoteName?: string;
+  credentialHost?: string;
+  refused?: boolean;
 }
 
 /**
@@ -1436,7 +1461,7 @@ async function resolveRepoToken(
     const { AccountCredentials } = await import("./credential.service.ts");
 
     // GitHub
-    const ghRepoResult = await detectGitHubRepo(repoPath);
+    const ghRepoResult = await detectGitHubRepo(repoPath, remoteName);
     if (
       ghRepoResult.success &&
       ghRepoResult.data &&
@@ -1450,21 +1475,25 @@ async function resolveRepoToken(
       );
       if (account) {
         const token = await AccountCredentials.getToken("github", account.id);
-        if (token) return { token, remoteName: resolvedRemote };
+        if (token) return { token, remoteName: resolvedRemote, credentialHost: "github.com" };
         // This repo resolves to THIS account, but its keyring entry is gone. Every
         // fallback below re-resolves the global default, so continuing would push
         // as a different identity. Fail instead and let the user reconnect it.
-        if (repoSpecific) return {};
+        if (repoSpecific) return { refused: true };
       }
       // Legacy fallback for GitHub
       const tokenResult = await getGitHubToken();
       if (tokenResult.success && tokenResult.data) {
-        return { token: tokenResult.data, remoteName: resolvedRemote };
+        return {
+          token: tokenResult.data,
+          remoteName: resolvedRemote,
+          credentialHost: "github.com",
+        };
       }
     }
 
     // Azure DevOps
-    const adoRepoResult = await detectAdoRepo(repoPath);
+    const adoRepoResult = await detectAdoRepo(repoPath, remoteName);
     if (
       adoRepoResult.success &&
       adoRepoResult.data &&
@@ -1496,7 +1525,7 @@ async function resolveRepoToken(
         }
         // See the GitHub branch: a repo-specific account with no usable token
         // must not silently borrow the global default's.
-        if (repoSpecific) return {};
+        if (repoSpecific) return { refused: true };
       }
       // Legacy fallback for Azure DevOps
       const tokenResult = await getAdoToken();
@@ -1506,7 +1535,7 @@ async function resolveRepoToken(
     }
 
     // GitLab
-    const gitlabRepoResult = await detectGitLabRepo(repoPath);
+    const gitlabRepoResult = await detectGitLabRepo(repoPath, remoteName);
     if (
       gitlabRepoResult.success &&
       gitlabRepoResult.data &&
@@ -1520,15 +1549,28 @@ async function resolveRepoToken(
       );
       if (account) {
         const token = await AccountCredentials.getToken("gitlab", account.id);
-        if (token) return { token, remoteName: resolvedRemote };
+        const credentialHost =
+          account.config.type === "gitlab"
+            ? cloneUrlHost(account.config.instanceUrl)
+            : null;
+        if (token && credentialHost) {
+          return { token, remoteName: resolvedRemote, credentialHost };
+        }
         // See the GitHub branch: a repo-specific account with no usable token
         // must not silently borrow the global default's.
-        if (repoSpecific) return {};
+        if (repoSpecific) return { refused: true };
       }
       // Legacy fallback for GitLab
-      const tokenResult = await getGitLabToken();
-      if (tokenResult.success && tokenResult.data) {
-        return { token: tokenResult.data, remoteName: resolvedRemote };
+      const detectedHost = cloneUrlHost(gitlabRepoResult.data.instanceUrl);
+      if (detectedHost === "gitlab.com" || detectedHost?.endsWith(".gitlab.com")) {
+        const tokenResult = await getGitLabToken();
+        if (tokenResult.success && tokenResult.data) {
+          return {
+            token: tokenResult.data,
+            remoteName: resolvedRemote,
+            credentialHost: detectedHost,
+          };
+        }
       }
     }
   } catch (err) {
@@ -1549,6 +1591,32 @@ async function getRepoToken(
   remoteName?: string,
 ): Promise<string | undefined> {
   return (await resolveRepoToken(repoPath, remoteName)).token;
+}
+
+async function getRemoteToken(
+  repoPath: string,
+  remoteName: string,
+): Promise<string | undefined> {
+  let resolved = await resolveRepoToken(repoPath, remoteName);
+  if (!resolved.token && !resolved.refused) {
+    resolved = await resolveRepoToken(repoPath);
+  }
+  if (!resolved.token || resolved.refused || !resolved.remoteName) return undefined;
+
+  const [sourceUrl, targetUrl] = await Promise.all([
+    resolveRemoteUrl(repoPath, resolved.remoteName),
+    resolveRemoteUrl(repoPath, remoteName),
+  ]);
+  const sourceHost = sourceUrl ? cloneUrlHost(sourceUrl) : null;
+  const targetHost = targetUrl ? cloneUrlHost(targetUrl) : null;
+  return sourceHost &&
+    targetHost &&
+    sourceHost === targetHost &&
+    (!resolved.credentialHost || resolved.credentialHost === targetHost) &&
+    targetUrl &&
+    cloneUrlIsCredentialSafe(targetUrl)
+    ? resolved.token
+    : undefined;
 }
 
 /**
@@ -3576,9 +3644,11 @@ export async function checkGitHubConnectionWithToken(
 // Repository Detection
 export async function detectGitHubRepo(
   path: string,
+  remoteName?: string,
 ): Promise<CommandResult<DetectedGitHubRepo | null>> {
   return invokeCommand<DetectedGitHubRepo | null>("detect_github_repo", {
     path,
+    ...(remoteName ? { remoteName } : {}),
   });
 }
 
@@ -4191,8 +4261,12 @@ export async function listAdoOrganizations(
 
 export async function detectAdoRepo(
   path: string,
+  remoteName?: string,
 ): Promise<CommandResult<DetectedAdoRepo | null>> {
-  return invokeCommand<DetectedAdoRepo | null>("detect_ado_repo", { path });
+  return invokeCommand<DetectedAdoRepo | null>("detect_ado_repo", {
+    path,
+    ...(remoteName ? { remoteName } : {}),
+  });
 }
 
 // Azure DevOps Pull Requests
@@ -4472,9 +4546,11 @@ export async function checkGitLabConnectionWithToken(
 
 export async function detectGitLabRepo(
   path: string,
+  remoteName?: string,
 ): Promise<CommandResult<DetectedGitLabRepo | null>> {
   return invokeCommand<DetectedGitLabRepo | null>("detect_gitlab_repo", {
     path,
+    ...(remoteName ? { remoteName } : {}),
   });
 }
 
@@ -4993,24 +5069,46 @@ export async function startAutoFetch(
   repoPath: string,
   intervalMinutes: number,
 ): Promise<CommandResult<void>> {
+  const resolved = await invokeCommand<string>("get_fetch_remote", { path: repoPath });
+  if (!resolved.success || !resolved.data) {
+    return { success: false, error: resolved.error };
+  }
+  const remote = resolved.data;
+  const remoteUrl = await resolveRemoteUrl(repoPath, remote);
+  if (!remoteUrl) {
+    return {
+      success: false,
+      error: {
+        code: "REMOTE_NOT_FOUND",
+        message: `Could not resolve URL for remote "${remote}"`,
+      },
+    };
+  }
+
   // Hard blocks only: the background loop is not a gesture the user is standing
   // in front of, so a confirm here would be a dialog out of nowhere. Offline
   // mode and the allowlist still apply — otherwise "offline" leaks a fetch
   // every N minutes.
-  if (await checkNetworkAllowed(repoPath, undefined, true)) {
+  if (await checkNetworkAllowed(repoPath, remote, true)) {
     return blockedResult();
   }
 
   // The background loop authenticates with whatever token we hand it; without
   // one it could only ever use SSH or an OS-keyring credential, so auto-fetch
   // failed silently on token-authenticated HTTPS remotes.
-  const token = await getRepoToken(repoPath);
+  const token = await getRemoteToken(repoPath, remote);
 
   return invokeCommand<void>("start_auto_fetch", {
     path: repoPath,
     intervalMinutes,
+    remote,
+    remoteUrl,
     token,
   });
+}
+
+export async function triggerAutoFetch(repoPath: string): Promise<CommandResult<void>> {
+  return invokeCommand<void>("trigger_auto_fetch", { path: repoPath });
 }
 
 /**

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -1191,13 +1191,28 @@ export async function fetch(
 export async function pull(
   args?: PullCommand & { silent?: boolean },
 ): Promise<CommandResult<void>> {
+  // Same reason `fetch` resolves first: no pull surface in the app names a
+  // remote, and the backend pulls from the branch's UPSTREAM. Gating on the
+  // "origin" fallback checked the allowlist against the wrong host and handed
+  // origin's token to whatever host the upstream actually lives on.
+  if (args?.path && !args.remote) {
+    const resolved = await invokeCommand<string>('get_pull_remote', {
+      path: args.path,
+      ...(args.branch ? { branch: args.branch } : {}),
+    });
+    if (resolved.success && resolved.data) {
+      args.remote = resolved.data;
+    }
+  }
   if (!await checkNetworkPermission('pull', args?.path ?? null, args?.remote)) {
     return blockedResult();
   }
 
   // If no token is provided, try to find one for the repository
   if (args && !args.token) {
-    const token = await getRepoToken(args.path, args.remote);
+    const token = args.remote
+      ? await getRemoteToken(args.path, args.remote)
+      : await getRepoToken(args.path);
     if (token) {
       args.token = token;
     }
@@ -1226,13 +1241,25 @@ export async function pull(
 export async function push(
   args?: PushCommand & { silent?: boolean },
 ): Promise<CommandResult<void>> {
+  // No push surface names a remote either, and the backend follows
+  // branch.<n>.pushRemote / remote.pushDefault / branch.<n>.remote — none of
+  // which need be origin. Resolve it up front so the gate and the credential
+  // are scoped to the host this push will really reach.
+  if (args?.path && !args.remote) {
+    const resolved = await invokeCommand<string>('get_push_remote', { path: args.path });
+    if (resolved.success && resolved.data) {
+      args.remote = resolved.data;
+    }
+  }
   if (!await checkNetworkPermission('push', args?.path ?? null, args?.remote)) {
     return blockedResult();
   }
 
   // If no token is provided, try to find one for the repository
   if (args && !args.token) {
-    const token = await getRepoToken(args.path, args.remote);
+    const token = args.remote
+      ? await getRemoteToken(args.path, args.remote)
+      : await getRepoToken(args.path);
     if (token) {
       args.token = token;
     }


### PR DESCRIPTION
## Summary
- resolve fetch destinations using the checked-out branch upstream, sole remote, or origin fallback
- scope network permissions and provider credentials to the exact fetch remote and URL
- keep foreground, focus, and timer auto-fetch behavior consistent across remote and branch changes
- harden allowlist hostname matching and auto-fetch lifecycle races

## Validation
- TypeScript typecheck
- targeted frontend service and lifecycle tests
- targeted Rust fetch resolver and auto-fetch tests
- three-model unanimous review convergence