### PR TITLE
fix: correct declared Rust MSRV to match the dependency tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ This package is community-maintained and is not an official Leviathan release ch
 #### Prerequisites
 
 - [Node.js](https://nodejs.org/) 20+
-- [Rust](https://rustup.rs/) 1.70+
+- [Rust](https://rustup.rs/) 1.95+
 - Platform-specific dependencies (see below)
 
 #### macOS

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -4,7 +4,13 @@ version = "0.8.0"
 description = "A fully-featured, open-source, cross-platform Git GUI client"
 authors = ["Leviathan Contributors"]
 edition = "2021"
-rust-version = "1.70"
+# Derived from the dependency tree's own `rust_version` requirements, not chosen by hand.
+# Recompute with:
+#   cargo metadata --format-version 1 | python3 -c \
+#     "import json,sys; d=json.load(sys.stdin); \
+#      print(max((p['rust_version'], p['name'], p['version']) for p in d['packages'] if p.get('rust_version')))"
+# As of this writing the ceiling is set by sysinfo 0.39.x (rust-version = 1.95).
+rust-version = "1.95"
 
 [lib]
 name = "leviathan_lib"

--- a/src-tauri/src/commands/gitignore.rs
+++ b/src-tauri/src/commands/gitignore.rs
@@ -275,7 +275,7 @@ fn parse_check_ignore_z(stdout: &[u8]) -> Vec<IgnoreCheckVerboseResult> {
     }
 
     let mut results = Vec::with_capacity(fields.len() / 4);
-    for record in fields.chunks_exact(4) {
+    for record in fields.as_chunks::<4>().0 {
         let source = &record[0];
         let line_num_str = &record[1];
         let pattern = &record[2];


### PR DESCRIPTION
## Summary
- `src-tauri/Cargo.toml` declared `rust-version = "1.70"`, but the dependency tree cannot actually build on that toolchain — the declared MSRV was fiction.
- Computed the real minimum programmatically from `cargo metadata`'s own `rust_version` fields and set `rust-version = "1.95"`, with a comment explaining the derivation and how to recompute it.
- Updated `README.md`'s Prerequisites line (`Rust 1.70+` → `Rust 1.95+`) to match — no other file in the repo documents a Rust version requirement (no `CONTRIBUTING.md`, nothing in `docs/`).
- Raising the declared MSRV activates a new MSRV-aware clippy lint (`chunks_exact_to_as_chunks`, whose suggested `as_chunks` API only stabilized at 1.88), which then fails `cargo clippy --all-targets -- -D warnings` at one call site. Fixed that one site in `src-tauri/src/commands/gitignore.rs` so the crate still builds clean at the corrected MSRV.

## Review finding
`src-tauri/Cargo.toml` (line ~7) declared `rust-version = "1.70"`, but this was never actually buildable: `sysinfo@0.39.6` alone requires rustc 1.95, confirmed empirically (`cargo` refuses with "rustc 1.94.1 is not supported by the following package: sysinfo@0.39.6 requires rustc 1.95"). Anyone trusting the declared MSRV to set up a matching toolchain would waste time hitting that wall. I computed the true minimum programmatically rather than guessing:

```bash
cd src-tauri && CARGO_TARGET_DIR=/home/user/cargo-target cargo metadata --format-version 1 \
  | python3 -c "
import json, sys
d = json.load(sys.stdin)
rows = [(p['rust_version'], p['name'], p['version']) for p in d['packages'] if p.get('rust_version')]
rows.sort(reverse=True)
for r in rows[:10]: print(r)
"
```

Top of the resolved graph (768 packages total, 508 declare `rust_version`):

| rust_version | crate | version |
|---|---|---|
| **1.95** | **sysinfo** | **0.39.6** |
| 1.88.0 | time-macros / time-core / time | 0.2.27 / 0.1.8 / 0.3.47 |
| 1.88.0 | plist | 1.10.0 |
| 1.88.0 | jsonwebtoken | 11.0.0 |
| 1.88.0 | darling / darling_core / darling_macro | 0.23.0 |
| 1.88 | zip | 8.6.0 |
| 1.88 | serde_with / serde_with_macros | 3.21.0 |

`sysinfo` (a direct dependency, `Cargo.toml:55`) alone drives the floor to 1.95; everything else in the tree tops out at 1.88 or lower. The installed toolchain here is 1.98.1 and CI uses `dtolnay/rust-toolchain@stable`, so 1.95 is comfortably satisfied by both today.

Setting the true MSRV had one knock-on effect worth calling out: clippy's MSRV-aware lints re-evaluate suggestions against the crate's declared `rust-version`. With 1.95 declared, `clippy::chunks_exact_to_as_chunks` now fires on `gitignore.rs:278` (it didn't at the fictional 1.70, since `[T]::as_chunks` wasn't stable then). I applied clippy's own suggested fix (`chunks_exact(4)` → `as_chunks::<4>().0`) — a one-line, behavior-preserving change confirmed by the existing 24 `gitignore` unit tests still passing.

I deliberately did **not** add a `rust-toolchain.toml`. The item's scope is "fix the declared MSRV to be truthful," not "pin a specific toolchain" — CI already resolves `stable` dynamically via `dtolnay/rust-toolchain@stable`, and pinning would change contributor/CI behavior beyond what was asked. If the maintainer wants reproducible toolchain pinning as a follow-up, that's a separate, deliberate decision (trading "always test against current stable" for "pin and manually bump"), not something to bundle into a truthfulness fix.

## Test plan
- [x] `cd src-tauri && CARGO_TARGET_DIR=/home/user/cargo-target cargo fmt --check` — clean
- [x] `mkdir -p dist && cd src-tauri && CARGO_TARGET_DIR=/home/user/cargo-target cargo clippy --all-targets -- -D warnings` — clean (0 warnings) both before and after confirming the `as_chunks` fix was needed (verified by temporarily stashing the change and reproducing the failure)
- [x] `cd src-tauri && CARGO_TARGET_DIR=/home/user/cargo-target cargo build` — succeeds
- [x] `cd src-tauri && CARGO_TARGET_DIR=/home/user/cargo-target cargo test gitignore` — 24/24 passed (module touched by the clippy fix)
- [x] `npm run lint` — 0 errors, 204 warnings (matches documented pre-existing baseline)
- [x] `npm run typecheck` — clean
- [x] `PW_CHROMIUM_PATH=/opt/pw-browsers/chromium npm test` — 5334 passed, 2 failed (`network-gate-coverage.test.ts`, the documented pre-existing timeout-under-load flake; re-ran that file alone and it still timed out under current machine load — unrelated to this change, which touches no TypeScript)
- [x] snake_case check from `CLAUDE.md` — no new matches (all three existing hits are pre-existing comments/unused-param prefixes, not Tauri call sites)
- A reviewer can independently verify the MSRV computation with the `cargo metadata | python3 -c ...` one-liner in the comment above `rust-version` in `src-tauri/Cargo.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_