### PR TITLE
Fix Windows file manager reveal

### DIFF
--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -178,11 +178,21 @@ pub async fn reveal_in_file_manager(path: String) -> Result<OpenResult> {
     })
 }
 
+/// Build the percent-encoded `file://` URI handed to FileManager1.ShowItems.
+/// Returns `None` for paths that cannot be expressed as a file URL (for
+/// example a relative path), so the caller can fall back to `xdg-open`.
+#[cfg(target_os = "linux")]
+fn dbus_reveal_uri(path: &Path) -> Option<String> {
+    url::Url::from_file_path(path)
+        .ok()
+        .map(|url| url.to_string())
+}
+
 #[cfg(target_os = "linux")]
 fn try_dbus_reveal(path: &Path) -> bool {
     // Try to use dbus to reveal file in file manager
     // This works with Nautilus, Dolphin, and other modern file managers
-    let Ok(uri) = url::Url::from_file_path(path) else {
+    let Some(uri) = dbus_reveal_uri(path) else {
         return false;
     };
     std::process::Command::new("dbus-send")
@@ -580,6 +590,25 @@ mod tests {
         let argument = windows_reveal_argument(target);
 
         assert_eq!(argument, r#"/select,"C:\repo with spaces\src\main.rs""#);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_dbus_reveal_uri_percent_encodes_reserved_characters() {
+        assert_eq!(
+            dbus_reveal_uri(Path::new("/home/u/my repo/a b.txt")).as_deref(),
+            Some("file:///home/u/my%20repo/a%20b.txt")
+        );
+        assert_eq!(
+            dbus_reveal_uri(Path::new("/home/u/repo/a#b?c.txt")).as_deref(),
+            Some("file:///home/u/repo/a%23b%3Fc.txt")
+        );
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn test_dbus_reveal_uri_rejects_relative_path() {
+        assert!(dbus_reveal_uri(Path::new("relative/a.txt")).is_none());
     }
 
     #[tokio::test]

--- a/src-tauri/src/commands/file.rs
+++ b/src-tauri/src/commands/file.rs
@@ -40,6 +40,27 @@ pub struct EditorConfig {
     pub visual: Option<String>,
 }
 
+#[cfg(target_os = "windows")]
+fn windows_reveal_argument(target: &Path) -> std::ffi::OsString {
+    use std::ffi::OsString;
+
+    // Explorer parses its own command line and requires the switch outside
+    // quotes with only the path quoted.
+    let mut select_arg = OsString::from("/select,\"");
+    select_arg.push(target.as_os_str());
+    select_arg.push("\"");
+    select_arg
+}
+
+#[cfg(target_os = "windows")]
+fn windows_reveal_command(target: &Path) -> std::process::Command {
+    use std::os::windows::process::CommandExt;
+
+    let mut command = create_command("explorer.exe");
+    command.raw_arg(windows_reveal_argument(target));
+    command
+}
+
 /// Run git config command to get a value
 fn get_git_config_value(repo_path: Option<&Path>, key: &str, global: bool) -> Option<String> {
     let mut cmd = create_command("git");
@@ -116,13 +137,9 @@ pub async fn reveal_in_file_manager(path: String) -> Result<OpenResult> {
 
     #[cfg(target_os = "windows")]
     {
-        // On Windows, use explorer /select, to highlight the file
-        std::process::Command::new("explorer")
-            .args(["/select,", &path])
-            .spawn()
-            .map_err(|e| {
-                LeviathanError::OperationFailed(format!("Failed to reveal in explorer: {}", e))
-            })?;
+        windows_reveal_command(target).spawn().map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to reveal in explorer: {}", e))
+        })?;
     }
 
     #[cfg(target_os = "macos")]
@@ -139,7 +156,7 @@ pub async fn reveal_in_file_manager(path: String) -> Result<OpenResult> {
     #[cfg(target_os = "linux")]
     {
         // On Linux, try dbus first for better integration, fall back to xdg-open for parent dir
-        let revealed = try_dbus_reveal(&path);
+        let revealed = try_dbus_reveal(target);
         if !revealed {
             // Fall back to opening the parent directory
             let parent = target.parent().unwrap_or(target);
@@ -162,9 +179,12 @@ pub async fn reveal_in_file_manager(path: String) -> Result<OpenResult> {
 }
 
 #[cfg(target_os = "linux")]
-fn try_dbus_reveal(path: &str) -> bool {
+fn try_dbus_reveal(path: &Path) -> bool {
     // Try to use dbus to reveal file in file manager
     // This works with Nautilus, Dolphin, and other modern file managers
+    let Ok(uri) = url::Url::from_file_path(path) else {
+        return false;
+    };
     std::process::Command::new("dbus-send")
         .args([
             "--session",
@@ -172,7 +192,7 @@ fn try_dbus_reveal(path: &str) -> bool {
             "--type=method_call",
             "/org/freedesktop/FileManager1",
             "org.freedesktop.FileManager1.ShowItems",
-            &format!("array:string:file://{}", path),
+            &format!("array:string:{}", uri),
             "string:",
         ])
         .status()
@@ -551,6 +571,15 @@ mod tests {
         let result =
             reveal_in_file_manager("/nonexistent/path/that/does/not/exist".to_string()).await;
         assert!(result.is_err());
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn test_windows_reveal_uses_single_select_argument() {
+        let target = Path::new(r"C:\repo with spaces\src\main.rs");
+        let argument = windows_reveal_argument(target);
+
+        assert_eq!(argument, r#"/select,"C:\repo with spaces\src\main.rs""#);
     }
 
     #[tokio::test]

--- a/src/components/__tests__/lv-file-status.test.ts
+++ b/src/components/__tests__/lv-file-status.test.ts
@@ -26,6 +26,7 @@ import { expect, fixture, html } from '@open-wc/testing';
 import type { LvFileStatus } from '../sidebar/lv-file-status.ts';
 import '../sidebar/lv-file-status.ts';
 import { repositoryStore } from '../../stores/repository.store.ts';
+import { uiStore } from '../../stores/ui.store.ts';
 import type { Repository } from '../../types/git.types.ts';
 
 // ── Test data ──────────────────────────────────────────────────────────────
@@ -644,6 +645,42 @@ describe('lv-file-status', () => {
       expect(revealCalls).to.have.length(1);
       expect((revealCalls[0].args as { path: string }).path).to.equal(windowsPath);
       expect(findCommands('plugin:shell|open')).to.have.length(0);
+    });
+
+    it('shows an error toast when the reveal command is rejected', async () => {
+      const el = await renderFileStatus();
+      const windowsPath = String.raw`C:\repo\src\app.ts`;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:path|join') return windowsPath;
+        if (command === 'reveal_in_file_manager') {
+          return Promise.reject({
+            code: 'INVALID_PATH',
+            message: String.raw`Invalid path: C:\repo\src\app.ts`,
+          });
+        }
+        return baseMock(command, args);
+      };
+
+      uiStore.setState({ toasts: [] });
+
+      const stagedItem = el.shadowRoot!.querySelector('.section .file-item')!;
+      stagedItem.dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, clientX: 100, clientY: 100 }),
+      );
+      await el.updateComplete;
+      const revealItem = Array.from(
+        el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.context-menu-item'),
+      ).find((item) => item.textContent?.includes('Reveal'));
+      expect(revealItem).to.not.be.undefined;
+
+      revealItem!.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const toasts = uiStore.getState().toasts;
+      expect(toasts).to.have.length(1);
+      expect(toasts[0].type).to.equal('error');
+      expect(toasts[0].message).to.equal(String.raw`Invalid path: C:\repo\src\app.ts`);
     });
 
     it('does not offer Reveal for a deleted file that no longer exists', async () => {

--- a/src/components/__tests__/lv-file-status.test.ts
+++ b/src/components/__tests__/lv-file-status.test.ts
@@ -52,6 +52,10 @@ function findCommands(name: string): Array<{ command: string; args?: unknown }> 
   return invokeHistory.filter((h) => h.command === name);
 }
 
+function isConfirmCommand(command: string): boolean {
+  return command === 'plugin:dialog|message' || command === 'plugin:dialog|confirm';
+}
+
 function setupDefaultMocks(
   opts: { entries?: typeof mockStatusEntries; postStageEntries?: typeof mockStatusEntries } = {},
 ): void {
@@ -75,9 +79,8 @@ function setupDefaultMocks(
         return null;
       case 'start_watching':
         return null;
-      // plugin-dialog 2.7 routes confirm() through `message` and returns the
-      // clicked button label; 'Ok' means the user confirmed.
       case 'plugin:dialog|message':
+      case 'plugin:dialog|confirm':
         return 'Ok';
       default:
         return null;
@@ -612,6 +615,54 @@ describe('lv-file-status', () => {
       expect(stageItem).to.not.be.undefined;
     });
 
+    it('reveals the selected file through the native file-manager command', async () => {
+      const el = await renderFileStatus();
+      const windowsPath = String.raw`C:\repo\src\app.ts`;
+      const baseMock = mockInvoke;
+      mockInvoke = async (command: string, args?: unknown) => {
+        if (command === 'plugin:path|join') return windowsPath;
+        if (command === 'reveal_in_file_manager') {
+          return { success: true, message: null };
+        }
+        return baseMock(command, args);
+      };
+
+      const stagedItem = el.shadowRoot!.querySelector('.section .file-item')!;
+      stagedItem.dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, clientX: 100, clientY: 100 }),
+      );
+      await el.updateComplete;
+      const revealItem = Array.from(
+        el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.context-menu-item'),
+      ).find((item) => item.textContent?.includes('Reveal'));
+      expect(revealItem).to.not.be.undefined;
+
+      revealItem!.click();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      const revealCalls = findCommands('reveal_in_file_manager');
+      expect(revealCalls).to.have.length(1);
+      expect((revealCalls[0].args as { path: string }).path).to.equal(windowsPath);
+      expect(findCommands('plugin:shell|open')).to.have.length(0);
+    });
+
+    it('does not offer Reveal for a deleted file that no longer exists', async () => {
+      const el = await renderFileStatus();
+      const deletedItem = Array.from(el.shadowRoot!.querySelectorAll<HTMLElement>('.file-item')).find(
+        (item) => item.textContent?.includes('README.md'),
+      )!;
+      deletedItem.dispatchEvent(
+        new MouseEvent('contextmenu', { bubbles: true, clientX: 100, clientY: 100 }),
+      );
+      await el.updateComplete;
+
+      const menuText = Array.from(
+        el.shadowRoot!.querySelectorAll<HTMLElement>('.context-menu-item'),
+      ).map((item) => item.textContent ?? '');
+      expect(menuText.some((text) => text.includes('Copy file path'))).to.be.true;
+      expect(menuText.some((text) => text.includes('Reveal'))).to.be.false;
+    });
+
     it('shows "Discard changes" menu item with danger class on an unstaged row', async () => {
       const el = await renderFileStatus();
 
@@ -989,7 +1040,7 @@ describe('lv-file-status', () => {
 
       let resolveConfirm!: (v: unknown) => void;
       mockInvoke = async (command: string) => {
-        if (command === 'plugin:dialog|message') {
+        if (isConfirmCommand(command)) {
           return new Promise((resolve) => {
             resolveConfirm = resolve;
           });

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -1849,8 +1849,10 @@ export class LvFileStatus extends LitElement {
     this.contextMenu = { ...this.contextMenu, visible: false };
     try {
       const fullPath = await join(this.repositoryPath, file.path);
-      const dirPath = fullPath.substring(0, fullPath.lastIndexOf("/"));
-      await shellOpen(dirPath);
+      const result = await gitService.revealInFileManager(fullPath);
+      if (!result.success) {
+        showToast(result.error?.message ?? "Failed to reveal file in file manager", "error");
+      }
     } catch (err) {
       console.error("Failed to reveal:", err);
       showToast("Failed to reveal file in file manager", "error");
@@ -2400,27 +2402,29 @@ export class LvFileStatus extends LitElement {
           </svg>
           Open in editor
         </button>
-        <button
-          class="context-menu-item"
-          role="menuitem"
-          @click=${this.handleContextRevealInFinder}
-        >
-          <svg
-            viewBox="0 0 24 24"
-            fill="none"
-            stroke="currentColor"
-            stroke-width="2"
-          >
-            <path
-              d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
-            ></path>
-          </svg>
-          ${navigator.userAgent.includes("Win")
-            ? "Reveal in Explorer"
-            : navigator.userAgent.includes("Linux")
-              ? "Reveal in File Manager"
-              : "Reveal in Finder"}
-        </button>
+        ${file.status !== "deleted"
+          ? html`<button
+              class="context-menu-item"
+              role="menuitem"
+              @click=${this.handleContextRevealInFinder}
+            >
+              <svg
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="2"
+              >
+                <path
+                  d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"
+                ></path>
+              </svg>
+              ${navigator.userAgent.includes("Win")
+                ? "Reveal in Explorer"
+                : navigator.userAgent.includes("Linux")
+                  ? "Reveal in File Manager"
+                  : "Reveal in Finder"}
+            </button>`
+          : nothing}
         <button class="context-menu-item" role="menuitem" @click=${this.handleContextCopyPath}>
           <svg
             viewBox="0 0 24 24"


### PR DESCRIPTION
## Summary
- route file-status Reveal through the native reveal command with the full joined path
- pass Explorer its required raw `/select,"path"` command line so paths with spaces are highlighted
- percent-encode Linux FileManager1 file URIs
- hide Reveal for deleted files and add platform-focused regression coverage

## Validation
- `npm test -- src/components/__tests__/lv-file-status.test.ts`
- `npm run typecheck`
- `cargo test --lib commands::file::tests --manifest-path src-tauri/Cargo.toml -- --test-threads=1`
