### PR TITLE
feat: add winget, Homebrew, and Scoop delivery channels

### DIFF
--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -1,0 +1,174 @@
+name: Publish Packages
+
+# Publishes each GitHub release to package managers:
+#   - winget   (Windows)  — opens a PR against microsoft/winget-pkgs
+#   - Homebrew (macOS)    — updates the cask in the hegsie/homebrew-leviathan tap
+#   - Scoop    (Windows)  — updates packaging/scoop/leviathan.json on main
+#
+# One-time maintainer setup (secrets, tap repository, first winget submission)
+# is documented in docs/packaging.md. Jobs that are missing their secret are
+# skipped rather than failed, so the workflow degrades gracefully until each
+# channel is set up.
+
+on:
+  release:
+    types: [released]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to publish packages for (e.g. v0.8.0)'
+        required: true
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ inputs.tag || github.event.release.tag_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  preflight:
+    name: Resolve release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.release.outputs.tag }}
+      version: ${{ steps.release.outputs.version }}
+      has-winget-token: ${{ steps.secrets.outputs.has-winget-token }}
+      has-homebrew-token: ${{ steps.secrets.outputs.has-homebrew-token }}
+    steps:
+      - name: Resolve tag and version
+        id: release
+        env:
+          TAG: ${{ inputs.tag || github.event.release.tag_name }}
+        run: |
+          if [ -z "$TAG" ]; then
+            echo "::error::No release tag available"
+            exit 1
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          echo "version=${TAG#v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify release assets exist
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag }}
+          VERSION: ${{ steps.release.outputs.version }}
+        run: |
+          assets=$(curl -fsSL -H "Authorization: Bearer $GH_TOKEN" \
+            "https://api.github.com/repos/${{ github.repository }}/releases/tags/${TAG}" \
+            | jq -r '.assets[].name')
+          for name in \
+            "Leviathan_${VERSION}_x64-setup.exe" \
+            "Leviathan_${VERSION}_x64_en-US.msi" \
+            "Leviathan_${VERSION}_aarch64.dmg"; do
+            if ! echo "$assets" | grep -qxF "$name"; then
+              echo "::error::Release ${TAG} is missing asset ${name}"
+              exit 1
+            fi
+          done
+
+      # Secrets are not readable in job-level `if` conditions, so surface their
+      # presence as outputs and gate the downstream jobs on those.
+      - name: Check publishing secrets
+        id: secrets
+        env:
+          WINGET_TOKEN: ${{ secrets.WINGET_TOKEN }}
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+        run: |
+          echo "has-winget-token=$([ -n "$WINGET_TOKEN" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+          echo "has-homebrew-token=$([ -n "$HOMEBREW_TAP_TOKEN" ] && echo true || echo false)" >> "$GITHUB_OUTPUT"
+
+  winget:
+    name: Publish to winget
+    needs: preflight
+    if: needs.preflight.outputs.has-winget-token == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Publish to winget-pkgs
+        uses: vedantmgoyal9/winget-releaser@v2
+        with:
+          identifier: hegsie.Leviathan
+          installers-regex: '\.(exe|msi)$'
+          release-tag: ${{ needs.preflight.outputs.tag }}
+          max-versions-to-keep: 5
+          token: ${{ secrets.WINGET_TOKEN }}
+
+  homebrew:
+    name: Update Homebrew cask
+    needs: preflight
+    if: needs.preflight.outputs.has-homebrew-token == 'true'
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ needs.preflight.outputs.tag }}
+      VERSION: ${{ needs.preflight.outputs.version }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Compute DMG checksum
+        id: dmg
+        run: |
+          curl -fsSL -o leviathan.dmg \
+            "https://github.com/${{ github.repository }}/releases/download/${TAG}/Leviathan_${VERSION}_aarch64.dmg"
+          echo "sha256=$(sha256sum leviathan.dmg | cut -d' ' -f1)" >> "$GITHUB_OUTPUT"
+          rm leviathan.dmg
+
+      - name: Push cask to tap
+        env:
+          HOMEBREW_TAP_TOKEN: ${{ secrets.HOMEBREW_TAP_TOKEN }}
+          SHA256: ${{ steps.dmg.outputs.sha256 }}
+        run: |
+          git clone "https://x-access-token:${HOMEBREW_TAP_TOKEN}@github.com/${{ github.repository_owner }}/homebrew-leviathan.git" tap
+          mkdir -p tap/Casks
+          sed -e "s/__VERSION__/${VERSION}/g" -e "s/__SHA256__/${SHA256}/g" \
+            packaging/homebrew/leviathan.rb.template > tap/Casks/leviathan.rb
+          cd tap
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add Casks/leviathan.rb
+          if git diff --cached --quiet; then
+            echo "Cask already up to date for ${VERSION}"
+            exit 0
+          fi
+          git commit -m "leviathan ${VERSION}"
+          git push
+
+  scoop:
+    name: Update Scoop manifest
+    needs: preflight
+    runs-on: ubuntu-latest
+    env:
+      TAG: ${{ needs.preflight.outputs.tag }}
+      VERSION: ${{ needs.preflight.outputs.version }}
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v7
+        with:
+          ref: main
+
+      - name: Update manifest
+        run: |
+          url="https://github.com/${{ github.repository }}/releases/download/${TAG}/Leviathan_${VERSION}_x64_en-US.msi"
+          curl -fsSL -o leviathan.msi "$url"
+          hash=$(sha256sum leviathan.msi | cut -d' ' -f1)
+          rm leviathan.msi
+          jq --arg version "$VERSION" --arg url "$url" --arg hash "$hash" \
+            '.version = $version
+             | .architecture."64bit".url = $url
+             | .architecture."64bit".hash = $hash' \
+            packaging/scoop/leviathan.json > leviathan.json.tmp
+          mv leviathan.json.tmp packaging/scoop/leviathan.json
+
+      - name: Commit and push
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add packaging/scoop/leviathan.json
+          if git diff --cached --quiet; then
+            echo "Scoop manifest already up to date for ${VERSION}"
+            exit 0
+          fi
+          git commit -m "chore: update Scoop manifest for ${TAG} [skip ci]"
+          git pull --rebase origin main
+          git push origin main

--- a/README.md
+++ b/README.md
@@ -237,6 +237,29 @@ Pre-built binaries are available from the [Releases](https://github.com/hegsie/L
 | Linux | `.deb` or `.AppImage` |
 | Arch Linux | [AUR](https://aur.archlinux.org/packages/leviathan-bin) |
 
+### Package Managers
+
+New releases are published to package managers automatically (see
+[docs/packaging.md](docs/packaging.md) for how this works).
+
+#### Windows (winget)
+
+```powershell
+winget install hegsie.Leviathan
+```
+
+#### Windows (Scoop)
+
+```powershell
+scoop install https://raw.githubusercontent.com/hegsie/Leviathan/main/packaging/scoop/leviathan.json
+```
+
+#### macOS (Homebrew, Apple Silicon)
+
+```bash
+brew install --cask hegsie/leviathan/leviathan
+```
+
 ### Arch Linux (AUR)
 
 Leviathan is available on the AUR as [`leviathan-bin`](https://aur.archlinux.org/packages/leviathan-bin), repackaged from the official `.deb` release:

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -233,6 +233,8 @@ Our north star: *A privacy-first, AI-native Git workstation where intelligence r
 
 - ✅ **Auto-updates** — Tauri updater with signing key, background download with install prompt
 
+- ✅ **Package manager delivery** — winget, Homebrew cask (Apple Silicon tap), and Scoop manifest published automatically on each release; community-maintained AUR package. Future candidates: Chocolatey, Flathub, Snapcraft
+
 ---
 
 ### AI & Machine Learning Features

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -1,0 +1,110 @@
+# Package Manager Distribution
+
+Leviathan is delivered through package managers in addition to the direct
+downloads on the [Releases](https://github.com/hegsie/Leviathan/releases) page.
+The [`publish-packages.yml`](../.github/workflows/publish-packages.yml)
+workflow runs automatically whenever a release is published (moved out of
+draft) and pushes the new version to each channel. It can also be re-run
+manually from the Actions tab (workflow dispatch) with a release tag such as
+`v0.8.0`, e.g. after fixing a one-time setup issue.
+
+| Channel | Platform | Automation | One-time setup required |
+|---------|----------|------------|-------------------------|
+| winget | Windows | PR against `microsoft/winget-pkgs` | `WINGET_TOKEN` secret, fork of winget-pkgs, initial manual submission |
+| Homebrew | macOS (Apple Silicon) | Push to `hegsie/homebrew-leviathan` tap | Tap repository, `HOMEBREW_TAP_TOKEN` secret |
+| Scoop | Windows | Commit to `packaging/scoop/leviathan.json` on `main` | None |
+| AUR | Arch Linux | Community-maintained (`leviathan-bin`) | — |
+
+Jobs whose secret is missing are skipped, not failed, so the workflow works
+before every channel is set up.
+
+## winget
+
+The `winget` job uses
+[winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) to open a
+version-update PR against
+[microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) with the
+`.exe` (NSIS) and `.msi` installers. Package identifier: `hegsie.Leviathan`.
+
+One-time setup:
+
+1. Fork [microsoft/winget-pkgs](https://github.com/microsoft/winget-pkgs) under
+   the `hegsie` account (the action pushes manifest branches to this fork).
+2. Create a **classic** personal access token with the `public_repo` scope
+   (fine-grained tokens are not supported by winget-releaser) and add it as
+   the `WINGET_TOKEN` repository secret.
+3. The package must already exist in winget-pkgs before the action can update
+   it, so submit the first version manually with
+   [wingetcreate](https://github.com/microsoft/winget-create):
+
+   ```powershell
+   wingetcreate new `
+     https://github.com/hegsie/Leviathan/releases/download/v0.8.0/Leviathan_0.8.0_x64-setup.exe `
+     https://github.com/hegsie/Leviathan/releases/download/v0.8.0/Leviathan_0.8.0_x64_en-US.msi
+   # PackageIdentifier: hegsie.Leviathan — then review and submit the PR
+   ```
+
+Once the initial PR is merged, every later release is submitted automatically.
+Users install with `winget install hegsie.Leviathan`.
+
+## Homebrew
+
+The `homebrew` job downloads the release DMG, computes its SHA-256, renders
+[`packaging/homebrew/leviathan.rb.template`](../packaging/homebrew/leviathan.rb.template)
+and pushes the result to `Casks/leviathan.rb` in the
+`hegsie/homebrew-leviathan` tap. Only Apple Silicon is published because CI
+builds `aarch64-apple-darwin` only; the cask declares `depends_on arch: :arm64`.
+
+One-time setup:
+
+1. Create a public repository named `homebrew-leviathan` under the `hegsie`
+   account (an empty repository with a README is enough; the workflow creates
+   `Casks/leviathan.rb`).
+2. Create a personal access token with write access to that repository
+   (fine-grained with Contents read/write, or classic with `repo`) and add it
+   as the `HOMEBREW_TAP_TOKEN` repository secret in the Leviathan repository.
+
+Users install with `brew install --cask hegsie/leviathan/leviathan`.
+
+## Scoop
+
+[`packaging/scoop/leviathan.json`](../packaging/scoop/leviathan.json) is a
+Scoop manifest that installs the MSI by extraction (`extract_dir:
+"PFiles/Leviathan"`), the same pattern the Scoop Extras bucket uses for other
+Tauri apps. The `scoop` job updates its version, URL, and hash on each release
+and commits to `main` with `[skip ci]`. No secret is needed — the default
+`GITHUB_TOKEN` has `contents: write`. If branch protection on `main` blocks
+pushes from `github-actions[bot]`, either allow it or replace the token with a
+PAT.
+
+Users install with:
+
+```powershell
+scoop install https://raw.githubusercontent.com/hegsie/Leviathan/main/packaging/scoop/leviathan.json
+```
+
+Because Scoop extracts the MSI rather than running it, the WebView2 runtime
+bootstrap never executes; the manifest's `notes` tell users where to get
+WebView2 in the unlikely case it is missing. The manifest also carries
+`checkver`/`autoupdate` metadata so it could be adopted into a community
+bucket (e.g. Extras) unchanged.
+
+## Release asset naming
+
+The manifests and workflow depend on the Tauri bundle asset names staying
+stable:
+
+- `Leviathan_<version>_x64-setup.exe` (NSIS)
+- `Leviathan_<version>_x64_en-US.msi` (WiX)
+- `Leviathan_<version>_aarch64.dmg` (macOS)
+
+If `productName`, bundle targets, or the Windows installer language in
+`src-tauri/tauri.conf.json` change, update `publish-packages.yml`, the Scoop
+manifest, and the Homebrew template together. The preflight job verifies these
+assets exist on the release and fails early with a clear error if not.
+
+## Future candidates
+
+Not yet automated, in rough order of value: Chocolatey (needs a community
+account and moderation), Flathub (needs a flatpak manifest and review), and
+Snapcraft (needs a store account).

--- a/packaging/homebrew/leviathan.rb.template
+++ b/packaging/homebrew/leviathan.rb.template
@@ -1,0 +1,30 @@
+# Rendered by .github/workflows/publish-packages.yml on each release and
+# pushed to the hegsie/homebrew-leviathan tap as Casks/leviathan.rb.
+cask "leviathan" do
+  version "__VERSION__"
+  sha256 "__SHA256__"
+
+  url "https://github.com/hegsie/Leviathan/releases/download/v#{version}/Leviathan_#{version}_aarch64.dmg"
+  name "Leviathan"
+  desc "Fast, privacy-first Git GUI client"
+  homepage "https://github.com/hegsie/Leviathan"
+
+  livecheck do
+    url :url
+    strategy :github_latest
+  end
+
+  auto_updates true
+  depends_on arch: :arm64
+  depends_on macos: ">= :big_sur"
+
+  app "Leviathan.app"
+
+  zap trash: [
+    "~/Library/Application Support/io.github.hegsie.leviathan",
+    "~/Library/Caches/io.github.hegsie.leviathan",
+    "~/Library/Preferences/io.github.hegsie.leviathan.plist",
+    "~/Library/Saved Application State/io.github.hegsie.leviathan.savedState",
+    "~/Library/WebKit/io.github.hegsie.leviathan",
+  ]
+end

--- a/packaging/scoop/leviathan.json
+++ b/packaging/scoop/leviathan.json
@@ -1,0 +1,30 @@
+{
+    "version": "0.8.0",
+    "description": "Fast, privacy-first Git GUI client",
+    "homepage": "https://github.com/hegsie/Leviathan",
+    "license": "MIT",
+    "notes": "Leviathan needs the Microsoft Edge WebView2 runtime, which is preinstalled on Windows 11 and most Windows 10 systems. If the app does not start, install it from https://developer.microsoft.com/microsoft-edge/webview2/",
+    "architecture": {
+        "64bit": {
+            "url": "https://github.com/hegsie/Leviathan/releases/download/v0.8.0/Leviathan_0.8.0_x64_en-US.msi",
+            "hash": "99968f1dfb284413df2a5c987f77bd414705ec219e1a7a2953640f2e0e3e8dce",
+            "extract_dir": "PFiles/Leviathan"
+        }
+    },
+    "shortcuts": [
+        [
+            "Leviathan.exe",
+            "Leviathan"
+        ]
+    ],
+    "checkver": {
+        "github": "https://github.com/hegsie/Leviathan"
+    },
+    "autoupdate": {
+        "architecture": {
+            "64bit": {
+                "url": "https://github.com/hegsie/Leviathan/releases/download/v$version/Leviathan_$version_x64_en-US.msi"
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Adds automated delivery to three package managers, alongside the existing GitHub Releases downloads and community AUR package:

- **winget** (Windows) — a new `publish-packages.yml` workflow submits the `.exe`/`.msi` installers to `microsoft/winget-pkgs` via [winget-releaser](https://github.com/vedantmgoyal9/winget-releaser) as `hegsie.Leviathan`, keeping the last 5 versions.
- **Homebrew** (macOS, Apple Silicon) — renders `packaging/homebrew/leviathan.rb.template` with the release DMG's SHA-256 and pushes the cask to a `hegsie/homebrew-leviathan` tap. The cask sets `auto_updates true` since the Tauri updater handles upgrades in-app.
- **Scoop** (Windows) — `packaging/scoop/leviathan.json` installs by extracting the MSI (`extract_dir: "PFiles/Leviathan"`, the same pattern Scoop Extras uses for other Tauri apps such as GitButler) and is installable directly by raw URL. The workflow updates its version/URL/hash on each release and commits back to `main` with `[skip ci]`. Seeded with the real v0.8.0 MSI URL and checksum.

## How it works

The workflow fires on `release: [released]` (i.e. when a draft release is published) or manual dispatch with a tag. A preflight job verifies the expected installer assets exist on the release and fails early otherwise. The winget and Homebrew jobs are gated on their secrets (`WINGET_TOKEN`, `HOMEBREW_TAP_TOKEN`) and skip gracefully until those are configured, so merging this is safe before setup.

## One-time setup required (documented in docs/packaging.md)

1. **winget**: fork `microsoft/winget-pkgs`, add a classic PAT with `public_repo` scope as `WINGET_TOKEN`, and submit the first version manually with `wingetcreate new` (the action can only update existing packages).
2. **Homebrew**: create a public `hegsie/homebrew-leviathan` repo and add a PAT with write access to it as `HOMEBREW_TAP_TOKEN`.
3. **Scoop**: nothing.

## Docs

- README: new "Package Managers" install section (winget / Scoop / Homebrew)
- `docs/packaging.md`: maintainer guide for setup, asset-naming dependencies, and future candidates (Chocolatey, Flathub, Snapcraft)
- ROADMAP: package-manager delivery bullet under Distribution

## Validation

- Workflow YAML and Scoop JSON parse cleanly; cask template renders correctly via the same `sed` invocation the workflow uses
- Release asset names verified against the actual v0.8.0 release assets
- No TypeScript/Rust code touched, so app test suites are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoUA6Psr1kPCJK3pFMie8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoUA6Psr1kPCJK3pFMie8F)_