### PR TITLE
feat: honour reduced motion and show a keyboard focus ring

### DIFF
--- a/e2e/tests/accessibility.spec.ts
+++ b/e2e/tests/accessibility.spec.ts
@@ -1,0 +1,180 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupOpenRepository } from '../fixtures/tauri-mock';
+
+/**
+ * Keyboard focus visibility and the OS "reduce motion" setting.
+ *
+ * Both are asserted through real browser behaviour rather than through the
+ * stylesheet text: Tab really moves focus (so :focus-visible really matches),
+ * and Playwright's emulateMedia really flips prefers-reduced-motion — the only
+ * way to prove the rules landed inside the component shadow roots, which a
+ * light-DOM stylesheet can never reach.
+ */
+
+interface FocusInfo {
+  tag: string;
+  className: string;
+  outlineStyle: string;
+  outlineWidth: number;
+  outlineColorAlpha: number;
+}
+
+/**
+ * The genuinely focused element, following focus down through shadow roots.
+ *
+ * Read through expect.poll, never once: several controls carry
+ * `transition: all var(--transition-fast)`, so outline-width is mid-transition
+ * (still 0) for the first ~100ms after focus lands.
+ */
+async function deepActiveElement(page: Page): Promise<FocusInfo | null> {
+  return page.evaluate(() => {
+    let el: Element | null = document.activeElement;
+    while (el?.shadowRoot?.activeElement) el = el.shadowRoot.activeElement;
+    if (!el || el === document.body) return null;
+    const style = getComputedStyle(el);
+    // rgb(r, g, b) has no alpha component and is fully opaque; rgba(...) does.
+    const alphaMatch = /rgba\([^)]*,\s*([\d.]+)\s*\)$/.exec(style.outlineColor.trim());
+    return {
+      tag: el.tagName.toLowerCase(),
+      className: typeof el.className === 'string' ? el.className : '',
+      outlineStyle: style.outlineStyle,
+      outlineWidth: parseFloat(style.outlineWidth) || 0,
+      outlineColorAlpha: alphaMatch ? parseFloat(alphaMatch[1]) : 1,
+    };
+  });
+}
+
+/** Waits for the focused control to paint a solid, opaque ring of >= 2px. */
+async function expectVisibleFocusRing(page: Page): Promise<FocusInfo> {
+  await expect
+    .poll(async () => {
+      const focused = await deepActiveElement(page);
+      if (!focused) return 'nothing focused';
+      return `${focused.outlineStyle} ${focused.outlineWidth >= 2} ${focused.outlineColorAlpha > 0}`;
+    })
+    .toBe('solid true true');
+
+  return (await deepActiveElement(page)) as FocusInfo;
+}
+
+/** Focus starts nowhere in particular; click a dead area of the chrome first. */
+async function resetFocus(page: Page): Promise<void> {
+  await page.locator('lv-app-shell').click({ position: { x: 5, y: 5 } });
+}
+
+test.describe('Accessibility — keyboard focus ring', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+  });
+
+  test('the first Tab lands on a control with a visible focus ring', async ({ page }) => {
+    await resetFocus(page);
+    await page.keyboard.press('Tab');
+
+    const focused = await expectVisibleFocusRing(page);
+    expect(focused.tag, 'Tab did not reach a control').not.toBe('body');
+  });
+
+  test('every control reached by tabbing keeps a visible ring', async ({ page }) => {
+    await resetFocus(page);
+
+    const seen: string[] = [];
+    for (let i = 0; i < 10; i++) {
+      await page.keyboard.press('Tab');
+      if (!(await deepActiveElement(page))) continue;
+      const focused = await expectVisibleFocusRing(page);
+      seen.push(`${focused.tag}.${focused.className}`);
+    }
+
+    // Guards the test itself: without this the loop above could pass vacuously.
+    expect(seen.length, 'tabbing reached no controls at all').toBeGreaterThan(2);
+  });
+
+  test('the focus ring is visible in the dark theme too', async ({ page }) => {
+    await page.evaluate(() => document.documentElement.setAttribute('data-theme', 'dark'));
+    await resetFocus(page);
+    await page.keyboard.press('Tab');
+
+    await expectVisibleFocusRing(page);
+  });
+});
+
+test.describe('Accessibility — reduced motion', () => {
+  /** Computed style of the first matching element anywhere in the shadow tree. */
+  async function computedInShadowTree(
+    page: Page,
+    selector: string,
+    property: string
+  ): Promise<string | null> {
+    return page.evaluate(
+      ({ selector, property }) => {
+        const search = (root: Document | ShadowRoot): Element | null => {
+          const direct = root.querySelector(selector);
+          if (direct) return direct;
+          for (const el of Array.from(root.querySelectorAll('*'))) {
+            if (el.shadowRoot) {
+              const found = search(el.shadowRoot);
+              if (found) return found;
+            }
+          }
+          return null;
+        };
+        const el = search(document);
+        return el ? getComputedStyle(el).getPropertyValue(property) : null;
+      },
+      { selector, property }
+    );
+  }
+
+  // The clamp lives in sharedStyles, adopted into every component's shadow
+  // root — a rule in the light-DOM stylesheet could not reach these elements.
+  test('component transitions are clamped inside shadow roots', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await setupOpenRepository(page);
+
+    const duration = await computedInShadowTree(page, '.menu-btn', 'transition-duration');
+    expect(duration, 'could not find a transitioned toolbar control').not.toBeNull();
+    // 0.01ms — near-zero rather than exactly 0, so transitionend still fires.
+    for (const part of duration!.split(',')) {
+      expect(parseFloat(part)).toBeLessThan(0.001);
+    }
+  });
+
+  test('transitions still run when motion is not reduced', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'no-preference' });
+    await setupOpenRepository(page);
+
+    const duration = await computedInShadowTree(page, '.menu-btn', 'transition-duration');
+    expect(duration).not.toBeNull();
+    expect(parseFloat(duration!.split(',')[0])).toBeGreaterThan(0.001);
+  });
+
+  test('an infinite spinner stops animating when motion is reduced', async ({ page }) => {
+    await page.emulateMedia({ reducedMotion: 'reduce' });
+    await setupOpenRepository(page);
+
+    // lv-progress-indicator is always mounted by app-shell and owns one of the
+    // app's infinite spinners (.progress-icon.spinning). Probe its already
+    // adopted styles so the assertion does not depend on an operation being in
+    // flight.
+    const result = await page.evaluate(() => {
+      const shell = document.querySelector('lv-app-shell')?.shadowRoot;
+      const root = shell?.querySelector('lv-progress-indicator')?.shadowRoot;
+      if (!root) return null;
+      const probe = document.createElement('div');
+      probe.className = 'progress-icon spinning';
+      root.appendChild(probe);
+      const style = getComputedStyle(probe);
+      const out = {
+        duration: style.animationDuration,
+        iterations: style.animationIterationCount,
+      };
+      probe.remove();
+      return out;
+    });
+
+    expect(result, 'lv-progress-indicator is not mounted').not.toBeNull();
+    expect(parseFloat(result!.duration)).toBeLessThan(0.001);
+    expect(result!.iterations).toBe('1');
+  });
+});

--- a/src/__tests__/app-shell-loading-bar.test.ts
+++ b/src/__tests__/app-shell-loading-bar.test.ts
@@ -64,6 +64,34 @@ describe('app-shell global loading bar', () => {
     ).to.be.greaterThan(0);
   });
 
+  // The shared reduced-motion clamp stops every animation after a single
+  // 0.01ms iteration. For this bar that would park the ::after slider at its
+  // final keyframe — translateX(350%), i.e. entirely off-screen — so a user
+  // with "reduce motion" on would see an empty track during every long
+  // operation. app-shell therefore paints it as a static full-width fill.
+  it('keeps the bar visible when motion is reduced', async () => {
+    const el = await shellWithLoading(true);
+    const root = el.shadowRoot!;
+    const sheets = [...(root.adoptedStyleSheets ?? []), ...Array.from(root.styleSheets ?? [])];
+
+    const overrides = sheets
+      .flatMap((sheet) => Array.from(sheet.cssRules))
+      .filter(
+        (rule): rule is CSSMediaRule =>
+          rule instanceof CSSMediaRule && rule.conditionText.includes('prefers-reduced-motion'),
+      )
+      .flatMap((media) => Array.from(media.cssRules))
+      .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+      .filter((rule) => rule.selectorText.includes('.global-loading-bar'));
+
+    expect(
+      overrides.length,
+      'no reduced-motion override for the loading bar — it would be parked off-screen',
+    ).to.be.greaterThan(0);
+    expect(overrides[0].style.getPropertyValue('width')).to.equal('100%');
+    expect(overrides[0].style.getPropertyValue('transform')).to.equal('none');
+  });
+
   it('styles the skip link, whose declarations sat after the keyframes', async () => {
     const el = await shellWithLoading(false);
     const skip = el.shadowRoot!.querySelector('.skip-link') as HTMLElement;

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -226,6 +226,18 @@ export class AppShell extends LitElement {
         100% { transform: translateX(350%); }
       }
 
+      /* The shared reduced-motion rules clamp every animation to one 0.01ms
+         iteration, which would park this bar at its final keyframe — 350% to
+         the right, i.e. completely off-screen — and the app would look idle
+         during long operations. Paint a static full-width bar instead so the
+         "busy" state is still visible without motion. */
+      @media (prefers-reduced-motion: reduce) {
+        .global-loading-bar::after {
+          width: 100%;
+          transform: none;
+        }
+      }
+
       .skip-link:focus {
         top: 0;
       }

--- a/src/components/common/lv-progress-indicator.ts
+++ b/src/components/common/lv-progress-indicator.ts
@@ -108,6 +108,16 @@ export class LvProgressIndicator extends LitElement {
         100% { transform: translateX(400%); }
       }
 
+      /* Same reasoning as the global loading bar in app-shell: with motion
+         reduced the sliding fill would end up parked off-screen, so show a
+         static full-width fill instead of nothing. */
+      @media (prefers-reduced-motion: reduce) {
+        .progress-fill.indeterminate {
+          width: 100% !important;
+          transform: none;
+        }
+      }
+
       .cancel-btn {
         display: flex;
         align-items: center;

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -217,9 +217,12 @@ export class LvAzureDevOpsDialog extends LitElement {
         background: #f5f5f5;
       }
 
-      .ms-signin-btn:focus-visible {
-        outline: 2px solid #0067b8;
-        outline-offset: 1px;
+      /* Keeps the Microsoft-blue ring on the branded sign-in button. Expressed
+         through the shared focus-ring properties rather than an outline
+         declaration, because the shared rule in sharedStyles is !important. */
+      .ms-signin-btn {
+        --lv-focus-ring-color: #0067b8;
+        --lv-focus-ring-offset: 1px;
       }
 
       .ms-signin-btn:disabled {

--- a/src/components/panels/lv-diff-view.ts
+++ b/src/components/panels/lv-diff-view.ts
@@ -675,6 +675,13 @@ export class LvDiffView extends CodeRenderMixin(LitElement) {
         outline: none;
       }
 
+      /* The editor fills its pane edge to edge, so the shared keyboard focus
+         ring is drawn inside the textarea instead of outside it, where the
+         surrounding overflow: hidden would clip it away. */
+      .editor-textarea {
+        --lv-focus-ring-offset: -2px;
+      }
+
       .edit-indicator {
         padding: var(--spacing-xs) var(--spacing-sm);
         background: var(--color-warning-bg);

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -71,7 +71,10 @@ export class LvBranchList extends LitElement {
         border-bottom: none;
       }
 
+      /* Full-bleed row inside a scrolling list: draw the shared keyboard
+         focus ring inside the row so the scroll container cannot clip it. */
       .group-header {
+        --lv-focus-ring-offset: -2px;
         display: flex;
         align-items: center;
         gap: 4px;
@@ -142,7 +145,10 @@ export class LvBranchList extends LitElement {
         margin-left: 0;
       }
 
+      /* Full-bleed row inside a scrolling list: draw the shared keyboard
+         focus ring inside the row so the scroll container cannot clip it. */
       .subgroup-header {
+        --lv-focus-ring-offset: -2px;
         display: flex;
         align-items: center;
         gap: 6px;

--- a/src/components/sidebar/lv-file-status.ts
+++ b/src/components/sidebar/lv-file-status.ts
@@ -80,7 +80,10 @@ export class LvFileStatus extends LitElement {
         border-bottom: none;
       }
 
+      /* Full-bleed row inside a scrolling list: draw the shared keyboard
+         focus ring inside the row so the scroll container cannot clip it. */
       .section-header {
+        --lv-focus-ring-offset: -2px;
         display: flex;
         align-items: center;
         gap: 6px;

--- a/src/components/sidebar/lv-stash-list.ts
+++ b/src/components/sidebar/lv-stash-list.ts
@@ -40,7 +40,10 @@ export class LvStashList extends LitElement {
         padding: 0;
       }
 
+      /* Full-bleed row inside a scrolling list: draw the shared keyboard
+         focus ring inside the row so the scroll container cannot clip it. */
       .stash-item {
+        --lv-focus-ring-offset: -2px;
         display: flex;
         align-items: center;
         gap: 6px;

--- a/src/components/sidebar/lv-tag-list.ts
+++ b/src/components/sidebar/lv-tag-list.ts
@@ -55,7 +55,10 @@ export class LvTagList extends LitElement {
         padding: 0;
       }
 
+      /* Full-bleed row inside a scrolling list: draw the shared keyboard
+         focus ring inside the row so the scroll container cannot clip it. */
       .tag-item {
+        --lv-focus-ring-offset: -2px;
         display: flex;
         align-items: center;
         gap: 6px;
@@ -294,8 +297,11 @@ export class LvTagList extends LitElement {
         color: var(--color-primary);
       }
 
-      /* Group headers */
+      /* Group headers.
+         Full-bleed row inside a scrolling list: draw the shared keyboard
+         focus ring inside the row so the scroll container cannot clip it. */
       .group-header {
+        --lv-focus-ring-offset: -2px;
         display: flex;
         align-items: center;
         gap: 4px;

--- a/src/components/toolbar/lv-toolbar.ts
+++ b/src/components/toolbar/lv-toolbar.ts
@@ -220,7 +220,10 @@ export class LvToolbar extends LitElement {
         color: #0052cc;
       }
 
+      /* Sits flush inside the tab, which clips its overflow: draw the shared
+         keyboard focus ring inside the hit area so it is not cut off. */
       .tab-close {
+        --lv-focus-ring-offset: -2px;
         display: flex;
         align-items: center;
         justify-content: center;

--- a/src/styles/__tests__/a11y-styles.test.ts
+++ b/src/styles/__tests__/a11y-styles.test.ts
@@ -1,0 +1,174 @@
+/**
+ * Accessibility styling contract: the reduced-motion clamp and the shared
+ * keyboard focus ring.
+ *
+ * Both live in `sharedStyles` on purpose. Lit renders into shadow roots, so the
+ * `@media (prefers-reduced-motion: reduce)` block in src/styles/tokens.css
+ * cannot reach a component's own `animation:` declarations — only a fragment
+ * adopted into the shadow root can. These tests therefore assert through the
+ * CSSOM of a real shadow root rather than by string-matching the source, so
+ * they fail if the fragment stops being composed in, or if a nesting mistake
+ * means the browser never parses the rules.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+let cbId = 0;
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: () => Promise.resolve([]),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import { LitElement, html as litHtml } from 'lit';
+import { sharedStyles, focusRingStyles, reducedMotionStyles } from '../shared-styles.ts';
+import '../../components/sidebar/lv-branch-list.ts';
+import '../../components/common/lv-progress-indicator.ts';
+
+function sheetsOf(root: ShadowRoot): CSSStyleSheet[] {
+  return [...(root.adoptedStyleSheets ?? []), ...Array.from(root.styleSheets ?? [])];
+}
+
+/** Every top-level style rule adopted into a shadow root. */
+function styleRules(root: ShadowRoot): CSSStyleRule[] {
+  const out: CSSStyleRule[] = [];
+  for (const sheet of sheetsOf(root)) {
+    for (const rule of Array.from(sheet.cssRules)) {
+      if (rule instanceof CSSStyleRule) out.push(rule);
+    }
+  }
+  return out;
+}
+
+/** The prefers-reduced-motion media rules adopted into a shadow root. */
+function reducedMotionRules(root: ShadowRoot): CSSMediaRule[] {
+  const out: CSSMediaRule[] = [];
+  for (const sheet of sheetsOf(root)) {
+    for (const rule of Array.from(sheet.cssRules)) {
+      if (rule instanceof CSSMediaRule && rule.conditionText.includes('prefers-reduced-motion')) {
+        out.push(rule);
+      }
+    }
+  }
+  return out;
+}
+
+class A11yStylesProbe extends LitElement {
+  static styles = [sharedStyles];
+  render() {
+    return litHtml`
+      <button class="probe-button">press</button>
+      <input class="probe-input" />
+      <div class="probe-row" tabindex="0">row</div>
+    `;
+  }
+}
+customElements.define('a11y-styles-probe', A11yStylesProbe);
+
+describe('shared accessibility styles', () => {
+  describe('reduced motion', () => {
+    it('exports a fragment that clamps animation and transition', () => {
+      const text = reducedMotionStyles.cssText;
+      expect(text).to.contain('prefers-reduced-motion');
+      expect(text).to.contain('animation-duration');
+      expect(text).to.contain('animation-iteration-count');
+      expect(text).to.contain('transition-duration');
+      expect(text).to.contain('scroll-behavior');
+    });
+
+    it('composes the fragment into sharedStyles', () => {
+      expect(sharedStyles.cssText).to.contain(reducedMotionStyles.cssText.trim());
+    });
+
+    it('reaches a component shadow root, where a light-DOM rule could not', async () => {
+      const el = await fixture<A11yStylesProbe>(html`<a11y-styles-probe></a11y-styles-probe>`);
+      const media = reducedMotionRules(el.shadowRoot as ShadowRoot);
+      expect(media.length, 'no prefers-reduced-motion rule in the shadow root').to.be.greaterThan(0);
+
+      const declarations = media
+        .flatMap((m) => Array.from(m.cssRules))
+        .filter((r): r is CSSStyleRule => r instanceof CSSStyleRule);
+      const clamped = declarations.find((r) => r.style.getPropertyValue('animation-iteration-count'));
+      expect(clamped, 'reduced-motion block does not clamp animation-iteration-count').to.exist;
+      expect(clamped?.style.getPropertyValue('animation-iteration-count')).to.equal('1');
+      // !important is what lets it beat the component's own `animation:`
+      // declarations, which come later in the styles array.
+      expect(clamped?.style.getPropertyPriority('animation-iteration-count')).to.equal('important');
+      expect(clamped?.style.getPropertyPriority('transition-duration')).to.equal('important');
+    });
+  });
+
+  describe('focus ring', () => {
+    it('drives the ring from the --lv-focus-ring custom properties', () => {
+      const text = focusRingStyles.cssText;
+      expect(text).to.contain('--lv-focus-ring-color');
+      expect(text).to.contain('--lv-focus-ring-width');
+      expect(text).to.contain('--lv-focus-ring-offset');
+    });
+
+    it('composes the fragment into sharedStyles', () => {
+      expect(sharedStyles.cssText).to.contain(focusRingStyles.cssText.trim());
+    });
+
+    it('adopts an outlined :focus-visible rule covering buttons, fields and tabindex items', async () => {
+      const el = await fixture<A11yStylesProbe>(html`<a11y-styles-probe></a11y-styles-probe>`);
+      const focusRules = styleRules(el.shadowRoot as ShadowRoot).filter(
+        (r) => r.selectorText.includes(':focus-visible') && r.style.getPropertyValue('outline')
+      );
+      expect(focusRules.length, 'no :focus-visible rule with an outline was adopted').to.be.greaterThan(0);
+
+      const selectors = focusRules.map((r) => r.selectorText).join(' ');
+      for (const selector of ['button', 'input', 'select', 'textarea', '[tabindex]']) {
+        expect(selectors, `focus ring does not cover ${selector}`).to.contain(selector);
+      }
+
+      // !important is what lets the shared ring beat the per-component
+      // `outline: none` rules this change exists to fix.
+      const ringRule = focusRules.find((r) => r.selectorText.includes('button'));
+      expect(ringRule?.style.getPropertyPriority('outline')).to.equal('important');
+    });
+
+    it('keeps mouse focus quiet', async () => {
+      const el = await fixture<A11yStylesProbe>(html`<a11y-styles-probe></a11y-styles-probe>`);
+      const quiet = styleRules(el.shadowRoot as ShadowRoot).find(
+        (r) => r.selectorText.replace(/\s/g, '') === ':focus:not(:focus-visible)'
+      );
+      expect(quiet, 'missing :focus:not(:focus-visible) reset').to.exist;
+      expect(quiet?.style.getPropertyValue('outline')).to.equal('none');
+    });
+
+    it('hugs form fields with a zero offset', async () => {
+      const el = await fixture<A11yStylesProbe>(html`<a11y-styles-probe></a11y-styles-probe>`);
+      const input = el.shadowRoot?.querySelector('.probe-input') as HTMLElement;
+      expect(getComputedStyle(input).getPropertyValue('--lv-focus-ring-offset').trim()).to.equal('0px');
+    });
+
+    it('insets the ring on full-bleed list rows so a scroll container cannot clip it', async () => {
+      const el = await fixture<LitElement>(html`<lv-branch-list></lv-branch-list>`);
+      const rule = styleRules(el.shadowRoot as ShadowRoot).find(
+        (r) => r.selectorText === '.group-header'
+      );
+      expect(rule, 'lv-branch-list has no .group-header rule').to.exist;
+      expect(rule?.style.getPropertyValue('--lv-focus-ring-offset').trim()).to.equal('-2px');
+    });
+  });
+
+  // An indeterminate bar animates by translating itself across its track. The
+  // reduced-motion clamp stops it after one 0.01ms iteration, which would leave
+  // it parked at its final keyframe — off the end of the track — so the
+  // component paints a static full-width fill instead of nothing.
+  describe('indeterminate progress with motion reduced', () => {
+    it('keeps the progress indicator fill visible', async () => {
+      const el = await fixture<LitElement>(html`<lv-progress-indicator></lv-progress-indicator>`);
+      const overrides = reducedMotionRules(el.shadowRoot as ShadowRoot)
+        .flatMap((media) => Array.from(media.cssRules))
+        .filter((rule): rule is CSSStyleRule => rule instanceof CSSStyleRule)
+        .filter((rule) => rule.selectorText.includes('.progress-fill'));
+
+      expect(overrides.length, 'no reduced-motion override for the indeterminate fill').to.be.greaterThan(0);
+      expect(overrides[0].style.getPropertyValue('width')).to.equal('100%');
+      expect(overrides[0].style.getPropertyValue('transform')).to.equal('none');
+    });
+  });
+});

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,1 +1,7 @@
-export { sharedStyles, buttonStyles, inputStyles } from './shared-styles.ts';
+export {
+  sharedStyles,
+  buttonStyles,
+  inputStyles,
+  focusRingStyles,
+  reducedMotionStyles,
+} from './shared-styles.ts';

--- a/src/styles/shared-styles.ts
+++ b/src/styles/shared-styles.ts
@@ -1,6 +1,108 @@
 import { css } from 'lit';
 
 /**
+ * Reduced-motion fragment.
+ *
+ * Lit components render into shadow roots, so a `@media (prefers-reduced-motion)`
+ * block in the light-DOM stylesheet (src/styles/tokens.css) can NOT reach the
+ * animations declared inside a component's `static styles`. This fragment is
+ * therefore interpolated into `sharedStyles`, which every animating component
+ * already includes as the first entry of its styles array, so the rules are
+ * adopted into each shadow root.
+ *
+ * `!important` is deliberate: `sharedStyles` comes first in every styles array,
+ * so at equal specificity the component's own `animation:` / `transition:`
+ * declarations would otherwise win — and the spinner markup in
+ * lv-azure-devops-dialog sets `animation` in an inline `style` attribute, which
+ * only an important declaration can override.
+ *
+ * Indeterminate progress bars translate themselves off-screen and would be left
+ * parked at their final keyframe (invisible) by the blanket rule, so app-shell
+ * and lv-progress-indicator each carry a small reduced-motion override that
+ * paints them as a static filled bar instead.
+ */
+export const reducedMotionStyles = css`
+  @media (prefers-reduced-motion: reduce) {
+    :host,
+    *,
+    *::before,
+    *::after {
+      animation-duration: 0.01ms !important;
+      animation-iteration-count: 1 !important;
+      animation-delay: 0ms !important;
+      transition-duration: 0.01ms !important;
+      transition-delay: 0ms !important;
+      scroll-behavior: auto !important;
+    }
+  }
+`;
+
+/**
+ * Keyboard focus ring fragment.
+ *
+ * Most components suppress the native ring with `outline: none` on `:focus`
+ * (usually paired with a border-colour change that only reads for mouse users),
+ * and those class-based rules out-specify a bare `:focus-visible` rule coming
+ * from `sharedStyles`. The ring is therefore declared `!important` on an
+ * explicit list of interactive selectors so keyboard users get an indicator
+ * everywhere, while mouse focus stays quiet.
+ *
+ * The ring is expressed through the `--lv-focus-ring-*` custom properties
+ * defined in src/styles/tokens.css (they inherit through shadow boundaries), so
+ * a component can still tune it — e.g. set `--lv-focus-ring-offset: -2px` on a
+ * full-bleed list row so the ring is not clipped by the scroll container —
+ * without fighting the `!important`.
+ *
+ * `[tabindex="-1"]` is excluded on purpose: those elements only ever receive
+ * programmatic focus (dialog containers, scroll panes) and should not flash a
+ * ring when a dialog opens.
+ */
+export const focusRingStyles = css`
+  a[href]:focus-visible,
+  button:focus-visible,
+  input:focus-visible,
+  select:focus-visible,
+  textarea:focus-visible,
+  summary:focus-visible,
+  [tabindex]:not([tabindex='-1']):focus-visible,
+  [role='button']:focus-visible,
+  [role='tab']:focus-visible,
+  [role='option']:focus-visible,
+  [role='menuitem']:focus-visible,
+  [role='menuitemcheckbox']:focus-visible,
+  [role='menuitemradio']:focus-visible,
+  [role='checkbox']:focus-visible,
+  [role='switch']:focus-visible {
+    outline: var(--lv-focus-ring-width, 2px) solid
+      var(--lv-focus-ring-color, var(--color-primary, #1a73e8)) !important;
+    outline-offset: var(--lv-focus-ring-offset, 2px) !important;
+  }
+
+  /* Form fields sit flush against their own border, so the ring hugs the field
+     rather than floating 2px off it (this preserves the offset the previous
+     input focus rule used). Components can still override the property. */
+  input,
+  select,
+  textarea {
+    --lv-focus-ring-offset: 0px;
+  }
+
+  /* Hosts that put themselves in the tab order (lv-file-status, lv-diff-view)
+     cannot be reached by the [tabindex] rule above from inside their own
+     shadow root, so they get a matching inset ring here. */
+  :host([tabindex]:not([tabindex='-1']):focus-visible) {
+    outline: var(--lv-focus-ring-width, 2px) solid
+      var(--lv-focus-ring-color, var(--color-primary, #1a73e8)) !important;
+    outline-offset: calc(-1 * var(--lv-focus-ring-width, 2px)) !important;
+  }
+
+  /* Mouse/touch focus stays quiet — only :focus-visible paints a ring. */
+  :focus:not(:focus-visible) {
+    outline: none;
+  }
+`;
+
+/**
  * Shared styles for Lit components
  * Import into component static styles array
  */
@@ -16,24 +118,10 @@ export const sharedStyles = css`
   }
 
   /* Focus styles — keyboard-only focus indicators (WCAG 2.4.7) */
-  :focus-visible {
-    outline: 2px solid var(--color-primary);
-    outline-offset: 2px;
-  }
+  ${focusRingStyles}
 
-  /* Ensure inputs/textareas/selects show focus ring on keyboard navigation
-     even when components suppress outline on :focus for mouse users */
-  input:focus-visible,
-  textarea:focus-visible,
-  select:focus-visible {
-    outline: 2px solid var(--color-primary);
-    outline-offset: 0;
-  }
-
-  /* Suppress focus ring for mouse clicks (non-keyboard) */
-  :focus:not(:focus-visible) {
-    outline: none;
-  }
+  /* Honour the OS "reduce motion" setting inside this shadow root */
+  ${reducedMotionStyles}
 
   /* Button reset */
   button {

--- a/src/styles/tokens.css
+++ b/src/styles/tokens.css
@@ -167,6 +167,18 @@
   --transition-normal: 200ms ease;
   --transition-slow: 300ms ease;
 
+  /* Keyboard focus ring (WCAG 2.4.7 / 1.4.11).
+     Custom properties inherit through shadow boundaries, so these reach every
+     Lit component; the rules that consume them live in the focusRingStyles
+     fragment in src/styles/shared-styles.ts. Components may override
+     --lv-focus-ring-offset locally (e.g. -2px on a full-bleed list row that a
+     scroll container would otherwise clip). The colour tracks --color-primary,
+     which is themed per light/dark, so the ring stays visible in both. */
+  --lv-focus-ring-color: var(--color-primary);
+  --lv-focus-ring-width: 2px;
+  --lv-focus-ring-offset: 2px;
+  --lv-focus-ring: var(--lv-focus-ring-width) solid var(--lv-focus-ring-color);
+
   /* Z-Index */
   --z-dropdown: 100;
   --z-modal: 200;
@@ -411,4 +423,38 @@ body {
 * {
   scrollbar-width: thin;
   scrollbar-color: rgba(128, 128, 128, 0.3) transparent;
+}
+
+/* Keyboard focus ring for light-DOM chrome (anything rendered outside a Lit
+   shadow root). Component-internal focus styling comes from the focusRingStyles
+   fragment in src/styles/shared-styles.ts, which this rule mirrors. */
+a[href]:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible,
+summary:focus-visible,
+[tabindex]:not([tabindex="-1"]):focus-visible {
+  outline: var(--lv-focus-ring);
+  outline-offset: var(--lv-focus-ring-offset);
+}
+
+/* Honour the OS "reduce motion" setting for light-DOM chrome. This block does
+   NOT cross shadow boundaries — the equivalent rules for component internals
+   are in the reducedMotionStyles fragment in src/styles/shared-styles.ts. */
+@media (prefers-reduced-motion: reduce) {
+  html {
+    scroll-behavior: auto;
+  }
+
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    animation-delay: 0ms !important;
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
+  }
 }


### PR DESCRIPTION
## Summary

- **Reduced motion now works.** A `@media (prefers-reduced-motion: reduce)` fragment (`reducedMotionStyles`) is composed into `sharedStyles`, so the OS setting reaches the animations that live *inside* component shadow roots — the full-width global loading bar, every `spin`/`pulse` spinner and status dot, toast and progress slide-ins, `slideDown`, and the `scroll-behavior: smooth` in the toolbar. A matching block in `tokens.css` covers light-DOM chrome.
- **Indeterminate bars stay visible.** The clamp stops animations after one 0.01ms iteration, which would have parked the two sliding progress bars at their final keyframe (`translateX(350%)` / `translateX(400%)` — entirely off-screen). `app-shell` and `lv-progress-indicator` each paint a static full-width fill under reduced motion instead, so long operations still look busy.
- **Keyboard focus is visible again.** New `--lv-focus-ring-color` / `-width` / `-offset` / `--lv-focus-ring` tokens in `tokens.css`, consumed by a reusable `focusRingStyles` fragment covering `a[href]`, `button`, `input`, `select`, `textarea`, `summary`, `[tabindex]:not([tabindex="-1"])` and the common ARIA roles (`button`, `tab`, `option`, `menuitem*`, `checkbox`, `switch`), plus a `:host([tabindex])` rule for the panels that put themselves in the tab order. Mouse focus stays quiet via the existing `:focus:not(:focus-visible)` reset.
- **No design-language change.** The ring uses the existing `--color-primary` accent (themed for light and dark), and the branded Microsoft sign-in button keeps its own blue ring by overriding `--lv-focus-ring-color` instead of an `outline` declaration.
- **No behaviour or markup changes** — CSS only, plus the two tests files.

### Surfaces covered

Because the ring is declared once in `sharedStyles`, it applies to **every** component that includes `sharedStyles` — which is all of them. The per-surface work in this PR was tuning the offset so a scroll container or clipped tab cannot cut the ring off:

| Surface | What was done |
| --- | --- |
| Toolbar (`lv-toolbar`) | ring on all buttons/inputs; `.tab-close` inset so the tab's `overflow` cannot clip it |
| Left panel — branches (`lv-branch-list`) | filter input ring restored; `.group-header` / `.subgroup-header` inset |
| Left panel — tags (`lv-tag-list`) | `.tag-item`, `.group-header` inset |
| Left panel — stashes (`lv-stash-list`) | `.stash-item` inset |
| File status (`lv-file-status`) | `.section-header` inset; host ring for the `tabindex="0"` panel |
| Diff view (`lv-diff-view`) | host ring; `.editor-textarea` inset |
| Command palette, dialogs, welcome, dashboard | ring via the shared fragment (their `outline: none` rules no longer win) |
| Graph canvas | already had its own `canvas:focus` ring — left untouched |

**Not covered / left as-is:** file rows in `lv-file-status` keep their existing `.file-item.focused` roving-focus highlight (they are not in the tab order); list items in the branch list are `<li>`s with no `tabindex`, so making them tabbable was out of scope for a styling PR; and the remaining ~35 dialogs were not individually offset-tuned — they get the default 2px ring from the shared fragment, which is correct for their non-full-bleed controls.

### Theming

The ring colour tracks `--color-primary` (`#1a73e8` light, `#4fc3f7` dark), so it is visible in both themes and against the selected-row washes. The high-contrast *graph colour scheme* only recolours branch lines drawn into the canvas; it does not change any DOM background, so it does not affect ring contrast — the graph canvas keeps its own pre-existing focus ring.

## Review finding

There were zero `prefers-reduced-motion` rules anywhere in `src/` while the app ran several infinite animations — `loading-slide 1.2s infinite` on the full-width global loading bar (`src/app-shell.ts:214-227`), `spin`/`pulse` in `src/styles/shared-styles.ts` (`animationStyles`) and in 17 components, and the toast slide transitions in `src/components/common/lv-toast-container.ts:37-64`. At the same time only three `:focus-visible` rules existed across the whole component tree, while 45 `outline: none` declarations actively suppressed the native indicator, so keyboard users had no visible focus on the toolbar, the branch/tag/stash lists, the file status panel, the command palette, the diff view, or almost any dialog. A single global stylesheet block could not fix either problem, because Lit renders into shadow roots that light-DOM rules cannot reach.

## Test plan

- [ ] `npm run lint` — 204 warnings, 0 errors (unchanged from baseline)
- [ ] `npm run typecheck` — clean
- [ ] `npm test` — 5345 passed, 2 failed; the two failures are the known pre-existing `network-gate-coverage` timeouts, verified to fail identically with these changes stashed
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` — clean (no Rust changed)
- [ ] New unit tests `src/styles/__tests__/a11y-styles.test.ts` (10 assertions) assert through the CSSOM of a real shadow root — that the reduced-motion media rule is adopted and clamps `animation-iteration-count` with `!important`, that the focus rule covers buttons/fields/`[tabindex]`, that form fields get a 0px offset and full-bleed rows a -2px one
- [ ] `src/__tests__/app-shell-loading-bar.test.ts` gains a case asserting the loading bar's reduced-motion override, so it cannot silently regress to an off-screen slider
- [ ] New E2E spec `e2e/tests/accessibility.spec.ts` (6 tests): real `Tab` presses assert a solid, opaque, >=2px outline on the focused control in both light and dark themes, and `emulateMedia({ reducedMotion })` asserts transitions and an infinite spinner really are clamped inside the shadow roots (and still animate when motion is not reduced)
- [ ] Regression runs: `keyboard.spec.ts`, `command-palette.spec.ts`, `context-menus.spec.ts` (71 passed) and `branches.spec.ts`, `diff.spec.ts`, `stash.spec.ts`, `tags.spec.ts` (83 passed), plus `azure-devops-dialog.spec.ts`
- [ ] Manual check a reviewer can do: enable "reduce motion" in the OS, run a fetch — the loading bar should show as a static full-width accent bar rather than a slider; then Tab through the toolbar and left panel and confirm every stop shows an accent ring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_