### PR TITLE
Fix duplicate GitFlow squash commits on retry

### DIFF
--- a/src-tauri/src/commands/gitflow.rs
+++ b/src-tauri/src/commands/gitflow.rs
@@ -611,6 +611,47 @@ pub async fn gitflow_finish_feature(
     })
 }
 
+/// Record that a squash finish's commit has landed on develop.
+///
+/// A squash finish whose merge CONFLICTS returns `MergeConflict` before
+/// `gitflow_finish_feature` ever reaches its own recorder — the squash commit
+/// is then created by the conflict-resolution flow instead. Without a marker
+/// for that commit, a retry after a failed branch delete finds neither an
+/// ancestry match nor a marker, re-merges the same divergence, and mints a
+/// SECOND squash commit. The conflict flow therefore records the marker itself
+/// once its commit has landed and before it attempts the branch delete.
+#[command]
+pub async fn gitflow_record_squash_finish(path: String, name: String) -> Result<()> {
+    let repo = git2::Repository::open(Path::new(&path))?;
+    let config = repo.config()?;
+
+    let develop = config
+        .get_string("gitflow.branch.develop")
+        .unwrap_or_else(|_| "develop".to_string());
+    let prefix = config
+        .get_string("gitflow.prefix.feature")
+        .unwrap_or_else(|_| "feature/".to_string());
+    let branch_name = format!("{}{}", prefix, name);
+
+    let feature_commit = repo
+        .find_branch(&branch_name, git2::BranchType::Local)
+        .map_err(|_| LeviathanError::BranchNotFound(branch_name.clone()))?
+        .get()
+        .peel_to_commit()?;
+    let develop_commit = repo
+        .find_branch(&develop, git2::BranchType::Local)
+        .map_err(|_| LeviathanError::BranchNotFound(develop.clone()))?
+        .get()
+        .peel_to_commit()?;
+
+    record_completed_squash(
+        &repo,
+        &branch_name,
+        feature_commit.id(),
+        develop_commit.id(),
+    )
+}
+
 /// Start a git flow release branch
 #[command]
 pub async fn gitflow_start_release(path: String, version: String) -> Result<Branch> {
@@ -1233,8 +1274,8 @@ mod tests {
     }
 
     /// A delete failure must never fail the whole finish: the merge is already
-    /// committed, and a squash retry is not idempotent — it would mint a second
-    /// squash commit every time the user retried.
+    /// committed, and a squash finish records a completion marker so a retry
+    /// only attempts the pending branch cleanup.
     #[tokio::test]
     async fn test_gitflow_finish_feature_survives_unreadable_branch_rules() {
         let repo = TestRepo::with_initial_commit();
@@ -1999,6 +2040,136 @@ mod tests {
             vec!["1"],
             "cleanup retry must not rerun post-merge"
         );
+    }
+
+    /// The marker is what makes a retry safe when develop has since moved to
+    /// content that CONFLICTS with the feature — `merge_commits` then produces a
+    /// conflicted index that has no tree to compare, so the check must answer
+    /// "already finished" from the marker alone.
+    #[tokio::test]
+    async fn test_finish_feature_squash_retry_with_conflicting_develop_only_cleans_up() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        gitflow_start_feature(repo.path_str(), "diverge-retry".to_string())
+            .await
+            .unwrap();
+        repo.create_commit("Feature work", &[("README.md", "# Feature\n")]);
+        gitflow_finish_feature(
+            repo.path_str(),
+            "diverge-retry".to_string(),
+            Some(false),
+            Some(true),
+        )
+        .await
+        .unwrap();
+
+        // Develop moves on to content that conflicts with the feature tip.
+        repo.create_commit("Diverge", &[("README.md", "# Diverged\n")]);
+        let diverged_tip = repo.head_oid();
+
+        let result = gitflow_finish_feature(
+            repo.path_str(),
+            "diverge-retry".to_string(),
+            Some(true),
+            Some(true),
+        )
+        .await
+        .expect("a finished squash must not re-conflict on retry");
+
+        assert_eq!(
+            repo.head_oid(),
+            diverged_tip,
+            "retry must not commit anything on top of the diverged develop"
+        );
+        assert!(result.branch_deleted);
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("README.md")).unwrap(),
+            "# Diverged\n",
+            "the retry must not resurrect the squashed content"
+        );
+    }
+
+    /// A squash finish whose merge conflicts is committed by the
+    /// conflict-resolution flow, not by `gitflow_finish_feature`. Without the
+    /// marker that flow records, a retry after a blocked branch delete
+    /// re-conflicts and mints a SECOND squash commit on develop.
+    #[tokio::test]
+    async fn test_record_squash_finish_lets_a_conflicted_squash_retry_clean_up_only() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        gitflow_start_feature(repo.path_str(), "conflicted".to_string())
+            .await
+            .unwrap();
+        repo.create_commit("Feature work", &[("README.md", "# Feature\n")]);
+        repo.checkout_branch("develop");
+        repo.create_commit("Develop work", &[("README.md", "# Develop\n")]);
+
+        assert!(
+            matches!(
+                gitflow_finish_feature(
+                    repo.path_str(),
+                    "conflicted".to_string(),
+                    Some(true),
+                    Some(true),
+                )
+                .await,
+                Err(LeviathanError::MergeConflict)
+            ),
+            "the squash merge must conflict before any commit is made"
+        );
+
+        // What the conflict-resolution dialog does: resolve, commit the squash
+        // as a single parent, then record the completion.
+        repo.create_file("README.md", "# Resolved\n");
+        repo.stage_file("README.md");
+        crate::commands::merge::commit_merge(repo.path_str(), None, Some(true))
+            .await
+            .unwrap();
+        gitflow_record_squash_finish(repo.path_str(), "conflicted".to_string())
+            .await
+            .unwrap();
+        let squash_tip = repo.head_oid();
+
+        // The delete was blocked (e.g. a preventDeletion rule), so the user
+        // retries the whole finish from the Git Flow panel.
+        let result = gitflow_finish_feature(
+            repo.path_str(),
+            "conflicted".to_string(),
+            Some(true),
+            Some(true),
+        )
+        .await
+        .expect("the recorded squash must make the retry cleanup-only");
+
+        assert_eq!(
+            repo.head_oid(),
+            squash_tip,
+            "retry must not mint a second squash commit"
+        );
+        assert!(result.branch_deleted);
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("README.md")).unwrap(),
+            "# Resolved\n",
+            "the retry must leave the resolved content alone"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_record_squash_finish_rejects_an_unknown_feature() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        let result = gitflow_record_squash_finish(repo.path_str(), "missing".to_string()).await;
+
+        assert!(matches!(result, Err(LeviathanError::BranchNotFound(_))));
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/gitflow.rs
+++ b/src-tauri/src/commands/gitflow.rs
@@ -2,6 +2,8 @@
 //! Implements the git-flow branching model
 
 use std::path::Path;
+
+use sha2::{Digest, Sha256};
 use tauri::command;
 
 use crate::error::{LeviathanError, Result};
@@ -301,6 +303,81 @@ pub struct GitFlowFinishResult {
     pub branch_kept_reason: Option<String>,
 }
 
+#[derive(serde::Deserialize, serde::Serialize)]
+struct GitFlowSquashMarker {
+    feature_oid: String,
+    squash_oid: String,
+}
+
+fn squash_marker_path(repo: &git2::Repository, branch_name: &str) -> std::path::PathBuf {
+    let branch_hash = Sha256::digest(branch_name.as_bytes())
+        .iter()
+        .map(|byte| format!("{byte:02x}"))
+        .collect::<String>();
+    repo.commondir()
+        .join("leviathan")
+        .join("gitflow-squash")
+        .join(format!("{}.json", branch_hash))
+}
+
+fn completed_squash_is_reachable(
+    repo: &git2::Repository,
+    branch_name: &str,
+    feature_oid: git2::Oid,
+    develop_oid: git2::Oid,
+) -> Result<bool> {
+    let Ok(contents) = std::fs::read_to_string(squash_marker_path(repo, branch_name)) else {
+        return Ok(false);
+    };
+    let Ok(marker) = serde_json::from_str::<GitFlowSquashMarker>(&contents) else {
+        return Ok(false);
+    };
+    let (Ok(recorded_feature), Ok(squash_commit)) = (
+        git2::Oid::from_str(&marker.feature_oid),
+        git2::Oid::from_str(&marker.squash_oid),
+    ) else {
+        return Ok(false);
+    };
+
+    if recorded_feature != feature_oid
+        || (develop_oid != squash_commit
+            && !repo
+                .graph_descendant_of(develop_oid, squash_commit)
+                .unwrap_or(false))
+    {
+        return Ok(false);
+    }
+
+    let develop = repo.find_commit(develop_oid)?;
+    let feature = repo.find_commit(feature_oid)?;
+    let mut merge_index = repo.merge_commits(&develop, &feature, None)?;
+    if merge_index.has_conflicts() {
+        return Ok(true);
+    }
+
+    Ok(merge_index.write_tree_to(repo)? == develop.tree_id())
+}
+
+fn record_completed_squash(
+    repo: &git2::Repository,
+    branch_name: &str,
+    feature_oid: git2::Oid,
+    squash_oid: git2::Oid,
+) -> Result<()> {
+    let marker_path = squash_marker_path(repo, branch_name);
+    if let Some(parent) = marker_path.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    std::fs::write(
+        marker_path,
+        serde_json::to_vec(&GitFlowSquashMarker {
+            feature_oid: feature_oid.to_string(),
+            squash_oid: squash_oid.to_string(),
+        })?,
+    )?;
+    Ok(())
+}
+
 /// Delete the finished branch unless a protection rule forbids it.
 ///
 /// Branch rules are enforced here as well as in `delete_branch` because these
@@ -312,9 +389,8 @@ pub struct GitFlowFinishResult {
 /// hotfix) the tag have already been committed by the time this runs, so
 /// deletion is the optional last step — returning `Err` would report a finish
 /// that actually succeeded as failed, leave the item listed as active, and
-/// invite a retry. A squash retry is NOT idempotent (a squash commit never
-/// makes the feature an ancestor of develop), so each retry mints another
-/// duplicate commit. Every path therefore degrades to `branch_kept_reason`.
+/// invite a retry. Every path therefore degrades to `branch_kept_reason`;
+/// squash finishes retain an internal marker so retry only attempts cleanup.
 fn delete_finished_branch(
     repo: &git2::Repository,
     repo_path: &str,
@@ -438,35 +514,57 @@ pub async fn gitflow_finish_feature(
         // parent, no merge commit). Conflicts abort BEFORE any branch
         // deletion so the user can resolve them.
         //
-        // Idempotency guard: if develop already contains the feature, skip the
-        // merge+commit so a re-run (e.g. after the squash was completed externally
-        // via the conflict-resolution flow) doesn't re-merge the same divergence
-        // and mint a duplicate commit. It then falls through to branch deletion.
+        // An ancestry check handles externally completed merges. The marker
+        // handles Leviathan's own squash commit because a squash never makes
+        // the feature tip an ancestor of develop, and develop may have moved
+        // before the user retries failed branch cleanup.
+        let develop_commit = develop_branch.get().peel_to_commit()?;
+        let squash_already_finished = completed_squash_is_reachable(
+            &repo,
+            &branch_name,
+            feature_commit.id(),
+            develop_commit.id(),
+        )?;
         let (analysis, _) = repo.merge_analysis(&[&annotated_commit])?;
-        if !analysis.is_up_to_date() {
+        if !squash_already_finished && !analysis.is_up_to_date() {
             repo.merge(&[&annotated_commit], None, None)?;
             if repo.index()?.has_conflicts() {
                 return Err(LeviathanError::MergeConflict);
             }
             let mut index = repo.index()?;
             let tree_oid = index.write_tree()?;
-            let tree = repo.find_tree(tree_oid)?;
-            let sig = repo.signature()?;
-            let develop_commit = develop_branch.get().peel_to_commit()?;
-            let message = format!("Squashed branch '{}' into {}", branch_name, develop);
-            repo.commit(
-                Some("HEAD"),
-                &sig,
-                &sig,
-                &message,
-                &tree,
-                &[&develop_commit],
-            )?;
+            // A previous squash finish leaves the feature tip unmerged by
+            // ancestry, so merge_analysis remains normal on retry even though
+            // develop already has the exact resulting tree. Do not mint an
+            // empty duplicate squash commit; finish the pending cleanup only.
+            let created_squash_commit = tree_oid != develop_commit.tree_id();
+            if created_squash_commit {
+                let tree = repo.find_tree(tree_oid)?;
+                let sig = repo.signature()?;
+                let message = format!("Squashed branch '{}' into {}", branch_name, develop);
+                repo.commit(
+                    Some("HEAD"),
+                    &sig,
+                    &sig,
+                    &message,
+                    &tree,
+                    &[&develop_commit],
+                )?;
+            }
+            let squash_commit = repo.head()?.peel_to_commit()?;
             repo.cleanup_state()?;
-            // git runs post-merge after a merge commit (flag 0 = not a squash
-            // merge). merge.rs fires it; gitflow reimplements the merge inline
-            // and fired nothing.
-            crate::commands::hooks::run_hook_noblock(&repo, "post-merge", &["0"]);
+            if let Err(error) = record_completed_squash(
+                &repo,
+                &branch_name,
+                feature_commit.id(),
+                squash_commit.id(),
+            ) {
+                tracing::warn!("Failed to record completed GitFlow squash: {}", error);
+            }
+            // git passes flag 1 to post-merge for a squash merge.
+            if created_squash_commit {
+                crate::commands::hooks::run_hook_noblock(&repo, "post-merge", &["1"]);
+            }
         }
     } else {
         // Regular merge (no-ff)
@@ -500,7 +598,11 @@ pub async fn gitflow_finish_feature(
 
     // Delete feature branch if requested
     if delete_branch.unwrap_or(true) {
-        return Ok(delete_finished_branch(&repo, &path, &branch_name));
+        let result = delete_finished_branch(&repo, &path, &branch_name);
+        if result.branch_deleted {
+            let _ = std::fs::remove_file(squash_marker_path(&repo, &branch_name));
+        }
+        return Ok(result);
     }
 
     Ok(GitFlowFinishResult {
@@ -1687,6 +1789,216 @@ mod tests {
         assert!(git_repo
             .find_branch("feature/noop", git2::BranchType::Local)
             .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_finish_feature_squash_retry_does_not_create_empty_commit() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        gitflow_start_feature(repo.path_str(), "retry".to_string())
+            .await
+            .unwrap();
+        repo.create_commit("Feature work", &[("feature.txt", "content\n")]);
+
+        gitflow_finish_feature(
+            repo.path_str(),
+            "retry".to_string(),
+            Some(false),
+            Some(true),
+        )
+        .await
+        .unwrap();
+        let first_finish_tip = repo.head_oid();
+        repo.create_commit("Later develop work", &[("develop.txt", "later\n")]);
+        let develop_tip_before_retry = repo.head_oid();
+
+        let result =
+            gitflow_finish_feature(repo.path_str(), "retry".to_string(), Some(true), Some(true))
+                .await
+                .expect("retry should only finish branch cleanup");
+
+        assert_ne!(develop_tip_before_retry, first_finish_tip);
+        assert_eq!(repo.head_oid(), develop_tip_before_retry);
+        assert!(result.branch_deleted);
+        assert!(repo
+            .repo()
+            .find_branch("feature/retry", git2::BranchType::Local)
+            .is_err());
+    }
+
+    #[tokio::test]
+    async fn test_finish_feature_squash_retry_reapplies_after_develop_reset() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        let develop_before_squash = repo.head_oid();
+
+        gitflow_start_feature(repo.path_str(), "reset-retry".to_string())
+            .await
+            .unwrap();
+        repo.create_commit("Feature work", &[("feature.txt", "content\n")]);
+        gitflow_finish_feature(
+            repo.path_str(),
+            "reset-retry".to_string(),
+            Some(false),
+            Some(true),
+        )
+        .await
+        .unwrap();
+
+        let git_repo = repo.repo();
+        git_repo
+            .reference(
+                "refs/heads/develop",
+                develop_before_squash,
+                true,
+                "test reset",
+            )
+            .unwrap();
+        git_repo
+            .checkout_head(Some(git2::build::CheckoutBuilder::new().force()))
+            .unwrap();
+
+        let result = gitflow_finish_feature(
+            repo.path_str(),
+            "reset-retry".to_string(),
+            Some(true),
+            Some(true),
+        )
+        .await
+        .expect("reset develop must invalidate the completion marker");
+
+        assert_ne!(repo.head_oid(), develop_before_squash);
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("feature.txt")).unwrap(),
+            "content\n"
+        );
+        assert!(result.branch_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_finish_feature_squash_retry_reapplies_reverted_content() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        gitflow_start_feature(repo.path_str(), "revert-retry".to_string())
+            .await
+            .unwrap();
+        repo.create_commit("Feature work", &[("README.md", "# Feature\n")]);
+        gitflow_finish_feature(
+            repo.path_str(),
+            "revert-retry".to_string(),
+            Some(false),
+            Some(true),
+        )
+        .await
+        .unwrap();
+        repo.create_commit("Revert feature work", &[("README.md", "# Test Repo")]);
+        let reverted_tip = repo.head_oid();
+
+        let result = gitflow_finish_feature(
+            repo.path_str(),
+            "revert-retry".to_string(),
+            Some(true),
+            Some(true),
+        )
+        .await
+        .expect("reverted squash content must be reapplied");
+
+        assert_ne!(repo.head_oid(), reverted_tip);
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("README.md")).unwrap(),
+            "# Feature\n"
+        );
+        assert!(result.branch_deleted);
+    }
+
+    #[tokio::test]
+    async fn test_finish_feature_squash_new_feature_tip_is_not_treated_as_retry() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+
+        gitflow_start_feature(repo.path_str(), "continued".to_string())
+            .await
+            .unwrap();
+        repo.create_commit("First feature work", &[("first.txt", "first\n")]);
+        gitflow_finish_feature(
+            repo.path_str(),
+            "continued".to_string(),
+            Some(false),
+            Some(true),
+        )
+        .await
+        .unwrap();
+        let first_squash = repo.head_oid();
+
+        repo.checkout_branch("feature/continued");
+        repo.create_commit("More feature work", &[("second.txt", "second\n")]);
+        gitflow_finish_feature(
+            repo.path_str(),
+            "continued".to_string(),
+            Some(true),
+            Some(true),
+        )
+        .await
+        .expect("a changed feature tip must be squashed");
+
+        assert_ne!(repo.head_oid(), first_squash);
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("second.txt")).unwrap(),
+            "second\n"
+        );
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn test_finish_feature_squash_retry_does_not_rerun_post_merge_hook() {
+        let repo = TestRepo::with_initial_commit();
+        init_gitflow(repo.path_str(), None, None, None, None, None, None, None)
+            .await
+            .unwrap();
+        gitflow_start_feature(repo.path_str(), "hook-retry".to_string())
+            .await
+            .unwrap();
+        repo.create_commit("Feature work", &[("feature.txt", "content\n")]);
+
+        let marker = repo.path.join("post-merge.log");
+        repo.install_hook(
+            "post-merge",
+            &format!("#!/bin/sh\necho \"$1\" >> \"{}\"\n", marker.display()),
+        );
+
+        gitflow_finish_feature(
+            repo.path_str(),
+            "hook-retry".to_string(),
+            Some(false),
+            Some(true),
+        )
+        .await
+        .unwrap();
+        gitflow_finish_feature(
+            repo.path_str(),
+            "hook-retry".to_string(),
+            Some(true),
+            Some(true),
+        )
+        .await
+        .unwrap();
+
+        let logged = std::fs::read_to_string(&marker).expect("post-merge must run once");
+        assert_eq!(
+            logged.lines().collect::<Vec<_>>(),
+            vec!["1"],
+            "cleanup retry must not rerun post-merge"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -693,6 +693,7 @@ pub fn run() {
             commands::gitflow::init_gitflow,
             commands::gitflow::gitflow_start_feature,
             commands::gitflow::gitflow_finish_feature,
+            commands::gitflow::gitflow_record_squash_finish,
             commands::gitflow::gitflow_start_release,
             commands::gitflow::gitflow_finish_release,
             commands::gitflow::gitflow_start_hotfix,

--- a/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-conflict-resolution-dialog.test.ts
@@ -2664,8 +2664,70 @@ describe('lv-conflict-resolution-dialog', () => {
       expect((delCall!.args as Record<string, unknown>).name).to.equal('feature/x');
       expect((delCall!.args as Record<string, unknown>).force).to.equal(true);
       expect(invokeHistory.some(h => h.command === 'gitflow_finish_feature'), 'finish NOT re-invoked for squash').to.be.false;
+
+      // The squash commit was made here, so the backend must be told about it —
+      // BEFORE the optional delete, since a blocked delete leaves the feature
+      // listed and the user's retry has to find the marker.
+      const recordIndex = invokeHistory.findIndex(h => h.command === 'gitflow_record_squash_finish');
+      expect(recordIndex, 'gitflow_record_squash_finish called').to.be.greaterThan(-1);
+      expect((invokeHistory[recordIndex].args as Record<string, unknown>).name).to.equal('x');
+      const deleteIndex = invokeHistory.findIndex(h => h.command === 'delete_branch');
+      expect(recordIndex, 'squash recorded before the delete attempt').to.be.lessThan(deleteIndex);
+
       expect(completedFired).to.be.true;
       expect(el.open).to.be.false;
+    });
+
+    it('records the completed squash even when the branch delete is blocked', async () => {
+      const el = await openWithFinish(
+        { kind: 'feature', name: 'blocked', branchName: 'feature/blocked', deleteBranch: true },
+        true, // squashMerge
+      );
+
+      mockInvoke = async (command: string) => {
+        if (command === 'delete_branch') {
+          throw { code: 'OPERATION_FAILED', message: 'Branch rule prevents deletion' };
+        }
+        if (command === 'get_conflicts') return [];
+        return null;
+      };
+
+      clearToasts();
+      invokeHistory.length = 0;
+      await (el as unknown as { handleContinue: () => Promise<void> }).handleContinue.bind(el)();
+
+      expect(
+        invokeHistory.some(h => h.command === 'gitflow_record_squash_finish'),
+        'squash recorded despite the blocked delete',
+      ).to.be.true;
+      const warn = uiStore.getState().toasts.find(t => t.type === 'warning');
+      expect(warn, 'blocked delete warned about').to.not.be.undefined;
+      expect(warn!.message).to.contain('Branch rule prevents deletion');
+      expect(el.open, 'a blocked delete still completes the finish').to.be.false;
+    });
+
+    it('warns when the completed squash could not be recorded', async () => {
+      const el = await openWithFinish(
+        { kind: 'feature', name: 'unrecorded', branchName: 'feature/unrecorded', deleteBranch: false },
+        true, // squashMerge
+      );
+
+      mockInvoke = async (command: string) => {
+        if (command === 'gitflow_record_squash_finish') {
+          throw { code: 'OPERATION_FAILED', message: 'marker directory is read-only' };
+        }
+        if (command === 'get_conflicts') return [];
+        return null;
+      };
+
+      clearToasts();
+      await (el as unknown as { handleContinue: () => Promise<void> }).handleContinue.bind(el)();
+
+      const warn = uiStore.getState().toasts.find(t => t.type === 'warning');
+      expect(warn, 'unrecorded squash warned about').to.not.be.undefined;
+      expect(warn!.message).to.contain('marker directory is read-only');
+      expect(warn!.message).to.contain('unrecorded');
+      expect(el.open, 'the squash commit landed, so the dialog still completes').to.be.false;
     });
 
     it('re-invokes gitflow_finish_feature (not delete) for a NON-squash feature finish', async () => {

--- a/src/components/dialogs/lv-conflict-resolution-dialog.ts
+++ b/src/components/dialogs/lv-conflict-resolution-dialog.ts
@@ -1487,10 +1487,26 @@ export class LvConflictResolutionDialog extends LitElement {
    */
   private async completeGitflowFinish(ctx: GitflowFinishContext): Promise<boolean> {
     // Squash feature: commitMerge already made the single-parent squash commit on
-    // develop. The backend finish is NOT idempotent for squash — a squash commit
-    // never makes the feature an ancestor of develop, so re-invoking it would
-    // re-merge the same divergence forever. Just delete the feature branch here.
+    // develop. Re-invoking the backend finish would re-merge the same divergence —
+    // a squash commit never makes the feature an ancestor of develop — so the
+    // remaining branch deletion is done here instead.
     if (ctx.kind === 'feature' && this.squashMerge) {
+      // The backend only records a completion marker for squash commits IT
+      // created, and this one was created here. Record it BEFORE the optional
+      // delete: if the delete is blocked (e.g. a preventDeletion rule) the
+      // feature stays listed as active, and the user's next "Squash and Finish"
+      // must find the marker and do cleanup only — without it the finish
+      // re-conflicts and resolving mints a SECOND squash commit on develop.
+      const recorded = await gitService.gitFlowRecordSquashFinish(this.repositoryPath, ctx.name);
+      if (!recorded.success) {
+        // The squash commit has landed either way, so this is not a failure of
+        // the finish — but an unrecorded squash makes a retry duplicate it, so
+        // the user has to be told rather than finding out on the retry.
+        showToast(
+          `${recorded.error?.message ?? 'Failed to record the completed squash'} — the squash commit landed; do not re-run the squash finish for "${ctx.name}"`,
+          'warning',
+        );
+      }
       if (ctx.deleteBranch) {
         const del = await gitService.deleteBranch(this.repositoryPath, ctx.branchName, true);
         if (!del.success) {

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -5508,6 +5508,21 @@ export async function gitFlowFinishFeature(
   });
 }
 
+/**
+ * Record that a squash finish's commit has landed on develop.
+ *
+ * A squash finish whose merge conflicted is committed by the conflict-resolution
+ * flow, not by `gitflow_finish_feature`, so the backend has no record of it. The
+ * marker written here makes a later retry (after e.g. a blocked branch delete)
+ * do the pending cleanup only instead of re-merging into a second squash commit.
+ */
+export async function gitFlowRecordSquashFinish(
+  repoPath: string,
+  name: string,
+): Promise<CommandResult<void>> {
+  return invokeCommand<void>("gitflow_record_squash_finish", { path: repoPath, name });
+}
+
 export async function gitFlowStartRelease(
   repoPath: string,
   version: string,


### PR DESCRIPTION
## Summary
- persist completed squash identity outside Git refs
- skip commit and hooks when retrying branch cleanup
- reapply when develop was reset/reverted or the feature advanced
- use the correct squash post-merge hook flag

## Tests
- cargo test --manifest-path src-tauri/Cargo.toml test_finish_feature_squash -- --test-threads=1