### PR TITLE
Fix rebases with already-applied commits

### DIFF
--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -686,6 +686,10 @@ pub async fn rebase(path: String, onto: String) -> Result<usize> {
         // continue_rebase eventually completes this rebase, so the hook
         // describes the whole thing rather than only the last leg.
         append_rewritten(&repo, &rewritten);
+        // Same reasoning for the skip count. This invocation returns
+        // RebaseConflict, so the commits it has already dropped never reach the
+        // UI; continue_rebase adds its own skips and reports the total.
+        append_skipped(&repo, skipped);
     }
 
     match result {
@@ -739,6 +743,46 @@ fn take_rewritten(repo: &git2::Repository) -> Vec<String> {
         .filter(|l| !l.is_empty())
         .map(|l| l.to_string())
         .collect()
+}
+
+/// Where the running skip total of a paused rebase is kept.
+///
+/// Same `<gitdir>/rebase-merge/` lifecycle as `rewritten_list_path`: git
+/// removes the directory when the rebase finishes or is aborted, so the file is
+/// scoped to exactly one rebase and needs no separate cleanup.
+fn skipped_count_path(repo: &git2::Repository) -> std::path::PathBuf {
+    repo.path().join("rebase-merge").join("leviathan-skipped")
+}
+
+/// Add the skips of one leg to the running total, so a conflict pause does not
+/// lose them.
+///
+/// A commit dropped as already-applied is a local commit that disappears from
+/// the branch, and the completion toast is the only place the user can learn
+/// that. A rebase that pauses returns RebaseConflict — not a count — so every
+/// commit it dropped before the conflict would go unreported unless it is
+/// carried across the pause to whichever `continue_rebase` finishes the rebase.
+pub(crate) fn append_skipped(repo: &git2::Repository, skipped: usize) {
+    if skipped == 0 {
+        return;
+    }
+    let path = skipped_count_path(repo);
+    let running = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .unwrap_or(0);
+    let _ = std::fs::write(&path, (running + skipped).to_string());
+}
+
+/// Read and clear the skips persisted by earlier passes of this rebase.
+fn take_skipped(repo: &git2::Repository) -> usize {
+    let path = skipped_count_path(repo);
+    let total = std::fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse::<usize>().ok())
+        .unwrap_or(0);
+    let _ = std::fs::remove_file(&path);
+    total
 }
 
 /// Join a command's stdout and stderr into one searchable block.
@@ -933,8 +977,15 @@ pub async fn preview_rebase(
 }
 
 /// Continue a paused rebase
+///
+/// Returns how many commits this rebase dropped because their patch is already
+/// present on the target — the skips of every leg, not just this one. Same
+/// contract as `rebase`, and for the same reason: those are local commits that
+/// disappear from the branch with nothing on stderr to say so. The CLI branch
+/// below drives `git rebase --continue`, which reports no such count, so it
+/// yields 0.
 #[command]
-pub async fn continue_rebase(path: String) -> Result<()> {
+pub async fn continue_rebase(path: String) -> Result<usize> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
     // Interactive rebases are driven by the git CLI (`git rebase -i`, see
@@ -944,7 +995,7 @@ pub async fn continue_rebase(path: String) -> Result<()> {
     // Rebases started through libgit2 (the `rebase` command) have no todo
     // file and are continued through libgit2 below.
     if repo.path().join("rebase-merge/git-rebase-todo").exists() {
-        return continue_rebase_cli(&path);
+        return continue_rebase_cli(&path).map(|()| 0);
     }
 
     let signature = repo.signature()?;
@@ -957,6 +1008,7 @@ pub async fn continue_rebase(path: String) -> Result<()> {
     // the user hit a conflict. Seeded from the pairs earlier passes persisted,
     // so commits replayed before each pause are not dropped.
     let mut rewritten: Vec<String> = Vec::new();
+    let mut skipped = 0usize;
 
     // Commit the current (just-resolved) operation; a patch that became
     // empty after resolution is skipped like `git rebase --skip` would.
@@ -968,6 +1020,10 @@ pub async fn continue_rebase(path: String) -> Result<()> {
         if let Some(old_oid) = resumed_old {
             rewritten.push(format!("{} {}", old_oid, new_oid));
         }
+    } else {
+        // Resolving the conflict to exactly the target's content leaves an
+        // empty patch, so this commit is dropped too — counted like any other.
+        skipped += 1;
     }
 
     // Continue with remaining operations
@@ -976,14 +1032,18 @@ pub async fn continue_rebase(path: String) -> Result<()> {
 
         if repo.index()?.has_conflicts() {
             // Paused again. Persist this leg so the eventual completion still
-            // sees every commit replayed across all of them.
+            // sees every commit replayed — and every commit dropped — across
+            // all of them.
             append_rewritten(&repo, &rewritten);
+            append_skipped(&repo, skipped);
             return Err(LeviathanError::RebaseConflict);
         }
 
         if let Some(new_oid) = commit_or_skip_empty(&repo, &mut rebase, &signature, Some(old_oid))?
         {
             rewritten.push(format!("{} {}", old_oid, new_oid));
+        } else {
+            skipped += 1;
         }
     }
 
@@ -991,6 +1051,7 @@ pub async fn continue_rebase(path: String) -> Result<()> {
     // lives in.
     let mut all_rewritten = take_rewritten(&repo);
     all_rewritten.extend(rewritten);
+    let all_skipped = take_skipped(&repo) + skipped;
 
     ensure_libgit2_rewritten_file(&repo)?;
     rebase.finish(Some(&signature))?;
@@ -1004,7 +1065,7 @@ pub async fn continue_rebase(path: String) -> Result<()> {
         );
     }
 
-    Ok(())
+    Ok(all_skipped)
 }
 
 /// Commit the current rebase operation, treating an empty patch
@@ -6550,8 +6611,11 @@ mod tests {
         .await
         .unwrap();
 
-        let result = continue_rebase(repo.path_str()).await;
-        assert!(result.is_ok(), "continue_rebase failed: {:?}", result.err());
+        let skipped = continue_rebase(repo.path_str())
+            .await
+            .expect("continue_rebase must succeed");
+        // Nothing disappeared from the branch, so nothing to report.
+        assert_eq!(skipped, 0);
         let git_repo = repo.repo();
         assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
         let content = std::fs::read_to_string(repo.path.join("shared.txt")).unwrap();
@@ -6579,12 +6643,12 @@ mod tests {
         .await
         .unwrap();
 
-        let result = continue_rebase(repo.path_str()).await;
-        assert!(
-            result.is_ok(),
-            "continue_rebase should skip the empty commit: {:?}",
-            result.err()
-        );
+        let skipped = continue_rebase(repo.path_str())
+            .await
+            .expect("continue_rebase should skip the empty commit, not fail");
+        // The resolved commit vanished from the branch — the continue is the
+        // only surface that can say so.
+        assert_eq!(skipped, 1);
         let git_repo = repo.repo();
         assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
         let content = std::fs::read_to_string(repo.path.join("shared.txt")).unwrap();
@@ -6643,6 +6707,118 @@ mod tests {
         assert_eq!(
             empty.parent(0).unwrap().message().unwrap(),
             "Feature change"
+        );
+    }
+
+    /// A rebase that pauses returns RebaseConflict, not a count — so every
+    /// commit it dropped before the conflict had no way to reach the UI. The
+    /// count is carried across the pause and reported by the continue, exactly
+    /// as the `<old> <new>` pairs already are.
+    #[tokio::test]
+    async fn test_continue_rebase_reports_skips_from_before_the_pause() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("feature");
+
+        repo.checkout_branch("feature");
+        // Dropped by rebase() BEFORE the conflict below.
+        repo.create_commit("Feature adds cross", &[("cross.txt", "cross\n")]);
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main adds cross", &[("cross.txt", "cross\n")]);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+
+        repo.checkout_branch("feature");
+        let result = rebase(repo.path_str(), initial_branch).await;
+        assert!(matches!(result, Err(LeviathanError::RebaseConflict)));
+
+        resolve_conflict(
+            repo.path_str(),
+            "shared.txt".to_string(),
+            "resolved".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let skipped = continue_rebase(repo.path_str())
+            .await
+            .expect("continue must finish the paused rebase");
+
+        assert_eq!(
+            skipped, 1,
+            "the commit dropped before the pause must still be reported"
+        );
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+    }
+
+    /// The other half: commits dropped by the continue's own
+    /// remaining-operations loop, after the conflict was resolved.
+    #[tokio::test]
+    async fn test_continue_rebase_counts_the_commits_it_drops_itself() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("feature");
+
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
+        // Replayed AFTER the conflict, by continue_rebase's own loop.
+        repo.create_commit("Feature adds cross", &[("cross.txt", "cross\n")]);
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main content")]);
+        repo.create_commit("Main adds cross", &[("cross.txt", "cross\n")]);
+
+        repo.checkout_branch("feature");
+        let result = rebase(repo.path_str(), initial_branch).await;
+        assert!(matches!(result, Err(LeviathanError::RebaseConflict)));
+
+        resolve_conflict(
+            repo.path_str(),
+            "shared.txt".to_string(),
+            "resolved".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let skipped = continue_rebase(repo.path_str())
+            .await
+            .expect("continue must finish the paused rebase");
+
+        assert_eq!(skipped, 1);
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(head.message().unwrap(), "Feature change");
+    }
+
+    /// The running total survives more than one pause, and the file it lives
+    /// in goes away with the rebase state.
+    #[test]
+    fn test_skipped_count_accumulates_across_legs_and_is_cleared() {
+        let repo = TestRepo::with_initial_commit();
+        let git_repo = repo.repo();
+        std::fs::create_dir_all(git_repo.path().join("rebase-merge")).unwrap();
+
+        assert_eq!(take_skipped(&git_repo), 0, "no file means nothing skipped");
+
+        append_skipped(&git_repo, 0);
+        assert!(
+            !skipped_count_path(&git_repo).exists(),
+            "zero must not create a file"
+        );
+
+        append_skipped(&git_repo, 2);
+        append_skipped(&git_repo, 3);
+        assert_eq!(take_skipped(&git_repo), 5);
+        assert!(
+            !skipped_count_path(&git_repo).exists(),
+            "taking the count clears it"
         );
     }
 

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -982,8 +982,9 @@ pub async fn preview_rebase(
 /// present on the target — the skips of every leg, not just this one. Same
 /// contract as `rebase`, and for the same reason: those are local commits that
 /// disappear from the branch with nothing on stderr to say so. The CLI branch
-/// below drives `git rebase --continue`, which reports no such count, so it
-/// yields 0.
+/// below reports the same count, and for the same reason: the drops there are
+/// performed by `continue_rebase_cli` itself, and git names none of them
+/// anywhere the user can see.
 #[command]
 pub async fn continue_rebase(path: String) -> Result<usize> {
     let repo = git2::Repository::open(Path::new(&path))?;
@@ -995,7 +996,7 @@ pub async fn continue_rebase(path: String) -> Result<usize> {
     // Rebases started through libgit2 (the `rebase` command) have no todo
     // file and are continued through libgit2 below.
     if repo.path().join("rebase-merge/git-rebase-todo").exists() {
-        return continue_rebase_cli(&path).map(|()| 0);
+        return continue_rebase_cli(&path);
     }
 
     let signature = repo.signature()?;
@@ -1194,9 +1195,77 @@ pub(crate) fn ensure_libgit2_rewritten_file(repo: &git2::Repository) -> Result<(
     Ok(())
 }
 
+/// Does continuing this rebase drop the commit it is stopped on?
+///
+/// `git rebase --continue` DROPS a pending commit whose patch came back empty
+/// — already applied on the target, or resolved to the target's content — and
+/// says nothing about it on either stream. It only stops and asks for
+/// `git rebase --skip` when a LATER commit comes back empty, so the one it is
+/// stopped on right now never appears in git's output at all and has to be
+/// read off the rebase state instead. Three conditions, all needed:
+///
+///  - no `amend` marker: git writes it when it stopped at an `edit` line AFTER
+///    applying the commit, and continuing from there drops nothing;
+///  - the last command in `done` is one that adds a commit: a `break` (or
+///    `exec`) stop also leaves a clean index matching HEAD and drops nothing,
+///    while `squash`/`fixup` fold INTO HEAD, so a HEAD-to-index diff does not
+///    describe their patch;
+///  - no conflicts, and the index holds nothing over HEAD — which is what "the
+///    pending patch is empty" means.
+fn pending_operation_is_empty(repo: &git2::Repository) -> bool {
+    let state_dir = repo.path().join("rebase-merge");
+    if state_dir.join("amend").exists() {
+        return false;
+    }
+
+    let done = std::fs::read_to_string(state_dir.join("done")).unwrap_or_default();
+    let adds_a_commit = done
+        .lines()
+        .rev()
+        .find(|line| !line.trim().is_empty())
+        .and_then(|line| line.split_whitespace().next())
+        .is_some_and(|command| matches!(command, "pick" | "p" | "reword" | "r" | "edit" | "e"));
+    if !adds_a_commit {
+        return false;
+    }
+
+    let Ok(index) = repo.index() else {
+        return false;
+    };
+    if index.has_conflicts() {
+        return false;
+    }
+    let Ok(head_tree) = repo
+        .head()
+        .and_then(|head| head.peel_to_commit())
+        .and_then(|commit| commit.tree())
+    else {
+        return false;
+    };
+    repo.diff_tree_to_index(Some(&head_tree), Some(&index), None)
+        .map(|diff| diff.deltas().len() == 0)
+        .unwrap_or(false)
+}
+
 /// Continue a CLI-initiated (interactive) rebase via `git rebase --continue`,
 /// advancing past patches that became empty with `git rebase --skip`.
-fn continue_rebase_cli(path: &str) -> Result<()> {
+///
+/// Returns how many commits this leg dropped, plus the ones earlier legs of
+/// the same rebase persisted. The count is this function's to report, not
+/// git's: the drops are performed here — by the `--skip` loop below, and by
+/// the `--continue` that silently drops the commit it was stopped on — and a
+/// dropped commit is a local commit that disappears from the branch with
+/// nothing on either stream to say so. The running total has to be read before
+/// the final `git rebase --continue`, which removes the `rebase-merge`
+/// directory it lives in.
+fn continue_rebase_cli(path: &str) -> Result<usize> {
+    let repo = git2::Repository::open(Path::new(path))?;
+    // Skips the earlier legs of this rebase persisted.
+    let carried = take_skipped(&repo);
+    // The commit this rebase is stopped on, when continuing would drop it.
+    let pending = usize::from(pending_operation_is_empty(&repo));
+    // Skips made by this leg's own `git rebase --skip` calls.
+    let mut skipped = 0usize;
     let mut args: Vec<&str> = vec!["rebase", "--continue"];
     loop {
         let output = create_command("git")
@@ -1220,13 +1289,15 @@ fn continue_rebase_cli(path: &str) -> Result<()> {
             // dialog with no message and left the repo mid-rebase on a
             // detached HEAD, where the most obvious remaining button was the
             // one that throws the rebase away.
-            let git_dir = git2::Repository::open(Path::new(path))?
-                .path()
-                .to_path_buf();
+            let git_dir = repo.path().to_path_buf();
             if git_dir.join("rebase-merge").exists() || git_dir.join("rebase-apply").exists() {
+                // Carry the skips across the pause, exactly as the libgit2 arm
+                // does: whichever continue finishes the rebase is the only
+                // surface that can report them.
+                append_skipped(&repo, carried + pending + skipped);
                 return Err(LeviathanError::RebasePaused);
             }
-            return Ok(());
+            return Ok(carried + pending + skipped);
         }
 
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1239,12 +1310,23 @@ fn continue_rebase_cli(path: &str) -> Result<()> {
             && (combined.contains("No changes") || combined.contains("nothing to commit"))
         {
             args = vec!["rebase", "--skip"];
+            skipped += 1;
             continue;
         }
 
         if combined.contains("CONFLICT") || combined.contains("conflict") {
+            // A conflict is raised by a LATER commit, so the pending one was
+            // dealt with — dropped or committed — before git got there.
+            append_skipped(&repo, carried + pending + skipped);
             return Err(LeviathanError::RebaseConflict);
         }
+        // A hard failure can leave the same commit pending, and the next
+        // Continue reads it off the rebase state again — so counting it here
+        // would report it twice. Anything this leg skipped did move past it.
+        append_skipped(
+            &repo,
+            carried + skipped + if skipped > 0 { pending } else { 0 },
+        );
         return Err(LeviathanError::OperationFailed(
             if stderr.trim().is_empty() {
                 stdout.to_string()
@@ -6795,6 +6877,223 @@ mod tests {
         assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
         let head = git_repo.head().unwrap().peel_to_commit().unwrap();
         assert_eq!(head.message().unwrap(), "Feature change");
+    }
+
+    /// The CLI (interactive) arm of `continue_rebase` is the arm that performs
+    /// the skips — `git rebase --continue` drops the commit it is stopped on,
+    /// and the loop's own `git rebase --skip` drops the ones after it — so it
+    /// has to report them. It returned a hard-coded 0, and the dialog it feeds
+    /// is the same conflict dialog an interactive-rebase conflict opens: the
+    /// identical gesture (resolve, click Continue) said a bare "Rebase
+    /// completed" while a local commit disappeared from the branch.
+    #[tokio::test]
+    async fn test_continue_rebase_counts_skips_on_the_interactive_arm() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        setup_conflicting_branches(&repo);
+        repo.checkout_branch("feature");
+
+        // A CLI interactive rebase (todo file on disk) whose single pick
+        // conflicts.
+        let todo = format!("pick {}\n", repo.head_oid());
+        let started = execute_interactive_rebase(repo.path_str(), initial_branch, todo).await;
+        assert!(started.is_err(), "the pick must stop on the conflict");
+
+        let git_dir = repo.repo().path().to_path_buf();
+        if !git_dir.join("rebase-merge/git-rebase-todo").exists() {
+            // The CLI rebase could not start in this environment; nothing to assert.
+            return;
+        }
+
+        // Resolving to exactly the target's content empties the patch, so the
+        // continue drops the commit.
+        resolve_conflict(
+            repo.path_str(),
+            "shared.txt".to_string(),
+            "main content".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let skipped = continue_rebase(repo.path_str())
+            .await
+            .expect("the interactive continue must finish, not fail");
+        assert_eq!(
+            skipped, 1,
+            "the commit the continue dropped must be reported"
+        );
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        assert_eq!(
+            git_repo
+                .head()
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .message()
+                .unwrap(),
+            "Main change",
+            "the dropped commit really is gone from the branch"
+        );
+    }
+
+    /// Both halves of the interactive arm's count in one rebase: the commit
+    /// `git rebase --continue` drops without a word, AND the one it stops on
+    /// and hands to the loop's `git rebase --skip`. Counting only the second
+    /// (or neither) under-reports commits that have left the branch.
+    #[tokio::test]
+    async fn test_interactive_continue_counts_both_the_silent_and_the_skipped_drop() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("feature");
+
+        repo.checkout_branch("feature");
+        let one = repo.create_commit("Feature one", &[("one.txt", "one\n")]);
+        let two = repo.create_commit("Feature two", &[("two.txt", "two\n")]);
+
+        // The same two changes land on the target independently, so both picks
+        // come back empty.
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main one", &[("one.txt", "one\n")]);
+        repo.create_commit("Main two", &[("two.txt", "two\n")]);
+
+        repo.checkout_branch("feature");
+        let todo = format!("pick {}\npick {}\n", one, two);
+        let started = execute_interactive_rebase(repo.path_str(), initial_branch, todo).await;
+        assert!(started.is_err(), "the first pick comes back empty");
+
+        let git_dir = repo.repo().path().to_path_buf();
+        if !git_dir.join("rebase-merge/git-rebase-todo").exists() {
+            // The CLI rebase could not start in this environment; nothing to assert.
+            return;
+        }
+
+        let skipped = continue_rebase(repo.path_str())
+            .await
+            .expect("the interactive continue must finish, not fail");
+        assert_eq!(
+            skipped, 2,
+            "both dropped commits must be reported, not just the one git asked to skip"
+        );
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        assert_eq!(
+            git_repo
+                .head()
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .message()
+                .unwrap(),
+            "Main two",
+            "neither commit survived the rebase"
+        );
+    }
+
+    /// And the interactive arm's skips survive its own pauses, as the libgit2
+    /// arm's already do: a rebase that drops a commit and then stops at an
+    /// `edit` line returns RebasePaused — not a count — so the drop would go
+    /// unreported unless it is carried to whichever continue finishes.
+    #[tokio::test]
+    async fn test_interactive_continue_carries_skips_across_a_pause() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("feature");
+
+        repo.checkout_branch("feature");
+        let dropped = repo.create_commit("Feature one", &[("one.txt", "one\n")]);
+        let kept = repo.create_commit("Feature extra", &[("extra.txt", "extra\n")]);
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main one", &[("one.txt", "one\n")]);
+
+        repo.checkout_branch("feature");
+        let todo = format!("pick {}\nedit {}\n", dropped, kept);
+        let started = execute_interactive_rebase(repo.path_str(), initial_branch, todo).await;
+        assert!(started.is_err(), "the first pick comes back empty");
+
+        let git_dir = repo.repo().path().to_path_buf();
+        if !git_dir.join("rebase-merge/git-rebase-todo").exists() {
+            // The CLI rebase could not start in this environment; nothing to assert.
+            return;
+        }
+
+        // First leg: drops the emptied commit, then stops at the `edit`.
+        let paused = continue_rebase(repo.path_str())
+            .await
+            .expect_err("the rebase stops at the edit line");
+        assert!(
+            paused.to_string().contains("paused"),
+            "the pause must be reported: {}",
+            paused
+        );
+
+        // Second leg: finishes, and still knows about the earlier drop. An
+        // `edit` stop has applied its commit already, so continuing from one
+        // must not be counted as a drop of its own.
+        let skipped = continue_rebase(repo.path_str())
+            .await
+            .expect("the second continue must finish the rebase");
+        assert_eq!(
+            skipped, 1,
+            "the commit dropped before the pause must still be reported, and only it"
+        );
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(head.message().unwrap(), "Feature extra");
+        assert_eq!(
+            head.parent(0).unwrap().message().unwrap(),
+            "Main one",
+            "the dropped commit is not between them"
+        );
+    }
+
+    /// A rebase that drops nothing must still report nothing: `break` and
+    /// `edit` stops leave the same clean index matching HEAD that an emptied
+    /// patch does, and counting those would invent skips the user never had.
+    #[tokio::test]
+    async fn test_interactive_continue_reports_no_skips_for_a_break_stop() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("feature");
+
+        repo.checkout_branch("feature");
+        let only = repo.create_commit("Feature only", &[("only.txt", "only\n")]);
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("main.txt", "main\n")]);
+
+        repo.checkout_branch("feature");
+        let todo = format!("break\npick {}\n", only);
+        let started = execute_interactive_rebase(repo.path_str(), initial_branch, todo).await;
+        let Ok(outcome) = started else {
+            // The CLI rebase could not start in this environment; nothing to assert.
+            return;
+        };
+        assert!(outcome.paused, "the rebase must stop at the break");
+
+        let skipped = continue_rebase(repo.path_str())
+            .await
+            .expect("continuing past a break must finish the rebase");
+        assert_eq!(skipped, 0, "a break drops nothing");
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        assert_eq!(
+            git_repo
+                .head()
+                .unwrap()
+                .peel_to_commit()
+                .unwrap()
+                .message()
+                .unwrap(),
+            "Feature only",
+            "and the commit is still on the branch"
+        );
     }
 
     /// The running total survives more than one pause, and the file it lives

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -561,9 +561,14 @@ async fn commit_merge_signed(path: &str, message: &str, is_squash: bool) -> Resu
     Ok(())
 }
 
-/// Rebase current branch onto another
+/// Rebase current branch onto another.
+///
+/// Returns how many commits were skipped because their patch is already
+/// present on `onto`. Those are local commits that disappear from the branch,
+/// and `git rebase` warns about each one on stderr — there is no stderr here,
+/// so the count is handed to the UI to say so instead.
 #[command]
-pub async fn rebase(path: String, onto: String) -> Result<()> {
+pub async fn rebase(path: String, onto: String) -> Result<usize> {
     let repo = git2::Repository::open(Path::new(&path))?;
 
     // Like canonical `git rebase`, refuse up front if another operation is in
@@ -637,6 +642,7 @@ pub async fn rebase(path: String, onto: String) -> Result<()> {
     // rebase state intact; the user can call abort_rebase explicitly.
     // post-rewrite reads `<old-sha> <new-sha>` lines, one per replayed commit.
     let mut rewritten: Vec<String> = Vec::new();
+    let mut skipped = 0usize;
     let result = (|| -> Result<()> {
         while let Some(op) = rebase.next() {
             let op = op?;
@@ -654,6 +660,8 @@ pub async fn rebase(path: String, onto: String) -> Result<()> {
                 commit_or_skip_empty(&repo, &mut rebase, &signature, Some(old_oid))?
             {
                 rewritten.push(format!("{} {}", old_oid, new_oid));
+            } else {
+                skipped += 1;
             }
         }
 
@@ -686,7 +694,7 @@ pub async fn rebase(path: String, onto: String) -> Result<()> {
             let _ = rebase.abort();
             Err(e)
         }
-        Ok(()) => Ok(()),
+        Ok(()) => Ok(skipped),
     }
 }
 
@@ -2869,10 +2877,13 @@ mod tests {
         let main_oid = repo.head_oid();
 
         repo.checkout_branch("feature");
-        rebase(repo.path_str(), initial_branch)
+        let skipped = rebase(repo.path_str(), initial_branch)
             .await
             .expect("an already-applied patch must be skipped, not abort the rebase");
 
+        // The dropped commit is the only signal the UI has that a local commit
+        // vanished from the branch.
+        assert_eq!(skipped, 1);
         let git_repo = repo.repo();
         assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
         let head = git_repo.head().unwrap().peel_to_commit().unwrap();
@@ -2913,10 +2924,13 @@ mod tests {
                 .set_str("notes.rewriteRef", "refs/notes/commits")
                 .unwrap();
         }
-        super::rebase(repo.path_str(), initial_branch)
+        let skipped = super::rebase(repo.path_str(), initial_branch)
             .await
             .unwrap();
 
+        // Every commit on `feature` is gone and the branch now equals `main` —
+        // the case that most needs reporting.
+        assert_eq!(skipped, 1);
         assert_eq!(repo.repo().state(), git2::RepositoryState::Clean);
         assert_eq!(repo.head_oid(), main_oid);
     }
@@ -2951,10 +2965,12 @@ mod tests {
         let main_oid = repo.head_oid();
 
         repo.checkout_branch("feature");
-        rebase(repo.path_str(), initial_branch)
+        let skipped = rebase(repo.path_str(), initial_branch)
             .await
             .expect("a commit that started empty must be preserved");
 
+        // Preserved, not skipped — nothing disappeared, so nothing to report.
+        assert_eq!(skipped, 0);
         let git_repo = repo.repo();
         let follow_up = git_repo.head().unwrap().peel_to_commit().unwrap();
         let empty = follow_up.parent(0).unwrap();
@@ -6573,6 +6589,61 @@ mod tests {
         assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
         let content = std::fs::read_to_string(repo.path.join("shared.txt")).unwrap();
         assert_eq!(content, "main content");
+    }
+
+    #[tokio::test]
+    async fn test_continue_rebase_preserves_a_commit_that_started_empty() {
+        // The other arm of GIT_EAPPLIED, on the continue path: a commit that
+        // was ALREADY empty before the rebase is not an already-applied patch,
+        // and git keeps it. Placed AFTER the conflicting commit so it is
+        // replayed by continue_rebase's remaining-operations loop.
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        setup_conflicting_branches(&repo);
+
+        repo.checkout_branch("feature");
+        {
+            let git_repo = repo.repo();
+            let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+            let tree = head.tree().unwrap();
+            let signature = git_repo.signature().unwrap();
+            git_repo
+                .commit(
+                    Some("HEAD"),
+                    &signature,
+                    &signature,
+                    "Intentional empty marker",
+                    &tree,
+                    &[&head],
+                )
+                .unwrap();
+        }
+
+        let result = rebase(repo.path_str(), initial_branch.clone()).await;
+        assert!(matches!(result, Err(LeviathanError::RebaseConflict)));
+
+        resolve_conflict(
+            repo.path_str(),
+            "shared.txt".to_string(),
+            "resolved".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        continue_rebase(repo.path_str())
+            .await
+            .expect("a commit that started empty must survive the continue");
+
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        let empty = git_repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(empty.message().unwrap(), "Intentional empty marker");
+        assert_eq!(empty.tree_id(), empty.parent(0).unwrap().tree_id());
+        assert_eq!(
+            empty.parent(0).unwrap().message().unwrap(),
+            "Feature change"
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -646,10 +646,18 @@ pub async fn rebase(path: String, onto: String) -> Result<()> {
                 return Err(LeviathanError::RebaseConflict);
             }
 
-            let new_oid = rebase.commit(None, &signature, None)?;
-            rewritten.push(format!("{} {}", old_oid, new_oid));
+            // A commit whose patch is already present on `onto` becomes empty.
+            // Canonical git rebase skips it and continues; libgit2 reports
+            // GIT_EAPPLIED from commit(), which used to enter the hard-error
+            // path below and abort the entire rebase.
+            if let Some(new_oid) =
+                commit_or_skip_empty(&repo, &mut rebase, &signature, Some(old_oid))?
+            {
+                rewritten.push(format!("{} {}", old_oid, new_oid));
+            }
         }
 
+        ensure_libgit2_rewritten_file(&repo)?;
         rebase.finish(Some(&signature))?;
         Ok(())
     })();
@@ -948,7 +956,7 @@ pub async fn continue_rebase(path: String) -> Result<()> {
     let resumed_old = rebase
         .operation_current()
         .and_then(|i| rebase.nth(i).map(|op| op.id()));
-    if let Some(new_oid) = commit_or_skip_empty(&mut rebase, &signature)? {
+    if let Some(new_oid) = commit_or_skip_empty(&repo, &mut rebase, &signature, resumed_old)? {
         if let Some(old_oid) = resumed_old {
             rewritten.push(format!("{} {}", old_oid, new_oid));
         }
@@ -965,7 +973,8 @@ pub async fn continue_rebase(path: String) -> Result<()> {
             return Err(LeviathanError::RebaseConflict);
         }
 
-        if let Some(new_oid) = commit_or_skip_empty(&mut rebase, &signature)? {
+        if let Some(new_oid) = commit_or_skip_empty(&repo, &mut rebase, &signature, Some(old_oid))?
+        {
             rewritten.push(format!("{} {}", old_oid, new_oid));
         }
     }
@@ -975,6 +984,7 @@ pub async fn continue_rebase(path: String) -> Result<()> {
     let mut all_rewritten = take_rewritten(&repo);
     all_rewritten.extend(rewritten);
 
+    ensure_libgit2_rewritten_file(&repo)?;
     rebase.finish(Some(&signature))?;
 
     if !all_rewritten.is_empty() {
@@ -994,15 +1004,125 @@ pub async fn continue_rebase(path: String) -> Result<()> {
 ///
 /// Returns the new commit's oid, or None when the patch was skipped — the
 /// caller pairs it with the original oid for the post-rewrite hook.
-fn commit_or_skip_empty(
+pub(crate) fn commit_or_skip_empty(
+    repo: &git2::Repository,
     rebase: &mut git2::Rebase,
     signature: &git2::Signature,
+    original_oid: Option<git2::Oid>,
 ) -> Result<Option<git2::Oid>> {
     match rebase.commit(None, signature, None) {
         Ok(oid) => Ok(Some(oid)),
-        Err(e) if e.code() == git2::ErrorCode::Applied => Ok(None),
+        Err(e) if e.code() == git2::ErrorCode::Applied => {
+            let Some(original_oid) = original_oid else {
+                return Ok(None);
+            };
+            let original = repo.find_commit(original_oid)?;
+            let started_empty =
+                original.parent_count() == 1 && original.tree_id() == original.parent(0)?.tree_id();
+            if !started_empty {
+                return Ok(None);
+            }
+
+            // Git keeps commits that were intentionally empty before the
+            // rebase, while dropping patches that only became empty because
+            // their change is already upstream. libgit2 reports GIT_EAPPLIED
+            // for both, so recreate the former on the current rebased HEAD.
+            let head = repo.head()?.peel_to_commit()?;
+            let author = original.author();
+            let oid = create_empty_rebase_commit(repo, &head, &author, signature, &original)?;
+            append_libgit2_rewritten(repo, original_oid, oid)?;
+            Ok(Some(oid))
+        }
         Err(e) => Err(e.into()),
     }
+}
+
+/// Recreate a commit that was intentionally empty before the rebase.
+///
+/// `Repository::commit` only accepts UTF-8 and has no encoding argument. Build
+/// the ordinary unsigned commit object directly so a legacy-encoded message is
+/// preserved byte-for-byte, including its encoding header.
+fn create_empty_rebase_commit(
+    repo: &git2::Repository,
+    head: &git2::Commit<'_>,
+    author: &git2::Signature<'_>,
+    committer: &git2::Signature<'_>,
+    original: &git2::Commit<'_>,
+) -> Result<git2::Oid> {
+    use std::io::Write;
+
+    fn write_signature(
+        output: &mut Vec<u8>,
+        label: &str,
+        signature: &git2::Signature<'_>,
+    ) -> std::io::Result<()> {
+        let when = signature.when();
+        let offset = when.offset_minutes();
+        // Match libgit2's serializer: preserve negative zero, but normalize a
+        // missing or malformed raw sign instead of writing NUL/garbage into the
+        // new commit header.
+        let sign = if offset < 0 || when.sign() == '-' {
+            '-'
+        } else {
+            '+'
+        };
+        let absolute = offset.abs();
+        write!(output, "{} ", label)?;
+        output.extend_from_slice(signature.name_bytes());
+        output.extend_from_slice(b" <");
+        output.extend_from_slice(signature.email_bytes());
+        writeln!(
+            output,
+            "> {} {}{:02}{:02}",
+            when.seconds(),
+            sign,
+            absolute / 60,
+            absolute % 60
+        )
+    }
+
+    let mut content = Vec::new();
+    writeln!(content, "tree {}", head.tree_id())?;
+    writeln!(content, "parent {}", head.id())?;
+    write_signature(&mut content, "author", author)?;
+    write_signature(&mut content, "committer", committer)?;
+    if let Some(encoding) = original.message_encoding()? {
+        writeln!(content, "encoding {}", encoding)?;
+    }
+    content.push(b'\n');
+    content.extend_from_slice(original.message_raw_bytes());
+
+    let oid = repo.odb()?.write(git2::ObjectType::Commit, &content)?;
+    repo.reference("HEAD", oid, true, "rebase: preserve empty commit")?;
+    Ok(oid)
+}
+
+/// libgit2 consumes this map during `rebase.finish()` to copy notes. Normally
+/// `Rebase::commit` writes it, but an intentionally empty commit is recreated
+/// directly after that call returns GIT_EAPPLIED.
+fn append_libgit2_rewritten(
+    repo: &git2::Repository,
+    old_oid: git2::Oid,
+    new_oid: git2::Oid,
+) -> Result<()> {
+    use std::io::Write;
+
+    let path = repo.path().join("rebase-merge").join("rewritten");
+    let mut file = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    writeln!(file, "{} {}", old_oid, new_oid)?;
+    Ok(())
+}
+
+pub(crate) fn ensure_libgit2_rewritten_file(repo: &git2::Repository) -> Result<()> {
+    let path = repo.path().join("rebase-merge").join("rewritten");
+    std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(path)?;
+    Ok(())
 }
 
 /// Continue a CLI-initiated (interactive) rebase via `git rebase --continue`,
@@ -2725,6 +2845,236 @@ mod tests {
 
         assert_eq!(parent.id(), main_oid);
         assert_ne!(parent.id(), initial_oid);
+    }
+
+    #[tokio::test]
+    async fn test_rebase_skips_commit_already_applied_upstream() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature adds shared file", &[("shared.txt", "shared\n")]);
+        repo.create_commit(
+            "Feature adds follow-up",
+            &[("follow-up.txt", "follow-up\n")],
+        );
+
+        repo.checkout_branch(&initial_branch);
+        // Same patch as the feature's first commit, but a distinct commit.
+        repo.create_commit(
+            "Main already has shared file",
+            &[("shared.txt", "shared\n")],
+        );
+        let main_oid = repo.head_oid();
+
+        repo.checkout_branch("feature");
+        rebase(repo.path_str(), initial_branch)
+            .await
+            .expect("an already-applied patch must be skipped, not abort the rebase");
+
+        let git_repo = repo.repo();
+        assert_eq!(git_repo.state(), git2::RepositoryState::Clean);
+        let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(head.message().unwrap(), "Feature adds follow-up");
+        assert_eq!(head.parent(0).unwrap().id(), main_oid);
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("shared.txt")).unwrap(),
+            "shared\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("follow-up.txt")).unwrap(),
+            "follow-up\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_rebase_empty_only_rebase() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature adds shared file", &[("shared.txt", "shared\n")]);
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit(
+            "Main already has shared file",
+            &[("shared.txt", "shared\n")],
+        );
+        let main_oid = repo.head_oid();
+
+        repo.checkout_branch("feature");
+        {
+            let git_repo = repo.repo();
+            let mut config = git_repo.config().unwrap();
+            config.set_bool("notes.rewrite.rebase", true).unwrap();
+            config
+                .set_str("notes.rewriteRef", "refs/notes/commits")
+                .unwrap();
+        }
+        super::rebase(repo.path_str(), initial_branch)
+            .await
+            .unwrap();
+
+        assert_eq!(repo.repo().state(), git2::RepositoryState::Clean);
+        assert_eq!(repo.head_oid(), main_oid);
+    }
+
+    #[tokio::test]
+    async fn test_rebase_preserves_commit_that_started_empty() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        {
+            let git_repo = repo.repo();
+            let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+            let tree = head.tree().unwrap();
+            let signature = git_repo.signature().unwrap();
+            git_repo
+                .commit(
+                    Some("HEAD"),
+                    &signature,
+                    &signature,
+                    "Intentional empty marker",
+                    &tree,
+                    &[&head],
+                )
+                .unwrap();
+        }
+        repo.create_commit("Feature follow-up", &[("feature.txt", "feature\n")]);
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main diverges", &[("main.txt", "main\n")]);
+        let main_oid = repo.head_oid();
+
+        repo.checkout_branch("feature");
+        rebase(repo.path_str(), initial_branch)
+            .await
+            .expect("a commit that started empty must be preserved");
+
+        let git_repo = repo.repo();
+        let follow_up = git_repo.head().unwrap().peel_to_commit().unwrap();
+        let empty = follow_up.parent(0).unwrap();
+        assert_eq!(follow_up.message().unwrap(), "Feature follow-up");
+        assert_eq!(empty.message().unwrap(), "Intentional empty marker");
+        assert_eq!(empty.parent(0).unwrap().id(), main_oid);
+        assert_eq!(empty.tree_id(), empty.parent(0).unwrap().tree_id());
+    }
+
+    #[tokio::test]
+    async fn test_rebase_preserves_raw_metadata_on_commit_that_started_empty() {
+        use std::io::Write;
+
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+
+        {
+            let git_repo = repo.repo();
+            let parent = git_repo.head().unwrap().peel_to_commit().unwrap();
+            let mut content = Vec::new();
+            writeln!(content, "tree {}", parent.tree_id()).unwrap();
+            writeln!(content, "parent {}", parent.id()).unwrap();
+            writeln!(content, "author Legacy <legacy@example.com> 1 -0000").unwrap();
+            writeln!(content, "committer Test User <test@example.com> 1 +0000").unwrap();
+            writeln!(content, "encoding ISO-8859-1").unwrap();
+            content.extend_from_slice(b"\nmarker \xe9\n");
+            let oid = git_repo
+                .odb()
+                .unwrap()
+                .write(git2::ObjectType::Commit, &content)
+                .unwrap();
+            git_repo
+                .find_reference("refs/heads/feature")
+                .unwrap()
+                .set_target(oid, "test raw empty commit")
+                .unwrap();
+            git_repo.set_head("refs/heads/feature").unwrap();
+            git_repo
+                .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+                .unwrap();
+        }
+        repo.create_commit("Feature follow-up", &[("feature.txt", "feature\n")]);
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main diverges", &[("main.txt", "main\n")]);
+        repo.checkout_branch("feature");
+        rebase(repo.path_str(), initial_branch).await.unwrap();
+
+        let git_repo = repo.repo();
+        let empty = git_repo
+            .head()
+            .unwrap()
+            .peel_to_commit()
+            .unwrap()
+            .parent(0)
+            .unwrap();
+        assert_eq!(empty.author().when().sign(), '-');
+        assert_eq!(empty.message_encoding().unwrap(), Some("ISO-8859-1"));
+        assert_eq!(empty.message_raw_bytes(), b"marker \xe9\n");
+    }
+
+    #[tokio::test]
+    async fn test_rebase_preserves_notes_on_commit_that_started_empty() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        let empty_oid = {
+            let git_repo = repo.repo();
+            let head = git_repo.head().unwrap().peel_to_commit().unwrap();
+            let tree = head.tree().unwrap();
+            let signature = git_repo.signature().unwrap();
+            git_repo
+                .commit(
+                    Some("HEAD"),
+                    &signature,
+                    &signature,
+                    "Noted empty marker",
+                    &tree,
+                    &[&head],
+                )
+                .unwrap()
+        };
+        {
+            let git_repo = repo.repo();
+            let signature = git_repo.signature().unwrap();
+            git_repo
+                .note(
+                    &signature,
+                    &signature,
+                    Some("refs/notes/commits"),
+                    empty_oid,
+                    "keep this note",
+                    true,
+                )
+                .unwrap();
+            let mut config = git_repo.config().unwrap();
+            config.set_bool("notes.rewrite.rebase", true).unwrap();
+            config
+                .set_str("notes.rewriteRef", "refs/notes/commits")
+                .unwrap();
+        }
+
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main diverges", &[("main.txt", "main\n")]);
+        repo.checkout_branch("feature");
+
+        rebase(repo.path_str(), initial_branch)
+            .await
+            .expect("notes rewriting must accept a synthetic empty commit");
+
+        let git_repo = repo.repo();
+        let rebased_empty = git_repo.head().unwrap().peel_to_commit().unwrap();
+        let note = git_repo
+            .find_note(Some("refs/notes/commits"), rebased_empty.id())
+            .expect("the original note must be copied");
+        assert_eq!(note.message().unwrap(), "keep this note");
     }
 
     // Like `git rebase`, a modification to a tracked file must abort the rebase

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -796,14 +796,23 @@ pub(crate) fn pull_branch(
         let mut commit_count = 0;
         let rebase_result = (|| -> Result<()> {
             while let Some(op) = rebase_obj.next() {
-                let _op = op?;
+                let op = op?;
                 if repo.index()?.has_conflicts() {
                     return Err(LeviathanError::RebaseConflict);
                 }
                 let signature = repo.signature()?;
-                rebase_obj.commit(None, &signature, None)?;
-                commit_count += 1;
+                if crate::commands::merge::commit_or_skip_empty(
+                    &repo,
+                    &mut rebase_obj,
+                    &signature,
+                    Some(op.id()),
+                )?
+                .is_some()
+                {
+                    commit_count += 1;
+                }
             }
+            crate::commands::merge::ensure_libgit2_rewritten_file(&repo)?;
             rebase_obj.finish(Some(&repo.signature()?))?;
             Ok(())
         })();

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -794,6 +794,7 @@ pub(crate) fn pull_branch(
         // RebaseConflict because the UI surfaces a "resolve
         // conflicts" flow that needs the rebase state intact.
         let mut commit_count = 0;
+        let mut skipped_count = 0;
         let rebase_result = (|| -> Result<()> {
             while let Some(op) = rebase_obj.next() {
                 let op = op?;
@@ -810,6 +811,8 @@ pub(crate) fn pull_branch(
                 .is_some()
                 {
                     commit_count += 1;
+                } else {
+                    skipped_count += 1;
                 }
             }
             crate::commands::merge::ensure_libgit2_rewritten_file(&repo)?;
@@ -826,7 +829,20 @@ pub(crate) fn pull_branch(
             }
             Ok(()) => {}
         }
-        message = format!("Rebased {} commit(s)", commit_count);
+        // A skipped commit is a local commit that silently disappears from the
+        // branch, so say so. `git rebase` prints "warning: skipped previously
+        // applied commit ..." on stderr; there is no stderr here, and without
+        // this the flagship case this fix unblocks (every local commit already
+        // upstream) reports the bare "Rebased 0 commit(s)" while the branch
+        // moves and the user's commits are gone.
+        message = if skipped_count > 0 {
+            format!(
+                "Rebased {} commit(s), skipped {} already applied upstream",
+                commit_count, skipped_count
+            )
+        } else {
+            format!("Rebased {} commit(s)", commit_count)
+        };
     } else {
         let (analysis, _preference) = repo.merge_analysis(&[&fetch_commit])?;
 
@@ -2265,6 +2281,144 @@ mod tests {
 
         assert_eq!(message, "Fast-forward merge completed");
         assert_eq!(local.head_oid(), upstream.head_oid());
+    }
+
+    // ---- pull's rebase arm ----
+
+    fn pull_rebase(local: &TestRepo, branch: &str) -> Result<(String, String)> {
+        pull_branch(
+            &local.path_str(),
+            Some("origin".to_string()),
+            Some(branch.to_string()),
+            Some(true),
+            None,
+            None,
+        )
+    }
+
+    /// The bug, on the path most users hit it: your patch landed upstream, so
+    /// replaying your own copy of it produces nothing and libgit2 reports
+    /// GIT_EAPPLIED. The pull used to abort the whole rebase with "this patch
+    /// has already been applied"; it must skip that one commit and keep the
+    /// rest.
+    #[test]
+    fn test_pull_rebase_skips_a_local_commit_already_applied_upstream() {
+        let (upstream, local, branch) = pull_fixture();
+        upstream.create_commit(
+            "upstream took the shared change",
+            &[("shared.txt", "shared\n")],
+        );
+        // The same patch as a distinct local commit, plus work only we have.
+        local.create_commit("local shared change", &[("shared.txt", "shared\n")]);
+        local.create_commit("local only", &[("local.txt", "local\n")]);
+
+        let (_, message) = pull_rebase(&local, &branch)
+            .expect("an already-applied local commit must be skipped, not abort the pull");
+
+        assert_eq!(
+            message,
+            "Rebased 1 commit(s), skipped 1 already applied upstream"
+        );
+        let repo = local.repo();
+        assert_eq!(repo.state(), git2::RepositoryState::Clean);
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(head.message().unwrap(), "local only");
+        assert_eq!(head.parent(0).unwrap().id(), upstream.head_oid());
+        assert_eq!(
+            std::fs::read_to_string(local.path.join("shared.txt")).unwrap(),
+            "shared\n"
+        );
+        assert_eq!(
+            std::fs::read_to_string(local.path.join("local.txt")).unwrap(),
+            "local\n"
+        );
+    }
+
+    /// Every local commit already upstream: the branch still moves to the
+    /// remote tip, so the message must not be the bare "Rebased 0 commit(s)" —
+    /// in a GUI it is the only feedback the user gets for commits disappearing
+    /// from their branch.
+    #[test]
+    fn test_pull_rebase_reports_when_every_local_commit_was_already_upstream() {
+        let (upstream, local, branch) = pull_fixture();
+        upstream.create_commit(
+            "upstream took the shared change",
+            &[("shared.txt", "shared\n")],
+        );
+        local.create_commit("local shared change", &[("shared.txt", "shared\n")]);
+
+        let (_, message) =
+            pull_rebase(&local, &branch).expect("a fully already-applied pull must succeed");
+
+        assert_eq!(
+            message,
+            "Rebased 0 commit(s), skipped 1 already applied upstream"
+        );
+        assert_eq!(local.head_oid(), upstream.head_oid());
+        assert_eq!(local.repo().state(), git2::RepositoryState::Clean);
+    }
+
+    /// The other arm of the same libgit2 error: a commit that was ALREADY
+    /// empty before the pull is not an already-applied patch, and git keeps
+    /// it. It must be recreated on the rebased HEAD and counted as rebased.
+    #[test]
+    fn test_pull_rebase_preserves_a_local_commit_that_started_empty() {
+        let (upstream, local, branch) = pull_fixture();
+        upstream.create_commit("upstream change", &[("up.txt", "up\n")]);
+        let empty_oid = {
+            let repo = local.repo();
+            let head = repo.head().unwrap().peel_to_commit().unwrap();
+            let tree = head.tree().unwrap();
+            let signature = repo.signature().unwrap();
+            repo.commit(
+                Some("HEAD"),
+                &signature,
+                &signature,
+                "Intentional empty marker",
+                &tree,
+                &[&head],
+            )
+            .unwrap()
+        };
+        local.create_commit("local follow-up", &[("local.txt", "local\n")]);
+
+        let (_, message) = pull_rebase(&local, &branch)
+            .expect("a commit that started empty must survive the pull");
+
+        assert_eq!(message, "Rebased 2 commit(s)");
+        let repo = local.repo();
+        assert_eq!(repo.state(), git2::RepositoryState::Clean);
+        let head = repo.head().unwrap().peel_to_commit().unwrap();
+        assert_eq!(head.message().unwrap(), "local follow-up");
+        let empty = head.parent(0).unwrap();
+        assert_ne!(
+            empty.id(),
+            empty_oid,
+            "the empty commit must be replayed onto the upstream tip"
+        );
+        assert_eq!(empty.message().unwrap(), "Intentional empty marker");
+        assert_eq!(empty.tree_id(), empty.parent(0).unwrap().tree_id());
+        assert_eq!(empty.parent(0).unwrap().id(), upstream.head_oid());
+    }
+
+    /// Skipping empty patches must not swallow a real conflict: that one still
+    /// stops the loop and leaves the rebase state in place for the UI's
+    /// resolve flow.
+    #[test]
+    fn test_pull_rebase_conflict_keeps_the_rebase_state() {
+        let (upstream, local, branch) = pull_fixture();
+        upstream.create_commit("upstream edit", &[("conflict.txt", "upstream\n")]);
+        local.create_commit("local edit", &[("conflict.txt", "local\n")]);
+
+        let err = pull_rebase(&local, &branch)
+            .expect_err("a conflicting rebase pull must report the conflict");
+
+        assert!(
+            matches!(err, LeviathanError::RebaseConflict),
+            "unexpected error: {}",
+            err
+        );
+        assert_eq!(local.repo().state(), git2::RepositoryState::RebaseMerge);
     }
 
     // ---- pull strategy comes from git config ----

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -794,7 +794,7 @@ pub(crate) fn pull_branch(
         // RebaseConflict because the UI surfaces a "resolve
         // conflicts" flow that needs the rebase state intact.
         let mut commit_count = 0;
-        let mut skipped_count = 0;
+        let mut skipped_count = 0usize;
         let rebase_result = (|| -> Result<()> {
             while let Some(op) = rebase_obj.next() {
                 let op = op?;
@@ -821,6 +821,11 @@ pub(crate) fn pull_branch(
         })();
         match rebase_result {
             Err(LeviathanError::RebaseConflict) => {
+                // Paused, not finished: this call reports a conflict, never a
+                // count, so the commits already dropped here would go
+                // unreported. Hand them to the continue_rebase that finishes
+                // this rebase, which adds its own and reports the total.
+                crate::commands::merge::append_skipped(&repo, skipped_count);
                 return Err(LeviathanError::RebaseConflict);
             }
             Err(e) => {
@@ -2355,6 +2360,45 @@ mod tests {
             "Rebased 0 commit(s), skipped 1 already applied upstream"
         );
         assert_eq!(local.head_oid(), upstream.head_oid());
+        assert_eq!(local.repo().state(), git2::RepositoryState::Clean);
+    }
+
+    /// A pull --rebase that stops on a conflict reports RebaseConflict, not a
+    /// message — so the commits it already dropped had nowhere to go. They are
+    /// handed to the continue_rebase that finishes the rebase, which reports
+    /// the total to the conflict dialog.
+    #[tokio::test]
+    async fn test_pull_rebase_carries_its_skips_across_a_conflict() {
+        let (upstream, local, branch) = pull_fixture();
+        upstream.create_commit(
+            "upstream took the shared change",
+            &[("shared.txt", "shared\n")],
+        );
+        upstream.create_commit("upstream edits contested", &[("contested.txt", "theirs\n")]);
+        // The same patch as a distinct local commit — dropped before the stop.
+        local.create_commit("local shared change", &[("shared.txt", "shared\n")]);
+        local.create_commit("local edits contested", &[("contested.txt", "ours\n")]);
+
+        let err = pull_rebase(&local, &branch).expect_err("the pull must stop on the conflict");
+        assert!(matches!(err, LeviathanError::RebaseConflict), "{:?}", err);
+
+        crate::commands::merge::resolve_conflict(
+            local.path_str(),
+            "contested.txt".to_string(),
+            "resolved\n".to_string(),
+            None,
+        )
+        .await
+        .unwrap();
+
+        let skipped = crate::commands::merge::continue_rebase(local.path_str())
+            .await
+            .expect("the resolved pull must finish");
+
+        assert_eq!(
+            skipped, 1,
+            "the commit the pull dropped before the conflict must still be reported"
+        );
         assert_eq!(local.repo().state(), git2::RepositoryState::Clean);
     }
 

--- a/src/__tests__/app-shell-ref-context-menu.integration.test.ts
+++ b/src/__tests__/app-shell-ref-context-menu.integration.test.ts
@@ -323,6 +323,39 @@ describe('app-shell ref context menu handlers (integration)', () => {
       expect(findCommands('open_repository').length).to.be.greaterThan(0);
     });
 
+    // A commit whose patch is already on `onto` is dropped by the rebase and
+    // disappears from the branch. `git rebase` warns on stderr; the toast is
+    // the only place this GUI can say it.
+    it('names the skipped commits in the success toast', async () => {
+      mockInvoke = async (command: string) => {
+        if (command === 'plugin:dialog|message') return 'Ok';
+        if (command === 'rebase') return 2;
+        return null;
+      };
+
+      const el = createAppShell();
+      setRefContextMenu(el, 'main');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRefRebase();
+
+      const toast = uiStore.getState().toasts.find((t) => t.type === 'success');
+      expect(toast?.message).to.equal(
+        'Rebased onto main, skipped 2 already applied upstream'
+      );
+    });
+
+    it('keeps the plain success toast when nothing was skipped', async () => {
+      const el = createAppShell();
+      setRefContextMenu(el, 'main');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRefRebase();
+
+      const toast = uiStore.getState().toasts.find((t) => t.type === 'success');
+      expect(toast?.message).to.equal('Rebased onto main');
+    });
+
     it('opens conflict dialog on REBASE_CONFLICT', async () => {
       mockInvoke = async (command: string) => {
         // These handlers now confirm first, like their sidebar counterparts.

--- a/src/__tests__/app-shell-ref-context-menu.integration.test.ts
+++ b/src/__tests__/app-shell-ref-context-menu.integration.test.ts
@@ -341,7 +341,7 @@ describe('app-shell ref context menu handlers (integration)', () => {
 
       const toast = uiStore.getState().toasts.find((t) => t.type === 'success');
       expect(toast?.message).to.equal(
-        'Rebased onto main, skipped 2 already applied upstream'
+        'Rebased onto main, skipped 2 commit(s) already applied upstream'
       );
     });
 

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -5,6 +5,7 @@ import { repositoryStore, uiStore, type OpenRepository } from './stores/index.ts
 import { registerDefaultShortcuts, keyboardService } from './services/keyboard.service.ts';
 import { loggers } from './utils/logger.ts';
 import { sweepRepoScopedDialogs } from './utils/repo-scoped-dialogs.ts';
+import { rebasedOntoMessage } from './utils/rebase-messages.ts';
 import * as watcherService from './services/watcher.service.ts';
 
 const log = loggers.app;
@@ -2341,7 +2342,7 @@ export class AppShell extends LitElement {
 
     if (result.success) {
       this.refreshConflictDialogRepo(repoPath);
-      showToast(`Rebased onto ${refName}`, 'success');
+      showToast(rebasedOntoMessage(refName, result.data), 'success');
     } else if (result.error?.code === 'REBASE_CONFLICT') {
       this.conflictOperationType = 'rebase';
       this.resetConflictDetailState();

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -45,6 +45,9 @@ function clearToasts(): void {
   state.toasts.forEach((t) => state.removeToast(t.id));
 }
 
+/** What `continue_rebase` resolves with — see setupDefaultMocks. */
+let continueRebaseSkipped: unknown = 0;
+
 const TEST_CONFLICTS: ConflictFile[] = [
   makeConflict('src/main.ts'),
   makeConflict('src/utils.ts'),
@@ -66,7 +69,10 @@ function setupDefaultMocks(conflicts: ConflictFile[] = TEST_CONFLICTS): void {
       case 'abort_cherry_pick':
       case 'abort_revert':
         return { success: true };
+      // The backend resolves continue_rebase with the number of commits the
+      // rebase dropped as already applied upstream — 0 for a clean continue.
       case 'continue_rebase':
+        return continueRebaseSkipped;
       case 'continue_cherry_pick':
       case 'continue_revert':
         return { success: true };
@@ -95,6 +101,7 @@ async function renderDialog(
 describe('lv-conflict-resolution-dialog', () => {
   beforeEach(() => {
     invokeHistory.length = 0;
+    continueRebaseSkipped = 0;
     setupDefaultMocks();
   });
 
@@ -935,6 +942,79 @@ describe('lv-conflict-resolution-dialog', () => {
       confirmAnswer = 'Ok';
       await internal.handleContinue.call(el);
       expect(completedFired).to.be.true;
+    });
+
+    // A rebase that paused on a conflict finishes HERE, not in rebase(). Every
+    // commit it drops as already-applied — before the pause and after it —
+    // disappears from the branch, and this toast is the only place the user can
+    // find out. The four direct-rebase toasts already say so.
+    it('names the commits a continued rebase dropped', async () => {
+      const el = await renderDialog('rebase');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        resolvedFiles: Set<string>;
+        conflicts: ConflictFile[];
+        handleContinue: () => Promise<void>;
+      };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+
+      continueRebaseSkipped = 2;
+      clearToasts();
+      await internal.handleContinue.call(el);
+
+      const success = uiStore.getState().toasts.find(t => t.type === 'success');
+      expect(success?.message).to.equal(
+        'Rebase completed, skipped 2 commit(s) already applied upstream'
+      );
+    });
+
+    it('keeps the plain completion when a continued rebase dropped nothing', async () => {
+      const el = await renderDialog('rebase');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        resolvedFiles: Set<string>;
+        conflicts: ConflictFile[];
+        handleContinue: () => Promise<void>;
+      };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+
+      continueRebaseSkipped = 0;
+      clearToasts();
+      await internal.handleContinue.call(el);
+
+      const success = uiStore.getState().toasts.find(t => t.type === 'success');
+      expect(success?.message).to.equal('Rebase completed');
+    });
+
+    // The other operations share this toast and have no such count; an
+    // undefined `data` must never render as "skipped undefined".
+    it('leaves a merge completion untouched', async () => {
+      const el = await renderDialog('merge');
+      el.open = true;
+      await el.updateComplete;
+      await new Promise(r => setTimeout(r, 100));
+      await el.updateComplete;
+
+      const internal = el as unknown as {
+        resolvedFiles: Set<string>;
+        conflicts: ConflictFile[];
+        handleContinue: () => Promise<void>;
+      };
+      internal.resolvedFiles = new Set(internal.conflicts.map(c => c.path));
+
+      clearToasts();
+      await internal.handleContinue.call(el);
+
+      const success = uiStore.getState().toasts.find(t => t.type === 'success');
+      expect(success?.message).to.equal('Merge completed');
     });
 
     it('dispatches operation-completed on successful continue', async () => {

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -23,7 +23,7 @@ import { containsDeepActiveElement } from '../../utils/focus.ts';
 // and report the refusal, so the operation stays serialized; only the
 // affordance stays live.
 import { tryAcquireRefOp, releaseRefOp } from '../../utils/ref-lock.ts';
-import { REBASE_PAUSED_MESSAGE } from '../../utils/rebase-messages.ts';
+import { REBASE_PAUSED_MESSAGE, skippedCommitsSuffix } from '../../utils/rebase-messages.ts';
 
 /**
  * Context threaded through a conflicted git-flow finish so the dialog can COMPLETE
@@ -1310,6 +1310,12 @@ export class LvConflictResolutionDialog extends LitElement {
 
     try {
       let result;
+      // A rebase that finishes here may have dropped commits whose patch is
+      // already on the target — across every leg, not just this one. The
+      // backend carries the running total over each conflict pause; this is
+      // the only surface that can report it, so the completion toast says so
+      // in the same words the four direct-rebase toasts use.
+      let completionSuffix = '';
       switch (this.operationType) {
         case 'rebase':
           result = await gitService.continueRebase({ path: this.repositoryPath });
@@ -1346,6 +1352,7 @@ export class LvConflictResolutionDialog extends LitElement {
             showToast(result.error?.message ?? 'Failed to continue rebase', 'error');
             return;
           }
+          completionSuffix = skippedCommitsSuffix(result.data);
           break;
         case 'cherry-pick':
           result = await gitService.continueCherryPick({ path: this.repositoryPath });
@@ -1465,7 +1472,7 @@ export class LvConflictResolutionDialog extends LitElement {
       // commit was created — the same gesture that, had it failed, produces a
       // red toast. (The paused-rebase branch above returns before this and
       // carries its own, different message.)
-      showToast(`${this.getOperationTitle()} completed`, 'success');
+      showToast(`${this.getOperationTitle()} completed${completionSuffix}`, 'success');
       this.dispatchEvent(
         new CustomEvent('operation-completed', {
           bubbles: true,

--- a/src/components/sidebar/__tests__/lv-branch-list-rebase-skipped.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-rebase-skipped.test.ts
@@ -54,6 +54,18 @@ function defaultMockInvoke(command: string): Promise<unknown> {
     return Promise.resolve('Ok');
   }
   if (command === 'rebase') return Promise.resolve(skipped);
+  // The drop-onto-a-non-HEAD-branch arm checks the target out first; without
+  // this it takes the checkout-failed branch and never reaches the rebase.
+  if (command === 'checkout_with_autostash') {
+    return Promise.resolve({
+      success: true,
+      stashed: false,
+      stashApplied: false,
+      stashConflict: false,
+      stashOid: null,
+      message: 'ok',
+    });
+  }
   if (command === 'get_branches') return Promise.resolve([]);
   if (command === 'get_remotes') return Promise.resolve([]);
   if (command === 'get_hidden_branches') return Promise.resolve([]);
@@ -106,7 +118,9 @@ describe('lv-branch-list rebase skip reporting', () => {
     await rebaseFromContextMenu(el, makeBranch('main'));
 
     expect(invokeCalls.some((c) => c.command === 'rebase'), 'rebase ran').to.be.true;
-    expect(successToast()).to.equal('Rebased onto main, skipped 2 already applied upstream');
+    expect(successToast()).to.equal(
+      'Rebased onto main, skipped 2 commit(s) already applied upstream'
+    );
   });
 
   it('keeps the plain success when nothing was skipped', async () => {
@@ -128,7 +142,7 @@ describe('lv-branch-list rebase skip reporting', () => {
     await rebaseFromContextMenu(el, makeBranch('origin/main'));
 
     expect(successToast()).to.equal(
-      'Rebased onto origin/main, skipped 3 already applied upstream'
+      'Rebased onto origin/main, skipped 3 commit(s) already applied upstream'
     );
   });
 
@@ -145,7 +159,31 @@ describe('lv-branch-list rebase skip reporting', () => {
 
     expect(invokeCalls.some((c) => c.command === 'rebase'), 'rebase ran').to.be.true;
     expect(successToast()).to.equal(
-      'Rebased onto feature/source, skipped 1 already applied upstream'
+      'Rebased onto feature/source, skipped 1 commit(s) already applied upstream'
+    );
+  });
+
+  // The third Rebase gesture: dropping onto a branch that is NOT HEAD checks
+  // that branch out first and rebases afterwards, through a separate arm with
+  // its own success toast.
+  it('names the dropped commits after an alt-drag rebase onto a non-HEAD branch', async () => {
+    const el = await createComponent();
+    skipped = 2;
+
+    const source = makeBranch('feature/source');
+    (el as unknown as { draggingBranch: unknown }).draggingBranch = source;
+
+    await (
+      el as unknown as { handleDrop: (e: DragEvent, b: unknown) => Promise<void> }
+    ).handleDrop(fakeDragEvent(true), makeBranch('other', /* isHead */ false));
+
+    expect(
+      invokeCalls.some((c) => c.command === 'checkout_with_autostash'),
+      'the target branch is checked out first'
+    ).to.be.true;
+    expect(invokeCalls.some((c) => c.command === 'rebase'), 'rebase ran').to.be.true;
+    expect(successToast()).to.equal(
+      'Rebased onto feature/source, skipped 2 commit(s) already applied upstream'
     );
   });
 });

--- a/src/components/sidebar/__tests__/lv-branch-list-rebase-skipped.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-rebase-skipped.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Tests that a rebase which dropped commits says so.
+ *
+ * A commit whose patch is already on the target is skipped by the rebase, so
+ * it disappears from the branch. `git rebase` prints "warning: skipped
+ * previously applied commit <sha>" for each one; there is no stderr here, and
+ * a bare green "Rebased onto <branch>" is the same message a clean rebase
+ * gets. `pull --rebase` already reports its skips — the branch list's three
+ * Rebase gestures must too.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeCalls: Array<{ command: string; args?: unknown }> = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeCalls.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { LvBranchList } from '../lv-branch-list.ts';
+import '../lv-branch-list.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
+import { resetRefOpLocks } from '../../../utils/ref-lock.ts';
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+const REPO_PATH = '/test/repo';
+
+function makeBranch(name: string, isHead = false) {
+  return {
+    name,
+    shorthand: name,
+    isHead,
+    isRemote: false,
+    upstream: null,
+    targetOid: 'abc123',
+    isStale: false,
+  };
+}
+
+/** `rebase` resolves with the number of commits it skipped. */
+let skipped: unknown = 0;
+
+function defaultMockInvoke(command: string): Promise<unknown> {
+  if (command === 'plugin:dialog|confirm' || command === 'plugin:dialog|message') {
+    return Promise.resolve('Ok');
+  }
+  if (command === 'rebase') return Promise.resolve(skipped);
+  if (command === 'get_branches') return Promise.resolve([]);
+  if (command === 'get_remotes') return Promise.resolve([]);
+  if (command === 'get_hidden_branches') return Promise.resolve([]);
+  if (command === 'get_branch_sort_mode') return Promise.resolve('name');
+  return Promise.resolve(null);
+}
+
+async function createComponent(): Promise<LvBranchList> {
+  mockInvoke = defaultMockInvoke;
+  const el = await fixture<LvBranchList>(
+    html`<lv-branch-list .repositoryPath=${REPO_PATH}></lv-branch-list>`
+  );
+  await el.updateComplete;
+  return el;
+}
+
+function successToast(): string | undefined {
+  return uiStore.getState().toasts.find((t) => t.type === 'success')?.message;
+}
+
+/** Runs the context-menu Rebase against `branch`. */
+async function rebaseFromContextMenu(el: LvBranchList, branch: ReturnType<typeof makeBranch>) {
+  (
+    el as unknown as {
+      contextMenu: { visible: boolean; x: number; y: number; branch: typeof branch | null };
+    }
+  ).contextMenu = { visible: true, x: 0, y: 0, branch };
+  await (el as unknown as { handleRebaseBranch: () => Promise<void> }).handleRebaseBranch();
+}
+
+// A minimal DragEvent stand-in. alt = rebase rather than merge.
+function fakeDragEvent(altKey: boolean): DragEvent {
+  return { preventDefault() {}, altKey } as unknown as DragEvent;
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+describe('lv-branch-list rebase skip reporting', () => {
+  beforeEach(() => {
+    resetRefOpLocks();
+    invokeCalls.length = 0;
+    skipped = 0;
+    const state = uiStore.getState();
+    state.toasts.forEach((t) => state.removeToast(t.id));
+  });
+
+  it('names the dropped commits after a context-menu rebase', async () => {
+    const el = await createComponent();
+    skipped = 2;
+
+    await rebaseFromContextMenu(el, makeBranch('main'));
+
+    expect(invokeCalls.some((c) => c.command === 'rebase'), 'rebase ran').to.be.true;
+    expect(successToast()).to.equal('Rebased onto main, skipped 2 already applied upstream');
+  });
+
+  it('keeps the plain success when nothing was skipped', async () => {
+    const el = await createComponent();
+    skipped = 0;
+
+    await rebaseFromContextMenu(el, makeBranch('main'));
+
+    expect(successToast()).to.equal('Rebased onto main');
+  });
+
+  // The backend reports every commit skipped when the whole branch was already
+  // applied upstream — the branch ref still moves, so this is the case the
+  // message exists for.
+  it('reports a rebase that dropped every commit', async () => {
+    const el = await createComponent();
+    skipped = 3;
+
+    await rebaseFromContextMenu(el, makeBranch('origin/main'));
+
+    expect(successToast()).to.equal(
+      'Rebased onto origin/main, skipped 3 already applied upstream'
+    );
+  });
+
+  it('names the dropped commits after an alt-drag rebase onto HEAD', async () => {
+    const el = await createComponent();
+    skipped = 1;
+
+    const source = makeBranch('feature/source');
+    (el as unknown as { draggingBranch: unknown }).draggingBranch = source;
+
+    await (
+      el as unknown as { handleDrop: (e: DragEvent, b: unknown) => Promise<void> }
+    ).handleDrop(fakeDragEvent(true), makeBranch('main', /* isHead */ true));
+
+    expect(invokeCalls.some((c) => c.command === 'rebase'), 'rebase ran').to.be.true;
+    expect(successToast()).to.equal(
+      'Rebased onto feature/source, skipped 1 already applied upstream'
+    );
+  });
+});

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -14,6 +14,7 @@ import '../dialogs/lv-branch-cleanup-dialog.ts';
 import type { LvBranchCleanupDialog } from '../dialogs/lv-branch-cleanup-dialog.ts';
 import type { Branch } from '../../types/git.types.ts';
 import { isTopOverlay } from '../../utils/overlay-stack.ts';
+import { rebasedOntoMessage } from '../../utils/rebase-messages.ts';
 import {
   tryAcquireRefOpOrWarn,
   releaseRefOp,
@@ -1458,7 +1459,7 @@ export class LvBranchList extends LitElement {
 
       if (result.success) {
         await this.loadBranches();
-        showToast(`Rebased onto ${branch.shorthand}`, 'success');
+        showToast(rebasedOntoMessage(branch.shorthand, result.data), 'success');
         this.dispatchBranchesChanged(repoPath);
       } else if (result.error?.code === 'REBASE_CONFLICT') {
         // Open the conflict-resolution dialog (same flow as the drag-drop path)
@@ -1913,7 +1914,7 @@ export class LvBranchList extends LitElement {
 
         if (result.success) {
           await this.loadBranches();
-          showToast(`Rebased onto ${sourceBranch.shorthand}`, 'success');
+          showToast(rebasedOntoMessage(sourceBranch.shorthand, result.data), 'success');
           this.dispatchBranchesChanged(repoPath);
         } else if (result.error?.code === 'REBASE_CONFLICT') {
           this.dispatchEvent(new CustomEvent('open-conflict-dialog', {
@@ -2021,7 +2022,7 @@ export class LvBranchList extends LitElement {
 
         if (result.success) {
           await this.loadBranches();
-          showToast(`Rebased onto ${sourceBranch.shorthand}`, 'success');
+          showToast(rebasedOntoMessage(sourceBranch.shorthand, result.data), 'success');
           this.dispatchBranchesChanged(repoPath);
         } else if (result.error?.code === 'REBASE_CONFLICT') {
           this.dispatchEvent(new CustomEvent('open-conflict-dialog', {

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -1581,10 +1581,14 @@ export async function commitMerge(
 /**
  * Rebase operations
  */
+/**
+ * Resolves with the number of commits the rebase skipped because their patch
+ * was already applied on the target — see `rebasedOntoMessage`.
+ */
 export async function rebase(
   args: RebaseCommand,
-): Promise<CommandResult<void>> {
-  return invokeCommand<void>("rebase", args);
+): Promise<CommandResult<number>> {
+  return invokeCommand<number>("rebase", args);
 }
 
 export interface RebasePreview {

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -1610,10 +1610,11 @@ export async function previewRebase(
   return invokeCommand<RebasePreview>("preview_rebase", { path, onto });
 }
 
+/** Resolves with how many commits the rebase dropped as already applied. */
 export async function continueRebase(
   args: ContinueRebaseCommand,
-): Promise<CommandResult<void>> {
-  return invokeCommand<void>("continue_rebase", args);
+): Promise<CommandResult<number>> {
+  return invokeCommand<number>("continue_rebase", args);
 }
 
 export async function abortRebase(

--- a/src/utils/__tests__/rebase-messages.test.ts
+++ b/src/utils/__tests__/rebase-messages.test.ts
@@ -1,0 +1,31 @@
+/**
+ * Tests for the shared rebase success wording.
+ *
+ * A rebase drops commits whose patch is already on the target. `git rebase`
+ * warns about each on stderr; a GUI has no stderr, so the toast is the only
+ * place the user can learn their local commits disappeared.
+ */
+import { expect } from '@open-wc/testing';
+import { rebasedOntoMessage } from '../rebase-messages.ts';
+
+describe('rebasedOntoMessage', () => {
+  it('reads as a plain success when nothing was skipped', () => {
+    expect(rebasedOntoMessage('main', 0)).to.equal('Rebased onto main');
+  });
+
+  it('names the skipped commits so they do not vanish silently', () => {
+    expect(rebasedOntoMessage('main', 1)).to.equal(
+      'Rebased onto main, skipped 1 already applied upstream'
+    );
+    expect(rebasedOntoMessage('origin/main', 3)).to.equal(
+      'Rebased onto origin/main, skipped 3 already applied upstream'
+    );
+  });
+
+  // `CommandResult.data` is optional, and older mocks resolve `rebase` with
+  // null — neither may turn the success toast into "skipped null".
+  it('falls back to the plain success when the count is missing', () => {
+    expect(rebasedOntoMessage('main')).to.equal('Rebased onto main');
+    expect(rebasedOntoMessage('main', null)).to.equal('Rebased onto main');
+  });
+});

--- a/src/utils/__tests__/rebase-messages.test.ts
+++ b/src/utils/__tests__/rebase-messages.test.ts
@@ -6,7 +6,7 @@
  * place the user can learn their local commits disappeared.
  */
 import { expect } from '@open-wc/testing';
-import { rebasedOntoMessage } from '../rebase-messages.ts';
+import { rebasedOntoMessage, skippedCommitsSuffix } from '../rebase-messages.ts';
 
 describe('rebasedOntoMessage', () => {
   it('reads as a plain success when nothing was skipped', () => {
@@ -15,10 +15,10 @@ describe('rebasedOntoMessage', () => {
 
   it('names the skipped commits so they do not vanish silently', () => {
     expect(rebasedOntoMessage('main', 1)).to.equal(
-      'Rebased onto main, skipped 1 already applied upstream'
+      'Rebased onto main, skipped 1 commit(s) already applied upstream'
     );
     expect(rebasedOntoMessage('origin/main', 3)).to.equal(
-      'Rebased onto origin/main, skipped 3 already applied upstream'
+      'Rebased onto origin/main, skipped 3 commit(s) already applied upstream'
     );
   });
 
@@ -27,5 +27,21 @@ describe('rebasedOntoMessage', () => {
   it('falls back to the plain success when the count is missing', () => {
     expect(rebasedOntoMessage('main')).to.equal('Rebased onto main');
     expect(rebasedOntoMessage('main', null)).to.equal('Rebased onto main');
+  });
+});
+
+describe('skippedCommitsSuffix', () => {
+  // The conflict-resolution dialog appends this to "Rebase completed", so it
+  // must carry its own leading comma and name the noun on its own.
+  it('names the count and the noun', () => {
+    expect(skippedCommitsSuffix(2)).to.equal(
+      ', skipped 2 commit(s) already applied upstream'
+    );
+  });
+
+  it('is empty when nothing was skipped or the count is missing', () => {
+    expect(skippedCommitsSuffix(0)).to.equal('');
+    expect(skippedCommitsSuffix()).to.equal('');
+    expect(skippedCommitsSuffix(null)).to.equal('');
   });
 });

--- a/src/utils/rebase-messages.ts
+++ b/src/utils/rebase-messages.ts
@@ -14,3 +14,25 @@
 export const REBASE_PAUSED_MESSAGE =
   'Rebase paused — amend the commit, then click "Resolve Conflicts" ' +
   'in the banner and choose Continue Rebase';
+
+/**
+ * The one wording for "the rebase finished" across the four surfaces that
+ * start one (branch context menu, the two drag-drop arms, and the graph's ref
+ * menu).
+ *
+ * A commit whose patch is already on the target is dropped by the rebase —
+ * `git rebase` prints "warning: skipped previously applied commit <sha>" for
+ * each. There is no stderr here, and without naming them the user sees the
+ * same green "Rebased onto X" a clean rebase gets while their local commits
+ * are gone from the branch. `pull --rebase` already reports this ("Rebased N
+ * commit(s), skipped M already applied upstream"); the suffix is worded to
+ * match.
+ */
+export function rebasedOntoMessage(
+  target: string,
+  skipped?: number | null
+): string {
+  return skipped
+    ? `Rebased onto ${target}, skipped ${skipped} already applied upstream`
+    : `Rebased onto ${target}`;
+}

--- a/src/utils/rebase-messages.ts
+++ b/src/utils/rebase-messages.ts
@@ -16,23 +16,30 @@ export const REBASE_PAUSED_MESSAGE =
   'in the banner and choose Continue Rebase';
 
 /**
- * The one wording for "the rebase finished" across the four surfaces that
- * start one (branch context menu, the two drag-drop arms, and the graph's ref
- * menu).
+ * The one wording for "and it dropped N of your commits", shared by every
+ * surface that finishes a rebase.
  *
  * A commit whose patch is already on the target is dropped by the rebase —
  * `git rebase` prints "warning: skipped previously applied commit <sha>" for
  * each. There is no stderr here, and without naming them the user sees the
- * same green "Rebased onto X" a clean rebase gets while their local commits
- * are gone from the branch. `pull --rebase` already reports this ("Rebased N
- * commit(s), skipped M already applied upstream"); the suffix is worded to
- * match.
+ * same green success a clean rebase gets while their local commits are gone
+ * from the branch. `pull --rebase` already reports this ("Rebased N commit(s),
+ * skipped M already applied upstream"); the suffix is worded to match — the
+ * noun included, because pull's sentence names `commit(s)` earlier and this
+ * one has nothing else to say WHAT was skipped.
+ */
+export function skippedCommitsSuffix(skipped?: number | null): string {
+  return skipped ? `, skipped ${skipped} commit(s) already applied upstream` : '';
+}
+
+/**
+ * The one wording for "the rebase finished" across the four surfaces that
+ * start one (branch context menu, the two drag-drop arms, and the graph's ref
+ * menu).
  */
 export function rebasedOntoMessage(
   target: string,
   skipped?: number | null
 ): string {
-  return skipped
-    ? `Rebased onto ${target}, skipped ${skipped} already applied upstream`
-    : `Rebased onto ${target}`;
+  return `Rebased onto ${target}${skippedCommitsSuffix(skipped)}`;
 }


### PR DESCRIPTION
## Summary
- skip patches already present upstream instead of aborting direct and pull rebases
- preserve commits that were intentionally empty before rebasing
- retain raw message encoding, negative-zero timezone metadata, notes, and rewrite mappings

## Validation
- 14 targeted rebase tests passed single-threaded
- three frontier-model reviewers converged on no issues
- Rust files formatted with rustfmt