### PR TITLE
Fix stash preview identity contract

### DIFF
--- a/src-tauri/src/commands/stash.rs
+++ b/src-tauri/src/commands/stash.rs
@@ -12,6 +12,7 @@ use crate::models::Stash;
 #[serde(rename_all = "camelCase")]
 pub struct StashShowResult {
     pub index: u32,
+    pub oid: String,
     pub message: String,
     pub files: Vec<StashFile>,
     pub total_additions: u32,
@@ -344,6 +345,7 @@ pub async fn stash_show(
 
     Ok(StashShowResult {
         index,
+        oid: stash_oid.to_string(),
         message,
         files,
         total_additions,
@@ -648,6 +650,7 @@ mod tests {
         assert!(result.is_ok());
         let show = result.unwrap();
         assert_eq!(show.index, 0);
+        assert_eq!(show.oid, get_stashes(repo.path_str()).await.unwrap()[0].oid);
         assert!(show.message.contains("Show test"));
         assert_eq!(show.files.len(), 1);
         assert_eq!(show.files[0].path, "file.txt");

--- a/src-tauri/src/commands/stash.rs
+++ b/src-tauri/src/commands/stash.rs
@@ -12,6 +12,13 @@ use crate::models::Stash;
 #[serde(rename_all = "camelCase")]
 pub struct StashShowResult {
     pub index: u32,
+    /// The stash commit this result describes.
+    ///
+    /// Echoed so the caller can prove the preview belongs to the entry it
+    /// asked for: `index` is a POSITION that shifts whenever any stash is
+    /// created or dropped, and the caller resolves the index in a separate
+    /// round trip. lv-stash-list compares this against the row's oid and
+    /// refuses to render a mismatched preview.
     pub oid: String,
     pub message: String,
     pub files: Vec<StashFile>,


### PR DESCRIPTION
## Summary
- include the stash commit OID in backend stash preview responses
- satisfy the existing TypeScript contract and stale-index safety guard
- verify the preview OID matches the stash-list identity

## Validation
- stash preview frontend tests: 15 passed
- targeted Rust stash test passed
- TypeScript typecheck passed
- three independent frontier-model reviewers found no issues