### PR TITLE
Disclose capped provider integration lists

### DIFF
--- a/e2e/tests/azure-devops-dialog.spec.ts
+++ b/e2e/tests/azure-devops-dialog.spec.ts
@@ -844,8 +844,27 @@ test.describe('Azure DevOps Dialog - Capped list disclosure', () => {
 
     await waitForCommand(page, 'plugin:shell|open');
     const opens = await findCommand(page, 'plugin:shell|open');
+    // The link has to open the same list the hint is attached to; the Azure
+    // DevOps PR page selects that list with `_a`.
     expect((opens[0].args as { path: string }).path).toBe(
-      'https://dev.azure.com/testorg/testproject/_git/testrepo/pullrequests',
+      'https://dev.azure.com/testorg/testproject/_git/testrepo/pullrequests?_a=active',
+    );
+
+    // Switching the filter must move the link with it, otherwise the "full list"
+    // link lands on a different list than the one on screen.
+    await page.locator('lv-azure-devops-dialog .filter-select').selectOption('abandoned');
+    await expect(hint.locator('a')).toHaveAttribute(
+      'href',
+      'https://dev.azure.com/testorg/testproject/_git/testrepo/pullrequests?_a=abandoned',
+    );
+    await hint.locator('a').click();
+
+    await expect
+      .poll(async () => (await findCommand(page, 'plugin:shell|open')).length)
+      .toBeGreaterThan(1);
+    const filteredOpens = await findCommand(page, 'plugin:shell|open');
+    expect((filteredOpens[1].args as { path: string }).path).toBe(
+      'https://dev.azure.com/testorg/testproject/_git/testrepo/pullrequests?_a=abandoned',
     );
   });
 

--- a/e2e/tests/azure-devops-dialog.spec.ts
+++ b/e2e/tests/azure-devops-dialog.spec.ts
@@ -645,3 +645,225 @@ test.describe('Azure DevOps Dialog - Pipelines scoping', () => {
     await expect(page.locator('.pipeline-item').first()).toContainText('CI Pipeline');
   });
 });
+
+
+/**
+ * Both Azure DevOps listings are capped: the dialog asks for an explicit page
+ * size and the tab must disclose it, with a link that opens the matching Azure
+ * DevOps list through the shell rather than navigating the webview.
+ */
+test.describe('Azure DevOps Dialog - Capped list disclosure', () => {
+  let app: AppPage;
+  let dialogs: DialogsPage;
+
+  const makeRun = (n: number) => ({
+    id: n,
+    name: `Capped run ${n}`,
+    state: 'completed',
+    result: 'succeeded',
+    sourceBranch: 'main',
+    createdDate: '2025-01-15T10:00:00Z',
+    finishedDate: '2025-01-15T10:05:00Z',
+    url: `https://dev.azure.com/testorg/testproject/_build/results?buildId=${n}`,
+  });
+
+  const makePr = (n: number) => ({
+    pullRequestId: n,
+    title: `Capped PR ${n}`,
+    description: null,
+    status: 'active',
+    createdBy: { id: 'user-1', displayName: 'Test User', uniqueName: 'test@example.com' },
+    creationDate: '2025-01-15T10:00:00Z',
+    sourceRefName: `refs/heads/feature/${n}`,
+    targetRefName: 'refs/heads/main',
+    isDraft: false,
+    url: `https://dev.azure.com/testorg/testproject/_git/testrepo/pullrequest/${n}`,
+  });
+
+  test.beforeEach(async ({ page }) => {
+    app = new AppPage(page);
+    dialogs = new DialogsPage(page);
+
+    await setupProfilesAndAccounts(
+      page,
+      {
+        profiles: [
+          {
+            id: 'default',
+            name: 'Default',
+            gitName: 'Test User',
+            gitEmail: 'test@example.com',
+            signingKey: null,
+            urlPatterns: [],
+            isDefault: true,
+            color: '#3b82f6',
+            defaultAccounts: { 'azure-devops': 'ado-account-1' },
+          },
+        ],
+        accounts: [
+          {
+            id: 'ado-account-1',
+            name: 'My Azure DevOps',
+            integrationType: 'azure-devops',
+            config: { type: 'pat', organization: 'testorg' },
+            color: null,
+            cachedUser: { username: 'testuser', displayName: 'Test User', avatarUrl: null },
+            urlPatterns: ['dev.azure.com/testorg'],
+            isDefault: false,
+          },
+        ],
+        connectedAccounts: ['ado-account-1'],
+      },
+      {
+        remotes: [
+          { name: 'origin', url: 'https://dev.azure.com/testorg/testproject/_git/testrepo', pushUrl: null },
+        ],
+      },
+    );
+
+    await startCommandCaptureWithMocks(page, {
+      detect_ado_repo: {
+        organization: 'testorg',
+        project: 'testproject',
+        repository: 'testrepo',
+        remoteName: 'origin',
+      },
+      check_ado_connection: {
+        connected: true,
+        user: {
+          id: 'user-1',
+          displayName: 'Test User',
+          uniqueName: 'test@example.com',
+          imageUrl: null,
+        },
+        organization: 'testorg',
+      },
+      query_ado_work_items: [],
+      // The hint's link must reach the browser, not navigate the webview away.
+      'plugin:shell|open': null,
+    });
+  });
+
+  test('discloses the capped pipeline run list and opens the runs view', async ({ page }) => {
+    // Serve exactly the page size the dialog asked for, so the hint can only
+    // render if the requested cap and the disclosed cap are the same number.
+    await page.evaluate(() => {
+      const internals = (window as unknown as {
+        __TAURI_INTERNALS__: { invoke: (cmd: string, args?: unknown) => Promise<unknown> };
+      }).__TAURI_INTERNALS__;
+      const originalInvoke = internals.invoke;
+      internals.invoke = async (command: string, args?: unknown) => {
+        if (command !== 'list_ado_pipeline_runs') return originalInvoke(command, args);
+        const captured = (window as unknown as {
+          __INVOKED_COMMANDS__?: { command: string; args: unknown }[];
+        }).__INVOKED_COMMANDS__;
+        if (captured) captured.push({ command, args });
+        const top = Number((args as { top?: number })?.top ?? 0);
+        return Array.from({ length: top }, (_, i) => ({
+          id: i + 1,
+          name: `Capped run ${i + 1}`,
+          state: 'completed',
+          result: 'succeeded',
+          sourceBranch: 'main',
+          createdDate: '2025-01-15T10:00:00Z',
+          finishedDate: '2025-01-15T10:05:00Z',
+          url: `https://dev.azure.com/testorg/testproject/_build/results?buildId=${i + 1}`,
+        }));
+      };
+    });
+
+    await app.executeCommand('Azure DevOps');
+    await expect(dialogs.azureDevOps.dialog).toBeVisible();
+    await dialogs.azureDevOps.pipelinesTab.click();
+
+    await waitForCommand(page, 'list_ado_pipeline_runs');
+    const runCalls = await findCommand(page, 'list_ado_pipeline_runs');
+    const requestedTop = (runCalls[0].args as { top: number }).top;
+    await expect(page.locator('lv-azure-devops-dialog .pipeline-item')).toHaveCount(requestedTop);
+
+    const hint = page.locator('lv-azure-devops-dialog .capped-list-hint');
+    await expect(hint).toContainText('more may exist');
+    await expect(hint).toContainText(String(requestedTop));
+
+    await hint.locator('a').click();
+
+    await waitForCommand(page, 'plugin:shell|open');
+    const opens = await findCommand(page, 'plugin:shell|open');
+    expect((opens[0].args as { path: string }).path).toBe(
+      'https://dev.azure.com/testorg/testproject/_build?view=runs',
+    );
+
+    await expect(dialogs.azureDevOps.dialog).toBeVisible();
+  });
+
+  test('discloses the capped pull request list and opens the PR list', async ({ page }) => {
+    await page.evaluate(() => {
+      const internals = (window as unknown as {
+        __TAURI_INTERNALS__: { invoke: (cmd: string, args?: unknown) => Promise<unknown> };
+      }).__TAURI_INTERNALS__;
+      const originalInvoke = internals.invoke;
+      internals.invoke = async (command: string, args?: unknown) => {
+        if (command !== 'list_ado_pull_requests') return originalInvoke(command, args);
+        const captured = (window as unknown as {
+          __INVOKED_COMMANDS__?: { command: string; args: unknown }[];
+        }).__INVOKED_COMMANDS__;
+        if (captured) captured.push({ command, args });
+        const top = Number((args as { top?: number })?.top ?? 0);
+        return Array.from({ length: top }, (_, i) => ({
+          pullRequestId: i + 1,
+          title: `Capped PR ${i + 1}`,
+          description: null,
+          status: 'active',
+          createdBy: { id: 'user-1', displayName: 'Test User', uniqueName: 'test@example.com' },
+          creationDate: '2025-01-15T10:00:00Z',
+          sourceRefName: `refs/heads/feature/${i + 1}`,
+          targetRefName: 'refs/heads/main',
+          isDraft: false,
+          url: `https://dev.azure.com/testorg/testproject/_git/testrepo/pullrequest/${i + 1}`,
+        }));
+      };
+    });
+
+    await app.executeCommand('Azure DevOps');
+    await expect(dialogs.azureDevOps.dialog).toBeVisible();
+    await dialogs.azureDevOps.pullRequestsTab.click();
+
+    await waitForCommand(page, 'list_ado_pull_requests');
+    const prCalls = await findCommand(page, 'list_ado_pull_requests');
+    // Without an explicit $top the Azure DevOps server default silently caps the
+    // list and the dialog has no number to disclose.
+    const requestedTop = (prCalls[0].args as { top: number }).top;
+    expect(requestedTop).toBeGreaterThan(0);
+    await expect(page.locator('lv-azure-devops-dialog .pr-item')).toHaveCount(requestedTop);
+
+    const hint = page.locator('lv-azure-devops-dialog .capped-list-hint');
+    await expect(hint).toContainText('more may exist');
+    await expect(hint).toContainText(String(requestedTop));
+
+    await hint.locator('a').click();
+
+    await waitForCommand(page, 'plugin:shell|open');
+    const opens = await findCommand(page, 'plugin:shell|open');
+    expect((opens[0].args as { path: string }).path).toBe(
+      'https://dev.azure.com/testorg/testproject/_git/testrepo/pullrequests',
+    );
+  });
+
+  test('shows no cap disclosure when the lists are short', async ({ page }) => {
+    await injectCommandMock(page, {
+      list_ado_pipeline_runs: [makeRun(1)],
+      list_ado_pull_requests: [makePr(1)],
+    });
+
+    await app.executeCommand('Azure DevOps');
+    await expect(dialogs.azureDevOps.dialog).toBeVisible();
+
+    await dialogs.azureDevOps.pullRequestsTab.click();
+    await expect(page.locator('lv-azure-devops-dialog .pr-item')).toHaveCount(1);
+    await expect(page.locator('lv-azure-devops-dialog .capped-list-hint')).toHaveCount(0);
+
+    await dialogs.azureDevOps.pipelinesTab.click();
+    await expect(page.locator('lv-azure-devops-dialog .pipeline-item')).toHaveCount(1);
+    await expect(page.locator('lv-azure-devops-dialog .capped-list-hint')).toHaveCount(0);
+  });
+});

--- a/e2e/tests/azure-devops-dialog.spec.ts
+++ b/e2e/tests/azure-devops-dialog.spec.ts
@@ -868,6 +868,95 @@ test.describe('Azure DevOps Dialog - Capped list disclosure', () => {
     );
   });
 
+  // Azure DevOps defaults `searchCriteria.status` to `active`, so the "All"
+  // filter has to send `all` explicitly — omitting it renders the Active list
+  // again with completed and abandoned pull requests silently missing.
+  test('requests every state when the All pull request filter is selected', async ({ page }) => {
+    await page.evaluate(() => {
+      const internals = (window as unknown as {
+        __TAURI_INTERNALS__: { invoke: (cmd: string, args?: unknown) => Promise<unknown> };
+      }).__TAURI_INTERNALS__;
+      const originalInvoke = internals.invoke;
+      internals.invoke = async (command: string, args?: unknown) => {
+        if (command !== 'list_ado_pull_requests') return originalInvoke(command, args);
+        const captured = (window as unknown as {
+          __INVOKED_COMMANDS__?: { command: string; args: unknown }[];
+        }).__INVOKED_COMMANDS__;
+        if (captured) captured.push({ command, args });
+        // Stand in for the API: `all` returns every state, anything else returns
+        // just that one.
+        const status = (args as { status?: string })?.status ?? 'active';
+        const states = status === 'all' ? ['active', 'completed', 'abandoned'] : [status];
+        return states.map((state, i) => ({
+          pullRequestId: i + 1,
+          title: `${state} PR`,
+          description: null,
+          status: state,
+          createdBy: { id: 'user-1', displayName: 'Test User', uniqueName: 'test@example.com' },
+          creationDate: '2025-01-15T10:00:00Z',
+          sourceRefName: `refs/heads/feature/${i + 1}`,
+          targetRefName: 'refs/heads/main',
+          isDraft: false,
+          url: `https://dev.azure.com/testorg/testproject/_git/testrepo/pullrequest/${i + 1}`,
+        }));
+      };
+    });
+
+    await app.executeCommand('Azure DevOps');
+    await expect(dialogs.azureDevOps.dialog).toBeVisible();
+    await dialogs.azureDevOps.pullRequestsTab.click();
+    await expect(page.locator('lv-azure-devops-dialog .pr-item')).toHaveCount(1);
+
+    await page.locator('lv-azure-devops-dialog .filter-select').selectOption('all');
+    await expect(page.locator('lv-azure-devops-dialog .pr-item')).toHaveCount(3);
+    await expect(page.locator('lv-azure-devops-dialog .pr-list')).toContainText('completed PR');
+    await expect(page.locator('lv-azure-devops-dialog .pr-list')).toContainText('abandoned PR');
+
+    const prCalls = await findCommand(page, 'list_ado_pull_requests');
+    expect((prCalls[prCalls.length - 1].args as { status?: string }).status).toBe('all');
+  });
+
+  // The work-item cap is disclosed from the same constant the request asks for,
+  // so serving exactly the requested `limit` is the only way the hint can match.
+  test('discloses the capped work item list from the size it requested', async ({ page }) => {
+    await page.evaluate(() => {
+      const internals = (window as unknown as {
+        __TAURI_INTERNALS__: { invoke: (cmd: string, args?: unknown) => Promise<unknown> };
+      }).__TAURI_INTERNALS__;
+      const originalInvoke = internals.invoke;
+      internals.invoke = async (command: string, args?: unknown) => {
+        if (command !== 'query_ado_work_items') return originalInvoke(command, args);
+        const captured = (window as unknown as {
+          __INVOKED_COMMANDS__?: { command: string; args: unknown }[];
+        }).__INVOKED_COMMANDS__;
+        if (captured) captured.push({ command, args });
+        const limit = Number((args as { limit?: number })?.limit ?? 0);
+        return Array.from({ length: limit }, (_, i) => ({
+          id: i + 1,
+          title: `Capped work item ${i + 1}`,
+          workItemType: 'Task',
+          state: 'Active',
+          assignedTo: null,
+          createdDate: '2025-01-15T10:00:00Z',
+          url: `https://dev.azure.com/testorg/_workitems/edit/${i + 1}`,
+        }));
+      };
+    });
+
+    await app.executeCommand('Azure DevOps');
+    await expect(dialogs.azureDevOps.dialog).toBeVisible();
+    await dialogs.azureDevOps.workItemsTab.click();
+
+    await waitForCommand(page, 'query_ado_work_items');
+    const workItemCalls = await findCommand(page, 'query_ado_work_items');
+    const requestedLimit = (workItemCalls[0].args as { limit: number }).limit;
+    expect(requestedLimit).toBeGreaterThan(0);
+    await expect(page.locator('lv-azure-devops-dialog .work-item')).toHaveCount(requestedLimit);
+
+    const hint = page.locator('lv-azure-devops-dialog .capped-list-hint');
+    await expect(hint).toContainText(String(requestedLimit));
+  });
+
   test('shows no cap disclosure when the lists are short', async ({ page }) => {
     await injectCommandMock(page, {
       list_ado_pipeline_runs: [makeRun(1)],

--- a/e2e/tests/bitbucket-dialog.spec.ts
+++ b/e2e/tests/bitbucket-dialog.spec.ts
@@ -1,5 +1,10 @@
 import { test, expect } from '@playwright/test';
-import { setupOpenRepository } from '../fixtures/tauri-mock';
+import {
+  setupOpenRepository,
+  setupProfilesAndAccounts,
+  type MockIntegrationAccount,
+  type MockUnifiedProfile,
+} from '../fixtures/tauri-mock';
 import { AppPage } from '../pages/app.page';
 import { DialogsPage } from '../pages/dialogs.page';
 import {
@@ -270,5 +275,111 @@ test.describe('Bitbucket Dialog - Cancelling a pending OAuth sign-in', () => {
     // And the form is usable again.
     await expect(dialogs.bitbucket.oauthCancelButton).toHaveCount(0);
     await expect(dialogs.bitbucket.oauthSignInButton).toBeEnabled();
+  });
+});
+
+
+/**
+ * The pull-request listing is capped at one page by the backend (`pagelen=30`).
+ * The tab must say so and hand the user a link that opens the same filtered list
+ * in Bitbucket - through the shell, not by navigating the webview.
+ */
+test.describe('Bitbucket Dialog - Capped list disclosure', () => {
+  let app: AppPage;
+  let dialogs: DialogsPage;
+
+  const cappedProfile: MockUnifiedProfile = {
+    id: 'profile-1',
+    name: 'Default',
+    gitName: 'Test User',
+    gitEmail: 'test@example.com',
+    signingKey: null,
+    urlPatterns: [],
+    isDefault: true,
+    color: '#0052cc',
+    defaultAccounts: { bitbucket: 'bb-acc-1' },
+  };
+
+  const cappedAccount: MockIntegrationAccount = {
+    id: 'bb-acc-1',
+    name: 'Bitbucket (bbuser)',
+    integrationType: 'bitbucket',
+    config: { type: 'bitbucket' },
+    color: '#0052cc',
+    cachedUser: { username: 'bbuser', displayName: 'BB User', avatarUrl: null },
+    urlPatterns: [],
+    isDefault: true,
+  };
+
+  const makePr = (n: number) => ({
+    id: n,
+    title: `Capped PR ${n}`,
+    description: null,
+    state: 'OPEN',
+    author: { uuid: '{u1}', displayName: 'BB User', nickname: 'bbuser', avatarUrl: '' },
+    createdOn: '2025-01-15T10:00:00Z',
+    sourceBranch: `feature/${n}`,
+    destinationBranch: 'main',
+    url: `https://bitbucket.org/acme/widgets/pull-requests/${n}`,
+  });
+
+  test.beforeEach(async ({ page }) => {
+    app = new AppPage(page);
+    dialogs = new DialogsPage(page);
+
+    await setupProfilesAndAccounts(
+      page,
+      { profiles: [cappedProfile], accounts: [cappedAccount], connectedAccounts: ['bb-acc-1'] },
+      { remotes: [{ name: 'origin', url: 'https://bitbucket.org/acme/widgets.git', pushUrl: null }] },
+    );
+
+    await startCommandCaptureWithMocks(page, {
+      detect_bitbucket_repo: { workspace: 'acme', repoSlug: 'widgets', remoteName: 'origin' },
+      check_bitbucket_connection: {
+        connected: true,
+        user: { uuid: '{u1}', displayName: 'BB User', nickname: 'bbuser', avatarUrl: '' },
+      },
+      check_bitbucket_connection_with_token: {
+        connected: true,
+        user: { uuid: '{u1}', displayName: 'BB User', nickname: 'bbuser', avatarUrl: '' },
+      },
+      list_bitbucket_pull_requests: Array.from({ length: 30 }, (_, index) => makePr(index + 1)),
+      // The hint's link must reach the browser, not navigate the webview away.
+      'plugin:shell|open': null,
+    });
+  });
+
+  test('discloses the capped pull request list and opens Bitbucket for the rest', async ({ page }) => {
+    await app.executeCommand('Bitbucket');
+    await expect(dialogs.bitbucket.dialog).toBeVisible();
+    await dialogs.bitbucket.pullRequestsTab.click();
+
+    await expect(page.locator('lv-bitbucket-dialog .pr-item')).toHaveCount(30);
+
+    const hint = page.locator('lv-bitbucket-dialog .capped-list-hint');
+    await expect(hint).toContainText('more may exist');
+    await expect(hint).toContainText('30');
+
+    await hint.locator('a').click();
+
+    await waitForCommand(page, 'plugin:shell|open');
+    const opens = await findCommand(page, 'plugin:shell|open');
+    expect((opens[0].args as { path: string }).path).toBe(
+      'https://bitbucket.org/acme/widgets/pull-requests?state=OPEN',
+    );
+
+    // The dialog stays put - the link opened externally.
+    await expect(dialogs.bitbucket.dialog).toBeVisible();
+  });
+
+  test('shows no cap disclosure when the pull request list is short', async ({ page }) => {
+    await injectCommandMock(page, { list_bitbucket_pull_requests: [makePr(1)] });
+
+    await app.executeCommand('Bitbucket');
+    await expect(dialogs.bitbucket.dialog).toBeVisible();
+    await dialogs.bitbucket.pullRequestsTab.click();
+
+    await expect(page.locator('lv-bitbucket-dialog .pr-item')).toHaveCount(1);
+    await expect(page.locator('lv-bitbucket-dialog .capped-list-hint')).toHaveCount(0);
   });
 });

--- a/e2e/tests/gitlab-dialog.spec.ts
+++ b/e2e/tests/gitlab-dialog.spec.ts
@@ -295,3 +295,110 @@ test.describe('GitLab Dialog - OAuth token refresh', () => {
     await expect(dialogs2.gitlab.connectionStatus).toContainText('gluser');
   });
 });
+
+
+/**
+ * The merge-request listing is capped at one page by the backend (`per_page=30`).
+ * The tab must say so and hand the user a link that opens the same filtered list
+ * in GitLab - through the shell, not by navigating the webview.
+ */
+test.describe('GitLab Dialog - Capped list disclosure', () => {
+  let app: AppPage;
+  let dialogs: DialogsPage;
+
+  const cappedProfile: MockUnifiedProfile = {
+    id: 'profile-1',
+    name: 'Default',
+    gitName: 'Test User',
+    gitEmail: 'test@example.com',
+    signingKey: null,
+    urlPatterns: [],
+    isDefault: true,
+    color: '#4f46e5',
+    defaultAccounts: { gitlab: 'gl-acc-1' },
+  };
+
+  const cappedAccount: MockIntegrationAccount = {
+    id: 'gl-acc-1',
+    name: 'GitLab (gluser)',
+    integrationType: 'gitlab',
+    config: { type: 'gitlab', instanceUrl: 'https://gitlab.com' },
+    color: '#4f46e5',
+    cachedUser: { username: 'gluser', displayName: 'GL User', avatarUrl: null },
+    urlPatterns: [],
+    isDefault: true,
+  };
+
+  const makeMr = (n: number) => ({
+    iid: n,
+    title: `Capped MR ${n}`,
+    description: null,
+    state: 'opened',
+    author: { id: 1, username: 'gluser', name: 'GL User', avatarUrl: '', webUrl: '' },
+    createdAt: '2025-01-15T10:00:00Z',
+    sourceBranch: `feature/${n}`,
+    targetBranch: 'main',
+    draft: false,
+    webUrl: `https://gitlab.com/acme/widgets/-/merge_requests/${n}`,
+  });
+
+  test.beforeEach(async ({ page }) => {
+    app = new AppPage(page);
+    dialogs = new DialogsPage(page);
+
+    await setupProfilesAndAccounts(
+      page,
+      { profiles: [cappedProfile], accounts: [cappedAccount], connectedAccounts: ['gl-acc-1'] },
+      { remotes: [{ name: 'origin', url: 'https://gitlab.com/acme/widgets.git', pushUrl: null }] },
+    );
+
+    await startCommandCaptureWithMocks(page, {
+      detect_gitlab_repo: {
+        instanceUrl: 'https://gitlab.com',
+        projectPath: 'acme/widgets',
+        remoteName: 'origin',
+      },
+      check_gitlab_connection: {
+        connected: true,
+        user: { username: 'gluser', name: 'GL User', avatarUrl: '' },
+      },
+      list_gitlab_merge_requests: Array.from({ length: 30 }, (_, index) => makeMr(index + 1)),
+      // The hint's link must reach the browser, not navigate the webview away.
+      'plugin:shell|open': null,
+    });
+  });
+
+  test('discloses the capped merge request list and opens GitLab for the rest', async ({ page }) => {
+    await app.executeCommand('GitLab');
+    await expect(dialogs.gitlab.dialog).toBeVisible();
+    await dialogs.gitlab.mergeRequestsTab.click();
+
+    await expect(page.locator('lv-gitlab-dialog .mr-item')).toHaveCount(30);
+
+    const hint = page.locator('lv-gitlab-dialog .capped-list-hint');
+    await expect(hint).toContainText('more may exist');
+    await expect(hint).toContainText('30');
+
+    await hint.locator('a').click();
+
+    await waitForCommand(page, 'plugin:shell|open');
+    const opens = await findCommand(page, 'plugin:shell|open');
+    expect((opens[0].args as { path: string }).path).toBe(
+      'https://gitlab.com/acme/widgets/-/merge_requests?state=opened',
+    );
+
+    // The dialog stays put - the link opened externally.
+    await expect(dialogs.gitlab.dialog).toBeVisible();
+  });
+
+  test('shows no cap disclosure when the merge request list is short', async ({ page }) => {
+    await injectCommandMock(page, { list_gitlab_merge_requests: [makeMr(1)] });
+
+    await app.executeCommand('GitLab');
+    await expect(dialogs.gitlab.dialog).toBeVisible();
+    await dialogs.gitlab.mergeRequestsTab.click();
+
+    await expect(page.locator('lv-gitlab-dialog .mr-item')).toHaveCount(1);
+    await expect(page.locator('lv-gitlab-dialog .capped-list-hint')).toHaveCount(0);
+  });
+});

--- a/src-tauri/src/commands/azure_devops.rs
+++ b/src-tauri/src/commands/azure_devops.rs
@@ -169,10 +169,10 @@ fn build_api_url_with_params(
 
 /// Build the `searchCriteria.status` query fragment for a PR status filter.
 ///
-/// Azure DevOps returns pull requests in *all* states when
-/// `searchCriteria.status` is omitted. A `None` status therefore means "All"
-/// and must not append any status filter (previously this defaulted to
-/// `active`, hiding completed/abandoned PRs from the "All" filter).
+/// Azure DevOps defaults `searchCriteria.status` to `active` when the parameter
+/// is omitted, so omitting it is *not* "All" — a caller wanting every state must
+/// pass the `all` status explicitly. `None` here means only "no filter
+/// supplied", which leaves that server default in place.
 fn ado_pr_status_param(status: Option<&str>) -> Option<String> {
     status.map(|s| format!("searchCriteria.status={}", s))
 }
@@ -867,9 +867,22 @@ pub async fn get_ado_work_items(
         .collect())
 }
 
-/// Max work items fetched for the "My Work Items" list. When the caller receives
-/// exactly this many, more may exist — the dialog surfaces a "capped" hint.
-const WORK_ITEMS_LIMIT: usize = 50;
+/// Default number of work items fetched for the "My Work Items" list. When the
+/// caller receives exactly this many, more may exist — the dialog surfaces a
+/// "capped" hint.
+///
+/// Kept in sync with WORK_ITEMS_PAGE_SIZE in lv-azure-devops-dialog.ts, which
+/// discloses it to the user.
+const WORK_ITEMS_DEFAULT_LIMIT: u32 = 50;
+
+/// Resolve how many work items to fetch details for.
+///
+/// The dialog discloses the size it asked for ("Showing your N most recent"), so
+/// taking the size from the caller keeps the number the request caps at and the
+/// number the hint quotes the same value, instead of two literals that drift.
+fn work_items_limit(limit: Option<u32>) -> usize {
+    limit.unwrap_or(WORK_ITEMS_DEFAULT_LIMIT) as usize
+}
 
 /// Build the WIQL for the work-items list.
 ///
@@ -909,6 +922,7 @@ pub async fn query_ado_work_items(
     organization: String,
     project: String,
     state: Option<String>,
+    limit: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<AdoWorkItem>> {
     let token = resolve_ado_token(token)?;
@@ -963,13 +977,13 @@ pub async fn query_ado_work_items(
         LeviathanError::OperationFailed(format!("Failed to parse WIQL response: {}", e))
     })?;
 
-    // Fetch full details for at most WORK_ITEMS_LIMIT of the user's most-recent
-    // items. The dialog flags the list as capped when it receives this many (kept
-    // in sync with WORK_ITEMS_PAGE_SIZE on the frontend).
+    // Fetch full details for at most the caller's page size of the user's
+    // most-recent items. The dialog flags the list as capped when it receives
+    // exactly this many, and it asks for the number it discloses.
     let ids: Vec<u32> = data
         .work_items
         .into_iter()
-        .take(WORK_ITEMS_LIMIT)
+        .take(work_items_limit(limit))
         .map(|w| w.id)
         .collect();
 
@@ -1492,9 +1506,26 @@ mod tests {
             ado_pr_query_params(Some("active"), 100),
             "$top=100&searchCriteria.status=active"
         );
-        // "All" (None) still gets an explicit page size, just no status filter.
+        // "All" is a real Azure DevOps status, so it is sent like any other —
+        // omitting it would leave the API's `active` default in place and hide
+        // completed and abandoned pull requests.
+        assert_eq!(
+            ado_pr_query_params(Some("all"), 100),
+            "$top=100&searchCriteria.status=all"
+        );
+        // No filter supplied still gets an explicit page size.
         assert_eq!(ado_pr_query_params(None, 100), "$top=100");
         assert_eq!(ado_pr_query_params(None, 5), "$top=5");
+    }
+
+    #[test]
+    fn test_work_items_limit() {
+        // The caller's page size wins, so the size requested is the size the
+        // dialog discloses.
+        assert_eq!(work_items_limit(Some(50)), 50);
+        assert_eq!(work_items_limit(Some(3)), 3);
+        // No caller size falls back to this file's default.
+        assert_eq!(work_items_limit(None), WORK_ITEMS_DEFAULT_LIMIT as usize);
     }
 
     #[test]

--- a/src-tauri/src/commands/azure_devops.rs
+++ b/src-tauri/src/commands/azure_devops.rs
@@ -177,6 +177,26 @@ fn ado_pr_status_param(status: Option<&str>) -> Option<String> {
     status.map(|s| format!("searchCriteria.status={}", s))
 }
 
+/// Default page size for the pull-request listing.
+///
+/// Kept in sync with PULL_REQUESTS_PAGE_SIZE in lv-azure-devops-dialog.ts, which
+/// discloses it to the user.
+const PULL_REQUESTS_DEFAULT_TOP: u32 = 100;
+
+/// Build the `pullrequests` query fragment: an explicit page size plus the
+/// optional status filter.
+///
+/// Omitting `$top` does not mean "everything" — Azure DevOps still applies a
+/// server-side default page size, so the list was silently truncated with no
+/// number the UI could disclose. Sending `$top` makes the cap ours and lets the
+/// dialog say how many it is showing.
+fn ado_pr_query_params(status: Option<&str>, top: u32) -> String {
+    match ado_pr_status_param(status) {
+        Some(status_param) => format!("$top={}&{}", top, status_param),
+        None => format!("$top={}", top),
+    }
+}
+
 // ============================================================================
 // Connection Commands
 // ============================================================================
@@ -505,15 +525,19 @@ pub async fn list_ado_pull_requests(
     project: String,
     repository: String,
     status: Option<String>,
+    top: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<AdoPullRequest>> {
     let token = resolve_ado_token(token)?;
 
+    let top = top.unwrap_or(PULL_REQUESTS_DEFAULT_TOP);
     let path = format!("git/repositories/{}/pullrequests", repository);
-    let url = match ado_pr_status_param(status.as_deref()) {
-        Some(params) => build_api_url_with_params(&organization, &project, &path, &params),
-        None => build_api_url(&organization, &project, &path),
-    };
+    let url = build_api_url_with_params(
+        &organization,
+        &project,
+        &path,
+        &ado_pr_query_params(status.as_deref(), top),
+    );
 
     let client = reqwest::Client::new();
     let response = client
@@ -1458,6 +1482,19 @@ mod tests {
         );
         // "All" (None) omits the filter so every PR state is returned.
         assert_eq!(ado_pr_status_param(None), None);
+    }
+
+    #[test]
+    fn test_ado_pr_query_params_always_sends_top() {
+        // Without $top the Azure DevOps server default silently caps the list,
+        // leaving the dialog no number to disclose.
+        assert_eq!(
+            ado_pr_query_params(Some("active"), 100),
+            "$top=100&searchCriteria.status=active"
+        );
+        // "All" (None) still gets an explicit page size, just no status filter.
+        assert_eq!(ado_pr_query_params(None, 100), "$top=100");
+        assert_eq!(ado_pr_query_params(None, 5), "$top=5");
     }
 
     #[test]

--- a/src-tauri/src/commands/bitbucket.rs
+++ b/src-tauri/src/commands/bitbucket.rs
@@ -21,6 +21,26 @@ const BITBUCKET_API_BASE: &str = "https://api.bitbucket.org/2.0";
 /// `src/services/credential.service.ts`.
 const APP_PASSWORD_PREFIX: &str = "bbapp:";
 
+/// Default page size for the pull-request and issue listings.
+///
+/// Kept in sync with BITBUCKET_LIST_PAGE_SIZE in lv-bitbucket-dialog.ts, which
+/// discloses it to the user.
+const LIST_DEFAULT_PAGELEN: u32 = 30;
+
+/// Default page size for the pipeline listing.
+///
+/// Kept in sync with BITBUCKET_PIPELINE_PAGE_SIZE in lv-bitbucket-dialog.ts.
+const PIPELINES_DEFAULT_PAGELEN: u32 = 20;
+
+/// Build the `pagelen=<n>` query fragment for a listing.
+///
+/// The dialog discloses the page size it asked for ("Showing the first N ...").
+/// Taking the size from the caller keeps the number the request caps at and the
+/// number the hint quotes the same value, instead of two literals that drift.
+fn pagelen_query_param(pagelen: Option<u32>, default_pagelen: u32) -> String {
+    format!("pagelen={}", pagelen.unwrap_or(default_pagelen))
+}
+
 // ============================================================================
 // Credential Management (handled by frontend credential service via OS keyring - these are stubs)
 // ============================================================================
@@ -417,6 +437,7 @@ pub async fn list_bitbucket_pull_requests(
     workspace: String,
     repo_slug: String,
     state: Option<String>,
+    pagelen: Option<u32>,
     token: Option<String>,
     username: Option<String>,
     app_password: Option<String>,
@@ -429,8 +450,12 @@ pub async fn list_bitbucket_pull_requests(
 
     let state_param = state.unwrap_or_else(|| "OPEN".to_string());
     let url = format!(
-        "{}/repositories/{}/{}/pullrequests?state={}&pagelen=30",
-        BITBUCKET_API_BASE, workspace, repo_slug, state_param
+        "{}/repositories/{}/{}/pullrequests?state={}&{}",
+        BITBUCKET_API_BASE,
+        workspace,
+        repo_slug,
+        state_param,
+        pagelen_query_param(pagelen, LIST_DEFAULT_PAGELEN)
     );
 
     tracing::debug!(
@@ -800,6 +825,7 @@ pub async fn list_bitbucket_issues(
     workspace: String,
     repo_slug: String,
     state: Option<String>,
+    pagelen: Option<u32>,
     token: Option<String>,
     username: Option<String>,
     app_password: Option<String>,
@@ -811,8 +837,11 @@ pub async fn list_bitbucket_issues(
     )?;
 
     let mut url = format!(
-        "{}/repositories/{}/{}/issues?pagelen=30",
-        BITBUCKET_API_BASE, workspace, repo_slug
+        "{}/repositories/{}/{}/issues?{}",
+        BITBUCKET_API_BASE,
+        workspace,
+        repo_slug,
+        pagelen_query_param(pagelen, LIST_DEFAULT_PAGELEN)
     );
 
     if let Some(state_str) = state {
@@ -1077,6 +1106,7 @@ fn build_create_issue_body(input: &CreateBitbucketIssueInput) -> serde_json::Val
 pub async fn list_bitbucket_pipelines(
     workspace: String,
     repo_slug: String,
+    pagelen: Option<u32>,
     token: Option<String>,
     username: Option<String>,
     app_password: Option<String>,
@@ -1088,8 +1118,11 @@ pub async fn list_bitbucket_pipelines(
     )?;
 
     let url = format!(
-        "{}/repositories/{}/{}/pipelines/?pagelen=20&sort=-created_on",
-        BITBUCKET_API_BASE, workspace, repo_slug
+        "{}/repositories/{}/{}/pipelines/?{}&sort=-created_on",
+        BITBUCKET_API_BASE,
+        workspace,
+        repo_slug,
+        pagelen_query_param(pagelen, PIPELINES_DEFAULT_PAGELEN)
     );
 
     let client = reqwest::Client::new();
@@ -1189,6 +1222,17 @@ pub async fn list_bitbucket_pipelines(
 mod tests {
     use super::*;
     use crate::test_utils::TestRepo;
+
+    #[test]
+    fn test_pagelen_query_param() {
+        // The caller's page size wins, so the size requested is the size the
+        // dialog discloses.
+        assert_eq!(pagelen_query_param(Some(30), 30), "pagelen=30");
+        assert_eq!(pagelen_query_param(Some(5), 30), "pagelen=5");
+        // No caller size falls back to this file's default.
+        assert_eq!(pagelen_query_param(None, 30), "pagelen=30");
+        assert_eq!(pagelen_query_param(None, 20), "pagelen=20");
+    }
 
     // ========================================================================
     // parse_bitbucket_url Tests

--- a/src-tauri/src/commands/gitlab.rs
+++ b/src-tauri/src/commands/gitlab.rs
@@ -207,6 +207,26 @@ fn state_query_param(state: Option<&str>) -> String {
     }
 }
 
+/// Default page size for the merge-request and issue listings.
+///
+/// Kept in sync with GITLAB_LIST_PAGE_SIZE in lv-gitlab-dialog.ts, which
+/// discloses it to the user.
+const LIST_DEFAULT_PER_PAGE: u32 = 30;
+
+/// Default page size for the pipeline listing.
+///
+/// Kept in sync with GITLAB_PIPELINE_PAGE_SIZE in lv-gitlab-dialog.ts.
+const PIPELINES_DEFAULT_PER_PAGE: u32 = 20;
+
+/// Build the `per_page=<n>` query fragment for a listing.
+///
+/// The dialog discloses the page size it asked for ("Showing the first N ...").
+/// Taking the size from the caller keeps the number the request caps at and the
+/// number the hint quotes the same value, instead of two literals that drift.
+fn per_page_query_param(per_page: Option<u32>, default_per_page: u32) -> String {
+    format!("per_page={}", per_page.unwrap_or(default_per_page))
+}
+
 // ============================================================================
 // Connection Commands
 // ============================================================================
@@ -376,17 +396,19 @@ pub async fn list_gitlab_merge_requests(
     instance_url: String,
     project_path: String,
     state: Option<String>,
+    per_page: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<GitLabMergeRequest>> {
     let token = resolve_token(token)?;
 
     let encoded_path = url_encode(&project_path);
     let url = format!(
-        "{}?per_page=30{}",
+        "{}?{}{}",
         build_api_url(
             &instance_url,
             &format!("projects/{}/merge_requests", encoded_path)
         ),
+        per_page_query_param(per_page, LIST_DEFAULT_PER_PAGE),
         state_query_param(state.as_deref())
     );
 
@@ -637,14 +659,16 @@ pub async fn list_gitlab_issues(
     project_path: String,
     state: Option<String>,
     labels: Option<String>,
+    per_page: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<GitLabIssue>> {
     let token = resolve_token(token)?;
 
     let encoded_path = url_encode(&project_path);
     let mut url = format!(
-        "{}?per_page=30{}",
+        "{}?{}{}",
         build_api_url(&instance_url, &format!("projects/{}/issues", encoded_path)),
+        per_page_query_param(per_page, LIST_DEFAULT_PER_PAGE),
         state_query_param(state.as_deref())
     );
 
@@ -827,17 +851,19 @@ pub async fn list_gitlab_pipelines(
     instance_url: String,
     project_path: String,
     status: Option<String>,
+    per_page: Option<u32>,
     token: Option<String>,
 ) -> Result<Vec<GitLabPipeline>> {
     let token = resolve_token(token)?;
 
     let encoded_path = url_encode(&project_path);
     let mut url = format!(
-        "{}?per_page=20&order_by=updated_at&sort=desc",
+        "{}?{}&order_by=updated_at&sort=desc",
         build_api_url(
             &instance_url,
             &format!("projects/{}/pipelines", encoded_path)
-        )
+        ),
+        per_page_query_param(per_page, PIPELINES_DEFAULT_PER_PAGE)
     );
 
     if let Some(status_str) = status {
@@ -949,6 +975,17 @@ mod tests {
             build_api_url("https://gitlab.example.com", "projects/123"),
             "https://gitlab.example.com/api/v4/projects/123"
         );
+    }
+
+    #[test]
+    fn test_per_page_query_param() {
+        // The caller's page size wins, so the size requested is the size the
+        // dialog discloses.
+        assert_eq!(per_page_query_param(Some(30), 30), "per_page=30");
+        assert_eq!(per_page_query_param(Some(5), 30), "per_page=5");
+        // No caller size falls back to this file's default.
+        assert_eq!(per_page_query_param(None, 30), "per_page=30");
+        assert_eq!(per_page_query_param(None, 20), "per_page=20");
     }
 
     #[test]
@@ -1114,6 +1151,7 @@ mod tests {
             "user/repo".to_string(),
             None,
             None,
+            None,
         )
         .await;
         assert!(result.is_err());
@@ -1139,6 +1177,7 @@ mod tests {
             None,
             None,
             None,
+            None,
         )
         .await;
         assert!(result.is_err());
@@ -1149,6 +1188,7 @@ mod tests {
         let result = list_gitlab_pipelines(
             "https://gitlab.com".to_string(),
             "user/repo".to_string(),
+            None,
             None,
             None,
         )

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -573,6 +573,60 @@ describe('lv-azure-devops-dialog', () => {
       expect(firstPr.querySelector('.pr-branch')?.textContent).to.include('refs/heads/main');
     });
 
+    // Azure DevOps caps `pullrequests` server-side when no `$top` is sent, so the
+    // dialog asks for an explicit page size and discloses that same number.
+    it('discloses the same page size it requests when the PR list is full', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      let requestedTop = 0;
+      const baseInvoke = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'list_ado_pull_requests') {
+          requestedTop = Number((args as Record<string, unknown>).top);
+          return Array.from({ length: requestedTop }, (_, index) => ({
+            ...mockPullRequests[0],
+            pullRequestId: 500 + index,
+          }));
+        }
+        return baseInvoke(command, args);
+      };
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      expect(requestedTop).to.be.greaterThan(0);
+      expect(el.shadowRoot!.querySelectorAll('.pr-item').length).to.equal(requestedTop);
+      const hint = el.shadowRoot!.querySelector('.capped-list-hint');
+      expect(hint, 'capped hint rendered for a full page').to.not.be.null;
+      expect(hint!.textContent).to.include(String(requestedTop));
+      expect(hint!.querySelector('a')?.getAttribute('href')).to.equal(
+        'https://dev.azure.com/testorg/test-project/_git/test-repo/pullrequests',
+      );
+    });
+
+    it('does not disclose a cap when fewer pull requests come back', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.pr-item').length).to.equal(mockPullRequests.length);
+      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(0);
+    });
+
     it('shows filter dropdown and New PR button', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
@@ -625,6 +679,53 @@ describe('lv-azure-devops-dialog', () => {
 
       const secondItem = workItems[1];
       expect(secondItem.querySelector('.work-item-type')?.textContent).to.include('Bug');
+    });
+
+    // The work-items hint predates the shared `capped-list-hint` marker; it is the
+    // same disclosure as its siblings and must carry the same class.
+    it('marks the capped work-item hint with the shared hint class', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const baseInvoke = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'query_ado_work_items') {
+          return Array.from({ length: 50 }, (_, index) => ({
+            ...mockWorkItems[0],
+            id: 600 + index,
+          }));
+        }
+        return baseInvoke(command, args);
+      };
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'My Work Items'
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      const hints = el.shadowRoot!.querySelectorAll('.capped-list-hint');
+      expect(hints.length).to.equal(1);
+      expect(hints[0].querySelector('a')?.getAttribute('href')).to.include('/_workitems/');
+    });
+
+    it('does not disclose a cap when fewer work items come back', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'My Work Items'
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.work-item').length).to.equal(mockWorkItems.length);
+      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(0);
     });
 
     it('shows the @Me-scoped empty state when the user has no assigned work items', async () => {
@@ -998,13 +1099,18 @@ describe('lv-azure-devops-dialog', () => {
       expect(args.top).to.equal(20);
     });
 
-    it('discloses when the pipeline list may be truncated', async () => {
+    // The request size and the disclosed size must be the same number. Serving a
+    // full page of exactly `top` runs and then requiring the hint to name that
+    // same `top` fails if the call site and the hint ever drift apart.
+    it('discloses the same page size it requests when the pipeline list is full', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
+      let requestedTop = 0;
       const baseInvoke = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'list_ado_pipeline_runs') {
-          return Array.from({ length: 20 }, (_, index) => ({
+          requestedTop = Number((args as Record<string, unknown>).top);
+          return Array.from({ length: requestedTop }, (_, index) => ({
             ...mockPipelineRuns[0],
             id: 300 + index,
           }));
@@ -1022,9 +1128,32 @@ describe('lv-azure-devops-dialog', () => {
       tab.click();
       await waitForLoad(el);
 
+      expect(requestedTop).to.be.greaterThan(0);
+      expect(el.shadowRoot!.querySelectorAll('.pipeline-item').length).to.equal(requestedTop);
       const hint = el.shadowRoot!.querySelector('.capped-list-hint');
-      expect(hint?.textContent).to.include('20');
-      expect(hint?.querySelector('a')?.getAttribute('href')).to.include('/_build');
+      expect(hint, 'capped hint rendered for a full page').to.not.be.null;
+      expect(hint!.textContent).to.include(String(requestedTop));
+      // The Pipelines landing page lists definitions; the runs view is the list
+      // the hint promises to complete.
+      expect(hint!.querySelector('a')?.getAttribute('href')).to.include('/_build?view=runs');
+    });
+
+    it('does not disclose a cap when fewer pipeline runs come back', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      const tab = Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (item) => item.textContent?.trim() === 'Pipelines',
+      ) as HTMLButtonElement;
+      tab.click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.pipeline-item').length).to.equal(mockPipelineRuns.length);
+      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(0);
     });
 
     it('surfaces a repository resolution failure in the pipelines tab', async () => {

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -998,6 +998,35 @@ describe('lv-azure-devops-dialog', () => {
       expect(args.top).to.equal(20);
     });
 
+    it('discloses when the pipeline list may be truncated', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const baseInvoke = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'list_ado_pipeline_runs') {
+          return Array.from({ length: 20 }, (_, index) => ({
+            ...mockPipelineRuns[0],
+            id: 300 + index,
+          }));
+        }
+        return baseInvoke(command, args);
+      };
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      const tab = Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (item) => item.textContent?.trim() === 'Pipelines',
+      ) as HTMLButtonElement;
+      tab.click();
+      await waitForLoad(el);
+
+      const hint = el.shadowRoot!.querySelector('.capped-list-hint');
+      expect(hint?.textContent).to.include('20');
+      expect(hint?.querySelector('a')?.getAttribute('href')).to.include('/_build');
+    });
+
     it('surfaces a repository resolution failure in the pipelines tab', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -658,6 +658,43 @@ describe('lv-azure-devops-dialog', () => {
       );
     });
 
+    // Azure DevOps defaults `searchCriteria.status` to `active`, so sending no
+    // status for "All" returns the Active list again — completed and abandoned
+    // PRs would go missing while the empty state claims to be showing "all".
+    it('sends the all status when the All filter is selected', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      const prTab = Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'Pull Requests'
+      ) as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const filterSelect = el.shadowRoot!.querySelector('.filter-select') as HTMLSelectElement;
+      invokeHistory.length = 0;
+      filterSelect.value = 'all';
+      filterSelect.dispatchEvent(new Event('change'));
+      await waitForLoad(el);
+
+      const allCall = invokeHistory.find((c) => c.command === 'list_ado_pull_requests');
+      expect(allCall, 'pull requests reloaded for the All filter').to.not.be.undefined;
+      expect((allCall!.args as Record<string, unknown>).status).to.equal('all');
+
+      // A concrete state still sends itself, unchanged.
+      invokeHistory.length = 0;
+      filterSelect.value = 'abandoned';
+      filterSelect.dispatchEvent(new Event('change'));
+      await waitForLoad(el);
+
+      const abandonedCall = invokeHistory.find((c) => c.command === 'list_ado_pull_requests');
+      expect((abandonedCall!.args as Record<string, unknown>).status).to.equal('abandoned');
+    });
+
     it('does not disclose a cap when fewer pull requests come back', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
@@ -730,14 +767,18 @@ describe('lv-azure-devops-dialog', () => {
     });
 
     // The work-items hint predates the shared `capped-list-hint` marker; it is the
-    // same disclosure as its siblings and must carry the same class.
-    it('marks the capped work-item hint with the shared hint class', async () => {
+    // same disclosure as its siblings and must carry the same class. Serving
+    // exactly the requested `limit` and then requiring the hint to name that same
+    // number fails if the call site and the hint ever drift apart.
+    it('discloses the same page size it requests when the work-item list is full', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
+      let requestedLimit = 0;
       const baseInvoke = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'query_ado_work_items') {
-          return Array.from({ length: 50 }, (_, index) => ({
+          requestedLimit = Number((args as Record<string, unknown>).limit);
+          return Array.from({ length: requestedLimit }, (_, index) => ({
             ...mockWorkItems[0],
             id: 600 + index,
           }));
@@ -754,8 +795,11 @@ describe('lv-azure-devops-dialog', () => {
       ) as HTMLButtonElement).click();
       await waitForLoad(el);
 
+      expect(requestedLimit).to.be.greaterThan(0);
+      expect(el.shadowRoot!.querySelectorAll('.work-item').length).to.equal(requestedLimit);
       const hints = el.shadowRoot!.querySelectorAll('.capped-list-hint');
       expect(hints.length).to.equal(1);
+      expect(hints[0].textContent).to.include(String(requestedLimit));
       expect(hints[0].querySelector('a')?.getAttribute('href')).to.include('/_workitems/');
     });
 

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -606,6 +606,54 @@ describe('lv-azure-devops-dialog', () => {
       expect(hint, 'capped hint rendered for a full page').to.not.be.null;
       expect(hint!.textContent).to.include(String(requestedTop));
       expect(hint!.querySelector('a')?.getAttribute('href')).to.equal(
+        'https://dev.azure.com/testorg/test-project/_git/test-repo/pullrequests?_a=active',
+      );
+    });
+
+    // The hint promises the rest of the list the user is looking at, so the link
+    // has to open that same list - not the PR page's default Active tab.
+    it('carries the PR filter into the capped-list link', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const baseInvoke = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'list_ado_pull_requests') {
+          const top = Number((args as Record<string, unknown>).top);
+          return Array.from({ length: top }, (_, index) => ({
+            ...mockPullRequests[0],
+            pullRequestId: 500 + index,
+          }));
+        }
+        return baseInvoke(command, args);
+      };
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+      const tabs = el.shadowRoot!.querySelectorAll('.tab');
+      const prTab = Array.from(tabs).find((t) => t.textContent?.trim() === 'Pull Requests') as HTMLButtonElement;
+      prTab.click();
+      await waitForLoad(el);
+
+      const filterSelect = el.shadowRoot!.querySelector('.filter-select') as HTMLSelectElement;
+      filterSelect.value = 'completed';
+      filterSelect.dispatchEvent(new Event('change'));
+      await waitForLoad(el);
+
+      const completedHint = el.shadowRoot!.querySelector('.capped-list-hint');
+      expect(completedHint, 'capped hint rendered for a full page').to.not.be.null;
+      expect(completedHint!.querySelector('a')?.getAttribute('href')).to.equal(
+        'https://dev.azure.com/testorg/test-project/_git/test-repo/pullrequests?_a=completed',
+      );
+
+      // "All" has no dedicated tab on the Azure DevOps PR page, so it stays bare.
+      filterSelect.value = 'all';
+      filterSelect.dispatchEvent(new Event('change'));
+      await waitForLoad(el);
+
+      const allHint = el.shadowRoot!.querySelector('.capped-list-hint');
+      expect(allHint!.querySelector('a')?.getAttribute('href')).to.equal(
         'https://dev.azure.com/testorg/test-project/_git/test-repo/pullrequests',
       );
     });

--- a/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
@@ -564,14 +564,24 @@ describe('lv-bitbucket-dialog', () => {
       expect(newPrBtn).to.not.be.undefined;
     });
 
+    // The dialog asks the backend for an explicit page size and discloses that
+    // same number, so serving exactly what was requested keeps the requested cap
+    // and the disclosed cap from drifting apart unnoticed.
     it('discloses capped pull requests with the active filter', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
+      let requestedPagelen = 0;
       const baseInvoke = mockInvoke;
-      mockInvoke = async (command: string, args?: unknown) =>
-        command === 'list_bitbucket_pull_requests'
-          ? Array.from({ length: 30 }, (_, index) => ({ ...mockPullRequests[0], id: index + 1 }))
-          : baseInvoke(command, args);
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'list_bitbucket_pull_requests') {
+          requestedPagelen = Number((args as Record<string, unknown>).pagelen);
+          return Array.from({ length: requestedPagelen }, (_, index) => ({
+            ...mockPullRequests[0],
+            id: index + 1,
+          }));
+        }
+        return baseInvoke(command, args);
+      };
       const el = await fixture<LvBitbucketDialog>(html`
         <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
       `);
@@ -581,8 +591,10 @@ describe('lv-bitbucket-dialog', () => {
       ) as HTMLButtonElement).click();
       await waitForLoad(el);
 
+      expect(requestedPagelen, 'dialog requested an explicit page size').to.be.greaterThan(0);
+      expect(el.shadowRoot!.querySelectorAll('.pr-item').length).to.equal(requestedPagelen);
       const hint = el.shadowRoot!.querySelector('.capped-list-hint');
-      expect(hint?.textContent).to.include('30');
+      expect(hint?.textContent).to.include(String(requestedPagelen));
       expect(hint?.querySelector('a')?.getAttribute('href')).to.include('state=OPEN');
     });
   });
@@ -635,11 +647,18 @@ describe('lv-bitbucket-dialog', () => {
     it('discloses capped issues once', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
+      let requestedPagelen = 0;
       const baseInvoke = mockInvoke;
-      mockInvoke = async (command: string, args?: unknown) =>
-        command === 'list_bitbucket_issues'
-          ? Array.from({ length: 30 }, (_, index) => ({ ...mockIssues[0], id: index + 1 }))
-          : baseInvoke(command, args);
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'list_bitbucket_issues') {
+          requestedPagelen = Number((args as Record<string, unknown>).pagelen);
+          return Array.from({ length: requestedPagelen }, (_, index) => ({
+            ...mockIssues[0],
+            id: index + 1,
+          }));
+        }
+        return baseInvoke(command, args);
+      };
       const el = await fixture<LvBitbucketDialog>(html`
         <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
       `);
@@ -649,7 +668,10 @@ describe('lv-bitbucket-dialog', () => {
       ) as HTMLButtonElement).click();
       await waitForLoad(el);
 
-      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(1);
+      expect(requestedPagelen, 'dialog requested an explicit page size').to.be.greaterThan(0);
+      const hints = el.shadowRoot!.querySelectorAll('.capped-list-hint');
+      expect(hints.length).to.equal(1);
+      expect(hints[0].textContent).to.include(String(requestedPagelen));
     });
   });
 
@@ -847,10 +869,12 @@ describe('lv-bitbucket-dialog', () => {
     it('discloses when the pipeline list may be truncated', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
+      let requestedPagelen = 0;
       const baseInvoke = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'list_bitbucket_pipelines') {
-          return Array.from({ length: 20 }, (_, index) => ({
+          requestedPagelen = Number((args as Record<string, unknown>).pagelen);
+          return Array.from({ length: requestedPagelen }, (_, index) => ({
             ...mockPipelines[0],
             uuid: `{pipeline-${index}}`,
             buildNumber: index + 1,
@@ -869,8 +893,10 @@ describe('lv-bitbucket-dialog', () => {
       tab.click();
       await waitForLoad(el);
 
+      expect(requestedPagelen, 'dialog requested an explicit page size').to.be.greaterThan(0);
+      expect(el.shadowRoot!.querySelectorAll('.pipeline-item').length).to.equal(requestedPagelen);
       const hint = el.shadowRoot!.querySelector('.capped-list-hint');
-      expect(hint?.textContent).to.include('20');
+      expect(hint?.textContent).to.include(String(requestedPagelen));
       expect(hint?.querySelector('a')?.getAttribute('href')).to.include('/pipelines');
     });
   });

--- a/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
@@ -523,6 +523,23 @@ describe('lv-bitbucket-dialog', () => {
       expect(firstPr.querySelector('.pr-branch')?.textContent).to.include('main');
     });
 
+    it('does not disclose a cap when fewer pull requests come back', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'Pull Requests',
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.pr-item').length).to.equal(mockPullRequests.length);
+      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(0);
+    });
+
     it('shows filter dropdown and New PR button', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
@@ -596,6 +613,23 @@ describe('lv-bitbucket-dialog', () => {
       const metaText = firstIssue.querySelector('.issue-meta')?.textContent;
       expect(metaText).to.include('bug');
       expect(metaText).to.include('critical');
+    });
+
+    it('does not disclose a cap when fewer issues come back', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'Issues',
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.issue-item').length).to.equal(mockIssues.length);
+      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(0);
     });
 
     it('discloses capped issues once', async () => {
@@ -791,6 +825,23 @@ describe('lv-bitbucket-dialog', () => {
       // Status indicator should exist
       const statusDot = firstPipeline.querySelector('.pipeline-status');
       expect(statusDot).to.not.be.null;
+    });
+
+    it('does not disclose a cap when fewer pipelines come back', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'Pipelines',
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.pipeline-item').length).to.equal(mockPipelines.length);
+      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(0);
     });
 
     it('discloses when the pipeline list may be truncated', async () => {

--- a/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-bitbucket-dialog.test.ts
@@ -546,6 +546,28 @@ describe('lv-bitbucket-dialog', () => {
       );
       expect(newPrBtn).to.not.be.undefined;
     });
+
+    it('discloses capped pull requests with the active filter', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const baseInvoke = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) =>
+        command === 'list_bitbucket_pull_requests'
+          ? Array.from({ length: 30 }, (_, index) => ({ ...mockPullRequests[0], id: index + 1 }))
+          : baseInvoke(command, args);
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (tab) => tab.textContent?.trim() === 'Pull Requests',
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      const hint = el.shadowRoot!.querySelector('.capped-list-hint');
+      expect(hint?.textContent).to.include('30');
+      expect(hint?.querySelector('a')?.getAttribute('href')).to.include('state=OPEN');
+    });
   });
 
   describe('Issues Tab', () => {
@@ -574,6 +596,26 @@ describe('lv-bitbucket-dialog', () => {
       const metaText = firstIssue.querySelector('.issue-meta')?.textContent;
       expect(metaText).to.include('bug');
       expect(metaText).to.include('critical');
+    });
+
+    it('discloses capped issues once', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const baseInvoke = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) =>
+        command === 'list_bitbucket_issues'
+          ? Array.from({ length: 30 }, (_, index) => ({ ...mockIssues[0], id: index + 1 }))
+          : baseInvoke(command, args);
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (tab) => tab.textContent?.trim() === 'Issues',
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(1);
     });
   });
 
@@ -749,6 +791,36 @@ describe('lv-bitbucket-dialog', () => {
       // Status indicator should exist
       const statusDot = firstPipeline.querySelector('.pipeline-status');
       expect(statusDot).to.not.be.null;
+    });
+
+    it('discloses when the pipeline list may be truncated', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const baseInvoke = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'list_bitbucket_pipelines') {
+          return Array.from({ length: 20 }, (_, index) => ({
+            ...mockPipelines[0],
+            uuid: `{pipeline-${index}}`,
+            buildNumber: index + 1,
+          }));
+        }
+        return baseInvoke(command, args);
+      };
+
+      const el = await fixture<LvBitbucketDialog>(html`
+        <lv-bitbucket-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-bitbucket-dialog>
+      `);
+      await waitForLoad(el);
+      const tab = Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (item) => item.textContent?.trim() === 'Pipelines',
+      ) as HTMLButtonElement;
+      tab.click();
+      await waitForLoad(el);
+
+      const hint = el.shadowRoot!.querySelector('.capped-list-hint');
+      expect(hint?.textContent).to.include('20');
+      expect(hint?.querySelector('a')?.getAttribute('href')).to.include('/pipelines');
     });
   });
 

--- a/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
@@ -572,14 +572,24 @@ describe('lv-gitlab-dialog', () => {
       expect(newMrBtn).to.not.be.undefined;
     });
 
+    // The dialog asks the backend for an explicit page size and discloses that
+    // same number, so serving exactly what was requested keeps the requested cap
+    // and the disclosed cap from drifting apart unnoticed.
     it('discloses capped merge requests with the active filter', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
+      let requestedPerPage = 0;
       const baseInvoke = mockInvoke;
-      mockInvoke = async (command: string, args?: unknown) =>
-        command === 'list_gitlab_merge_requests'
-          ? Array.from({ length: 30 }, (_, index) => ({ ...mockMergeRequests[0], iid: index + 1 }))
-          : baseInvoke(command, args);
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'list_gitlab_merge_requests') {
+          requestedPerPage = Number((args as Record<string, unknown>).perPage);
+          return Array.from({ length: requestedPerPage }, (_, index) => ({
+            ...mockMergeRequests[0],
+            iid: index + 1,
+          }));
+        }
+        return baseInvoke(command, args);
+      };
       const el = await fixture<LvGitLabDialog>(html`
         <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
       `);
@@ -589,8 +599,10 @@ describe('lv-gitlab-dialog', () => {
       ) as HTMLButtonElement).click();
       await waitForLoad(el);
 
+      expect(requestedPerPage, 'dialog requested an explicit page size').to.be.greaterThan(0);
+      expect(el.shadowRoot!.querySelectorAll('.mr-item').length).to.equal(requestedPerPage);
       const hint = el.shadowRoot!.querySelector('.capped-list-hint');
-      expect(hint?.textContent).to.include('30');
+      expect(hint?.textContent).to.include(String(requestedPerPage));
       expect(hint?.querySelector('a')?.getAttribute('href')).to.include('state=opened');
     });
   });
@@ -644,15 +656,19 @@ describe('lv-gitlab-dialog', () => {
     it('renders one capped hint for label-less issues', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
+      let requestedPerPage = 0;
       const baseInvoke = mockInvoke;
-      mockInvoke = async (command: string, args?: unknown) =>
-        command === 'list_gitlab_issues'
-          ? Array.from({ length: 30 }, (_, index) => ({
-              ...mockIssues[0],
-              iid: index + 1,
-              labels: [],
-            }))
-          : baseInvoke(command, args);
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'list_gitlab_issues') {
+          requestedPerPage = Number((args as Record<string, unknown>).perPage);
+          return Array.from({ length: requestedPerPage }, (_, index) => ({
+            ...mockIssues[0],
+            iid: index + 1,
+            labels: [],
+          }));
+        }
+        return baseInvoke(command, args);
+      };
       const el = await fixture<LvGitLabDialog>(html`
         <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
       `);
@@ -662,8 +678,10 @@ describe('lv-gitlab-dialog', () => {
       ) as HTMLButtonElement).click();
       await waitForLoad(el);
 
+      expect(requestedPerPage, 'dialog requested an explicit page size').to.be.greaterThan(0);
       const hints = el.shadowRoot!.querySelectorAll('.capped-list-hint');
       expect(hints.length).to.equal(1);
+      expect(hints[0].textContent).to.include(String(requestedPerPage));
       expect(hints[0].querySelector('a')?.getAttribute('href')).to.include('state=opened');
     });
   });
@@ -719,10 +737,12 @@ describe('lv-gitlab-dialog', () => {
     it('discloses when the pipeline list may be truncated', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
+      let requestedPerPage = 0;
       const baseInvoke = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'list_gitlab_pipelines') {
-          return Array.from({ length: 20 }, (_, index) => ({
+          requestedPerPage = Number((args as Record<string, unknown>).perPage);
+          return Array.from({ length: requestedPerPage }, (_, index) => ({
             ...mockPipelines[0],
             id: 1000 + index,
             iid: index + 1,
@@ -741,8 +761,10 @@ describe('lv-gitlab-dialog', () => {
       tab.click();
       await waitForLoad(el);
 
+      expect(requestedPerPage, 'dialog requested an explicit page size').to.be.greaterThan(0);
+      expect(el.shadowRoot!.querySelectorAll('.pipeline-item').length).to.equal(requestedPerPage);
       const hint = el.shadowRoot!.querySelector('.capped-list-hint');
-      expect(hint?.textContent).to.include('20');
+      expect(hint?.textContent).to.include(String(requestedPerPage));
       expect(hint?.querySelector('a')?.getAttribute('href')).to.include('/-/pipelines');
     });
   });

--- a/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
@@ -554,6 +554,28 @@ describe('lv-gitlab-dialog', () => {
       );
       expect(newMrBtn).to.not.be.undefined;
     });
+
+    it('discloses capped merge requests with the active filter', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const baseInvoke = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) =>
+        command === 'list_gitlab_merge_requests'
+          ? Array.from({ length: 30 }, (_, index) => ({ ...mockMergeRequests[0], iid: index + 1 }))
+          : baseInvoke(command, args);
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (tab) => tab.textContent?.trim() === 'Merge Requests',
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      const hint = el.shadowRoot!.querySelector('.capped-list-hint');
+      expect(hint?.textContent).to.include('30');
+      expect(hint?.querySelector('a')?.getAttribute('href')).to.include('state=opened');
+    });
   });
 
   describe('Issues Tab', () => {
@@ -583,6 +605,32 @@ describe('lv-gitlab-dialog', () => {
       expect(labels.length).to.equal(2);
       expect(labels[0].textContent?.trim()).to.equal('bug');
       expect(labels[1].textContent?.trim()).to.equal('performance');
+    });
+
+    it('renders one capped hint for label-less issues', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const baseInvoke = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) =>
+        command === 'list_gitlab_issues'
+          ? Array.from({ length: 30 }, (_, index) => ({
+              ...mockIssues[0],
+              iid: index + 1,
+              labels: [],
+            }))
+          : baseInvoke(command, args);
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (tab) => tab.textContent?.trim() === 'Issues',
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      const hints = el.shadowRoot!.querySelectorAll('.capped-list-hint');
+      expect(hints.length).to.equal(1);
+      expect(hints[0].querySelector('a')?.getAttribute('href')).to.include('state=opened');
     });
   });
 
@@ -615,6 +663,36 @@ describe('lv-gitlab-dialog', () => {
       // Should show truncated sha
       const metaText = firstPipeline.querySelector('.pipeline-meta')?.textContent;
       expect(metaText).to.include('abc12345');
+    });
+
+    it('discloses when the pipeline list may be truncated', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+      const baseInvoke = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'list_gitlab_pipelines') {
+          return Array.from({ length: 20 }, (_, index) => ({
+            ...mockPipelines[0],
+            id: 1000 + index,
+            iid: index + 1,
+          }));
+        }
+        return baseInvoke(command, args);
+      };
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+      const tab = Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (item) => item.textContent?.trim() === 'Pipelines',
+      ) as HTMLButtonElement;
+      tab.click();
+      await waitForLoad(el);
+
+      const hint = el.shadowRoot!.querySelector('.capped-list-hint');
+      expect(hint?.textContent).to.include('20');
+      expect(hint?.querySelector('a')?.getAttribute('href')).to.include('/-/pipelines');
     });
   });
 

--- a/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-gitlab-dialog.test.ts
@@ -531,6 +531,23 @@ describe('lv-gitlab-dialog', () => {
       expect(firstMr.querySelector('.mr-branch')?.textContent).to.include('main');
     });
 
+    it('does not disclose a cap when fewer merge requests come back', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'Merge Requests',
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.mr-item').length).to.equal(mockMergeRequests.length);
+      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(0);
+    });
+
     it('shows filter dropdown and New MR button', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
@@ -607,6 +624,23 @@ describe('lv-gitlab-dialog', () => {
       expect(labels[1].textContent?.trim()).to.equal('performance');
     });
 
+    it('does not disclose a cap when fewer issues come back', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'Issues',
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.issue-item').length).to.equal(mockIssues.length);
+      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(0);
+    });
+
     it('renders one capped hint for label-less issues', async () => {
       connectionResponse = mockConnectedStatus;
       detectedRepoResponse = mockDetectedRepo;
@@ -663,6 +697,23 @@ describe('lv-gitlab-dialog', () => {
       // Should show truncated sha
       const metaText = firstPipeline.querySelector('.pipeline-meta')?.textContent;
       expect(metaText).to.include('abc12345');
+    });
+
+    it('does not disclose a cap when fewer pipelines come back', async () => {
+      connectionResponse = mockConnectedStatus;
+      detectedRepoResponse = mockDetectedRepo;
+
+      const el = await fixture<LvGitLabDialog>(html`
+        <lv-gitlab-dialog .open=${true} .repositoryPath=${'/mock/repo'}></lv-gitlab-dialog>
+      `);
+      await waitForLoad(el);
+      (Array.from(el.shadowRoot!.querySelectorAll('.tab')).find(
+        (t) => t.textContent?.trim() === 'Pipelines',
+      ) as HTMLButtonElement).click();
+      await waitForLoad(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.pipeline-item').length).to.equal(mockPipelines.length);
+      expect(el.shadowRoot!.querySelectorAll('.capped-list-hint').length).to.equal(0);
     });
 
     it('discloses when the pipeline list may be truncated', async () => {

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -40,7 +40,15 @@ type TabType = 'connection' | 'pull-requests' | 'work-items' | 'pipelines' | 'cr
  * this long, more may exist and the tab shows a "capped" hint.
  */
 const WORK_ITEMS_PAGE_SIZE = 50;
+
+/**
+ * Page size this dialog asks for when listing pipeline runs and pull requests.
+ * Both are passed straight into the listing call as `top`, so the number the
+ * request caps at and the number the "capped" hint discloses are the same
+ * constant — never a literal at the call site.
+ */
 const PIPELINE_RUNS_PAGE_SIZE = 20;
+const PULL_REQUESTS_PAGE_SIZE = 100;
 
 /** Shown when a PAT connect succeeded but writing the keyring git credential did not. */
 const GIT_CRED_WRITE_FAILED_TOAST =
@@ -1120,6 +1128,7 @@ export class LvAzureDevOpsDialog extends LitElement {
         this.detectedRepo.project,
         this.detectedRepo.repository,
         this.prFilter === 'all' ? undefined : this.prFilter,
+        PULL_REQUESTS_PAGE_SIZE,
         token
       );
 
@@ -1174,7 +1183,7 @@ export class LvAzureDevOpsDialog extends LitElement {
         this.detectedRepo.organization,
         this.detectedRepo.project,
         this.detectedRepo.repository,
-        20,
+        PIPELINE_RUNS_PAGE_SIZE,
         token
       );
 
@@ -2138,6 +2147,16 @@ export class LvAzureDevOpsDialog extends LitElement {
           </div>
         `)}
       </div>
+      ${this.pullRequests.length >= PULL_REQUESTS_PAGE_SIZE ? html`
+        <p class="help-text capped-list-hint" style="text-align:center;padding-top:8px">
+          Showing the first ${PULL_REQUESTS_PAGE_SIZE} pull requests; more may exist.
+          <a
+            class="help-link"
+            href="https://dev.azure.com/${this.detectedRepo.organization}/${this.detectedRepo.project}/_git/${this.detectedRepo.repository}/pullrequests"
+            @click=${handleExternalLink}
+          >Open in Azure DevOps</a> for the full list.
+        </p>
+      ` : nothing}
     `;
   }
 
@@ -2206,7 +2225,7 @@ export class LvAzureDevOpsDialog extends LitElement {
         `)}
       </div>
       ${this.workItems.length >= WORK_ITEMS_PAGE_SIZE ? html`
-        <p class="help-text" style="text-align:center;padding-top:8px">
+        <p class="help-text capped-list-hint" style="text-align:center;padding-top:8px">
           Showing your ${WORK_ITEMS_PAGE_SIZE} most recent.
           ${this.detectedRepo ? html`<a
             class="help-link"
@@ -2275,7 +2294,7 @@ export class LvAzureDevOpsDialog extends LitElement {
           Showing the ${PIPELINE_RUNS_PAGE_SIZE} most recent pipeline runs; more may exist.
           <a
             class="help-link"
-            href="https://dev.azure.com/${this.detectedRepo.organization}/${this.detectedRepo.project}/_build"
+            href="https://dev.azure.com/${this.detectedRepo.organization}/${this.detectedRepo.project}/_build?view=runs"
             @click=${handleExternalLink}
           >Open in Azure DevOps</a> for the full list.
         </p>

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -40,6 +40,7 @@ type TabType = 'connection' | 'pull-requests' | 'work-items' | 'pipelines' | 'cr
  * this long, more may exist and the tab shows a "capped" hint.
  */
 const WORK_ITEMS_PAGE_SIZE = 50;
+const PIPELINE_RUNS_PAGE_SIZE = 20;
 
 /** Shown when a PAT connect succeeded but writing the keyring git credential did not. */
 const GIT_CRED_WRITE_FAILED_TOAST =
@@ -2269,6 +2270,16 @@ export class LvAzureDevOpsDialog extends LitElement {
           </div>
         `)}
       </div>
+      ${this.pipelineRuns.length >= PIPELINE_RUNS_PAGE_SIZE ? html`
+        <p class="help-text capped-list-hint" style="text-align:center;padding-top:8px">
+          Showing the ${PIPELINE_RUNS_PAGE_SIZE} most recent pipeline runs; more may exist.
+          <a
+            class="help-link"
+            href="https://dev.azure.com/${this.detectedRepo.organization}/${this.detectedRepo.project}/_build"
+            @click=${handleExternalLink}
+          >Open in Azure DevOps</a> for the full list.
+        </p>
+      ` : nothing}
     `;
   }
 

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -2105,6 +2105,13 @@ export class LvAzureDevOpsDialog extends LitElement {
       `;
     }
 
+    // The Azure DevOps PR page opens on its Active tab, so a bare link would send
+    // someone reading the Completed or Abandoned list to a different list than the
+    // one the hint promises to complete. `_a` selects that page's own tabs and
+    // takes the filter values verbatim; "All" has no tab of its own, so it stays
+    // on the default view.
+    const prListQuery = this.prFilter === 'all' ? '' : `?_a=${this.prFilter}`;
+
     return html`
       <div class="filter-row">
         <select class="filter-select" @change=${this.handlePrFilterChange}>
@@ -2152,7 +2159,7 @@ export class LvAzureDevOpsDialog extends LitElement {
           Showing the first ${PULL_REQUESTS_PAGE_SIZE} pull requests; more may exist.
           <a
             class="help-link"
-            href="https://dev.azure.com/${this.detectedRepo.organization}/${this.detectedRepo.project}/_git/${this.detectedRepo.repository}/pullrequests"
+            href="https://dev.azure.com/${this.detectedRepo.organization}/${this.detectedRepo.project}/_git/${this.detectedRepo.repository}/pullrequests${prListQuery}"
             @click=${handleExternalLink}
           >Open in Azure DevOps</a> for the full list.
         </p>

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -35,9 +35,10 @@ import './lv-account-selector.ts';
 type TabType = 'connection' | 'pull-requests' | 'work-items' | 'pipelines' | 'create-pr' | 'create-work-item';
 
 /**
- * Max work items the backend returns for the "My Work Items" list (kept in sync
- * with WORK_ITEMS_LIMIT in commands/azure_devops.rs). When the list is exactly
- * this long, more may exist and the tab shows a "capped" hint.
+ * Page size this dialog asks for when listing work items. Passed straight into
+ * the listing call as `limit`, so the number the request caps at and the number
+ * the "capped" hint discloses are the same constant. When the list is exactly
+ * this long, more may exist and the tab shows the hint.
  */
 const WORK_ITEMS_PAGE_SIZE = 50;
 
@@ -1127,7 +1128,11 @@ export class LvAzureDevOpsDialog extends LitElement {
         this.detectedRepo.organization,
         this.detectedRepo.project,
         this.detectedRepo.repository,
-        this.prFilter === 'all' ? undefined : this.prFilter,
+        // Always send the filter: Azure DevOps defaults `searchCriteria.status`
+        // to `active`, so omitting it for "All" would return the Active list
+        // again and silently drop completed and abandoned pull requests. `all`
+        // is a valid PullRequestStatus, so it goes over the wire like the rest.
+        this.prFilter,
         PULL_REQUESTS_PAGE_SIZE,
         token
       );
@@ -1157,6 +1162,7 @@ export class LvAzureDevOpsDialog extends LitElement {
         this.detectedRepo.organization,
         this.detectedRepo.project,
         this.workItemFilter || undefined,
+        WORK_ITEMS_PAGE_SIZE,
         token
       );
 

--- a/src/components/dialogs/lv-bitbucket-dialog.ts
+++ b/src/components/dialogs/lv-bitbucket-dialog.ts
@@ -31,6 +31,8 @@ import './lv-modal.ts';
 import './lv-account-selector.ts';
 
 type TabType = 'connection' | 'pull-requests' | 'issues' | 'pipelines' | 'create-pr' | 'create-issue';
+const BITBUCKET_LIST_PAGE_SIZE = 30;
+const BITBUCKET_PIPELINE_PAGE_SIZE = 20;
 
 @customElement('lv-bitbucket-dialog')
 export class LvBitbucketDialog extends LitElement {
@@ -1732,6 +1734,13 @@ export class LvBitbucketDialog extends LitElement {
           </div>
         `)}
       </div>
+      ${this.renderCappedListHint(
+        this.pullRequests.length,
+        BITBUCKET_LIST_PAGE_SIZE,
+        'pull requests',
+        'pull-requests',
+        this.prFilter,
+      )}
     `;
   }
 
@@ -1785,6 +1794,12 @@ export class LvBitbucketDialog extends LitElement {
           </div>
         `)}
       </div>
+      ${this.renderCappedListHint(
+        this.issues.length,
+        BITBUCKET_LIST_PAGE_SIZE,
+        'issues',
+        'issues',
+      )}
     `;
   }
 
@@ -1824,6 +1839,33 @@ export class LvBitbucketDialog extends LitElement {
           </div>
         `)}
       </div>
+      ${this.renderCappedListHint(
+        this.pipelines.length,
+        BITBUCKET_PIPELINE_PAGE_SIZE,
+        'pipelines',
+        'pipelines',
+      )}
+    `;
+  }
+
+  private renderCappedListHint(
+    count: number,
+    limit: number,
+    label: string,
+    route: string,
+    state?: string,
+  ) {
+    if (count < limit || !this.detectedRepo) return nothing;
+    const query = state ? `?state=${encodeURIComponent(state)}` : '';
+    return html`
+      <p class="help-text capped-list-hint" style="text-align:center;padding-top:8px">
+        Showing the first ${limit} ${label}; more may exist.
+        <a
+          class="help-link"
+          href="https://bitbucket.org/${this.detectedRepo.workspace}/${this.detectedRepo.repoSlug}/${route}${query}"
+          @click=${handleExternalLink}
+        >Open in Bitbucket</a> for the full list.
+      </p>
     `;
   }
 

--- a/src/components/dialogs/lv-bitbucket-dialog.ts
+++ b/src/components/dialogs/lv-bitbucket-dialog.ts
@@ -31,6 +31,13 @@ import './lv-modal.ts';
 import './lv-account-selector.ts';
 
 type TabType = 'connection' | 'pull-requests' | 'issues' | 'pipelines' | 'create-pr' | 'create-issue';
+
+/**
+ * Page sizes this dialog asks for when listing pull requests, issues and
+ * pipelines. Each is passed straight into the listing call as `pagelen`, so the
+ * number the request caps at and the number the "capped" hint discloses are the
+ * same constant — never a literal at the call site or in commands/bitbucket.rs.
+ */
 const BITBUCKET_LIST_PAGE_SIZE = 30;
 const BITBUCKET_PIPELINE_PAGE_SIZE = 20;
 
@@ -1049,6 +1056,7 @@ export class LvBitbucketDialog extends LitElement {
         this.detectedRepo.workspace,
         this.detectedRepo.repoSlug,
         this.prFilter,
+        BITBUCKET_LIST_PAGE_SIZE,
         token
       );
 
@@ -1073,6 +1081,7 @@ export class LvBitbucketDialog extends LitElement {
         this.detectedRepo.workspace,
         this.detectedRepo.repoSlug,
         undefined,
+        BITBUCKET_LIST_PAGE_SIZE,
         token
       );
 
@@ -1096,6 +1105,7 @@ export class LvBitbucketDialog extends LitElement {
       const result = await gitService.listBitbucketPipelines(
         this.detectedRepo.workspace,
         this.detectedRepo.repoSlug,
+        BITBUCKET_PIPELINE_PAGE_SIZE,
         token
       );
 

--- a/src/components/dialogs/lv-gitlab-dialog.ts
+++ b/src/components/dialogs/lv-gitlab-dialog.ts
@@ -31,6 +31,13 @@ import './lv-modal.ts';
 import './lv-account-selector.ts';
 
 const log = loggers.gitlab;
+
+/**
+ * Page sizes this dialog asks for when listing merge requests, issues and
+ * pipelines. Each is passed straight into the listing call as `perPage`, so the
+ * number the request caps at and the number the "capped" hint discloses are the
+ * same constant — never a literal at the call site or in commands/gitlab.rs.
+ */
 const GITLAB_LIST_PAGE_SIZE = 30;
 const GITLAB_PIPELINE_PAGE_SIZE = 20;
 
@@ -1003,6 +1010,7 @@ export class LvGitLabDialog extends LitElement {
         this.detectedRepo.instanceUrl,
         this.detectedRepo.projectPath,
         this.mrFilter === 'all' ? undefined : this.mrFilter,
+        GITLAB_LIST_PAGE_SIZE,
         token
       );
 
@@ -1028,6 +1036,7 @@ export class LvGitLabDialog extends LitElement {
         this.detectedRepo.projectPath,
         this.issueFilter === 'all' ? undefined : this.issueFilter,
         undefined, // labels
+        GITLAB_LIST_PAGE_SIZE,
         token
       );
 
@@ -1050,6 +1059,7 @@ export class LvGitLabDialog extends LitElement {
         this.detectedRepo.instanceUrl,
         this.detectedRepo.projectPath,
         undefined, // status
+        GITLAB_PIPELINE_PAGE_SIZE,
         token
       );
 

--- a/src/components/dialogs/lv-gitlab-dialog.ts
+++ b/src/components/dialogs/lv-gitlab-dialog.ts
@@ -31,6 +31,8 @@ import './lv-modal.ts';
 import './lv-account-selector.ts';
 
 const log = loggers.gitlab;
+const GITLAB_LIST_PAGE_SIZE = 30;
+const GITLAB_PIPELINE_PAGE_SIZE = 20;
 
 type TabType = 'connection' | 'merge-requests' | 'issues' | 'pipelines' | 'create-mr' | 'create-issue';
 
@@ -1734,6 +1736,13 @@ export class LvGitLabDialog extends LitElement {
           </div>
         `)}
       </div>
+      ${this.renderCappedListHint(
+        this.mergeRequests.length,
+        GITLAB_LIST_PAGE_SIZE,
+        'merge requests',
+        'merge_requests',
+        this.mrFilter,
+      )}
     `;
   }
 
@@ -1791,6 +1800,13 @@ export class LvGitLabDialog extends LitElement {
           </div>
         `)}
       </div>
+      ${this.renderCappedListHint(
+        this.issues.length,
+        GITLAB_LIST_PAGE_SIZE,
+        'issues',
+        'issues',
+        this.issueFilter,
+      )}
     `;
   }
 
@@ -1831,6 +1847,34 @@ export class LvGitLabDialog extends LitElement {
           </div>
         `)}
       </div>
+      ${this.renderCappedListHint(
+        this.pipelines.length,
+        GITLAB_PIPELINE_PAGE_SIZE,
+        'pipelines',
+        'pipelines',
+      )}
+    `;
+  }
+
+  private renderCappedListHint(
+    count: number,
+    limit: number,
+    label: string,
+    route: string,
+    state?: string,
+  ) {
+    if (count < limit || !this.detectedRepo) return nothing;
+    const base = this.detectedRepo.instanceUrl.replace(/\/$/, '');
+    const query = state ? `?state=${encodeURIComponent(state)}` : '';
+    return html`
+      <p class="help-text capped-list-hint" style="text-align:center;padding-top:8px">
+        Showing the first ${limit} ${label}; more may exist.
+        <a
+          class="help-link"
+          href="${base}/${this.detectedRepo.projectPath}/-/${route}${query}"
+          @click=${handleExternalLink}
+        >Open in GitLab</a> for the full list.
+      </p>
     `;
   }
 

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -4267,12 +4267,14 @@ export async function queryAdoWorkItems(
   organization: string,
   project: string,
   state?: string,
+  limit?: number,
   token?: string | null,
 ): Promise<CommandResult<AdoWorkItem[]>> {
   return invokeProviderCommand<AdoWorkItem[]>("query_ado_work_items", {
     organization,
     project,
     state,
+    limit,
     token,
   });
 }

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -4202,6 +4202,7 @@ export async function listAdoPullRequests(
   project: string,
   repository: string,
   status?: string,
+  top?: number,
   token?: string | null,
 ): Promise<CommandResult<AdoPullRequest[]>> {
   return invokeProviderCommand<AdoPullRequest[]>("list_ado_pull_requests", {
@@ -4209,6 +4210,7 @@ export async function listAdoPullRequests(
     project,
     repository,
     status,
+    top,
     token,
   });
 }

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -4486,12 +4486,14 @@ export async function listGitLabMergeRequests(
   instanceUrl: string,
   projectPath: string,
   state?: string,
+  perPage?: number,
   token?: string | null,
 ): Promise<CommandResult<GitLabMergeRequest[]>> {
   return invokeProviderCommand<GitLabMergeRequest[]>("list_gitlab_merge_requests", {
     instanceUrl,
     projectPath,
     state,
+    perPage,
     token,
   });
 }
@@ -4531,6 +4533,7 @@ export async function listGitLabIssues(
   projectPath: string,
   state?: string,
   labels?: string,
+  perPage?: number,
   token?: string | null,
 ): Promise<CommandResult<GitLabIssue[]>> {
   return invokeProviderCommand<GitLabIssue[]>("list_gitlab_issues", {
@@ -4538,6 +4541,7 @@ export async function listGitLabIssues(
     projectPath,
     state,
     labels,
+    perPage,
     token,
   });
 }
@@ -4562,12 +4566,14 @@ export async function listGitLabPipelines(
   instanceUrl: string,
   projectPath: string,
   status?: string,
+  perPage?: number,
   token?: string | null,
 ): Promise<CommandResult<GitLabPipeline[]>> {
   return invokeProviderCommand<GitLabPipeline[]>("list_gitlab_pipelines", {
     instanceUrl,
     projectPath,
     status,
+    perPage,
     token,
   });
 }
@@ -4745,12 +4751,14 @@ export async function listBitbucketPullRequests(
   workspace: string,
   repoSlug: string,
   state?: string,
+  pagelen?: number,
   token?: string | null,
 ): Promise<CommandResult<BitbucketPullRequest[]>> {
   return invokeProviderCommand<BitbucketPullRequest[]>("list_bitbucket_pull_requests", {
     workspace,
     repoSlug,
     state,
+    pagelen,
     token,
   });
 }
@@ -4789,12 +4797,14 @@ export async function listBitbucketIssues(
   workspace: string,
   repoSlug: string,
   state?: string,
+  pagelen?: number,
   token?: string | null,
 ): Promise<CommandResult<BitbucketIssue[]>> {
   return invokeProviderCommand<BitbucketIssue[]>("list_bitbucket_issues", {
     workspace,
     repoSlug,
     state,
+    pagelen,
     token,
   });
 }
@@ -4825,11 +4835,13 @@ export async function createBitbucketIssue(
 export async function listBitbucketPipelines(
   workspace: string,
   repoSlug: string,
+  pagelen?: number,
   token?: string | null,
 ): Promise<CommandResult<BitbucketPipeline[]>> {
   return invokeProviderCommand<BitbucketPipeline[]>("list_bitbucket_pipelines", {
     workspace,
     repoSlug,
+    pagelen,
     token,
   });
 }


### PR DESCRIPTION
## Summary
- disclose API caps for GitLab and Bitbucket merge request, issue, and pipeline lists
- disclose the Azure DevOps pipeline-run cap
- link to each provider's full filtered list

## Tests
- npm run typecheck
- 152 targeted provider-dialog tests passed