### PR TITLE
Fix workspace literal search and partial failures

### DIFF
--- a/e2e/tests/workspace-manager.spec.ts
+++ b/e2e/tests/workspace-manager.spec.ts
@@ -41,7 +41,7 @@ test.describe('Workspace Manager - open-repo-file handler', () => {
 
     await injectCommandMock(page, {
       get_workspaces: [],
-      search_workspace: [],
+      search_workspace: { results: [], failures: [] },
     });
   });
 
@@ -130,7 +130,7 @@ test.describe('Workspace Manager - repo status chips', () => {
           lastOpened: null,
         },
       ],
-      search_workspace: [],
+      search_workspace: { results: [], failures: [] },
       validate_workspace_repositories: [
         {
           path: '/repos/alpha',
@@ -170,5 +170,91 @@ test.describe('Workspace Manager - repo status chips', () => {
     // with no ahead/behind, which is what git reports for it.
     await expect(dialog.locator('.repo-branch.detached')).toHaveText('detached HEAD');
     await expect(dialog.locator('.repo-ahead-behind')).toHaveCount(1);
+  });
+});
+
+test.describe('Workspace Manager - partial search failures', () => {
+  test('shows matches from the repos that worked alongside the ones that could not be searched', async ({ page }) => {
+    await setupOpenRepository(page);
+
+    await startCommandCaptureWithMocks(page, {
+      get_workspaces: [
+        {
+          id: 'ws-1',
+          name: 'Alpha Workspace',
+          description: '',
+          color: '#4fc3f7',
+          repositories: [
+            { path: '/repos/alpha', name: 'alpha' },
+            { path: '/repos/beta', name: 'beta' },
+          ],
+          createdAt: '2024-01-01T00:00:00Z',
+          lastOpened: null,
+        },
+      ],
+      validate_workspace_repositories: [],
+      search_workspace: {
+        results: [
+          {
+            repoName: 'alpha',
+            repoPath: '/repos/alpha',
+            filePath: 'src/main.ts',
+            lineNumber: 42,
+            lineContent: 'const needle = true',
+            matchStart: 6,
+            matchEnd: 12,
+          },
+        ],
+        failures: ['Failed to search repository "beta": repository path does not exist'],
+      },
+    });
+
+    await openWorkspaceManager(page);
+
+    const dialog = page.locator('lv-workspace-manager-dialog');
+    await dialog.locator('.search-input').fill('needle');
+    await dialog.locator('.search-btn').click();
+
+    // The matches that were found are still shown...
+    await expect(dialog.locator('.search-result-item')).toHaveCount(1);
+    // ...and the repository that could not be searched is named, not silently dropped.
+    await expect(dialog.locator('.search-failures')).toContainText('beta');
+  });
+
+  test('clears a stale failure banner when the dialog is reopened', async ({ page }) => {
+    await setupOpenRepository(page);
+
+    await startCommandCaptureWithMocks(page, {
+      get_workspaces: [
+        {
+          id: 'ws-1',
+          name: 'Alpha Workspace',
+          description: '',
+          color: '#4fc3f7',
+          repositories: [{ path: '/repos/alpha', name: 'alpha' }],
+          createdAt: '2024-01-01T00:00:00Z',
+          lastOpened: null,
+        },
+      ],
+      validate_workspace_repositories: [],
+      search_workspace: {
+        results: [],
+        failures: ['Failed to search repository "alpha": repository path does not exist'],
+      },
+    });
+
+    await openWorkspaceManager(page);
+
+    const dialog = page.locator('lv-workspace-manager-dialog');
+    await dialog.locator('.search-input').fill('needle');
+    await dialog.locator('.search-btn').click();
+    await expect(dialog.locator('.search-failures')).toContainText('alpha');
+
+    await page.keyboard.press('Escape');
+    await expect(page.locator('lv-workspace-manager-dialog[open]')).not.toBeVisible();
+
+    await openWorkspaceManager(page);
+    await expect(dialog.locator('.search-failures')).toHaveCount(0);
+    await expect(dialog.locator('.search-input')).toHaveValue('');
   });
 });

--- a/e2e/tests/workspace-manager.spec.ts
+++ b/e2e/tests/workspace-manager.spec.ts
@@ -221,6 +221,37 @@ test.describe('Workspace Manager - partial search failures', () => {
     await expect(dialog.locator('.search-failures')).toContainText('beta');
   });
 
+  test('reports an empty search only once it has completed', async ({ page }) => {
+    await setupOpenRepository(page);
+
+    await startCommandCaptureWithMocks(page, {
+      get_workspaces: [
+        {
+          id: 'ws-1',
+          name: 'Alpha Workspace',
+          description: '',
+          color: '#4fc3f7',
+          repositories: [{ path: '/repos/alpha', name: 'alpha' }],
+          createdAt: '2024-01-01T00:00:00Z',
+          lastOpened: null,
+        },
+      ],
+      validate_workspace_repositories: [],
+      search_workspace: { results: [], failures: [] },
+    });
+
+    await openWorkspaceManager(page);
+
+    const dialog = page.locator('lv-workspace-manager-dialog');
+    await dialog.locator('.search-input').fill('needle');
+    // Typing is not a search: the verdict only arrives once the search has run.
+    await expect(dialog.locator('.search-no-results')).toHaveCount(0);
+
+    await dialog.locator('.search-btn').click();
+    await expect(dialog.locator('.search-no-results')).toContainText('No results found');
+    await expect(dialog.locator('.search-failures')).toHaveCount(0);
+  });
+
   test('clears a stale failure banner when the dialog is reopened', async ({ page }) => {
     await setupOpenRepository(page);
 

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -950,7 +950,12 @@ mod tests {
     /// The default `path:line:content` framing is ambiguous when the path
     /// itself contains a colon: the fields shift, the line-number parse fails
     /// and the match is dropped, so a query that does match reports nothing.
+    /// Windows cannot host the fixture — git rejects a colon as an invalid path
+    /// character, and the situation cannot arise there — so the end-to-end leg
+    /// runs on Unix only; `test_workspace_grep_parser_accepts_colons_in_file_names`
+    /// pins the parsing itself on every platform.
     #[tokio::test]
+    #[cfg_attr(windows, ignore = "a colon is not a legal path character on Windows")]
     async fn test_search_in_files_finds_matches_in_paths_containing_a_colon() {
         let repo = TestRepo::with_initial_commit();
         repo.create_commit(

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -2,6 +2,7 @@
 //! Search in files, diffs, commits, and commit messages
 
 use std::collections::HashMap;
+use std::io::BufRead;
 use std::process::Command;
 use tauri::command;
 
@@ -58,6 +59,54 @@ pub(crate) fn find_match_position(line: &str, query: &str, case_sensitive: bool)
     }
 }
 
+/// Read NUL-framed `git grep -z -n` records (path\0line\0content\n) from a
+/// reader, stopping once `limit` records have been collected.
+pub(crate) fn read_grep_records<R: BufRead>(
+    reader: &mut R,
+    limit: usize,
+) -> std::io::Result<Vec<(String, u32, String)>> {
+    let mut records = Vec::with_capacity(limit.min(128));
+    let mut path = Vec::new();
+    let mut line = Vec::new();
+    let mut content = Vec::new();
+
+    while records.len() < limit {
+        path.clear();
+        if reader.read_until(0, &mut path)? == 0 {
+            break;
+        }
+        if path.pop() != Some(0) {
+            break;
+        }
+
+        line.clear();
+        if reader.read_until(0, &mut line)? == 0 || line.pop() != Some(0) {
+            break;
+        }
+
+        content.clear();
+        if reader.read_until(b'\n', &mut content)? == 0 {
+            break;
+        }
+        if content.last() == Some(&b'\n') {
+            content.pop();
+        }
+        if content.last() == Some(&b'\r') {
+            content.pop();
+        }
+
+        if let Ok(line_number) = String::from_utf8_lossy(&line).parse::<u32>() {
+            records.push((
+                String::from_utf8_lossy(&path).into_owned(),
+                line_number,
+                String::from_utf8_lossy(&content).into_owned(),
+            ));
+        }
+    }
+
+    Ok(records)
+}
+
 /// Search for a pattern in repository files using git grep
 #[command]
 pub async fn search_in_files(
@@ -78,14 +127,24 @@ pub async fn search_in_files(
     // the line number in SGR escapes even into a pipe, so the line-number
     // parse fails and every match is silently dropped, and `grep.column`
     // inserts an extra column field that would end up prefixed to the reported
-    // line content. Kept in step with the workspace grep, which parses the
+    // line content. `-z` because the default `path:line:content` framing is
+    // ambiguous and lossy: a path containing a colon shifts every field (and
+    // the match is then dropped by the line-number parse), a path containing a
+    // newline splits one record into two, and `core.quotePath` — on by default
+    // — emits any path with a non-ASCII byte double-quoted and octal-escaped,
+    // which would be shown to the user and opened as a file that does not
+    // exist. `-I` because `git grep -z` still prints an unframed
+    // `Binary file <path> matches` line, which would desynchronise the
+    // NUL-framed reader. Kept in step with the workspace grep, which parses the
     // same records.
     cmd.arg("-C")
         .arg(&path)
         .arg("grep")
         .arg("--no-color")
         .arg("--no-column")
-        .arg("-n");
+        .arg("-n")
+        .arg("-z")
+        .arg("-I");
 
     if !case_sensitive {
         cmd.arg("-i");
@@ -120,30 +179,17 @@ pub async fn search_in_files(
         )));
     }
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
+    let records = read_grep_records(
+        &mut std::io::Cursor::new(&output.stdout),
+        max_results as usize,
+    )
+    .map_err(|e| {
+        LeviathanError::OperationFailed(format!("Failed to read git grep output: {}", e))
+    })?;
+
     let mut file_map: HashMap<String, Vec<SearchResult>> = HashMap::new();
-    let mut total_results: u32 = 0;
 
-    for line in stdout.lines() {
-        if total_results >= max_results {
-            break;
-        }
-
-        // Format: file:linenum:content
-        // We need to handle filenames that might contain colons on some systems,
-        // but the standard git grep format is file:num:content
-        let parts: Vec<&str> = line.splitn(3, ':').collect();
-        if parts.len() < 3 {
-            continue;
-        }
-
-        let file_path = parts[0].to_string();
-        let line_number: u32 = match parts[1].parse() {
-            Ok(n) => n,
-            Err(_) => continue,
-        };
-        let line_content = parts[2].to_string();
-
+    for (file_path, line_number, line_content) in records {
         let (match_start, match_end) = find_match_position(&line_content, &query, case_sensitive);
 
         let result = SearchResult {
@@ -155,7 +201,6 @@ pub async fn search_in_files(
         };
 
         file_map.entry(file_path).or_default().push(result);
-        total_results += 1;
     }
 
     let results: Vec<SearchFileResult> = file_map
@@ -900,6 +945,108 @@ mod tests {
         .await
         .unwrap();
         assert!(missing.is_empty());
+    }
+
+    /// The default `path:line:content` framing is ambiguous when the path
+    /// itself contains a colon: the fields shift, the line-number parse fails
+    /// and the match is dropped, so a query that does match reports nothing.
+    #[tokio::test]
+    async fn test_search_in_files_finds_matches_in_paths_containing_a_colon() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit(
+            "Add search content",
+            &[("folder/na:me.txt", "literal a.b\n")],
+        );
+
+        let files = search_in_files(
+            repo.path_str(),
+            "a.b".to_string(),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let file = files
+            .iter()
+            .find(|f| f.file_path == "folder/na:me.txt")
+            .expect("a colon in the path must not hide the match");
+        assert_eq!(file.match_count, 1);
+        assert_eq!(file.matches[0].line_number, 1);
+        assert_eq!(file.matches[0].line_content, "literal a.b");
+    }
+
+    /// `core.quotePath` is on by default, so without `-z` git emits any path
+    /// holding a non-ASCII byte double-quoted and octal-escaped. That string is
+    /// what the search dialog shows and what it asks the app to open, so the
+    /// path must come back exactly as it is on disk.
+    #[tokio::test]
+    async fn test_search_in_files_reports_a_non_ascii_path_verbatim() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add search content", &[("café.txt", "literal a.b\n")]);
+        repo.repo()
+            .config()
+            .unwrap()
+            .set_bool("core.quotePath", true)
+            .unwrap();
+
+        let files = search_in_files(
+            repo.path_str(),
+            "a.b".to_string(),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let paths: Vec<&str> = files.iter().map(|f| f.file_path.as_str()).collect();
+        assert_eq!(
+            paths,
+            vec!["café.txt"],
+            "path must not be escaped or quoted"
+        );
+        assert_eq!(files[0].matches[0].line_content, "literal a.b");
+    }
+
+    /// A binary file that matches makes git print an unframed
+    /// `Binary file <path> matches` line even under `-z`; `-I` keeps it out so
+    /// the following records stay readable and the text matches survive.
+    #[tokio::test]
+    async fn test_search_in_files_keeps_text_matches_alongside_a_binary_match() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit(
+            "Add search content",
+            &[
+                ("a-binary.dat", "literal a.b\u{0}binary\u{0}payload\n"),
+                ("z-text.txt", "literal a.b\n"),
+            ],
+        );
+
+        let files = search_in_files(
+            repo.path_str(),
+            "a.b".to_string(),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let file = files
+            .iter()
+            .find(|f| f.file_path == "z-text.txt")
+            .expect("a binary match must not swallow the text match that follows it");
+        assert_eq!(file.matches[0].line_number, 1);
+        assert_eq!(file.matches[0].line_content, "literal a.b");
+        assert!(
+            files.iter().all(|f| f.file_path != "a-binary.dat"),
+            "binary files are not reported as text matches"
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -73,7 +73,19 @@ pub async fn search_in_files(
     let max_results = max_results.unwrap_or(1000);
 
     let mut cmd = Command::new("git");
-    cmd.arg("-C").arg(&path).arg("grep").arg("-n");
+    // `--no-color` and `--no-column` because the output is parsed field by
+    // field: `color.grep` (or `color.ui`) set to `always` wraps the path and
+    // the line number in SGR escapes even into a pipe, so the line-number
+    // parse fails and every match is silently dropped, and `grep.column`
+    // inserts an extra column field that would end up prefixed to the reported
+    // line content. Kept in step with the workspace grep, which parses the
+    // same records.
+    cmd.arg("-C")
+        .arg(&path)
+        .arg("grep")
+        .arg("--no-color")
+        .arg("--no-column")
+        .arg("-n");
 
     if !case_sensitive {
         cmd.arg("-i");
@@ -781,6 +793,113 @@ mod tests {
         let files = result.unwrap();
         let total: u32 = files.iter().map(|f| f.match_count).sum();
         assert_eq!(total, 1);
+    }
+
+    /// `color.grep = always` makes git colour its output even into a pipe.
+    /// The `file:line:content` records are split field by field, so without
+    /// `--no-color` the SGR escapes around the line number fail to parse and
+    /// every match is dropped — a query that does match reads as no results.
+    #[tokio::test]
+    async fn test_search_in_files_ignores_forced_colour_output() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add search content", &[("search.txt", "literal a.b\n")]);
+        repo.repo()
+            .config()
+            .unwrap()
+            .set_str("color.grep", "always")
+            .unwrap();
+
+        let files = search_in_files(
+            repo.path_str(),
+            "a.b".to_string(),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let file = files
+            .iter()
+            .find(|f| f.file_path == "search.txt")
+            .expect("forced colour must not hide the match");
+        assert_eq!(file.match_count, 1);
+        assert_eq!(file.matches[0].line_number, 1);
+        assert_eq!(file.matches[0].line_content, "literal a.b");
+    }
+
+    /// `grep.column = true` adds a column field before the content, so without
+    /// `--no-column` the reported line content is prefixed with the column
+    /// number instead of being the matched line.
+    #[tokio::test]
+    async fn test_search_in_files_ignores_forced_column_output() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add search content", &[("search.txt", "literal a.b\n")]);
+        repo.repo()
+            .config()
+            .unwrap()
+            .set_bool("grep.column", true)
+            .unwrap();
+
+        let files = search_in_files(
+            repo.path_str(),
+            "a.b".to_string(),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let file = files
+            .iter()
+            .find(|f| f.file_path == "search.txt")
+            .expect("forced column must not hide the match");
+        assert_eq!(file.match_count, 1);
+        assert_eq!(file.matches[0].line_number, 1);
+        assert_eq!(file.matches[0].line_content, "literal a.b");
+    }
+
+    /// Colour and column forced together: neither neutralising flag may undo
+    /// the other, and a query that does not match must still report nothing.
+    #[tokio::test]
+    async fn test_search_in_files_ignores_forced_colour_and_column_together() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add search content", &[("search.txt", "literal a.b\n")]);
+        let git_repo = repo.repo();
+        let mut config = git_repo.config().unwrap();
+        config.set_str("color.grep", "always").unwrap();
+        config.set_bool("grep.column", true).unwrap();
+
+        let files = search_in_files(
+            repo.path_str(),
+            "a.b".to_string(),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        let file = files
+            .iter()
+            .find(|f| f.file_path == "search.txt")
+            .expect("forced colour and column must not hide the match");
+        assert_eq!(file.matches[0].line_content, "literal a.b");
+
+        let missing = search_in_files(
+            repo.path_str(),
+            "zzz-absent".to_string(),
+            Some(true),
+            Some(false),
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+        assert!(missing.is_empty());
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -98,11 +98,15 @@ fn run_workspace_grep(
     // `--no-color` because the records are parsed byte-for-byte: a user with
     // `color.grep` (or `color.ui`) set to `always` gets SGR escapes around the
     // path and the line number even into a pipe, and every match would then be
-    // dropped by the line-number parse rather than shown.
+    // dropped by the line-number parse rather than shown. `--no-column` for the
+    // same reason: `grep.column` adds a third NUL-delimited field, which would
+    // be read as the line content and shown with the column number and a raw
+    // NUL byte in front of the code.
     cmd.arg("-C")
         .arg(&repo_entry.path)
         .arg("grep")
         .arg("--no-color")
+        .arg("--no-column")
         .arg("-n")
         .arg("-z")
         .arg("-I");
@@ -846,6 +850,56 @@ mod tests {
             matches,
             vec![("search.txt".to_string(), 1, "literal a.b".to_string())]
         );
+    }
+
+    /// `grep.column = true` adds a column field to every record, so without
+    /// `--no-column` the NUL-framed records are read one field out of step and
+    /// the column number plus a raw NUL byte are shown in front of the code.
+    #[test]
+    fn test_workspace_grep_ignores_forced_column_output() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add search content", &[("search.txt", "literal a.b\n")]);
+        repo.repo()
+            .config()
+            .unwrap()
+            .set_bool("grep.column", true)
+            .unwrap();
+        let entry = WorkspaceRepository {
+            path: repo.path_str(),
+            name: "search-repo".to_string(),
+        };
+
+        let matches = run_workspace_grep(&entry, "a.b", true, false, None, 10).unwrap();
+
+        assert_eq!(
+            matches,
+            vec![("search.txt".to_string(), 1, "literal a.b".to_string())]
+        );
+    }
+
+    /// Colour and column forced together: neither neutralising flag may undo
+    /// the other, and a query that does not match must still report nothing.
+    #[test]
+    fn test_workspace_grep_ignores_forced_colour_and_column_together() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add search content", &[("search.txt", "literal a.b\n")]);
+        let git_repo = repo.repo();
+        let mut config = git_repo.config().unwrap();
+        config.set_str("color.grep", "always").unwrap();
+        config.set_bool("grep.column", true).unwrap();
+        let entry = WorkspaceRepository {
+            path: repo.path_str(),
+            name: "search-repo".to_string(),
+        };
+
+        let matches = run_workspace_grep(&entry, "a.b", true, false, None, 10).unwrap();
+        assert_eq!(
+            matches,
+            vec![("search.txt".to_string(), 1, "literal a.b".to_string())]
+        );
+
+        let missing = run_workspace_grep(&entry, "zzz-absent", true, false, None, 10).unwrap();
+        assert!(missing.is_empty());
     }
 
     /// The grep error carries only the underlying detail: the repository name

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -95,9 +95,14 @@ fn run_workspace_grep(
     limit: usize,
 ) -> std::result::Result<Vec<(String, u32, String)>, String> {
     let mut cmd = Command::new("git");
+    // `--no-color` because the records are parsed byte-for-byte: a user with
+    // `color.grep` (or `color.ui`) set to `always` gets SGR escapes around the
+    // path and the line number even into a pipe, and every match would then be
+    // dropped by the line-number parse rather than shown.
     cmd.arg("-C")
         .arg(&repo_entry.path)
         .arg("grep")
+        .arg("--no-color")
         .arg("-n")
         .arg("-z")
         .arg("-I");
@@ -804,6 +809,32 @@ mod tests {
             "Add search content",
             &[("search.txt", "literal a.b\nregex axb\n")],
         );
+        let entry = WorkspaceRepository {
+            path: repo.path_str(),
+            name: "search-repo".to_string(),
+        };
+
+        let matches = run_workspace_grep(&entry, "a.b", true, false, None, 10).unwrap();
+
+        assert_eq!(
+            matches,
+            vec![("search.txt".to_string(), 1, "literal a.b".to_string())]
+        );
+    }
+
+    /// `color.grep = always` makes git colour its output even into a pipe. The
+    /// records are parsed byte-for-byte, so without `--no-color` the escape
+    /// codes wrapping the line number fail to parse and every match is silently
+    /// dropped — a query that does match reads as "No results found".
+    #[test]
+    fn test_workspace_grep_ignores_forced_colour_output() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add search content", &[("search.txt", "literal a.b\n")]);
+        repo.repo()
+            .config()
+            .unwrap()
+            .set_str("color.grep", "always")
+            .unwrap();
         let entry = WorkspaceRepository {
             path: repo.path_str(),
             name: "search-repo".to_string(),

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -35,6 +35,57 @@ pub struct WorkspaceSearchResponse {
     pub failures: Vec<String>,
 }
 
+/// Read NUL-framed `git grep -z -n` records (path\0line\0content\n) from a
+/// reader, stopping once `limit` records have been collected.
+fn read_grep_records<R: BufRead>(
+    reader: &mut R,
+    limit: usize,
+) -> std::io::Result<Vec<(String, u32, String)>> {
+    let mut records = Vec::with_capacity(limit.min(128));
+    let mut path = Vec::new();
+    let mut line = Vec::new();
+    let mut content = Vec::new();
+
+    while records.len() < limit {
+        path.clear();
+        if reader.read_until(0, &mut path)? == 0 {
+            break;
+        }
+        if path.pop() != Some(0) {
+            break;
+        }
+
+        line.clear();
+        if reader.read_until(0, &mut line)? == 0 || line.pop() != Some(0) {
+            break;
+        }
+
+        content.clear();
+        if reader.read_until(b'\n', &mut content)? == 0 {
+            break;
+        }
+        if content.last() == Some(&b'\n') {
+            content.pop();
+        }
+        if content.last() == Some(&b'\r') {
+            content.pop();
+        }
+
+        if let Ok(line_number) = String::from_utf8_lossy(&line).parse::<u32>() {
+            records.push((
+                String::from_utf8_lossy(&path).into_owned(),
+                line_number,
+                String::from_utf8_lossy(&content).into_owned(),
+            ));
+        }
+    }
+
+    Ok(records)
+}
+
+/// Run `git grep` in one repository. Errors carry only the underlying detail;
+/// the repository name is attached once, by the caller, so every entry in the
+/// user-visible failure list has the same shape.
 fn run_workspace_grep(
     repo_entry: &WorkspaceRepository,
     query: &str,
@@ -42,7 +93,7 @@ fn run_workspace_grep(
     use_regex: bool,
     file_pattern: Option<&str>,
     limit: usize,
-) -> Result<Vec<(String, u32, String)>> {
+) -> std::result::Result<Vec<(String, u32, String)>, String> {
     let mut cmd = Command::new("git");
     cmd.arg("-C")
         .arg(&repo_entry.path)
@@ -66,16 +117,12 @@ fn run_workspace_grep(
     }
 
     cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
-    let mut child = cmd.spawn().map_err(|error| {
-        LeviathanError::OperationFailed(format!(
-            "Failed to search repository \"{}\": {}",
-            repo_entry.name, error
-        ))
-    })?;
+    let mut child = cmd.spawn().map_err(|error| error.to_string())?;
 
-    let stderr = child.stderr.take().ok_or_else(|| {
-        LeviathanError::OperationFailed("Failed to capture git grep errors".to_string())
-    })?;
+    let stderr = child
+        .stderr
+        .take()
+        .ok_or_else(|| "Failed to capture git grep errors".to_string())?;
     let stderr_reader = std::thread::spawn(move || {
         let mut stderr = stderr;
         let mut bytes = Vec::new();
@@ -83,54 +130,18 @@ fn run_workspace_grep(
         bytes
     });
 
-    let stdout = child.stdout.take().ok_or_else(|| {
-        LeviathanError::OperationFailed("Failed to capture git grep output".to_string())
-    })?;
+    let stdout = child
+        .stdout
+        .take()
+        .ok_or_else(|| "Failed to capture git grep output".to_string())?;
     let mut stdout = BufReader::new(stdout);
-    let mut records = Vec::with_capacity(limit.min(128));
-    let mut path = Vec::new();
-    let mut line = Vec::new();
-    let mut content = Vec::new();
-
-    while records.len() < limit {
-        path.clear();
-        if stdout.read_until(0, &mut path)? == 0 {
-            break;
-        }
-        if path.pop() != Some(0) {
-            break;
-        }
-
-        line.clear();
-        if stdout.read_until(0, &mut line)? == 0 || line.pop() != Some(0) {
-            break;
-        }
-
-        content.clear();
-        if stdout.read_until(b'\n', &mut content)? == 0 {
-            break;
-        }
-        if content.last() == Some(&b'\n') {
-            content.pop();
-        }
-        if content.last() == Some(&b'\r') {
-            content.pop();
-        }
-
-        if let Ok(line_number) = String::from_utf8_lossy(&line).parse::<u32>() {
-            records.push((
-                String::from_utf8_lossy(&path).into_owned(),
-                line_number,
-                String::from_utf8_lossy(&content).into_owned(),
-            ));
-        }
-    }
+    let records = read_grep_records(&mut stdout, limit).map_err(|error| error.to_string())?;
 
     let reached_limit = records.len() == limit;
     if reached_limit {
         let _ = child.kill();
     }
-    let status = child.wait()?;
+    let status = child.wait().map_err(|error| error.to_string())?;
     let stderr = stderr_reader.join().unwrap_or_default();
 
     // git grep returns exit code 1 when no matches are found.
@@ -141,53 +152,108 @@ fn run_workspace_grep(
         } else {
             stderr
         };
-        return Err(LeviathanError::OperationFailed(format!(
-            "Failed to search repository \"{}\": {}",
-            repo_entry.name, details
-        )));
+        return Err(details);
     }
 
     Ok(records)
 }
 
-#[cfg(test)]
-fn parse_workspace_grep_output(output: &[u8], limit: usize) -> Vec<(String, u32, String)> {
-    let mut records = Vec::with_capacity(limit.min(128));
-    let mut cursor = 0;
-
-    while cursor < output.len() && records.len() < limit {
-        let Some(path_end) = output[cursor..].iter().position(|byte| *byte == 0) else {
-            break;
-        };
-        let path_end = cursor + path_end;
-        let line_start = path_end + 1;
-        let Some(line_end) = output[line_start..].iter().position(|byte| *byte == 0) else {
-            break;
-        };
-        let line_end = line_start + line_end;
-        let content_start = line_end + 1;
-        let content_end = output[content_start..]
-            .iter()
-            .position(|byte| *byte == b'\n')
-            .map(|offset| content_start + offset)
-            .unwrap_or(output.len());
-
-        if let Ok(line_number) =
-            String::from_utf8_lossy(&output[line_start..line_end]).parse::<u32>()
-        {
-            let content = &output[content_start..content_end];
-            let content = content.strip_suffix(b"\r").unwrap_or(content);
-            records.push((
-                String::from_utf8_lossy(&output[cursor..path_end]).into_owned(),
-                line_number,
-                String::from_utf8_lossy(content).into_owned(),
-            ));
-        }
-
-        cursor = content_end.saturating_add(1);
+/// Search one repository, returning a ready-to-display failure message on
+/// error so every entry in `failures` reads the same way.
+fn search_repository(
+    repo_entry: &WorkspaceRepository,
+    query: &str,
+    case_sensitive: bool,
+    use_regex: bool,
+    file_pattern: Option<&str>,
+    limit: usize,
+) -> std::result::Result<Vec<(String, u32, String)>, String> {
+    if !Path::new(&repo_entry.path).exists() {
+        return Err(format!(
+            "Failed to search repository \"{}\": repository path does not exist",
+            repo_entry.name
+        ));
     }
 
-    records
+    run_workspace_grep(
+        repo_entry,
+        query,
+        case_sensitive,
+        use_regex,
+        file_pattern,
+        limit,
+    )
+    .map_err(|detail| {
+        format!(
+            "Failed to search repository \"{}\": {}",
+            repo_entry.name, detail
+        )
+    })
+}
+
+/// Search every repository in turn, collecting matches and per-repository
+/// failures. Repositories left unsearched because the global match limit was
+/// reached are reported too, so a truncated list never reads as a complete one.
+fn search_repositories(
+    repositories: &[WorkspaceRepository],
+    query: &str,
+    case_sensitive: bool,
+    use_regex: bool,
+    file_pattern: Option<&str>,
+    max_results: u32,
+) -> WorkspaceSearchResponse {
+    let mut results: Vec<WorkspaceSearchResult> = Vec::new();
+    let mut failures = Vec::new();
+
+    for (index, repo_entry) in repositories.iter().enumerate() {
+        if results.len() as u32 >= max_results {
+            let skipped = repositories.len() - index;
+            failures.push(format!(
+                "Stopped at the {}-match limit; {} {} not searched",
+                max_results,
+                skipped,
+                if skipped == 1 {
+                    "repository was"
+                } else {
+                    "repositories were"
+                }
+            ));
+            break;
+        }
+
+        let remaining = max_results.saturating_sub(results.len() as u32) as usize;
+        let matches = match search_repository(
+            repo_entry,
+            query,
+            case_sensitive,
+            use_regex,
+            file_pattern,
+            remaining,
+        ) {
+            Ok(matches) => matches,
+            Err(failure) => {
+                failures.push(failure);
+                continue;
+            }
+        };
+
+        for (file_path, line_number, line_content) in matches {
+            let (match_start, match_end) =
+                find_match_position(&line_content, query, case_sensitive);
+
+            results.push(WorkspaceSearchResult {
+                repo_name: repo_entry.name.clone(),
+                repo_path: repo_entry.path.clone(),
+                file_path,
+                line_number,
+                line_content,
+                match_start,
+                match_end,
+            });
+        }
+    }
+
+    WorkspaceSearchResponse { results, failures }
 }
 
 /// Get the path to the workspaces config file
@@ -447,59 +513,14 @@ pub async fn search_workspace(
         .find(|w| w.id == workspace_id)
         .ok_or_else(|| LeviathanError::OperationFailed("Workspace not found".to_string()))?;
 
-    let case_sensitive = case_sensitive.unwrap_or(false);
-    let use_regex = regex.unwrap_or(false);
-    let max_results = max_results.unwrap_or(500);
-    let mut results: Vec<WorkspaceSearchResult> = Vec::new();
-    let mut failures = Vec::new();
-
-    for repo_entry in &workspace.repositories {
-        if results.len() as u32 >= max_results {
-            break;
-        }
-
-        let repo_path = Path::new(&repo_entry.path);
-        if !repo_path.exists() {
-            failures.push(format!(
-                "\"{}\": repository path does not exist",
-                repo_entry.name
-            ));
-            continue;
-        }
-
-        let remaining = max_results.saturating_sub(results.len() as u32) as usize;
-        let matches = match run_workspace_grep(
-            repo_entry,
-            &query,
-            case_sensitive,
-            use_regex,
-            file_pattern.as_deref(),
-            remaining,
-        ) {
-            Ok(matches) => matches,
-            Err(error) => {
-                failures.push(error.to_string());
-                continue;
-            }
-        };
-
-        for (file_path, line_number, line_content) in matches {
-            let (match_start, match_end) =
-                find_match_position(&line_content, &query, case_sensitive);
-
-            results.push(WorkspaceSearchResult {
-                repo_name: repo_entry.name.clone(),
-                repo_path: repo_entry.path.clone(),
-                file_path,
-                line_number,
-                line_content,
-                match_start,
-                match_end,
-            });
-        }
-    }
-
-    Ok(WorkspaceSearchResponse { results, failures })
+    Ok(search_repositories(
+        &workspace.repositories,
+        &query,
+        case_sensitive.unwrap_or(false),
+        regex.unwrap_or(false),
+        file_pattern.as_deref(),
+        max_results.unwrap_or(500),
+    ))
 }
 
 /// Export a workspace configuration as a JSON string
@@ -775,8 +796,11 @@ mod tests {
         );
     }
 
+    /// The grep error carries only the underlying detail: the repository name
+    /// and the "Failed to search repository" wording are added once, by
+    /// `search_repository`, so the user never reads either of them twice.
     #[test]
-    fn test_workspace_grep_surfaces_repository_failures() {
+    fn test_workspace_grep_returns_only_the_underlying_failure_detail() {
         let dir = tempfile::TempDir::new().unwrap();
         let entry = WorkspaceRepository {
             path: dir.path().to_string_lossy().to_string(),
@@ -785,13 +809,57 @@ mod tests {
 
         let error = run_workspace_grep(&entry, "query", false, false, None, 10).unwrap_err();
 
-        assert!(error.to_string().contains("broken-repo"));
+        assert!(
+            error.contains("not a git repository"),
+            "expected the git detail, got {error}"
+        );
+        assert!(!error.contains("Operation failed"), "got {error}");
+        assert!(
+            !error.contains("Failed to search repository"),
+            "got {error}"
+        );
+    }
+
+    /// Both kinds of failure entry read the same way, so a workspace with one
+    /// missing path and one broken repository does not show two shapes.
+    #[test]
+    fn test_search_repository_reports_a_missing_path_with_the_shared_wording() {
+        let entry = WorkspaceRepository {
+            path: "/definitely/not/here".to_string(),
+            name: "gone".to_string(),
+        };
+
+        assert_eq!(
+            search_repository(&entry, "query", false, false, None, 10).unwrap_err(),
+            "Failed to search repository \"gone\": repository path does not exist"
+        );
+    }
+
+    #[test]
+    fn test_search_repository_names_the_repository_on_a_grep_failure() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let entry = WorkspaceRepository {
+            path: dir.path().to_string_lossy().to_string(),
+            name: "broken-repo".to_string(),
+        };
+
+        let failure = search_repository(&entry, "query", false, false, None, 10).unwrap_err();
+
+        assert!(
+            failure.starts_with("Failed to search repository \"broken-repo\": "),
+            "got {failure}"
+        );
+        assert!(!failure.contains("Operation failed"), "got {failure}");
+    }
+
+    fn read_records(bytes: &[u8], limit: usize) -> Vec<(String, u32, String)> {
+        read_grep_records(&mut std::io::Cursor::new(bytes), limit).unwrap()
     }
 
     #[test]
     fn test_workspace_grep_parser_accepts_colons_in_file_names() {
         assert_eq!(
-            parse_workspace_grep_output(b"folder:name.txt\x0042\0matching text\n", 10),
+            read_records(b"folder:name.txt\x0042\0matching text\n", 10),
             vec![(
                 "folder:name.txt".to_string(),
                 42,
@@ -803,7 +871,7 @@ mod tests {
     #[test]
     fn test_workspace_grep_parser_accepts_newlines_in_file_names() {
         assert_eq!(
-            parse_workspace_grep_output(b"folder\nname.txt\x007\0matching text\n", 10),
+            read_records(b"folder\nname.txt\x007\0matching text\n", 10),
             vec![(
                 "folder\nname.txt".to_string(),
                 7,
@@ -815,9 +883,78 @@ mod tests {
     #[test]
     fn test_workspace_grep_parser_respects_result_limit() {
         assert_eq!(
-            parse_workspace_grep_output(b"a.txt\x001\0first\nb.txt\x002\0second\n", 1),
+            read_records(b"a.txt\x001\0first\nb.txt\x002\0second\n", 1),
             vec![("a.txt".to_string(), 1, "first".to_string())]
         );
+    }
+
+    #[test]
+    fn test_workspace_grep_parser_strips_a_trailing_carriage_return() {
+        assert_eq!(
+            read_records(b"a.txt\x001\0first\r\n", 10),
+            vec![("a.txt".to_string(), 1, "first".to_string())]
+        );
+    }
+
+    /// A workspace search that stops at the global match limit must say which
+    /// repositories it never looked at — otherwise the truncated list reads as
+    /// "the term is not in those repositories".
+    #[test]
+    fn test_search_repositories_reports_repositories_skipped_by_the_limit() {
+        let first = TestRepo::with_initial_commit();
+        first.create_commit("Add matches", &[("a.txt", "match\nmatch\n")]);
+        let second = TestRepo::with_initial_commit();
+        second.create_commit("Add matches", &[("b.txt", "match\n")]);
+
+        let repositories = vec![
+            WorkspaceRepository {
+                path: first.path_str(),
+                name: "alpha".to_string(),
+            },
+            WorkspaceRepository {
+                path: second.path_str(),
+                name: "beta".to_string(),
+            },
+        ];
+
+        let response = search_repositories(&repositories, "match", true, false, None, 2);
+
+        assert_eq!(response.results.len(), 2);
+        assert!(
+            response
+                .results
+                .iter()
+                .all(|result| result.repo_name == "alpha"),
+            "the limit should be consumed by the first repository"
+        );
+        assert_eq!(
+            response.failures,
+            vec!["Stopped at the 2-match limit; 1 repository was not searched".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_search_repositories_searches_every_repository_below_the_limit() {
+        let first = TestRepo::with_initial_commit();
+        first.create_commit("Add matches", &[("a.txt", "match\n")]);
+        let second = TestRepo::with_initial_commit();
+        second.create_commit("Add matches", &[("b.txt", "match\n")]);
+
+        let repositories = vec![
+            WorkspaceRepository {
+                path: first.path_str(),
+                name: "alpha".to_string(),
+            },
+            WorkspaceRepository {
+                path: second.path_str(),
+                name: "beta".to_string(),
+            },
+        ];
+
+        let response = search_repositories(&repositories, "match", true, false, None, 50);
+
+        assert_eq!(response.results.len(), 2);
+        assert!(response.failures.is_empty(), "{:?}", response.failures);
     }
 
     #[test]

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -192,8 +192,9 @@ fn search_repository(
 }
 
 /// Search every repository in turn, collecting matches and per-repository
-/// failures. Repositories left unsearched because the global match limit was
-/// reached are reported too, so a truncated list never reads as a complete one.
+/// failures. Both ways of hitting the global match limit are reported —
+/// repositories left unsearched, and matches dropped inside the repository that
+/// consumed the limit — so a truncated list never reads as a complete one.
 fn search_repositories(
     repositories: &[WorkspaceRepository],
     query: &str,
@@ -204,6 +205,8 @@ fn search_repositories(
 ) -> WorkspaceSearchResponse {
     let mut results: Vec<WorkspaceSearchResult> = Vec::new();
     let mut failures = Vec::new();
+    let mut skipped_repositories = false;
+    let mut truncated_matches = false;
 
     for (index, repo_entry) in repositories.iter().enumerate() {
         if results.len() as u32 >= max_results {
@@ -218,17 +221,21 @@ fn search_repositories(
                     "repositories were"
                 }
             ));
+            skipped_repositories = true;
             break;
         }
 
         let remaining = max_results.saturating_sub(results.len() as u32) as usize;
-        let matches = match search_repository(
+        // Ask for one more match than can be kept: a repository holding more
+        // than the limit is otherwise indistinguishable from one holding
+        // exactly the limit, and its dropped matches would go unreported.
+        let mut matches = match search_repository(
             repo_entry,
             query,
             case_sensitive,
             use_regex,
             file_pattern,
-            remaining,
+            remaining + 1,
         ) {
             Ok(matches) => matches,
             Err(failure) => {
@@ -236,6 +243,11 @@ fn search_repositories(
                 continue;
             }
         };
+
+        if matches.len() > remaining {
+            matches.truncate(remaining);
+            truncated_matches = true;
+        }
 
         for (file_path, line_number, line_content) in matches {
             let (match_start, match_end) =
@@ -251,6 +263,15 @@ fn search_repositories(
                 match_end,
             });
         }
+    }
+
+    // The repository that consumed the limit had more to give. Only say so when
+    // no repository was skipped, otherwise the skipped line already reports it.
+    if truncated_matches && !skipped_repositories {
+        failures.push(format!(
+            "Stopped at the {}-match limit; more matches were not shown",
+            max_results
+        ));
     }
 
     WorkspaceSearchResponse { results, failures }
@@ -931,6 +952,75 @@ mod tests {
             response.failures,
             vec!["Stopped at the 2-match limit; 1 repository was not searched".to_string()]
         );
+    }
+
+    /// The limit is just as often consumed inside the only repository, where no
+    /// repository is left to report as skipped. That truncation must still be
+    /// announced, or 200 of 500 matches read as all of them.
+    #[test]
+    fn test_search_repositories_reports_matches_dropped_by_the_limit() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add matches", &[("a.txt", "match\nmatch\nmatch\n")]);
+
+        let repositories = vec![WorkspaceRepository {
+            path: repo.path_str(),
+            name: "alpha".to_string(),
+        }];
+
+        let response = search_repositories(&repositories, "match", true, false, None, 2);
+
+        assert_eq!(response.results.len(), 2);
+        assert_eq!(
+            response.failures,
+            vec!["Stopped at the 2-match limit; more matches were not shown".to_string()]
+        );
+    }
+
+    /// The last repository in the list is the same case: the loop ends instead
+    /// of taking the skipped-repository branch.
+    #[test]
+    fn test_search_repositories_reports_matches_dropped_by_the_last_repository() {
+        let first = TestRepo::with_initial_commit();
+        first.create_commit("Add matches", &[("a.txt", "match\n")]);
+        let second = TestRepo::with_initial_commit();
+        second.create_commit("Add matches", &[("b.txt", "match\nmatch\nmatch\n")]);
+
+        let repositories = vec![
+            WorkspaceRepository {
+                path: first.path_str(),
+                name: "alpha".to_string(),
+            },
+            WorkspaceRepository {
+                path: second.path_str(),
+                name: "beta".to_string(),
+            },
+        ];
+
+        let response = search_repositories(&repositories, "match", true, false, None, 2);
+
+        assert_eq!(response.results.len(), 2);
+        assert_eq!(
+            response.failures,
+            vec!["Stopped at the 2-match limit; more matches were not shown".to_string()]
+        );
+    }
+
+    /// Filling the limit exactly is not truncation: a complete list must not be
+    /// labelled as cut short.
+    #[test]
+    fn test_search_repositories_stays_silent_when_matches_exactly_fill_the_limit() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit("Add matches", &[("a.txt", "match\nmatch\n")]);
+
+        let repositories = vec![WorkspaceRepository {
+            path: repo.path_str(),
+            name: "alpha".to_string(),
+        }];
+
+        let response = search_repositories(&repositories, "match", true, false, None, 2);
+
+        assert_eq!(response.results.len(), 2);
+        assert!(response.failures.is_empty(), "{:?}", response.failures);
     }
 
     #[test]

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -1047,6 +1047,37 @@ mod tests {
         assert!(response.failures.is_empty(), "{:?}", response.failures);
     }
 
+    /// A repository that cannot be searched must not cost the workspace the
+    /// matches from the ones that can be. The broken repository comes first, so
+    /// abandoning the loop on the first failure is caught here too.
+    #[test]
+    fn test_search_repositories_keeps_matches_when_one_repository_fails() {
+        let good = TestRepo::with_initial_commit();
+        good.create_commit("Add matches", &[("a.txt", "match\n")]);
+
+        let repositories = vec![
+            WorkspaceRepository {
+                path: "/definitely/not/here".to_string(),
+                name: "gone".to_string(),
+            },
+            WorkspaceRepository {
+                path: good.path_str(),
+                name: "alpha".to_string(),
+            },
+        ];
+
+        let response = search_repositories(&repositories, "match", true, false, None, 50);
+
+        assert_eq!(response.results.len(), 1);
+        assert_eq!(response.results[0].repo_name, "alpha");
+        assert_eq!(
+            response.failures,
+            vec![
+                "Failed to search repository \"gone\": repository path does not exist".to_string()
+            ]
+        );
+    }
+
     #[test]
     fn test_workspace_grep_stops_at_result_limit() {
         let repo = TestRepo::with_initial_commit();

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -2,8 +2,9 @@
 //! Manage multi-repository workspaces
 
 use std::fs;
+use std::io::{BufRead, BufReader, Read};
 use std::path::Path;
-use std::process::Command;
+use std::process::{Command, Stdio};
 
 use chrono::Utc;
 use git2::Repository;
@@ -25,6 +26,168 @@ pub struct WorkspaceSearchResult {
     pub line_content: String,
     pub match_start: u32,
     pub match_end: u32,
+}
+
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct WorkspaceSearchResponse {
+    pub results: Vec<WorkspaceSearchResult>,
+    pub failures: Vec<String>,
+}
+
+fn run_workspace_grep(
+    repo_entry: &WorkspaceRepository,
+    query: &str,
+    case_sensitive: bool,
+    use_regex: bool,
+    file_pattern: Option<&str>,
+    limit: usize,
+) -> Result<Vec<(String, u32, String)>> {
+    let mut cmd = Command::new("git");
+    cmd.arg("-C")
+        .arg(&repo_entry.path)
+        .arg("grep")
+        .arg("-n")
+        .arg("-z")
+        .arg("-I");
+
+    if !case_sensitive {
+        cmd.arg("-i");
+    }
+    if use_regex {
+        cmd.arg("-E");
+    } else {
+        cmd.arg("-F");
+    }
+
+    cmd.arg("-e").arg(query).arg("--");
+    if let Some(pattern) = file_pattern {
+        cmd.arg(pattern);
+    }
+
+    cmd.stdout(Stdio::piped()).stderr(Stdio::piped());
+    let mut child = cmd.spawn().map_err(|error| {
+        LeviathanError::OperationFailed(format!(
+            "Failed to search repository \"{}\": {}",
+            repo_entry.name, error
+        ))
+    })?;
+
+    let stderr = child.stderr.take().ok_or_else(|| {
+        LeviathanError::OperationFailed("Failed to capture git grep errors".to_string())
+    })?;
+    let stderr_reader = std::thread::spawn(move || {
+        let mut stderr = stderr;
+        let mut bytes = Vec::new();
+        let _ = stderr.read_to_end(&mut bytes);
+        bytes
+    });
+
+    let stdout = child.stdout.take().ok_or_else(|| {
+        LeviathanError::OperationFailed("Failed to capture git grep output".to_string())
+    })?;
+    let mut stdout = BufReader::new(stdout);
+    let mut records = Vec::with_capacity(limit.min(128));
+    let mut path = Vec::new();
+    let mut line = Vec::new();
+    let mut content = Vec::new();
+
+    while records.len() < limit {
+        path.clear();
+        if stdout.read_until(0, &mut path)? == 0 {
+            break;
+        }
+        if path.pop() != Some(0) {
+            break;
+        }
+
+        line.clear();
+        if stdout.read_until(0, &mut line)? == 0 || line.pop() != Some(0) {
+            break;
+        }
+
+        content.clear();
+        if stdout.read_until(b'\n', &mut content)? == 0 {
+            break;
+        }
+        if content.last() == Some(&b'\n') {
+            content.pop();
+        }
+        if content.last() == Some(&b'\r') {
+            content.pop();
+        }
+
+        if let Ok(line_number) = String::from_utf8_lossy(&line).parse::<u32>() {
+            records.push((
+                String::from_utf8_lossy(&path).into_owned(),
+                line_number,
+                String::from_utf8_lossy(&content).into_owned(),
+            ));
+        }
+    }
+
+    let reached_limit = records.len() == limit;
+    if reached_limit {
+        let _ = child.kill();
+    }
+    let status = child.wait()?;
+    let stderr = stderr_reader.join().unwrap_or_default();
+
+    // git grep returns exit code 1 when no matches are found.
+    if !reached_limit && !status.success() && status.code() != Some(1) {
+        let stderr = String::from_utf8_lossy(&stderr).trim().to_string();
+        let details = if stderr.is_empty() {
+            format!("git grep exited with {}", status)
+        } else {
+            stderr
+        };
+        return Err(LeviathanError::OperationFailed(format!(
+            "Failed to search repository \"{}\": {}",
+            repo_entry.name, details
+        )));
+    }
+
+    Ok(records)
+}
+
+#[cfg(test)]
+fn parse_workspace_grep_output(output: &[u8], limit: usize) -> Vec<(String, u32, String)> {
+    let mut records = Vec::with_capacity(limit.min(128));
+    let mut cursor = 0;
+
+    while cursor < output.len() && records.len() < limit {
+        let Some(path_end) = output[cursor..].iter().position(|byte| *byte == 0) else {
+            break;
+        };
+        let path_end = cursor + path_end;
+        let line_start = path_end + 1;
+        let Some(line_end) = output[line_start..].iter().position(|byte| *byte == 0) else {
+            break;
+        };
+        let line_end = line_start + line_end;
+        let content_start = line_end + 1;
+        let content_end = output[content_start..]
+            .iter()
+            .position(|byte| *byte == b'\n')
+            .map(|offset| content_start + offset)
+            .unwrap_or(output.len());
+
+        if let Ok(line_number) =
+            String::from_utf8_lossy(&output[line_start..line_end]).parse::<u32>()
+        {
+            let content = &output[content_start..content_end];
+            let content = content.strip_suffix(b"\r").unwrap_or(content);
+            records.push((
+                String::from_utf8_lossy(&output[cursor..path_end]).into_owned(),
+                line_number,
+                String::from_utf8_lossy(content).into_owned(),
+            ));
+        }
+
+        cursor = content_end.saturating_add(1);
+    }
+
+    records
 }
 
 /// Get the path to the workspaces config file
@@ -276,7 +439,7 @@ pub async fn search_workspace(
     regex: Option<bool>,
     file_pattern: Option<String>,
     max_results: Option<u32>,
-) -> Result<Vec<WorkspaceSearchResult>> {
+) -> Result<WorkspaceSearchResponse> {
     let config = load_workspaces_config()?;
     let workspace = config
         .workspaces
@@ -288,6 +451,7 @@ pub async fn search_workspace(
     let use_regex = regex.unwrap_or(false);
     let max_results = max_results.unwrap_or(500);
     let mut results: Vec<WorkspaceSearchResult> = Vec::new();
+    let mut failures = Vec::new();
 
     for repo_entry in &workspace.repositories {
         if results.len() as u32 >= max_results {
@@ -296,55 +460,30 @@ pub async fn search_workspace(
 
         let repo_path = Path::new(&repo_entry.path);
         if !repo_path.exists() {
+            failures.push(format!(
+                "\"{}\": repository path does not exist",
+                repo_entry.name
+            ));
             continue;
         }
 
-        let mut cmd = Command::new("git");
-        cmd.arg("-C").arg(&repo_entry.path).arg("grep").arg("-n");
-
-        if !case_sensitive {
-            cmd.arg("-i");
-        }
-
-        if use_regex {
-            cmd.arg("-E");
-        }
-
-        cmd.arg("--").arg(&query);
-
-        if let Some(ref pattern) = file_pattern {
-            cmd.arg(pattern);
-        }
-
-        let output = match cmd.output() {
-            Ok(o) => o,
-            Err(_) => continue,
-        };
-
-        // git grep returns exit code 1 when no matches found (not an error)
-        if !output.status.success() && output.status.code() != Some(1) {
-            continue;
-        }
-
-        let stdout = String::from_utf8_lossy(&output.stdout);
-
-        for line in stdout.lines() {
-            if results.len() as u32 >= max_results {
-                break;
-            }
-
-            let parts: Vec<&str> = line.splitn(3, ':').collect();
-            if parts.len() < 3 {
+        let remaining = max_results.saturating_sub(results.len() as u32) as usize;
+        let matches = match run_workspace_grep(
+            repo_entry,
+            &query,
+            case_sensitive,
+            use_regex,
+            file_pattern.as_deref(),
+            remaining,
+        ) {
+            Ok(matches) => matches,
+            Err(error) => {
+                failures.push(error.to_string());
                 continue;
             }
+        };
 
-            let file_path = parts[0].to_string();
-            let line_number: u32 = match parts[1].parse() {
-                Ok(n) => n,
-                Err(_) => continue,
-            };
-            let line_content = parts[2].to_string();
-
+        for (file_path, line_number, line_content) in matches {
             let (match_start, match_end) =
                 find_match_position(&line_content, &query, case_sensitive);
 
@@ -360,7 +499,7 @@ pub async fn search_workspace(
         }
     }
 
-    Ok(results)
+    Ok(WorkspaceSearchResponse { results, failures })
 }
 
 /// Export a workspace configuration as a JSON string
@@ -614,6 +753,88 @@ mod tests {
 
         let empty = TestRepo::new();
         assert_eq!(head_branch(&empty.repo()), (None, false));
+    }
+
+    #[test]
+    fn test_workspace_grep_treats_plain_query_as_literal_text() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit(
+            "Add search content",
+            &[("search.txt", "literal a.b\nregex axb\n")],
+        );
+        let entry = WorkspaceRepository {
+            path: repo.path_str(),
+            name: "search-repo".to_string(),
+        };
+
+        let matches = run_workspace_grep(&entry, "a.b", true, false, None, 10).unwrap();
+
+        assert_eq!(
+            matches,
+            vec![("search.txt".to_string(), 1, "literal a.b".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_workspace_grep_surfaces_repository_failures() {
+        let dir = tempfile::TempDir::new().unwrap();
+        let entry = WorkspaceRepository {
+            path: dir.path().to_string_lossy().to_string(),
+            name: "broken-repo".to_string(),
+        };
+
+        let error = run_workspace_grep(&entry, "query", false, false, None, 10).unwrap_err();
+
+        assert!(error.to_string().contains("broken-repo"));
+    }
+
+    #[test]
+    fn test_workspace_grep_parser_accepts_colons_in_file_names() {
+        assert_eq!(
+            parse_workspace_grep_output(b"folder:name.txt\042\0matching text\n", 10),
+            vec![(
+                "folder:name.txt".to_string(),
+                42,
+                "matching text".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn test_workspace_grep_parser_accepts_newlines_in_file_names() {
+        assert_eq!(
+            parse_workspace_grep_output(b"folder\nname.txt\07\0matching text\n", 10),
+            vec![(
+                "folder\nname.txt".to_string(),
+                7,
+                "matching text".to_string()
+            )]
+        );
+    }
+
+    #[test]
+    fn test_workspace_grep_parser_respects_result_limit() {
+        assert_eq!(
+            parse_workspace_grep_output(b"a.txt\01\0first\nb.txt\02\0second\n", 1),
+            vec![("a.txt".to_string(), 1, "first".to_string())]
+        );
+    }
+
+    #[test]
+    fn test_workspace_grep_stops_at_result_limit() {
+        let repo = TestRepo::with_initial_commit();
+        repo.create_commit(
+            "Add many matches",
+            &[("many.txt", "match\nmatch\nmatch\nmatch\n")],
+        );
+        let entry = WorkspaceRepository {
+            path: repo.path_str(),
+            name: "search-repo".to_string(),
+        };
+
+        let matches = run_workspace_grep(&entry, "match", true, false, None, 2).unwrap();
+
+        assert_eq!(matches.len(), 2);
     }
 
     #[test]

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -2,7 +2,7 @@
 //! Manage multi-repository workspaces
 
 use std::fs;
-use std::io::{BufRead, BufReader, Read};
+use std::io::{BufReader, Read};
 use std::path::Path;
 use std::process::{Command, Stdio};
 
@@ -11,7 +11,7 @@ use git2::Repository;
 use tauri::command;
 use uuid::Uuid;
 
-use crate::commands::search::find_match_position;
+use crate::commands::search::{find_match_position, read_grep_records};
 use crate::error::{LeviathanError, Result};
 use crate::models::{Workspace, WorkspaceRepoStatus, WorkspaceRepository, WorkspacesConfig};
 
@@ -33,54 +33,6 @@ pub struct WorkspaceSearchResult {
 pub struct WorkspaceSearchResponse {
     pub results: Vec<WorkspaceSearchResult>,
     pub failures: Vec<String>,
-}
-
-/// Read NUL-framed `git grep -z -n` records (path\0line\0content\n) from a
-/// reader, stopping once `limit` records have been collected.
-fn read_grep_records<R: BufRead>(
-    reader: &mut R,
-    limit: usize,
-) -> std::io::Result<Vec<(String, u32, String)>> {
-    let mut records = Vec::with_capacity(limit.min(128));
-    let mut path = Vec::new();
-    let mut line = Vec::new();
-    let mut content = Vec::new();
-
-    while records.len() < limit {
-        path.clear();
-        if reader.read_until(0, &mut path)? == 0 {
-            break;
-        }
-        if path.pop() != Some(0) {
-            break;
-        }
-
-        line.clear();
-        if reader.read_until(0, &mut line)? == 0 || line.pop() != Some(0) {
-            break;
-        }
-
-        content.clear();
-        if reader.read_until(b'\n', &mut content)? == 0 {
-            break;
-        }
-        if content.last() == Some(&b'\n') {
-            content.pop();
-        }
-        if content.last() == Some(&b'\r') {
-            content.pop();
-        }
-
-        if let Ok(line_number) = String::from_utf8_lossy(&line).parse::<u32>() {
-            records.push((
-                String::from_utf8_lossy(&path).into_owned(),
-                line_number,
-                String::from_utf8_lossy(&content).into_owned(),
-            ));
-        }
-    }
-
-    Ok(records)
 }
 
 /// Run `git grep` in one repository. Errors carry only the underlying detail;

--- a/src-tauri/src/commands/workspace.rs
+++ b/src-tauri/src/commands/workspace.rs
@@ -791,7 +791,7 @@ mod tests {
     #[test]
     fn test_workspace_grep_parser_accepts_colons_in_file_names() {
         assert_eq!(
-            parse_workspace_grep_output(b"folder:name.txt\042\0matching text\n", 10),
+            parse_workspace_grep_output(b"folder:name.txt\x0042\0matching text\n", 10),
             vec![(
                 "folder:name.txt".to_string(),
                 42,
@@ -803,7 +803,7 @@ mod tests {
     #[test]
     fn test_workspace_grep_parser_accepts_newlines_in_file_names() {
         assert_eq!(
-            parse_workspace_grep_output(b"folder\nname.txt\07\0matching text\n", 10),
+            parse_workspace_grep_output(b"folder\nname.txt\x007\0matching text\n", 10),
             vec![(
                 "folder\nname.txt".to_string(),
                 7,
@@ -815,7 +815,7 @@ mod tests {
     #[test]
     fn test_workspace_grep_parser_respects_result_limit() {
         assert_eq!(
-            parse_workspace_grep_output(b"a.txt\01\0first\nb.txt\02\0second\n", 1),
+            parse_workspace_grep_output(b"a.txt\x001\0first\nb.txt\x002\0second\n", 1),
             vec![("a.txt".to_string(), 1, "first".to_string())]
         );
     }

--- a/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
@@ -683,6 +683,85 @@ describe('lv-workspace-manager-dialog', () => {
       expect(uiStore.getState().toasts.at(-1)?.type).to.equal('warning');
     });
 
+    it('summarises several failures in the toast and lists them in the panel', async () => {
+      setupDefaultMocks({
+        searchFailures: [
+          'Failed to search repository "beta": repository path does not exist',
+          'Failed to search repository "gamma": not a git repository',
+        ],
+      });
+      uiStore.setState({ toasts: [] });
+      const el = await renderDialog();
+
+      const searchInput = el.shadowRoot!.querySelector('.search-input') as HTMLInputElement;
+      searchInput.value = 'test';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      (el.shadowRoot!.querySelector('.search-btn') as HTMLButtonElement).click();
+      await tick(el, 100);
+
+      // The toast collapses newlines, so it must summarise rather than concatenate.
+      const message = uiStore.getState().toasts.at(-1)!.message;
+      expect(message).to.not.include('\n');
+      expect(message).to.include('2 problems');
+      expect(message).to.not.include('gamma');
+
+      // The panel keeps the per-repository detail, one line each.
+      const failureLines = el.shadowRoot!.querySelectorAll('.search-failures div');
+      expect(failureLines.length).to.equal(2);
+      expect(failureLines[0].textContent).to.include('beta');
+      expect(failureLines[1].textContent).to.include('gamma');
+
+      // The panel is a container, not bare red text: it must paint a tinted
+      // background rather than relying on color-mix() for its outline.
+      const panel = el.shadowRoot!.querySelector('.search-failures') as HTMLElement;
+      expect(getComputedStyle(panel).backgroundColor).to.not.equal('rgba(0, 0, 0, 0)');
+    });
+
+    it('shows a single failure verbatim in the toast', async () => {
+      setupDefaultMocks({
+        searchFailures: ['Failed to search repository "beta": repository path does not exist'],
+      });
+      uiStore.setState({ toasts: [] });
+      const el = await renderDialog();
+
+      const searchInput = el.shadowRoot!.querySelector('.search-input') as HTMLInputElement;
+      searchInput.value = 'test';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      (el.shadowRoot!.querySelector('.search-btn') as HTMLButtonElement).click();
+      await tick(el, 100);
+
+      expect(uiStore.getState().toasts.at(-1)!.message).to.equal(
+        'Failed to search repository "beta": repository path does not exist',
+      );
+    });
+
+    it('clears a stale failure banner and query when the dialog is reopened', async () => {
+      setupDefaultMocks({
+        searchFailures: ['Failed to search repository "beta": repository path does not exist'],
+      });
+      const el = await renderDialog();
+
+      const searchInput = el.shadowRoot!.querySelector('.search-input') as HTMLInputElement;
+      searchInput.value = 'test';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      (el.shadowRoot!.querySelector('.search-btn') as HTMLButtonElement).click();
+      await tick(el, 100);
+      expect(el.shadowRoot!.querySelectorAll('.search-failures').length).to.equal(1);
+
+      el.close();
+      await tick(el, 20);
+      el.open = true;
+      await tick(el, 100);
+
+      expect(el.shadowRoot!.querySelectorAll('.search-failures').length).to.equal(0);
+      expect(
+        (el.shadowRoot!.querySelector('.search-input') as HTMLInputElement).value,
+      ).to.equal('');
+    });
+
     it('keeps the newest result when searches complete out of order', async () => {
       setupDefaultMocks();
       const defaultInvoke = mockInvoke;

--- a/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
@@ -23,7 +23,12 @@ let mockInvoke: MockInvoke = () => Promise.resolve(null);
 
 // ── Imports (after Tauri mock) ─────────────────────────────────────────────
 import { expect, fixture, html } from '@open-wc/testing';
-import type { Workspace, WorkspaceRepoStatus, WorkspaceSearchResult } from '../../../types/git.types.ts';
+import type {
+  Workspace,
+  WorkspaceRepoStatus,
+  WorkspaceSearchResponse,
+  WorkspaceSearchResult,
+} from '../../../types/git.types.ts';
 import type { LvWorkspaceManagerDialog } from '../lv-workspace-manager-dialog.ts';
 
 // Import the actual component — registers <lv-workspace-manager-dialog>
@@ -121,6 +126,8 @@ function setupDefaultMocks(opts: {
   savedWorkspace?: Workspace;
   deleteFails?: boolean;
   searchResults?: WorkspaceSearchResult[];
+  searchFailures?: string[];
+  searchError?: string;
   exportData?: string;
 } = {}): void {
   const workspaces = opts.workspaces ?? [WS_ALPHA, WS_BETA];
@@ -151,7 +158,11 @@ function setupDefaultMocks(opts: {
       case 'remove_repository_from_workspace':
         return workspaces[0] ?? null;
       case 'search_workspace':
-        return opts.searchResults ?? [];
+        if (opts.searchError) throw new Error(opts.searchError);
+        return {
+          results: opts.searchResults ?? [],
+          failures: opts.searchFailures ?? [],
+        };
       case 'export_workspace':
         return opts.exportData ?? '{"id":"ws-1","name":"Alpha"}';
       case 'import_workspace':
@@ -620,6 +631,108 @@ describe('lv-workspace-manager-dialog', () => {
 
       const searchCalls = findCommands('search_workspace');
       expect(searchCalls.length).to.equal(1);
+    });
+
+    it('shows the repository search failure to the user', async () => {
+      setupDefaultMocks({ searchError: 'Failed to search repository "beta": not a git repository' });
+      uiStore.setState({ toasts: [] });
+      const el = await renderDialog();
+
+      const searchInput = el.shadowRoot!.querySelector('.search-input') as HTMLInputElement;
+      searchInput.value = 'test';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+
+      (el.shadowRoot!.querySelector('.search-btn') as HTMLButtonElement).click();
+      await tick(el, 100);
+
+      const toasts = uiStore.getState().toasts;
+      expect(toasts[toasts.length - 1].message).to.include('beta');
+      expect(toasts[toasts.length - 1].type).to.equal('error');
+      expect(el.shadowRoot!.querySelector('.search-failures')!.textContent).to.include('beta');
+      expect(el.shadowRoot!.querySelector('.search-no-results')).to.be.null;
+    });
+
+    it('keeps successful results while showing skipped repositories', async () => {
+      setupDefaultMocks({
+        searchResults: [
+          {
+            repoName: 'alpha',
+            repoPath: '/repos/alpha',
+            filePath: 'src/main.ts',
+            lineNumber: 42,
+            lineContent: 'const test = true',
+            matchStart: 6,
+            matchEnd: 10,
+          },
+        ],
+        searchFailures: ['Failed to search repository "beta": not a git repository'],
+      });
+      uiStore.setState({ toasts: [] });
+      const el = await renderDialog();
+
+      const searchInput = el.shadowRoot!.querySelector('.search-input') as HTMLInputElement;
+      searchInput.value = 'test';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      (el.shadowRoot!.querySelector('.search-btn') as HTMLButtonElement).click();
+      await tick(el, 100);
+
+      expect(el.shadowRoot!.querySelectorAll('.search-result-item')).to.have.length(1);
+      expect(el.shadowRoot!.querySelector('.search-failures')!.textContent).to.include('beta');
+      expect(uiStore.getState().toasts.at(-1)?.type).to.equal('warning');
+    });
+
+    it('keeps the newest result when searches complete out of order', async () => {
+      setupDefaultMocks();
+      const defaultInvoke = mockInvoke;
+      const pending = new Map<string, (response: WorkspaceSearchResponse) => void>();
+      mockInvoke = (command: string, args?: unknown) => {
+        if (command !== 'search_workspace') return defaultInvoke(command, args);
+        const query = (args as Record<string, string>).query;
+        return new Promise((resolve) => pending.set(query, resolve));
+      };
+      const el = await renderDialog();
+      const searchInput = el.shadowRoot!.querySelector('.search-input') as HTMLInputElement;
+
+      searchInput.value = 'first';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      searchInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      searchInput.value = 'second';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      searchInput.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+
+      pending.get('second')!({
+        results: [{
+          repoName: 'alpha',
+          repoPath: '/repos/alpha',
+          filePath: 'second.txt',
+          lineNumber: 1,
+          lineContent: 'second',
+          matchStart: 0,
+          matchEnd: 6,
+        }],
+        failures: [],
+      });
+      await tick(el, 20);
+      pending.get('first')!({
+        results: [{
+          repoName: 'alpha',
+          repoPath: '/repos/alpha',
+          filePath: 'first.txt',
+          lineNumber: 1,
+          lineContent: 'first',
+          matchStart: 0,
+          matchEnd: 5,
+        }],
+        failures: [],
+      });
+      await tick(el, 20);
+
+      expect(el.shadowRoot!.querySelector('.search-result-file')!.textContent).to.equal('second.txt');
     });
 
     it('does not show search section for workspace with no repos', async () => {

--- a/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
@@ -737,6 +737,48 @@ describe('lv-workspace-manager-dialog', () => {
       );
     });
 
+    it('stays silent when the dialog is closed before the search resolves', async () => {
+      setupDefaultMocks();
+      const el = await renderDialog();
+
+      // Hold the search open so the dialog can be closed while it is in flight.
+      const base = mockInvoke;
+      let releaseSearch: (response: WorkspaceSearchResponse) => void = () => {};
+      mockInvoke = (command: string, args?: unknown) => {
+        if (command === 'search_workspace') {
+          return new Promise<unknown>((resolve) => {
+            releaseSearch = resolve as (response: WorkspaceSearchResponse) => void;
+          });
+        }
+        return base(command, args);
+      };
+
+      const searchInput = el.shadowRoot!.querySelector('.search-input') as HTMLInputElement;
+      searchInput.value = 'test';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      (el.shadowRoot!.querySelector('.search-btn') as HTMLButtonElement).click();
+      await el.updateComplete;
+
+      uiStore.setState({ toasts: [] });
+      el.close();
+      await el.updateComplete;
+
+      releaseSearch({
+        results: [],
+        failures: [
+          'Failed to search repository "beta": repository path does not exist',
+          'Failed to search repository "gamma": not a git repository',
+        ],
+      });
+      await tick(el, 100);
+
+      // A toast saying "see the details below" would point at a panel that is
+      // no longer on screen.
+      expect(uiStore.getState().toasts).to.have.length(0);
+      expect(el.shadowRoot!.querySelector('.search-failures')).to.be.null;
+    });
+
     it('clears a stale failure banner and query when the dialog is reopened', async () => {
       setupDefaultMocks({
         searchFailures: ['Failed to search repository "beta": repository path does not exist'],

--- a/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-workspace-manager-dialog.test.ts
@@ -653,6 +653,50 @@ describe('lv-workspace-manager-dialog', () => {
       expect(el.shadowRoot!.querySelector('.search-no-results')).to.be.null;
     });
 
+    it('reports an empty search only once it has completed', async () => {
+      setupDefaultMocks({ searchResults: [], searchFailures: [] });
+      const el = await renderDialog();
+
+      const searchInput = el.shadowRoot!.querySelector('.search-input') as HTMLInputElement;
+      searchInput.value = 'nowhere';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+
+      // Typing is not a search: claiming "no results" on the first keystroke
+      // would answer a question the user has not asked yet.
+      expect(el.shadowRoot!.querySelector('.search-no-results')).to.be.null;
+
+      (el.shadowRoot!.querySelector('.search-btn') as HTMLButtonElement).click();
+      await tick(el, 100);
+
+      expect(el.shadowRoot!.querySelector('.search-no-results')!.textContent).to.include(
+        'No results found',
+      );
+    });
+
+    it('says the searched repositories had no matches when one repository failed', async () => {
+      setupDefaultMocks({
+        searchResults: [],
+        searchFailures: ['Failed to search repository "beta": repository path does not exist'],
+      });
+      const el = await renderDialog();
+
+      const searchInput = el.shadowRoot!.querySelector('.search-input') as HTMLInputElement;
+      searchInput.value = 'test';
+      searchInput.dispatchEvent(new Event('input', { bubbles: true }));
+      await el.updateComplete;
+      (el.shadowRoot!.querySelector('.search-btn') as HTMLButtonElement).click();
+      await tick(el, 100);
+
+      // Both halves of the story: beta could not be searched, and the
+      // repositories that were searched held nothing. Showing only the red
+      // panel reads as a wholly failed search.
+      expect(el.shadowRoot!.querySelector('.search-failures')!.textContent).to.include('beta');
+      expect(el.shadowRoot!.querySelector('.search-no-results')!.textContent).to.include(
+        'No results found',
+      );
+    });
+
     it('keeps successful results while showing skipped repositories', async () => {
       setupDefaultMocks({
         searchResults: [

--- a/src/components/dialogs/lv-workspace-manager-dialog.ts
+++ b/src/components/dialogs/lv-workspace-manager-dialog.ts
@@ -1451,7 +1451,7 @@ export class LvWorkspaceManagerDialog extends LitElement {
                             `,
                           )}
                         </div>
-                      ` : this.searchCompleted && !this.searching && this.searchFailures.length === 0 ? html`
+                      ` : this.searchCompleted && !this.searching ? html`
                         <div class="search-no-results">No results found</div>
                       ` : nothing}
                     </div>

--- a/src/components/dialogs/lv-workspace-manager-dialog.ts
+++ b/src/components/dialogs/lv-workspace-manager-dialog.ts
@@ -1130,7 +1130,10 @@ export class LvWorkspaceManagerDialog extends LitElement {
       200,
     );
 
+    // A dialog closed mid-search has no failure panel left on screen, so a
+    // toast pointing at "the details below" would be a dead end.
     if (
+      !this.open ||
       requestId !== this.searchRequestId ||
       this.searchQuery !== query ||
       this.selectedWorkspace?.id !== ws.id

--- a/src/components/dialogs/lv-workspace-manager-dialog.ts
+++ b/src/components/dialogs/lv-workspace-manager-dialog.ts
@@ -649,6 +649,14 @@ export class LvWorkspaceManagerDialog extends LitElement {
         font-size: var(--font-size-sm);
       }
 
+      .search-failures {
+        padding: var(--spacing-sm);
+        border: 1px solid color-mix(in srgb, var(--color-error) 40%, transparent);
+        border-radius: var(--radius-sm);
+        color: var(--color-error);
+        font-size: var(--font-size-xs);
+      }
+
       .import-export-btns {
         display: flex;
         gap: var(--spacing-xs);
@@ -695,7 +703,10 @@ export class LvWorkspaceManagerDialog extends LitElement {
   // Search
   @state() private searchQuery = '';
   @state() private searchResults: WorkspaceSearchResult[] = [];
+  @state() private searchFailures: string[] = [];
+  @state() private searchCompleted = false;
   @state() private searching = false;
+  private searchRequestId = 0;
 
   // Editable fields
   @state() private editName = '';
@@ -736,6 +747,12 @@ export class LvWorkspaceManagerDialog extends LitElement {
   private selectWorkspace(id: string): void {
     this.selectedWorkspaceId = id;
     this.repoStatuses = new Map();
+    this.searchQuery = '';
+    this.searchResults = [];
+    this.searchFailures = [];
+    this.searchCompleted = false;
+    this.searching = false;
+    this.searchRequestId++;
     this.syncEditorFields();
     this.refreshStatus();
   }
@@ -1089,22 +1106,43 @@ export class LvWorkspaceManagerDialog extends LitElement {
     const ws = this.selectedWorkspace;
     if (!ws || !this.searchQuery.trim()) return;
 
+    const query = this.searchQuery;
+    const requestId = ++this.searchRequestId;
     this.searching = true;
     this.searchResults = [];
+    this.searchFailures = [];
+    this.searchCompleted = false;
 
     const result = await workspaceService.searchWorkspace(
       ws.id,
-      this.searchQuery,
+      query,
       false,
       false,
       undefined,
       200,
     );
 
+    if (
+      requestId !== this.searchRequestId ||
+      this.searchQuery !== query ||
+      this.selectedWorkspace?.id !== ws.id
+    ) {
+      return;
+    }
+
     if (result.success && result.data) {
-      this.searchResults = result.data;
+      this.searchResults = result.data.results;
+      this.searchFailures = result.data.failures;
+      this.searchCompleted = true;
+      if (result.data.failures.length > 0) {
+        showToast(
+          result.data.failures.join('\n'),
+          result.data.results.length > 0 ? 'warning' : 'error',
+        );
+      }
     } else {
-      showToast('Search failed', 'error');
+      showToast(result.error?.message ?? 'Search failed', 'error');
+      this.searchFailures = [result.error?.message ?? 'Search failed'];
     }
     this.searching = false;
   }
@@ -1351,6 +1389,11 @@ export class LvWorkspaceManagerDialog extends LitElement {
                           .value=${this.searchQuery}
                           @input=${(e: InputEvent) => {
                             this.searchQuery = (e.target as HTMLInputElement).value;
+                            this.searchResults = [];
+                            this.searchFailures = [];
+                            this.searchCompleted = false;
+                            this.searching = false;
+                            this.searchRequestId++;
                           }}
                           @keydown=${(e: KeyboardEvent) => this.handleSearchKeyDown(e)}
                         />
@@ -1362,6 +1405,11 @@ export class LvWorkspaceManagerDialog extends LitElement {
                           ${this.searching ? 'Searching...' : 'Search'}
                         </button>
                       </div>
+                      ${this.searchFailures.length > 0 ? html`
+                        <div class="search-failures">
+                          ${this.searchFailures.map((failure) => html`<div>${failure}</div>`)}
+                        </div>
+                      ` : nothing}
                       ${this.searchResults.length > 0 ? html`
                         <div class="search-results">
                           ${Array.from(this.getGroupedSearchResults().entries()).map(
@@ -1387,7 +1435,7 @@ export class LvWorkspaceManagerDialog extends LitElement {
                             `,
                           )}
                         </div>
-                      ` : this.searchQuery && !this.searching ? html`
+                      ` : this.searchCompleted && !this.searching && this.searchFailures.length === 0 ? html`
                         <div class="search-no-results">No results found</div>
                       ` : nothing}
                     </div>

--- a/src/components/dialogs/lv-workspace-manager-dialog.ts
+++ b/src/components/dialogs/lv-workspace-manager-dialog.ts
@@ -651,7 +651,8 @@ export class LvWorkspaceManagerDialog extends LitElement {
 
       .search-failures {
         padding: var(--spacing-sm);
-        border: 1px solid color-mix(in srgb, var(--color-error) 40%, transparent);
+        border: 1px solid var(--color-error);
+        background: var(--color-error-bg, rgba(239, 83, 80, 0.1));
         border-radius: var(--radius-sm);
         color: var(--color-error);
         font-size: var(--font-size-xs);
@@ -721,6 +722,9 @@ export class LvWorkspaceManagerDialog extends LitElement {
       if (this.open) { pushOverlay(this); } else { removeOverlay(this); }
     }
     if (changedProps.has('open') && this.open) {
+      // A stale failure banner from a previous session must not reappear as if
+      // it described a fresh search.
+      this.resetSearchState();
       await this.loadWorkspaces();
     }
   }
@@ -744,15 +748,19 @@ export class LvWorkspaceManagerDialog extends LitElement {
     }
   }
 
-  private selectWorkspace(id: string): void {
-    this.selectedWorkspaceId = id;
-    this.repoStatuses = new Map();
+  private resetSearchState(): void {
     this.searchQuery = '';
     this.searchResults = [];
     this.searchFailures = [];
     this.searchCompleted = false;
     this.searching = false;
     this.searchRequestId++;
+  }
+
+  private selectWorkspace(id: string): void {
+    this.selectedWorkspaceId = id;
+    this.repoStatuses = new Map();
+    this.resetSearchState();
     this.syncEditorFields();
     this.refreshStatus();
   }
@@ -1131,13 +1139,18 @@ export class LvWorkspaceManagerDialog extends LitElement {
     }
 
     if (result.success && result.data) {
-      this.searchResults = result.data.results;
-      this.searchFailures = result.data.failures;
+      this.searchResults = result.data.results ?? [];
+      this.searchFailures = result.data.failures ?? [];
       this.searchCompleted = true;
-      if (result.data.failures.length > 0) {
+      if (this.searchFailures.length > 0) {
+        // The toast renders as plain text, so newlines collapse: summarise here
+        // and leave the per-repository detail to the .search-failures panel,
+        // which stays on screen.
         showToast(
-          result.data.failures.join('\n'),
-          result.data.results.length > 0 ? 'warning' : 'error',
+          this.searchFailures.length === 1
+            ? this.searchFailures[0]
+            : `Search completed with ${this.searchFailures.length} problems — see the details below`,
+          this.searchResults.length > 0 ? 'warning' : 'error',
         );
       }
     } else {

--- a/src/services/workspace.service.ts
+++ b/src/services/workspace.service.ts
@@ -5,7 +5,11 @@
 
 import { invokeCommand } from './tauri-api.ts';
 import { showToast } from './notification.service.ts';
-import type { Workspace, WorkspaceRepoStatus, WorkspaceSearchResult } from '../types/git.types.ts';
+import type {
+  Workspace,
+  WorkspaceRepoStatus,
+  WorkspaceSearchResponse,
+} from '../types/git.types.ts';
 import type { CommandResult } from '../types/api.types.ts';
 
 export async function getWorkspaces(): Promise<CommandResult<Workspace[]>> {
@@ -72,8 +76,8 @@ export async function searchWorkspace(
   regex?: boolean,
   filePattern?: string,
   maxResults?: number,
-): Promise<CommandResult<WorkspaceSearchResult[]>> {
-  return invokeCommand<WorkspaceSearchResult[]>('search_workspace', {
+): Promise<CommandResult<WorkspaceSearchResponse>> {
+  return invokeCommand<WorkspaceSearchResponse>('search_workspace', {
     workspaceId,
     query,
     caseSensitive,

--- a/src/types/git.types.ts
+++ b/src/types/git.types.ts
@@ -677,3 +677,8 @@ export interface WorkspaceSearchResult {
   matchStart: number;
   matchEnd: number;
 }
+
+export interface WorkspaceSearchResponse {
+  results: WorkspaceSearchResult[];
+  failures: string[];
+}


### PR DESCRIPTION
## Summary
- use fixed-string semantics for normal workspace searches
- stream and safely parse git grep output with a global result cap
- preserve results from healthy repositories while surfacing skipped repositories
- prevent stale and out-of-order search results

## Tests
- cargo test --manifest-path src-tauri/Cargo.toml workspace_grep -- --test-threads=1
- npm run typecheck
- workspace dialog suite: 46 passed; 4 pre-existing delete/remove confirmation failures