### PR TITLE
Confirm before replacing merge resolutions

### DIFF
--- a/e2e/tests/merge-editor.spec.ts
+++ b/e2e/tests/merge-editor.spec.ts
@@ -2,6 +2,7 @@ import { test, expect } from '@playwright/test';
 import { setupOpenRepository, withConflicts } from '../fixtures/tauri-mock';
 import {
   startCommandCapture,
+  startCommandCaptureWithMocks,
   findCommand,
   waitForCommand,
   injectCommandError,
@@ -294,6 +295,77 @@ test.describe('Merge Editor - Conflict Resolution Dialog', () => {
     // After accepting ours, conflict count should show "No conflicts"
     const conflictCount = page.locator('lv-merge-editor .conflict-count');
     await expect(conflictCount).toContainText('No conflicts');
+  });
+
+  test('toolbar Use Ours confirms before replacing a per-block pick', async ({ page }) => {
+    await openConflictResolutionDialog(page);
+
+    // Make a per-block pick — this is the in-progress work the confirm guards.
+    const block = page.locator('lv-merge-editor .code-conflict-block');
+    await block.locator('button', { hasText: 'Use Theirs' }).click();
+    const output = page.locator('lv-merge-editor #panel-output');
+    await expect(output).toContainText('const value = "theirs";');
+
+    // Declining must leave the pick exactly as it was. The whole-file blobs
+    // all read as `base` here, so its absence proves nothing was overwritten.
+    await startCommandCaptureWithMocks(page, { 'plugin:dialog|confirm': false });
+    await page.locator('lv-merge-editor .toolbar-actions .btn-ours').click();
+    await waitForCommand(page, 'plugin:dialog|message');
+    await expect(output).toContainText('const value = "theirs";');
+    await expect(output).not.toContainText('const value = "base";');
+
+    // Accepting replaces the pick with the whole ours blob.
+    await startCommandCaptureWithMocks(page, { 'plugin:dialog|confirm': true });
+    await page.locator('lv-merge-editor .toolbar-actions .btn-ours').click();
+    await waitForCommand(page, 'plugin:dialog|message');
+    await expect(output).toContainText('const value = "base";');
+    await expect(output).not.toContainText('const value = "theirs";');
+  });
+
+  test('declining the take-side confirm keeps the deleted-side file unresolved', async ({
+    page,
+  }) => {
+    // Modify/delete: git leaves the workdir file marker-free, so the toolbar's
+    // "Use Theirs (delete file)" is a take-side that stages a deletion on disk.
+    await injectCommandMock(page, {
+      get_conflicts: [
+        {
+          path: 'src/conflict.ts',
+          ancestor: { oid: 'ancestor_oid_123' },
+          ours: { oid: 'ours_oid_456' },
+          theirs: null,
+        },
+      ],
+      read_file_content: 'const value = "ours";',
+      resolve_conflict_take_side: null,
+    });
+    await openConflictResolutionDialog(page);
+
+    // Accept ours whole-file first — the only in-editor work reachable here.
+    await page.locator('lv-merge-editor .toolbar-actions .btn-ours').click();
+    const output = page.locator('lv-merge-editor #panel-output');
+    await expect(output).toContainText('const value = "base";');
+
+    const deleteBtn = page.locator('lv-merge-editor .toolbar-actions .btn-theirs', {
+      hasText: 'Use Theirs (delete file)',
+    });
+    await expect(deleteBtn).toBeVisible();
+
+    await startCommandCaptureWithMocks(page, { 'plugin:dialog|confirm': false });
+    await deleteBtn.click();
+    await waitForCommand(page, 'plugin:dialog|message');
+    expect(await findCommand(page, 'resolve_conflict_take_side')).toHaveLength(0);
+    await expect(output).toContainText('const value = "base";');
+
+    // Confirming stages the deletion and lands in the terminal deleted state.
+    // (Each stacked mock wrapper records the call, so assert on the args, not
+    // on how many times the capture layers saw it.)
+    await startCommandCaptureWithMocks(page, { 'plugin:dialog|confirm': true });
+    await deleteBtn.click();
+    await waitForCommand(page, 'resolve_conflict_take_side');
+    const taken = await findCommand(page, 'resolve_conflict_take_side');
+    expect((taken[0].args as { side: string }).side).toBe('theirs');
+    await expect(output).toContainText('this file was deleted by the resolution');
   });
 
   test('clicking Use Theirs in toolbar replaces output with theirs content', async ({ page }) => {

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -1607,7 +1607,7 @@ describe('lv-merge-editor', () => {
       // The whole-file accept is unsaved work, so Reload confirms first.
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') return 'Ok';
+        if (command === 'plugin:dialog|confirm') return 'Ok';
         return baseMock(command, args);
       };
       const el = await renderLoadedEditor();
@@ -2798,7 +2798,7 @@ describe('lv-merge-editor', () => {
       let confirmAnswer: unknown = false;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'get_merge_tool_config') return { toolName: 'meld' };
-        if (command === 'plugin:dialog|message') return confirmAnswer;
+        if (command === 'plugin:dialog|confirm') return confirmAnswer;
         if (command === 'launch_merge_tool') {
           launchCalls++;
           return { success: true };
@@ -2842,7 +2842,7 @@ describe('lv-merge-editor', () => {
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'get_merge_tool_config') return { toolName: 'meld' };
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           confirmCalls++;
           // The native confirm is an async IPC round-trip — a second click
           // can land before it resolves.
@@ -2894,7 +2894,7 @@ describe('lv-merge-editor', () => {
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'get_merge_tool_config') return { toolName: 'meld' };
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           return new Promise((res) => {
             releaseConfirm = () => res('Ok');
           });
@@ -2939,7 +2939,7 @@ describe('lv-merge-editor', () => {
       let confirmAnswer: unknown = false;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'get_merge_tool_config') return { toolName: 'meld' };
-        if (command === 'plugin:dialog|message') return confirmAnswer;
+        if (command === 'plugin:dialog|confirm') return confirmAnswer;
         if (command === 'launch_merge_tool') {
           launchCalls++;
           return { success: true };
@@ -3271,7 +3271,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           confirmCalls++;
           return false; // decline
         }
@@ -3295,7 +3295,7 @@ describe('lv-merge-editor', () => {
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') return 'Ok';
+        if (command === 'plugin:dialog|confirm') return 'Ok';
         return baseMock(command, args);
       };
       const { el, internal } = await renderWithEdit();
@@ -3315,7 +3315,7 @@ describe('lv-merge-editor', () => {
       let releaseConfirm: (() => void) | null = null;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           return new Promise((res) => {
             releaseConfirm = () => res('Ok');
           });
@@ -3348,7 +3348,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           confirmCalls++;
           return confirmAnswer;
         }
@@ -3376,13 +3376,179 @@ describe('lv-merge-editor', () => {
       expect(internal.segments[0].origin).to.equal('ours');
     });
 
+    it('whole-file accepts do not confirm before any in-editor work exists', async () => {
+      setupDefaultMocks();
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|confirm') {
+          confirmCalls++;
+          return 'Ok';
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+
+      await (
+        el as unknown as { acceptWholeFile: (origin: string) => Promise<void> }
+      ).acceptWholeFile.call(el, 'ours');
+      await (
+        el as unknown as { acceptWholeFile: (origin: string) => Promise<void> }
+      ).acceptWholeFile.call(el, 'ours');
+      await el.updateComplete;
+
+      expect(confirmCalls).to.equal(0);
+      expect(internalOf(el).segments).to.have.length(1);
+      expect(internalOf(el).segments[0].origin).to.equal('ours');
+    });
+
+    for (const origin of ['ours', 'theirs'] as const) {
+      it(`whole-file ${origin} confirms before replacing per-block resolutions`, async () => {
+        setupDefaultMocks();
+        let confirmAnswer: unknown = false;
+        let confirmCalls = 0;
+        const baseMock = mockInvoke;
+        mockInvoke = async (command: string, args?: unknown) => {
+          if (command === 'plugin:dialog|confirm') {
+            confirmCalls++;
+            return confirmAnswer;
+          }
+          return baseMock(command, args);
+        };
+        const el = await renderLoadedEditor();
+        findConflictButton(el, 'Use Both').click();
+        await el.updateComplete;
+        const before = structuredClone(internalOf(el).segments);
+
+        const accept = (
+          el as unknown as { acceptWholeFile: (selected: string) => Promise<void> }
+        ).acceptWholeFile;
+        await accept.call(el, origin);
+        await el.updateComplete;
+
+        expect(confirmCalls).to.equal(1);
+        expect(internalOf(el).segments).to.deep.equal(before);
+
+        confirmAnswer = 'Ok';
+        await accept.call(el, origin);
+        await el.updateComplete;
+
+        expect(confirmCalls).to.equal(2);
+        expect(internalOf(el).segments).to.have.length(1);
+        expect(internalOf(el).segments[0].origin).to.equal(origin);
+      });
+    }
+
+    it('declining a verbatim take-side preserves per-block resolutions', async () => {
+      setupDefaultMocks();
+      let takeSideCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|confirm') return false;
+        if (command === 'resolve_conflict_take_side') {
+          takeSideCalls++;
+          return { success: true };
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      const before = structuredClone(internalOf(el).segments);
+
+      await (
+        el as unknown as { handleTakeSide: (side: string) => Promise<void> }
+      ).handleTakeSide.call(el, 'theirs');
+      await el.updateComplete;
+
+      expect(takeSideCalls).to.equal(0);
+      expect(internalOf(el).segments).to.deep.equal(before);
+      expect(el.hasUnsavedResolutions()).to.be.true;
+    });
+
+    it('accepting a deleted whole-file side confirms only once before taking it', async () => {
+      setupDefaultMocks();
+      let confirmCalls = 0;
+      let takeSideCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|confirm') {
+          confirmCalls++;
+          return 'Ok';
+        }
+        if (command === 'resolve_conflict_take_side') {
+          takeSideCalls++;
+          return { success: true };
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      internal.conflictFile = { ...internal.conflictFile!, theirs: null };
+
+      await (
+        el as unknown as { acceptWholeFile: (origin: string) => Promise<void> }
+      ).acceptWholeFile.call(el, 'theirs');
+      await el.updateComplete;
+
+      expect(confirmCalls).to.equal(1);
+      expect(takeSideCalls).to.equal(1);
+    });
+
+    it('serializes take-side clicks while the overwrite confirmation is open', async () => {
+      setupDefaultMocks();
+      let releaseConfirm: (() => void) | null = null;
+      let confirmCalls = 0;
+      let takeSideCalls = 0;
+      let externalToolCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|confirm') {
+          confirmCalls++;
+          return new Promise((resolve) => {
+            releaseConfirm = () => resolve('Ok');
+          });
+        }
+        if (command === 'resolve_conflict_take_side') {
+          takeSideCalls++;
+          return { success: true };
+        }
+        if (command === 'launch_merge_tool') {
+          externalToolCalls++;
+          return { success: true };
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      const takeSide = (
+        el as unknown as { handleTakeSide: (side: string) => Promise<void> }
+      ).handleTakeSide;
+
+      const first = takeSide.call(el, 'theirs');
+      const second = takeSide.call(el, 'theirs');
+      await (
+        el as unknown as { handleOpenExternalMergeTool: () => Promise<void> }
+      ).handleOpenExternalMergeTool.call(el);
+      await new Promise((resolve) => setTimeout(resolve, 0));
+      expect(confirmCalls).to.equal(1);
+      expect(externalToolCalls).to.equal(0);
+
+      releaseConfirm!();
+      await Promise.all([first, second]);
+      expect(takeSideCalls).to.equal(1);
+    });
+
     it('opening Edit on another segment confirms before discarding the open draft', async () => {
       setupDefaultMocks();
       let confirmAnswer: unknown = false;
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           confirmCalls++;
           return confirmAnswer;
         }
@@ -3416,7 +3582,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           confirmCalls++;
           return 'Ok';
         }
@@ -3443,7 +3609,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           confirmCalls++;
           return confirmAnswer;
         }
@@ -3483,6 +3649,7 @@ describe('lv-merge-editor', () => {
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:dialog|confirm') return 'Ok';
         if (command === 'resolve_conflict_take_side') return { success: true };
         return baseMock(command, args);
       };
@@ -3688,7 +3855,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           confirmCalls++;
           return false;
         }
@@ -3921,7 +4088,7 @@ describe('lv-merge-editor', () => {
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           confirmAnswers.calls++;
           return confirmAnswers.answer;
         }
@@ -3977,7 +4144,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           confirmCalls++;
           return false;
         }
@@ -4002,7 +4169,7 @@ describe('lv-merge-editor', () => {
       const baseMock = mockInvoke;
       let confirmCalls = 0;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|message') {
+        if (command === 'plugin:dialog|confirm') {
           confirmCalls++;
           return false;
         }

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -3381,8 +3381,8 @@ describe('lv-merge-editor', () => {
       ).to.contain('discards the edit that was typed but not applied');
       expect(
         confirms[0].message,
-        'no pick or applied edit exists to replace'
-      ).to.not.contain('conflict pick and edit currently in the output');
+        'no pick, edit or whole-file choice exists to replace'
+      ).to.not.contain('currently in the output');
       expect(internal.editingSegmentId, 'declining keeps the edit open').to.equal(editedId);
       expect(internal.editDraft).to.equal('careful hand-typed merge');
 
@@ -3429,12 +3429,68 @@ describe('lv-merge-editor', () => {
 
       expect(confirms).to.have.length(1);
       expect(confirms[0].message).to.contain(
-        'replaces every conflict pick and edit currently in the output'
+        'replaces the picks, edits and whole-file choice currently in the output'
       );
       expect(confirms[0].message, 'the open draft is lost too and must be named').to.contain(
         'discards the edit that was typed but not applied'
       );
       // Declining keeps both.
+      expect(internal.editingSegmentId).to.not.equal(null);
+      expect(internal.editDraft).to.equal('typed but never applied');
+    });
+
+    it('a whole-file accept plus an open draft is not described as conflict picks', async () => {
+      setupDefaultMocks();
+      const confirms: { title?: string; message?: string }[] = [];
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (isConfirmCommand(command)) {
+          const shown = (args ?? {}) as { title?: string; message?: string };
+          confirms.push({ title: shown.title, message: shown.message });
+          return false; // decline
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el) as EditorInternal & {
+        editingSegmentId: number | null;
+        editDraft: string;
+      };
+      const accept = (el as unknown as { acceptWholeFile: (o: string) => Promise<void> })
+        .acceptWholeFile;
+
+      // Toolbar "Use Ours" puts a whole-file accept — and nothing else — in
+      // the output. It has nothing to replace, so it must not confirm.
+      await accept.call(el, 'ours');
+      await el.updateComplete;
+      expect(confirms, 'the first whole-file accept replaces nothing').to.have.length(0);
+      expect(internal.segments.length).to.equal(1);
+
+      // Opening an edit on that accepted segment takes outputIsWholeFileAccept
+      // false, so the NEXT whole-file button does confirm.
+      await (
+        el as unknown as { startEditSegment: (s: unknown) => Promise<void> }
+      ).startEditSegment.call(el, internal.segments[0]);
+      await el.updateComplete;
+      internal.editDraft = 'typed but never applied';
+
+      await accept.call(el, 'theirs');
+      await el.updateComplete;
+
+      expect(confirms).to.have.length(1);
+      expect(confirms[0].title).to.equal('Replace in-progress resolution?');
+      expect(
+        confirms[0].message,
+        'the only thing in the output is the whole-file choice — name it, not picks'
+      ).to.not.contain('conflict pick');
+      expect(confirms[0].message).to.contain(
+        'replaces the picks, edits and whole-file choice currently in the output'
+      );
+      expect(confirms[0].message, 'the open draft is lost too and must be named').to.contain(
+        'discards the edit that was typed but not applied'
+      );
+      // Declining keeps the accepted side and the draft.
+      expect(internal.segments[0].origin).to.equal('ours');
       expect(internal.editingSegmentId).to.not.equal(null);
       expect(internal.editDraft).to.equal('typed but never applied');
     });
@@ -3812,8 +3868,8 @@ describe('lv-merge-editor', () => {
       expect(confirms[0].message).to.contain('deletes the file and stages the deletion');
       expect(
         confirms[0].message,
-        'the in-editor whole-file wording describes work that is not there'
-      ).to.not.contain('conflict pick and edit currently in the output');
+        'the in-editor whole-file lead describes a swap that is not what happens here'
+      ).to.not.contain('Using one whole-file version');
       // Declining leaves the accepted side in place and writes nothing.
       expect(takeSideCalls).to.equal(0);
       expect(internal.segments).to.deep.equal(before);

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -3406,6 +3406,144 @@ describe('lv-merge-editor', () => {
       expect(internalOf(el).segments[0].origin).to.equal('ours');
     });
 
+    it('swapping between whole-file sides does not confirm — nothing is lost', async () => {
+      setupDefaultMocks();
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (isConfirmCommand(command)) {
+          confirmCalls++;
+          return 'Ok';
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      const internal = internalOf(el);
+      const accept = (el as unknown as { acceptWholeFile: (o: string) => Promise<void> })
+        .acceptWholeFile;
+
+      await accept.call(el, 'ours');
+      await el.updateComplete;
+      expect(internal.segments[0].origin).to.equal('ours');
+
+      // Comparing the sides is a browse action, not a destructive one.
+      await accept.call(el, 'theirs');
+      await el.updateComplete;
+      expect(confirmCalls, 'swapping whole-file sides must not confirm').to.equal(0);
+      expect(internal.segments).to.have.length(1);
+      expect(internal.segments[0].origin).to.equal('theirs');
+      expect(internal.segments[0].lines.join('\n')).to.equal(internal.theirsContent);
+
+      await accept.call(el, 'base');
+      await el.updateComplete;
+      expect(confirmCalls).to.equal(0);
+      expect(internal.segments[0].origin).to.equal('base');
+      expect(internal.segments[0].lines.join('\n')).to.equal(internal.baseContent);
+
+      // And back — the first side is one click away, so it stays silent too.
+      await accept.call(el, 'ours');
+      await el.updateComplete;
+      expect(confirmCalls).to.equal(0);
+      expect(internal.segments[0].origin).to.equal('ours');
+      expect(internal.segments[0].lines.join('\n')).to.equal(internal.oursContent);
+    });
+
+    it('hand-editing a whole-file accept makes the next whole-file pick confirm', async () => {
+      setupDefaultMocks();
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (isConfirmCommand(command)) {
+          confirmCalls++;
+          return false; // decline
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      const internal = el as unknown as EditorInternal & {
+        startEditSegment: (segment: unknown) => Promise<void>;
+        applyEditSegment: () => Promise<void>;
+        editDraft: string;
+        acceptWholeFile: (origin: string) => Promise<void>;
+      };
+      await internal.acceptWholeFile.call(el, 'ours');
+      await el.updateComplete;
+      await internal.startEditSegment.call(el, internal.segments[0]);
+      internal.editDraft = 'hand written';
+      await internal.applyEditSegment.call(el);
+      await el.updateComplete;
+
+      await internal.acceptWholeFile.call(el, 'theirs');
+      await el.updateComplete;
+
+      expect(confirmCalls, 'a typed edit is real work and must confirm').to.equal(1);
+      expect(internal.segments[0].lines).to.deep.equal(['hand written']);
+      expect(internal.segments[0].origin).to.equal('manual');
+    });
+
+    it('a per-block pick that fills the whole file still confirms and is replaced', async () => {
+      // One conflict block IS the whole file, so a per-block "Use Ours"
+      // leaves a single ours-origin segment — but its lines are the block's
+      // ours side, not the ours blob, so the toolbar button must still act.
+      setupDefaultMocks();
+      let confirmAnswer: unknown = false;
+      let confirmCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (isConfirmCommand(command)) {
+          confirmCalls++;
+          return confirmAnswer;
+        }
+        if (command === 'get_blob_content') {
+          const oid = (args as { oid: string })?.oid;
+          if (oid === 'ours-oid') return 'ours-line\ntail';
+          if (oid === 'theirs-oid') return 'theirs-line\ntail';
+          return 'base-line\ntail';
+        }
+        return baseMock(command, args);
+      };
+      workdirContent = '<<<<<<< HEAD\nours-line\n=======\ntheirs-line\n>>>>>>> feature';
+      const el = await renderEditor();
+      const internal = internalOf(el);
+      internal.conflictFile = {
+        ...makeConflictFile('src/test.ts'),
+        conflictHunks: [{ start: 0, separator: 2, end: 4 }],
+      };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && (internal.segments.length > 0 || internal.loadFailed)) break;
+      }
+      await el.updateComplete;
+      expect(internal.segments).to.have.length(1);
+
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      expect(internal.segments[0].origin).to.equal('ours');
+      expect(internal.segments[0].fromConflict).to.be.true;
+      const before = structuredClone(internal.segments);
+
+      const accept = (el as unknown as { acceptWholeFile: (o: string) => Promise<void> })
+        .acceptWholeFile;
+      await accept.call(el, 'ours');
+      await el.updateComplete;
+
+      expect(confirmCalls, 'a per-block pick is real work and must confirm').to.equal(1);
+      expect(internal.segments, 'declining keeps the pick').to.deep.equal(before);
+
+      confirmAnswer = 'Ok';
+      await accept.call(el, 'ours');
+      await el.updateComplete;
+
+      expect(confirmCalls).to.equal(2);
+      expect(internal.segments).to.have.length(1);
+      expect(internal.segments[0].fromConflict).to.be.false;
+      expect(
+        internal.segments[0].lines,
+        'the whole ours blob replaces the block-only pick'
+      ).to.deep.equal(['ours-line', 'tail']);
+    });
+
     for (const origin of ['ours', 'theirs'] as const) {
       it(`whole-file ${origin} confirms before replacing per-block resolutions`, async () => {
         setupDefaultMocks();

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -81,6 +81,10 @@ let aiAvailable = false;
 let aiUnavailable: { reason: string; providerSelected: boolean } | null = null;
 let aiSuggestion: (() => Promise<unknown>) | null = null;
 
+function isConfirmCommand(command: string): boolean {
+  return command === 'plugin:dialog|message' || command === 'plugin:dialog|confirm';
+}
+
 function setupDefaultMocks(): void {
   workdirContent = DEFAULT_WORKDIR_CONTENT;
   aiAvailable = false;
@@ -1607,7 +1611,7 @@ describe('lv-merge-editor', () => {
       // The whole-file accept is unsaved work, so Reload confirms first.
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') return 'Ok';
+        if (isConfirmCommand(command)) return 'Ok';
         return baseMock(command, args);
       };
       const el = await renderLoadedEditor();
@@ -2798,7 +2802,7 @@ describe('lv-merge-editor', () => {
       let confirmAnswer: unknown = false;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'get_merge_tool_config') return { toolName: 'meld' };
-        if (command === 'plugin:dialog|confirm') return confirmAnswer;
+        if (isConfirmCommand(command)) return confirmAnswer;
         if (command === 'launch_merge_tool') {
           launchCalls++;
           return { success: true };
@@ -2842,7 +2846,7 @@ describe('lv-merge-editor', () => {
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'get_merge_tool_config') return { toolName: 'meld' };
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           // The native confirm is an async IPC round-trip — a second click
           // can land before it resolves.
@@ -2894,7 +2898,7 @@ describe('lv-merge-editor', () => {
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'get_merge_tool_config') return { toolName: 'meld' };
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           return new Promise((res) => {
             releaseConfirm = () => res('Ok');
           });
@@ -2939,7 +2943,7 @@ describe('lv-merge-editor', () => {
       let confirmAnswer: unknown = false;
       mockInvoke = async (command: string, args?: unknown) => {
         if (command === 'get_merge_tool_config') return { toolName: 'meld' };
-        if (command === 'plugin:dialog|confirm') return confirmAnswer;
+        if (isConfirmCommand(command)) return confirmAnswer;
         if (command === 'launch_merge_tool') {
           launchCalls++;
           return { success: true };
@@ -3271,7 +3275,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return false; // decline
         }
@@ -3295,7 +3299,7 @@ describe('lv-merge-editor', () => {
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') return 'Ok';
+        if (isConfirmCommand(command)) return 'Ok';
         return baseMock(command, args);
       };
       const { el, internal } = await renderWithEdit();
@@ -3315,7 +3319,7 @@ describe('lv-merge-editor', () => {
       let releaseConfirm: (() => void) | null = null;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           return new Promise((res) => {
             releaseConfirm = () => res('Ok');
           });
@@ -3348,7 +3352,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return confirmAnswer;
         }
@@ -3381,7 +3385,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return 'Ok';
         }
@@ -3409,7 +3413,7 @@ describe('lv-merge-editor', () => {
         let confirmCalls = 0;
         const baseMock = mockInvoke;
         mockInvoke = async (command: string, args?: unknown) => {
-          if (command === 'plugin:dialog|confirm') {
+          if (isConfirmCommand(command)) {
             confirmCalls++;
             return confirmAnswer;
           }
@@ -3444,7 +3448,7 @@ describe('lv-merge-editor', () => {
       let takeSideCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') return false;
+        if (isConfirmCommand(command)) return false;
         if (command === 'resolve_conflict_take_side') {
           takeSideCalls++;
           return { success: true };
@@ -3472,7 +3476,7 @@ describe('lv-merge-editor', () => {
       let takeSideCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return 'Ok';
         }
@@ -3505,7 +3509,7 @@ describe('lv-merge-editor', () => {
       let externalToolCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return new Promise((resolve) => {
             releaseConfirm = () => resolve('Ok');
@@ -3548,7 +3552,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return confirmAnswer;
         }
@@ -3582,7 +3586,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return 'Ok';
         }
@@ -3609,7 +3613,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return confirmAnswer;
         }
@@ -3649,7 +3653,7 @@ describe('lv-merge-editor', () => {
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') return 'Ok';
+        if (isConfirmCommand(command)) return 'Ok';
         if (command === 'resolve_conflict_take_side') return { success: true };
         return baseMock(command, args);
       };
@@ -3855,7 +3859,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return false;
         }
@@ -4088,7 +4092,7 @@ describe('lv-merge-editor', () => {
       setupDefaultMocks();
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmAnswers.calls++;
           return confirmAnswers.answer;
         }
@@ -4144,7 +4148,7 @@ describe('lv-merge-editor', () => {
       let confirmCalls = 0;
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return false;
         }
@@ -4169,7 +4173,7 @@ describe('lv-merge-editor', () => {
       const baseMock = mockInvoke;
       let confirmCalls = 0;
       mockInvoke = async (command: string, args?: unknown) => {
-        if (command === 'plugin:dialog|confirm') {
+        if (isConfirmCommand(command)) {
           confirmCalls++;
           return false;
         }

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -3639,6 +3639,91 @@ describe('lv-merge-editor', () => {
       expect(takeSideCalls).to.equal(1);
     });
 
+    it('the deleted-side take confirm names the staged deletion, not an output swap', async () => {
+      // Modify/delete: git leaves the workdir file marker-free, so the output
+      // parses to ONE plain segment with no per-block buttons at all. The only
+      // route to this confirm is Use Ours followed by a change of mind — so
+      // there is no conflict pick and no edit to "replace", and the thing the
+      // user must be told is that the file gets deleted and staged.
+      setupDefaultMocks();
+      workdirContent = 'const value = "ours";';
+      const confirms: { title?: string; message?: string }[] = [];
+      let takeSideCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (isConfirmCommand(command)) {
+          const shown = (args ?? {}) as { title?: string; message?: string };
+          confirms.push({ title: shown.title, message: shown.message });
+          return false; // decline
+        }
+        if (command === 'resolve_conflict_take_side') {
+          takeSideCalls++;
+          return { success: true };
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderEditor();
+      const internal = internalOf(el);
+      internal.conflictFile = { ...makeConflictFile('src/test.ts'), theirs: null };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && (internal.segments.length > 0 || internal.loadFailed)) break;
+      }
+      await el.updateComplete;
+      expect(el.shadowRoot!.querySelector('.code-conflict-block'), 'no per-block buttons exist')
+        .to.be.null;
+
+      await (
+        el as unknown as { acceptWholeFile: (origin: string) => Promise<void> }
+      ).acceptWholeFile.call(el, 'ours');
+      await el.updateComplete;
+      expect(confirms, 'the first whole-file accept has nothing to replace').to.have.length(0);
+      const before = structuredClone(internal.segments);
+
+      await (
+        el as unknown as { handleTakeSide: (side: string) => Promise<void> }
+      ).handleTakeSide.call(el, 'theirs');
+      await el.updateComplete;
+
+      expect(confirms).to.have.length(1);
+      expect(confirms[0].title).to.equal('Take this whole side?');
+      expect(confirms[0].message).to.contain('deletes the file and stages the deletion');
+      expect(
+        confirms[0].message,
+        'the in-editor whole-file wording describes work that is not there'
+      ).to.not.contain('conflict pick and edit currently in the output');
+      // Declining leaves the accepted side in place and writes nothing.
+      expect(takeSideCalls).to.equal(0);
+      expect(internal.segments).to.deep.equal(before);
+    });
+
+    it('a verbatim take-side confirm names the on-disk write, not an output swap', async () => {
+      setupDefaultMocks();
+      const confirms: { title?: string; message?: string }[] = [];
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (isConfirmCommand(command)) {
+          const shown = (args ?? {}) as { title?: string; message?: string };
+          confirms.push({ title: shown.title, message: shown.message });
+          return false;
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+
+      await (
+        el as unknown as { handleTakeSide: (side: string) => Promise<void> }
+      ).handleTakeSide.call(el, 'theirs');
+      await el.updateComplete;
+
+      expect(confirms).to.have.length(1);
+      expect(confirms[0].title).to.equal('Take this whole side?');
+      expect(confirms[0].message).to.contain('writes it to disk and stages the file');
+    });
+
     it('serializes take-side clicks while the overwrite confirmation is open', async () => {
       setupDefaultMocks();
       let releaseConfirm: (() => void) | null = null;

--- a/src/components/panels/__tests__/lv-merge-editor.test.ts
+++ b/src/components/panels/__tests__/lv-merge-editor.test.ts
@@ -3350,10 +3350,13 @@ describe('lv-merge-editor', () => {
       setupDefaultMocks();
       let confirmAnswer: unknown = false;
       let confirmCalls = 0;
+      const confirms: { title?: string; message?: string }[] = [];
       const baseMock = mockInvoke;
       mockInvoke = async (command: string, args?: unknown) => {
         if (isConfirmCommand(command)) {
           confirmCalls++;
+          const shown = (args ?? {}) as { title?: string; message?: string };
+          confirms.push({ title: shown.title, message: shown.message });
           return confirmAnswer;
         }
         return baseMock(command, args);
@@ -3368,6 +3371,18 @@ describe('lv-merge-editor', () => {
       await accept.call(el, 'ours');
       await el.updateComplete;
       expect(confirmCalls).to.equal(1);
+      // The draft is the ONLY unsaved work here — a freshly loaded file with
+      // an edit opened on it. The dialog must name the typed text it is about
+      // to throw away, and must not enumerate picks the user never made.
+      expect(confirms[0].title).to.equal('Replace in-progress resolution?');
+      expect(
+        confirms[0].message,
+        'the open draft is not in the output, so it must be named explicitly'
+      ).to.contain('discards the edit that was typed but not applied');
+      expect(
+        confirms[0].message,
+        'no pick or applied edit exists to replace'
+      ).to.not.contain('conflict pick and edit currently in the output');
       expect(internal.editingSegmentId, 'declining keeps the edit open').to.equal(editedId);
       expect(internal.editDraft).to.equal('careful hand-typed merge');
 
@@ -3378,6 +3393,112 @@ describe('lv-merge-editor', () => {
       expect(internal.editingSegmentId).to.equal(null);
       expect(internal.segments.length).to.equal(1);
       expect(internal.segments[0].origin).to.equal('ours');
+    });
+
+    it('whole-file accept with BOTH output work and an open draft names both losses', async () => {
+      setupDefaultMocks();
+      const confirms: { title?: string; message?: string }[] = [];
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (isConfirmCommand(command)) {
+          const shown = (args ?? {}) as { title?: string; message?: string };
+          confirms.push({ title: shown.title, message: shown.message });
+          return false; // decline
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderLoadedEditor();
+      // A real pick lands in the output...
+      findConflictButton(el, 'Use Ours').click();
+      await el.updateComplete;
+      const internal = internalOf(el) as EditorInternal & {
+        editingSegmentId: number | null;
+        editDraft: string;
+      };
+      // ...and an inline edit is opened on top of it, which is NOT in the output.
+      await (
+        el as unknown as { startEditSegment: (s: unknown) => Promise<void> }
+      ).startEditSegment.call(el, internal.segments[0]);
+      await el.updateComplete;
+      internal.editDraft = 'typed but never applied';
+
+      await (
+        el as unknown as { acceptWholeFile: (origin: string) => Promise<void> }
+      ).acceptWholeFile.call(el, 'theirs');
+      await el.updateComplete;
+
+      expect(confirms).to.have.length(1);
+      expect(confirms[0].message).to.contain(
+        'replaces every conflict pick and edit currently in the output'
+      );
+      expect(confirms[0].message, 'the open draft is lost too and must be named').to.contain(
+        'discards the edit that was typed but not applied'
+      );
+      // Declining keeps both.
+      expect(internal.editingSegmentId).to.not.equal(null);
+      expect(internal.editDraft).to.equal('typed but never applied');
+    });
+
+    it('take-side with only an open draft names the draft, not absent picks', async () => {
+      setupDefaultMocks();
+      const confirms: { title?: string; message?: string }[] = [];
+      let takeSideCalls = 0;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (isConfirmCommand(command)) {
+          const shown = (args ?? {}) as { title?: string; message?: string };
+          confirms.push({ title: shown.title, message: shown.message });
+          return false; // decline
+        }
+        if (command === 'resolve_conflict_take_side') {
+          takeSideCalls++;
+          return { success: true };
+        }
+        return baseMock(command, args);
+      };
+      const el = await renderEditor();
+      const internal = internalOf(el) as EditorInternal & {
+        editingSegmentId: number | null;
+        editDraft: string;
+      };
+      // A modify/delete conflict: theirs dropped the file, so the toolbar
+      // offers "Use Theirs (delete file)" -> handleTakeSide directly.
+      internal.conflictFile = { ...makeConflictFile('src/test.ts'), theirs: null };
+      await el.updateComplete;
+      for (let i = 0; i < 100; i++) {
+        await new Promise((r) => setTimeout(r, 20));
+        if (!internal.loading && (internal.segments.length > 0 || internal.loadFailed)) break;
+      }
+      await el.updateComplete;
+      expect(internal.segments.length, 'the marker-free workdir file renders as output').to.be
+        .greaterThan(0);
+
+      await (
+        el as unknown as { startEditSegment: (s: unknown) => Promise<void> }
+      ).startEditSegment.call(el, internal.segments[0]);
+      await el.updateComplete;
+      internal.editDraft = 'typed but never applied';
+
+      await (
+        el as unknown as { handleTakeSide: (side: string) => Promise<void> }
+      ).handleTakeSide.call(el, 'theirs');
+      await el.updateComplete;
+
+      expect(confirms).to.have.length(1);
+      expect(confirms[0].title).to.equal('Take this whole side?');
+      expect(confirms[0].message).to.contain('deletes the file and stages the deletion');
+      expect(
+        confirms[0].message,
+        'the typed text is the only thing being discarded — say so'
+      ).to.contain('discarding the edit that was typed but not applied');
+      expect(
+        confirms[0].message,
+        'no pick or whole-file choice is in the output to lose'
+      ).to.not.contain('picks, edits and whole-file choice');
+      // Declining writes nothing and keeps the draft.
+      expect(takeSideCalls).to.equal(0);
+      expect(internal.editingSegmentId).to.not.equal(null);
+      expect(internal.editDraft).to.equal('typed but never applied');
     });
 
     it('whole-file accepts do not confirm before any in-editor work exists', async () => {

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -1759,7 +1759,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     return this.confirmOverwrite(
       'Replace in-progress resolution?',
       `Using one whole-file version ${this.overwriteLossText(
-        'replaces every conflict pick and edit currently in the output',
+        'replaces the picks, edits and whole-file choice currently in the output',
         'discards the edit that was typed but not applied',
       )}. This cannot be undone.`,
     );
@@ -2094,8 +2094,8 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       // dropped the file that means staging a deletion. In the flow that
       // realistically reaches this — a whole-file accept on a modify/delete
       // conflict, whose marker-free workdir file renders no per-block
-      // buttons at all — "replaces every conflict pick and edit" would name
-      // work that is not there while hiding the on-disk consequence that is.
+      // buttons at all — "Using one whole-file version" would describe an
+      // in-editor swap while hiding the on-disk consequence that is real.
       const deletesFile = side === 'ours' ? !startFile.ours : !startFile.theirs;
       const lead = deletesFile
         ? 'Taking this side deletes the file and stages the deletion'

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -1574,6 +1574,23 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     this.updateSegment(id, { type: 'conflict', lines: [], origin: null, fromConflict: false });
   }
 
+  /**
+   * True when it is safe to throw away an open inline-edit draft: no edit
+   * is open, or the user confirmed the discard. Opening an edit on a
+   * DIFFERENT segment abandons the current typed draft, so this is the
+   * confirm for that one path — the same hazard Reload and file switches
+   * already confirm for. Whole-file operations use
+   * confirmWholeFileOverwrite instead.
+   */
+  private async confirmDiscardOpenEdit(): Promise<boolean> {
+    if (this.editingSegmentId === null) return true;
+    return showConfirm(
+      'Discard the open edit?',
+      'This section has an edit that was not applied — continuing discards the typed text.',
+      'warning',
+    );
+  }
+
   private async startEditSegment(segment: OutputSegment): Promise<void> {
     if (this.actionsBlocked) return;
     // Opening an edit on ANOTHER segment throws away the current typed
@@ -1677,22 +1694,6 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   // ── Whole-file operations ─────────────────────────────────────────────
 
   /**
-   * True when it is safe to throw away an open inline-edit draft: no edit
-   * is open, or the user confirmed the discard. Whole-file operations
-   * replace ALL segments, so a typed-but-unapplied draft would vanish
-   * silently without this — the same hazard Reload and file switches
-   * already confirm for.
-   */
-  private async confirmDiscardOpenEdit(): Promise<boolean> {
-    if (this.editingSegmentId === null) return true;
-    return showConfirm(
-      'Discard the open edit?',
-      'This section has an edit that was not applied — continuing discards the typed text.',
-      'warning',
-    );
-  }
-
-  /**
    * True when the output is nothing but a previous whole-file accept: no
    * per-block pick, no hand edit and no open draft is in it, so another
    * whole-file button loses nothing. Only acceptWholeFile produces such a
@@ -1708,18 +1709,29 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     );
   }
 
-  private async confirmWholeFileOverwrite(): Promise<boolean> {
-    if (!this.hasUnsavedResolutions()) return true;
+  /**
+   * Ask before an operation throws the current output away, holding the
+   * re-entrancy flag for the whole round trip: showConfirm is async IPC, so
+   * without it a second click (or an External Tool launch) would slip in
+   * behind the open dialog. The wording is the caller's — an in-editor
+   * whole-file swap and an on-disk take-side have different consequences
+   * and must not share one message.
+   */
+  private async confirmOverwrite(title: string, messageText: string): Promise<boolean> {
     this.confirmingWholeFileOverwrite = true;
     try {
-      return await showConfirm(
-        'Replace in-progress resolution?',
-        'Using one whole-file version replaces every conflict pick and edit currently in the output. This cannot be undone.',
-        'warning',
-      );
+      return await showConfirm(title, messageText, 'warning');
     } finally {
       this.confirmingWholeFileOverwrite = false;
     }
+  }
+
+  private async confirmWholeFileOverwrite(): Promise<boolean> {
+    if (!this.hasUnsavedResolutions()) return true;
+    return this.confirmOverwrite(
+      'Replace in-progress resolution?',
+      'Using one whole-file version replaces every conflict pick and edit currently in the output. This cannot be undone.',
+    );
   }
 
   private async acceptWholeFile(origin: 'ours' | 'theirs' | 'base'): Promise<void> {
@@ -2046,7 +2058,21 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
     const startFile = this.conflictFile;
     if (this.hasUnsavedResolutions()) {
-      if (!(await this.confirmWholeFileOverwrite())) return;
+      // Take-side is NOT the in-editor swap acceptWholeFile's copy describes:
+      // it writes the chosen blob to disk and stages it, and for a side that
+      // dropped the file that means staging a deletion. In the flow that
+      // realistically reaches this — a whole-file accept on a modify/delete
+      // conflict, whose marker-free workdir file renders no per-block
+      // buttons at all — "replaces every conflict pick and edit" would name
+      // work that is not there while hiding the on-disk consequence that is.
+      const deletesFile = side === 'ours' ? !startFile.ours : !startFile.theirs;
+      const proceed = await this.confirmOverwrite(
+        'Take this whole side?',
+        deletesFile
+          ? 'Taking this side deletes the file and stages the deletion, discarding the picks, edits and whole-file choice currently in the output. This cannot be undone.'
+          : 'Taking this side writes it to disk and stages the file, discarding the picks, edits and whole-file choice currently in the output. This cannot be undone.',
+      );
+      if (!proceed) return;
       // Re-check identity too: a file switch during the overwrite confirm
       // must not let this call take a side on a different file.
       if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -1692,6 +1692,22 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     );
   }
 
+  /**
+   * True when the output is nothing but a previous whole-file accept: no
+   * per-block pick, no hand edit and no open draft is in it, so another
+   * whole-file button loses nothing. Only acceptWholeFile produces such a
+   * segment — per-block picks and AI fills set fromConflict, hand edits set
+   * origin 'manual', and freshly parsed segments carry origin null.
+   */
+  private get outputIsWholeFileAccept(): boolean {
+    if (this.editingSegmentId !== null || this.segments.length !== 1) return false;
+    const only = this.segments[0];
+    return (
+      !only.fromConflict &&
+      (only.origin === 'ours' || only.origin === 'theirs' || only.origin === 'base')
+    );
+  }
+
   private async confirmWholeFileOverwrite(): Promise<boolean> {
     if (!this.hasUnsavedResolutions()) return true;
     this.confirmingWholeFileOverwrite = true;
@@ -1727,15 +1743,13 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       return this.handleTakeSide(origin);
     }
 
-    if (
-      this.editingSegmentId === null &&
-      this.segments.length === 1 &&
-      this.segments[0].origin === origin
-    ) {
-      return;
-    }
+    // Re-picking the side the output already holds verbatim changes nothing.
+    if (this.outputIsWholeFileAccept && this.segments[0].origin === origin) return;
 
-    if (this.hasUnsavedResolutions()) {
+    // A pure whole-file accept holds no pick and no edit to lose — the other
+    // buttons restore it in one click — so swapping sides to compare them
+    // must not raise a confirm that misdescribes the state.
+    if (!this.outputIsWholeFileAccept && this.hasUnsavedResolutions()) {
       if (!(await this.confirmWholeFileOverwrite())) return;
       // Re-check after the confirm's await — a resolve/tool session may
       // have started while it was up (same re-check as Reload and Apply),

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -1726,11 +1726,42 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     }
   }
 
+  /**
+   * Unsaved work that is actually IN the output — picks, applied hand edits
+   * and whole-file accepts. This is hasUnsavedResolutions() WITHOUT its
+   * open-draft shortcut, because an open draft is not in the output:
+   * buildResolvedContent() never sees editDraft.
+   */
+  private get outputHasUnsavedWork(): boolean {
+    return this.userTouched && this.buildResolvedContent() !== this.lastSavedContent;
+  }
+
+  /**
+   * Name what an overwrite destroys, in the words of the caller's operation.
+   * Both halves are needed: an open inline-edit draft is NOT in the output,
+   * so a message that only describes "work currently in the output" is
+   * silent about the typed text it discards — and when the draft is the ONLY
+   * unsaved work (hasUnsavedResolutions() is true on an open draft alone,
+   * which is the state after Edit-then-toolbar on a freshly loaded file) that
+   * message would also enumerate picks and edits the user does not have.
+   */
+  private overwriteLossText(inOutput: string, openDraft: string): string {
+    const parts: string[] = [];
+    if (this.outputHasUnsavedWork) parts.push(inOutput);
+    if (this.editingSegmentId !== null) parts.push(openDraft);
+    // Never empty: every caller gates on hasUnsavedResolutions(), which is
+    // exactly outputHasUnsavedWork || an open draft.
+    return parts.join(' and ');
+  }
+
   private async confirmWholeFileOverwrite(): Promise<boolean> {
     if (!this.hasUnsavedResolutions()) return true;
     return this.confirmOverwrite(
       'Replace in-progress resolution?',
-      'Using one whole-file version replaces every conflict pick and edit currently in the output. This cannot be undone.',
+      `Using one whole-file version ${this.overwriteLossText(
+        'replaces every conflict pick and edit currently in the output',
+        'discards the edit that was typed but not applied',
+      )}. This cannot be undone.`,
     );
   }
 
@@ -2066,11 +2097,15 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       // buttons at all — "replaces every conflict pick and edit" would name
       // work that is not there while hiding the on-disk consequence that is.
       const deletesFile = side === 'ours' ? !startFile.ours : !startFile.theirs;
+      const lead = deletesFile
+        ? 'Taking this side deletes the file and stages the deletion'
+        : 'Taking this side writes it to disk and stages the file';
       const proceed = await this.confirmOverwrite(
         'Take this whole side?',
-        deletesFile
-          ? 'Taking this side deletes the file and stages the deletion, discarding the picks, edits and whole-file choice currently in the output. This cannot be undone.'
-          : 'Taking this side writes it to disk and stages the file, discarding the picks, edits and whole-file choice currently in the output. This cannot be undone.',
+        `${lead}, discarding ${this.overwriteLossText(
+          'the picks, edits and whole-file choice currently in the output',
+          'the edit that was typed but not applied',
+        )}. This cannot be undone.`,
       );
       if (!proceed) return;
       // Re-check identity too: a file switch during the overwrite confirm

--- a/src/components/panels/lv-merge-editor.ts
+++ b/src/components/panels/lv-merge-editor.ts
@@ -558,6 +558,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
    * that errors "No conflict found" on an already-resolved file. */
   @state() private resolvedInPlace = false;
   @state() private launchingExternalTool = false;
+  @state() private confirmingWholeFileOverwrite = false;
   @state() private hasMergeTool = false;
   @state() private aiAvailable = false;
   /**
@@ -641,6 +642,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
       !this.conflictFile ||
       this.externalToolLocked ||
       this.launchingExternalTool ||
+      this.confirmingWholeFileOverwrite ||
       this.resolving ||
       this.resolvedAsDeleted ||
       // A chooser/verbatim take-side or gitlink resolution leaves the file
@@ -1490,6 +1492,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     return (
       this.resolving ||
       this.launchingExternalTool ||
+      this.confirmingWholeFileOverwrite ||
       this.externalToolLocked ||
       this.resolvedAsDeleted ||
       this.resolvedInPlace
@@ -1689,6 +1692,20 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     );
   }
 
+  private async confirmWholeFileOverwrite(): Promise<boolean> {
+    if (!this.hasUnsavedResolutions()) return true;
+    this.confirmingWholeFileOverwrite = true;
+    try {
+      return await showConfirm(
+        'Replace in-progress resolution?',
+        'Using one whole-file version replaces every conflict pick and edit currently in the output. This cannot be undone.',
+        'warning',
+      );
+    } finally {
+      this.confirmingWholeFileOverwrite = false;
+    }
+  }
+
   private async acceptWholeFile(origin: 'ours' | 'theirs' | 'base'): Promise<void> {
     // With a failed load the side contents are not trustworthy — accepting
     // one would replace the segments with fabricated (possibly empty) text.
@@ -1698,26 +1715,38 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
     if (this.loadFailed || this.actionsBlocked) return;
     if (origin === 'base' && this.sideReadErrors.base) return;
     const startFile = this.conflictFile;
-    if (this.editingSegmentId !== null) {
-      if (!(await this.confirmDiscardOpenEdit())) return;
+
+    // A side with no entry DELETED the file — accepting it means staging the
+    // deletion, not writing a 0-byte file from its empty content. The
+    // take-side path owns the overwrite confirmation so this delegates
+    // before prompting and never asks twice.
+    if (
+      (origin === 'ours' && !this.conflictFile?.ours) ||
+      (origin === 'theirs' && !this.conflictFile?.theirs)
+    ) {
+      return this.handleTakeSide(origin);
+    }
+
+    if (
+      this.editingSegmentId === null &&
+      this.segments.length === 1 &&
+      this.segments[0].origin === origin
+    ) {
+      return;
+    }
+
+    if (this.hasUnsavedResolutions()) {
+      if (!(await this.confirmWholeFileOverwrite())) return;
       // Re-check after the confirm's await — a resolve/tool session may
       // have started while it was up (same re-check as Reload and Apply),
       // and file IDENTITY too: a switch during the confirm must not let
       // this call overwrite a DIFFERENT file's segments with this side.
       if (this.loadFailed || this.actionsBlocked) return;
       if (this.conflictFile !== startFile) return;
+    }
+    if (this.editingSegmentId !== null) {
       this.editingSegmentId = null;
       this.editDraft = '';
-    }
-
-    // A side with no entry DELETED the file — accepting it means staging the
-    // deletion, not writing a 0-byte file from its empty content.
-    if (
-      (origin === 'ours' && !this.conflictFile?.ours) ||
-      (origin === 'theirs' && !this.conflictFile?.theirs)
-    ) {
-      void this.handleTakeSide(origin);
-      return;
     }
 
     const content =
@@ -2002,16 +2031,14 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
   private async handleTakeSide(side: 'ours' | 'theirs'): Promise<void> {
     if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
     const startFile = this.conflictFile;
-    // Taking a side writes the whole file — an open typed-but-unapplied
-    // draft would vanish silently. (The acceptWholeFile delegation already
-    // confirmed and cleared the edit, so this only fires for the direct
-    // deleted-side buttons.)
-    if (this.editingSegmentId !== null) {
-      if (!(await this.confirmDiscardOpenEdit())) return;
-      // Re-check identity too: a file switch during the discard confirm
+    if (this.hasUnsavedResolutions()) {
+      if (!(await this.confirmWholeFileOverwrite())) return;
+      // Re-check identity too: a file switch during the overwrite confirm
       // must not let this call take a side on a different file.
       if (!this.repositoryPath || !this.conflictFile || this.actionsBlocked) return;
       if (this.conflictFile !== startFile) return;
+    }
+    if (this.editingSegmentId !== null) {
       this.editingSegmentId = null;
       this.editDraft = '';
     }
@@ -2673,6 +2700,7 @@ export class LvMergeEditor extends CodeRenderMixin(LitElement) {
               class="btn"
               @click=${this.handleOpenExternalMergeTool}
               ?disabled=${this.launchingExternalTool ||
+              this.confirmingWholeFileOverwrite ||
               this.externalToolLocked ||
               this.resolving ||
               this.resolvedAsDeleted ||


### PR DESCRIPTION
## Summary
- confirm before whole-file merge actions discard in-progress block resolutions or edits
- serialize confirmation against duplicate clicks and external merge tool launches
- preserve direct whole-file actions when no work would be lost
- update dialog mocks and add regression coverage

## Validation
- npm test -- src/components/panels/__tests__/lv-merge-editor.test.ts
- npm run typecheck