### PR TITLE
feat: real cancellation and progress for fetch, pull and push

### DIFF
--- a/e2e/tests/remote-operations.spec.ts
+++ b/e2e/tests/remote-operations.spec.ts
@@ -8,10 +8,10 @@
  * - Badge updates after operations
  */
 
-import { test, expect } from '@playwright/test';
+import { test, expect, type Page } from '@playwright/test';
 import { setupOpenRepository, defaultMockData, withConflicts } from '../fixtures/tauri-mock';
 import { AppPage } from '../pages/app.page';
-import { startCommandCapture, startCommandCaptureWithMocks, findCommand, injectCommandError, waitForCommand } from '../fixtures/test-helpers';
+import { startCommandCapture, startCommandCaptureWithMocks, findCommand, injectCommandError, injectCommandHang, emitBackendEvent, waitForCommand } from '../fixtures/test-helpers';
 
 // ============================================================================
 // Helper function to create branches with ahead/behind status
@@ -818,5 +818,105 @@ test.describe('Remote Operations - UI Outcome Verification', () => {
     // The pull badge should still show 7 (unchanged because pull failed)
     await expect(pullBadge).toBeVisible();
     await expect(pullBadge).toHaveText('7');
+  });
+});
+
+// ============================================================================
+// Cancelling a remote operation
+//
+// Fetch/pull/push used to advertise cancellation that did not exist: the
+// progress row was never marked cancellable, so the indicator's Cancel button
+// was unreachable dead code, and no operation id reached the backend, so
+// `cancel_operation` had nothing to cancel. No backend code emitted
+// `operation-progress` either, so the row showed an indeterminate stripe with
+// no counts for as long as the transfer ran.
+// ============================================================================
+
+test.describe('Cancelling a remote operation', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+  });
+
+  /** The operation id the app handed the given command. */
+  async function operationIdOf(page: Page, command: string): Promise<string | undefined> {
+    const [call] = await findCommand(page, command);
+    return (call.args as { operationId?: string }).operationId;
+  }
+
+  test('a running fetch shows a cancellable progress row', async ({ page }) => {
+    await startCommandCapture(page);
+    await injectCommandHang(page, 'fetch');
+
+    await page.getByRole('button', { name: /Fetch/i }).click();
+    await waitForCommand(page, 'fetch');
+
+    const row = page.locator('lv-progress-indicator .progress-item');
+    await expect(row).toBeVisible();
+    await expect(row).toContainText(/fetch/i);
+    await expect(page.locator('lv-progress-indicator .cancel-btn')).toBeVisible();
+
+    // And the backend was told which row it belongs to, so a cancel can find it.
+    expect(await operationIdOf(page, 'fetch')).toBeTruthy();
+  });
+
+  test('clicking Cancel invokes cancel_operation for that row and dismisses it', async ({
+    page,
+  }) => {
+    await startCommandCapture(page);
+    await injectCommandHang(page, 'fetch');
+
+    await page.getByRole('button', { name: /Fetch/i }).click();
+    await waitForCommand(page, 'fetch');
+
+    const operationId = await operationIdOf(page, 'fetch');
+    await page.locator('lv-progress-indicator .cancel-btn').click();
+
+    await waitForCommand(page, 'cancel_operation');
+    const [cancel] = await findCommand(page, 'cancel_operation');
+    expect((cancel.args as { operationId?: string }).operationId).toBe(operationId);
+
+    // The row goes away immediately — the user's click has visibly taken effect.
+    await expect(page.locator('lv-progress-indicator .progress-item')).toHaveCount(0);
+  });
+
+  test('a running push is cancellable too', async ({ page }) => {
+    await startCommandCapture(page);
+    await injectCommandHang(page, 'push');
+
+    await page.getByRole('button', { name: /Push/i }).click();
+    await waitForCommand(page, 'push');
+
+    await expect(page.locator('lv-progress-indicator .cancel-btn')).toBeVisible();
+
+    const operationId = await operationIdOf(page, 'push');
+    await page.locator('lv-progress-indicator .cancel-btn').click();
+    await waitForCommand(page, 'cancel_operation');
+
+    const [cancel] = await findCommand(page, 'cancel_operation');
+    expect((cancel.args as { operationId?: string }).operationId).toBe(operationId);
+  });
+
+  test('the progress row shows the transfer counts the backend reports', async ({ page }) => {
+    await startCommandCapture(page);
+    await injectCommandHang(page, 'fetch');
+
+    await page.getByRole('button', { name: /Fetch/i }).click();
+    await waitForCommand(page, 'fetch');
+
+    const operationId = await operationIdOf(page, 'fetch');
+    await emitBackendEvent(page, 'operation-progress', {
+      operationId,
+      message: 'Fetching from origin',
+      progress: 40,
+      receivedObjects: 400,
+      totalObjects: 1000,
+      receivedBytes: 1024 * 1024,
+    });
+
+    const row = page.locator('lv-progress-indicator .progress-item');
+    await expect(row).toContainText('Fetching from origin');
+    await expect(row).toContainText('40%');
+    await expect(row).toContainText('400 / 1,000 objects');
+    await expect(row).toContainText('1.00 MiB');
   });
 });

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -9,9 +9,50 @@ use crate::models::{
     RemoteOperationResult, RemotePushResult,
 };
 use crate::services::cancellation::CancellationRegistry;
-use crate::services::credentials_service;
+use crate::services::credentials_service::{self, TransferAbort};
 use crate::services::remote_ops::{self, RemoteOp, RemoteOpRegistry};
+use crate::services::transfer_monitor::{OperationProgress, ProgressSink, TransferMonitor};
 use crate::utils::{create_command, reject_flag_like};
+
+/// The sink that turns a transfer snapshot into the `operation-progress` event
+/// `src/services/progress.service.ts` listens for.
+fn progress_sink(app_handle: &AppHandle) -> ProgressSink {
+    let app = app_handle.clone();
+    std::sync::Arc::new(move |progress: OperationProgress| {
+        let _ = app.emit("operation-progress", progress);
+    })
+}
+
+/// The monitor a user-initiated remote operation runs under: cancellable via
+/// `operation_id`, and reporting progress to the row that id belongs to.
+fn operation_monitor(
+    app_handle: &AppHandle,
+    operation_id: Option<String>,
+    message: impl Into<String>,
+    token: crate::services::cancellation::CancellationToken,
+) -> TransferMonitor {
+    TransferMonitor::new(operation_id, message, token, progress_sink(app_handle))
+}
+
+/// Name the reason a git2 transfer stopped.
+///
+/// A cancelled and a timed-out transfer both surface from libgit2 as a
+/// generic error, and the two flags are the only way to tell either of them
+/// from a real failure that merely happened to land at the same moment — see
+/// `credentials_service::TransferAbort`.
+fn transfer_failure(
+    abort: &TransferAbort,
+    error: git2::Error,
+    timeout_message: &str,
+) -> LeviathanError {
+    if abort.cancelled() {
+        LeviathanError::OperationCancelled
+    } else if abort.timed_out() {
+        LeviathanError::OperationTimeout(timeout_message.to_string())
+    } else {
+        error.into()
+    }
+}
 
 /// Add a new remote
 #[command]
@@ -160,13 +201,14 @@ pub async fn get_remotes(path: String) -> Result<Vec<Remote>> {
 pub async fn fetch(
     app_handle: AppHandle,
     remote_ops_registry: State<'_, RemoteOpRegistry>,
+    cancellation_registry: State<'_, CancellationRegistry>,
     path: String,
     remote: Option<String>,
     prune: Option<bool>,
     token: Option<String>,
     timeout_secs: Option<u64>,
     quiet: Option<bool>,
-    _operation_id: Option<String>,
+    operation_id: Option<String>,
 ) -> Result<()> {
     // A fetch the user did not ask for must not announce itself. The
     // window-focus refresh runs this same command, and the success event below
@@ -205,46 +247,33 @@ pub async fn fetch(
     let prune_val = prune.unwrap_or(false);
     let remote_name_for_event = remote_name_owned.clone();
 
+    // Registered so `cancel_operation` can actually find this fetch. The guard
+    // rides into the blocking task below and deregisters the id when the fetch
+    // really ends — on success, on an error, and on the late completion of a
+    // fetch whose caller already timed out.
+    let op_guard = cancellation_registry.guard(operation_id.clone());
+    let monitor = operation_monitor(
+        &app_handle,
+        operation_id,
+        format!("Fetching from {}", remote_name_owned),
+        op_guard.token(),
+    );
+
     // git2 fetch is blocking network I/O; offload to a blocking thread so
     // it doesn't starve the Tokio runtime. spawn_holding carries the slot into
     // that thread, so the claim is released when the fetch really ends rather
     // than when a timed-out caller drops this future.
     let handle = remote_ops::spawn_holding(slot, move || -> Result<()> {
-        let repo = git2::Repository::open(Path::new(&path_clone))?;
-        let mut git_remote = repo
-            .find_remote(&remote_name_owned)
-            .map_err(|_| LeviathanError::RemoteNotFound(remote_name_owned.clone()))?;
-
-        let (mut fetch_opts, aborted) =
-            credentials_service::get_fetch_options_with_deadline(token, deadline);
-        if prune_val {
-            fetch_opts.prune(git2::FetchPrune::On);
-        }
-
-        let refspecs: Vec<String> = git_remote
-            .fetch_refspecs()?
-            .iter()
-            .filter_map(|s| s.ok().flatten().map(|s| s.to_string()))
-            .collect();
-        let refspec_strs: Vec<&str> = refspecs.iter().map(|s| s.as_str()).collect();
-
-        git_remote
-            .fetch(&refspec_strs, Some(&mut fetch_opts), None)
-            .map_err(|e| {
-                // libgit2 reports a deadline abort as a generic error; name it.
-                // ONLY a transfer the deadline callback actually aborted, though
-                // — asking `deadline_passed` here relabelled every failure that
-                // happened to surface after the deadline (a wrong credential, a
-                // protocol error, a full disk) as "timed out", and on the pull
-                // path such an error is then dropped as an already-reported
-                // timeout, so the real cause never reached the user.
-                if aborted.load(std::sync::atomic::Ordering::SeqCst) {
-                    LeviathanError::OperationTimeout("Fetch operation timed out".to_string())
-                } else {
-                    e.into()
-                }
-            })?;
-        Ok(())
+        // Dropped when this closure returns, however it returns.
+        let _op_guard = op_guard;
+        fetch_internal(
+            &path_clone,
+            &remote_name_owned,
+            prune_val,
+            token,
+            deadline,
+            monitor,
+        )
     });
 
     let app_late = app_handle.clone();
@@ -804,6 +833,7 @@ pub(crate) fn pull_branch(
     rebase: Option<bool>,
     token: Option<String>,
     deadline: Option<std::time::Instant>,
+    monitor: TransferMonitor,
 ) -> Result<(String, String)> {
     // Refuse before the network round trip if another operation is
     // unresolved. merge() has always had this guard; pull never
@@ -836,15 +866,37 @@ pub(crate) fn pull_branch(
 
     // Fetch (network I/O) the remote we actually resolved. A transfer the
     // deadline aborted is this pull's timeout, and must read as one.
-    fetch_internal(path_for_task, &effective_remote, false, token, deadline).map_err(
-        |e| match e {
-            LeviathanError::OperationTimeout(_) => {
-                LeviathanError::OperationTimeout("Pull operation timed out".to_string())
-            }
-            other => other,
-        },
-    )?;
+    //
+    // THE FETCH IS THE ONLY CANCELLATION POINT OF A PULL. Everything after it
+    // — the fast-forward checkout, the merge, the rebase loop — rewrites the
+    // index and the working tree, and there is no point inside those at which
+    // stopping leaves a state a user could reason about (a half-applied
+    // rebase, a merged-but-unmarked tree). Cancelling during the fetch is
+    // safe because a fetch writes nothing but remote-tracking refs and
+    // FETCH_HEAD, which is exactly what a plain `Fetch` does and leaves the
+    // working tree untouched. So: cancel here, or let the merge finish.
+    fetch_internal(
+        path_for_task,
+        &effective_remote,
+        false,
+        token,
+        deadline,
+        monitor.with_message(format!("Pulling from {}", effective_remote)),
+    )
+    .map_err(|e| match e {
+        LeviathanError::OperationTimeout(_) => {
+            LeviathanError::OperationTimeout("Pull operation timed out".to_string())
+        }
+        other => other,
+    })?;
     let repo = git2::Repository::open(Path::new(path_for_task))?;
+
+    // The last moment a pull can be stopped (see the comment above the fetch).
+    // Reported as a plain cancellation, not a "cancelled after change": the
+    // repository is in exactly the state a fetch would have left it in.
+    if monitor.is_cancelled() {
+        return Err(LeviathanError::OperationCancelled);
+    }
 
     // Do NOT start the merge or rebase once the caller has already been told
     // the pull timed out. The outer timeout only drops the future, so this
@@ -961,13 +1013,14 @@ pub(crate) fn pull_branch(
 pub async fn pull(
     app_handle: AppHandle,
     remote_ops_registry: State<'_, RemoteOpRegistry>,
+    cancellation_registry: State<'_, CancellationRegistry>,
     path: String,
     remote: Option<String>,
     branch: Option<String>,
     rebase: Option<bool>,
     token: Option<String>,
     timeout_secs: Option<u64>,
-    _operation_id: Option<String>,
+    operation_id: Option<String>,
 ) -> Result<()> {
     // Claimed before the timeout wrapper and released by the blocking task,
     // not by this future — see services/remote_ops.rs. The ensure_pullable
@@ -983,10 +1036,21 @@ pub async fn pull(
     let requested_remote = remote.clone();
     let branch_for_task = branch.clone();
 
+    // Registered so `cancel_operation` can find this pull; the guard rides
+    // into the blocking task and deregisters when the pull really ends.
+    let op_guard = cancellation_registry.guard(operation_id.clone());
+    let monitor = operation_monitor(
+        &app_handle,
+        operation_id,
+        "Pulling from remote",
+        op_guard.token(),
+    );
+
     // Whole pull is git2 / blocking network I/O. Run it on a blocking
     // thread so the Tokio runtime stays responsive; the slot rides into that
     // thread so it is released when the pull really ends.
     let handle = remote_ops::spawn_holding(Some(slot), move || {
+        let _op_guard = op_guard;
         pull_branch(
             &path_for_task,
             requested_remote,
@@ -994,6 +1058,7 @@ pub async fn pull(
             rebase,
             token,
             deadline,
+            monitor,
         )
     });
 
@@ -1057,22 +1122,40 @@ pub async fn pull(
     Ok(())
 }
 
-/// Internal fetch without event emission (used by pull)
-fn fetch_internal(
+/// Internal fetch without event emission (used by `fetch` and by pull).
+///
+/// `monitor` carries the user's cancellation token and the progress sink;
+/// pass `TransferMonitor::disabled()` for a fetch that is neither cancellable
+/// nor reported (the background fetch, an internal one).
+pub(crate) fn fetch_internal(
     path: &str,
     remote_name: &str,
     prune: bool,
     token: Option<String>,
     deadline: Option<std::time::Instant>,
+    monitor: TransferMonitor,
 ) -> Result<()> {
+    // Checked before anything opens a socket: a cancel that arrived while the
+    // operation was still queued must not produce a network round trip at all.
+    // The in-transfer check lives in the git2 callback, which is the only
+    // abort point libgit2 offers.
+    if monitor.is_cancelled() {
+        return Err(LeviathanError::OperationCancelled);
+    }
+
     let repo = git2::Repository::open(Path::new(path))?;
 
     let mut git_remote = repo
         .find_remote(remote_name)
         .map_err(|_| LeviathanError::RemoteNotFound(remote_name.to_string()))?;
 
-    let (mut fetch_opts, aborted) =
-        credentials_service::get_fetch_options_with_deadline(token, deadline);
+    let (mut fetch_opts, abort) = credentials_service::get_fetch_options_with_monitor(
+        token, deadline,
+        // The message is the CALLER's: a pull's fetch phase must keep saying
+        // "Pulling from origin" rather than relabelling the row half-way
+        // through an operation the user asked for by another name.
+        monitor,
+    );
 
     if prune {
         fetch_opts.prune(git2::FetchPrune::On);
@@ -1088,16 +1171,15 @@ fn fetch_internal(
 
     git_remote
         .fetch(&refspec_strs, Some(&mut fetch_opts), None)
-        .map_err(|e| {
-            // libgit2 reports a deadline abort as a generic indexer error;
-            // name it for what it is — but only when the deadline callback is
-            // what aborted this transfer. See the same guard in `fetch`.
-            if aborted.load(std::sync::atomic::Ordering::SeqCst) {
-                LeviathanError::OperationTimeout("Fetch operation timed out".to_string())
-            } else {
-                e.into()
-            }
-        })?;
+        // libgit2 reports both a cancelled and a deadline-aborted transfer as
+        // a generic indexer error; name each for what it is — but only when
+        // the callback really aborted this transfer. Asking the condition here
+        // instead relabelled every failure that happened to surface after the
+        // deadline (a wrong credential, a protocol error, a full disk) as
+        // "timed out", and on the pull path such an error is then dropped as
+        // an already-reported timeout, so the real cause never reached the
+        // user.
+        .map_err(|e| transfer_failure(&abort, e, "Fetch operation timed out"))?;
 
     Ok(())
 }
@@ -1145,7 +1227,16 @@ pub(crate) fn push_branch(
     use_push_tags: bool,
     set_upstream_val: bool,
     token: Option<String>,
+    monitor: TransferMonitor,
 ) -> Result<(String, String)> {
+    // A cancel that arrived while the push was still queued must not reach the
+    // remote at all. The later checks are the branch-rule gate and, for the
+    // git2 path, `push_negotiation` — see `get_push_options_with_monitor` for
+    // why that is the last one git2 offers.
+    if monitor.is_cancelled() {
+        return Err(LeviathanError::OperationCancelled);
+    }
+
     let repo = git2::Repository::open(Path::new(path_for_task))?;
 
     // Resolve the remote from the branch's upstream, then the sole
@@ -1208,6 +1299,8 @@ pub(crate) fn push_branch(
         && !upstream_is_configured(&repo, &branch_name);
     let should_set_upstream = set_upstream_val || branch_lacks_upstream;
 
+    let monitor = monitor.with_message(format!("Pushing to {}", remote_for_task));
+
     if use_force_with_lease || use_push_tags {
         push_via_cli(
             path_for_task,
@@ -1218,17 +1311,25 @@ pub(crate) fn push_branch(
             use_push_tags,
             should_set_upstream,
             token,
+            &monitor,
         )?;
     } else {
         // Run pre-push like canonical git — the git2 push path
         // otherwise bypasses it. A non-zero exit aborts the push.
         crate::commands::hooks::run_pre_push_branch(&repo, &remote_for_task, &branch_name)?;
 
+        // The pre-push hook can take a while (test suites are a common one),
+        // so re-check before opening a connection.
+        if monitor.is_cancelled() {
+            return Err(LeviathanError::OperationCancelled);
+        }
+
         let mut git_remote = repo
             .find_remote(&remote_for_task)
             .map_err(|_| LeviathanError::RemoteNotFound(remote_for_task.clone()))?;
 
-        let mut push_opts = credentials_service::get_push_options(token);
+        let (mut push_opts, abort) =
+            credentials_service::get_push_options_with_monitor(token, monitor);
 
         let refspec = if force_val {
             format!("+refs/heads/{}:refs/heads/{}", branch_name, branch_name)
@@ -1236,7 +1337,9 @@ pub(crate) fn push_branch(
             format!("refs/heads/{}:refs/heads/{}", branch_name, branch_name)
         };
 
-        git_remote.push(&[&refspec], Some(&mut push_opts))?;
+        git_remote
+            .push(&[&refspec], Some(&mut push_opts))
+            .map_err(|e| transfer_failure(&abort, e, "Push operation timed out"))?;
 
         if should_set_upstream {
             let upstream_name = format!("{}/{}", remote_for_task, branch_name);
@@ -1285,6 +1388,7 @@ fn push_message(
 pub async fn push(
     app_handle: AppHandle,
     remote_ops_registry: State<'_, RemoteOpRegistry>,
+    cancellation_registry: State<'_, CancellationRegistry>,
     path: String,
     remote: Option<String>,
     branch: Option<String>,
@@ -1294,7 +1398,7 @@ pub async fn push(
     set_upstream: Option<bool>,
     token: Option<String>,
     timeout_secs: Option<u64>,
-    _operation_id: Option<String>,
+    operation_id: Option<String>,
 ) -> Result<()> {
     // Reject branch values that could be parsed as a flag by `git push`
     // (e.g. `--receive-pack=/tmp/evil`). The remote name is safer because
@@ -1322,9 +1426,20 @@ pub async fn push(
     let use_push_tags = push_tags.unwrap_or(false);
     let set_upstream_val = set_upstream.unwrap_or(false);
 
+    // Registered so `cancel_operation` can find this push; the guard rides
+    // into the blocking task and deregisters when the push really ends.
+    let op_guard = cancellation_registry.guard(operation_id.clone());
+    let monitor = operation_monitor(
+        &app_handle,
+        operation_id,
+        "Pushing to remote",
+        op_guard.token(),
+    );
+
     // git2/git-CLI push is blocking network I/O; offload so the runtime
     // stays responsive during slow remotes.
     let handle = remote_ops::spawn_holding(Some(slot), move || {
+        let _op_guard = op_guard;
         push_branch(
             &path_for_task,
             requested_remote,
@@ -1334,6 +1449,7 @@ pub async fn push(
             use_push_tags,
             set_upstream_val,
             token,
+            monitor,
         )
     });
 
@@ -1424,7 +1540,89 @@ fn push_remote_url(path: &str, remote_name: &str) -> Option<String> {
         .map(|u| u.to_string())
 }
 
+/// Run a prepared `git push` to completion, killing it if the user cancels.
+///
+/// `Command::output()` blocks until the child exits, which is why the force
+/// push had no cancellation point at all. Spawning and polling gives it one.
+/// Both pipes are drained on their own threads: git push writes its progress
+/// to stderr, and leaving a piped stream unread deadlocks the child once the
+/// pipe buffer fills — the same trap `clone_repository` documents.
+fn run_push_command(
+    mut cmd: std::process::Command,
+    monitor: &TransferMonitor,
+) -> Result<std::process::Output> {
+    if monitor.is_cancelled() {
+        return Err(LeviathanError::OperationCancelled);
+    }
+
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().map_err(|e| {
+        LeviathanError::OperationFailed(format!("Failed to execute git push: {}", e))
+    })?;
+
+    let drain = |pipe: Option<Box<dyn std::io::Read + Send>>| {
+        std::thread::spawn(move || {
+            let mut buf = Vec::new();
+            if let Some(mut pipe) = pipe {
+                use std::io::Read;
+                let _ = pipe.read_to_end(&mut buf);
+            }
+            buf
+        })
+    };
+    let stdout_reader = drain(
+        child
+            .stdout
+            .take()
+            .map(|p| Box::new(p) as Box<dyn std::io::Read + Send>),
+    );
+    let stderr_reader = drain(
+        child
+            .stderr
+            .take()
+            .map(|p| Box::new(p) as Box<dyn std::io::Read + Send>),
+    );
+
+    let status = loop {
+        if monitor.is_cancelled() {
+            // Killed and reaped before returning: an orphaned `git push` would
+            // keep talking to the remote after the user was told it stopped.
+            let _ = child.kill();
+            let _ = child.wait();
+            let _ = stdout_reader.join();
+            let _ = stderr_reader.join();
+            return Err(LeviathanError::OperationCancelled);
+        }
+        match child.try_wait() {
+            Ok(Some(status)) => break status,
+            Ok(None) => std::thread::sleep(std::time::Duration::from_millis(100)),
+            Err(e) => {
+                let _ = child.kill();
+                let _ = child.wait();
+                let _ = stdout_reader.join();
+                let _ = stderr_reader.join();
+                return Err(LeviathanError::OperationFailed(format!(
+                    "Failed to wait for git push: {}",
+                    e
+                )));
+            }
+        }
+    };
+
+    Ok(std::process::Output {
+        status,
+        stdout: stdout_reader.join().unwrap_or_default(),
+        stderr: stderr_reader.join().unwrap_or_default(),
+    })
+}
+
 /// Push via git CLI (used for --force-with-lease and --tags which git2 doesn't support)
+///
+/// Unlike the git2 path this one CAN be stopped mid-transfer: the child is
+/// spawned rather than run to completion, and a cancellation kills it — the
+/// same shape `clone_repository`'s CLI path uses.
 #[allow(clippy::too_many_arguments)]
 fn push_via_cli(
     path: &str,
@@ -1435,6 +1633,7 @@ fn push_via_cli(
     push_tags: bool,
     set_upstream: bool,
     token: Option<String>,
+    monitor: &TransferMonitor,
 ) -> Result<()> {
     let mut cmd = create_command("git");
     cmd.arg("-C").arg(path).arg("push");
@@ -1494,9 +1693,7 @@ fn push_via_cli(
         }
     }
 
-    let output = cmd.output().map_err(|e| {
-        LeviathanError::OperationFailed(format!("Failed to execute git push: {}", e))
-    })?;
+    let output = run_push_command(cmd, monitor)?;
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
@@ -1557,6 +1754,9 @@ fn push_single_remote(
             push_tags,
             false,
             token,
+            // The multi-remote push has no progress row and no operation id of
+            // its own, so nothing can cancel it — see `push_to_multiple_remotes`.
+            &TransferMonitor::disabled(),
         )
         .map_err(|e| e.to_string())
     } else {
@@ -2212,8 +2412,15 @@ mod tests {
             .checked_sub(Duration::from_secs(60))
             .expect("a deadline in the past");
 
-        let err = fetch_internal(&local.path_str(), "origin", false, None, Some(past))
-            .expect_err("fetching a remote that does not exist must fail");
+        let err = fetch_internal(
+            &local.path_str(),
+            "origin",
+            false,
+            None,
+            Some(past),
+            TransferMonitor::disabled(),
+        )
+        .expect_err("fetching a remote that does not exist must fail");
 
         assert!(
             !matches!(err, LeviathanError::OperationTimeout(_)),
@@ -2247,7 +2454,15 @@ mod tests {
         let upstream = TestRepo::with_initial_commit();
         let local = TestRepo::new();
         local.add_remote("origin", &upstream.path_str());
-        fetch_internal(&local.path_str(), "origin", false, None, None).expect("fixture fetch");
+        fetch_internal(
+            &local.path_str(),
+            "origin",
+            false,
+            None,
+            None,
+            TransferMonitor::disabled(),
+        )
+        .expect("fixture fetch");
 
         let branch = upstream.current_branch();
         let repo = local.repo();
@@ -2270,6 +2485,15 @@ mod tests {
         branch: &str,
         deadline: Option<Instant>,
     ) -> Result<(String, String)> {
+        pull_with_monitor(local, branch, deadline, TransferMonitor::disabled())
+    }
+
+    fn pull_with_monitor(
+        local: &TestRepo,
+        branch: &str,
+        deadline: Option<Instant>,
+        monitor: TransferMonitor,
+    ) -> Result<(String, String)> {
         pull_branch(
             &local.path_str(),
             Some("origin".to_string()),
@@ -2277,6 +2501,7 @@ mod tests {
             Some(false),
             None,
             deadline,
+            monitor,
         )
     }
 
@@ -2317,7 +2542,15 @@ mod tests {
         upstream.create_commit("second", &[("b.txt", "b")]);
         // Bring the remote-tracking ref (and its objects) over first, so the
         // pull's own fetch has nothing to transfer and runs to completion.
-        fetch_internal(&local.path_str(), "origin", false, None, None).expect("pre-fetch");
+        fetch_internal(
+            &local.path_str(),
+            "origin",
+            false,
+            None,
+            None,
+            TransferMonitor::disabled(),
+        )
+        .expect("pre-fetch");
         let before = local.head_oid();
         assert_ne!(before, upstream.head_oid(), "fixture must be behind");
 
@@ -2386,6 +2619,7 @@ mod tests {
             Some(true),
             None,
             None,
+            TransferMonitor::disabled(),
         )
     }
 
@@ -3561,6 +3795,7 @@ mod tests {
             false,
             false,
             None,
+            &TransferMonitor::disabled(),
         );
 
         assert!(
@@ -3615,6 +3850,7 @@ mod tests {
             false,
             false,
             None,
+            &TransferMonitor::disabled(),
         )
         .expect("an uncontested force push must still go through");
 
@@ -3744,6 +3980,7 @@ mod tests {
             false,
             false,
             None,
+            TransferMonitor::disabled(),
         )
         .expect("push should succeed");
 
@@ -3778,6 +4015,7 @@ mod tests {
             false,
             false,
             None,
+            TransferMonitor::disabled(),
         )
         .expect("first push should succeed");
         assert_eq!(
@@ -3803,6 +4041,7 @@ mod tests {
             false,
             false,
             None,
+            TransferMonitor::disabled(),
         )
         .expect("second push should succeed");
 
@@ -3835,6 +4074,7 @@ mod tests {
             false,
             false,
             None,
+            TransferMonitor::disabled(),
         )
         .expect("first push should succeed");
         assert_eq!(
@@ -3851,6 +4091,7 @@ mod tests {
             false,
             false,
             None,
+            TransferMonitor::disabled(),
         )
         .expect("second push should succeed");
 
@@ -4489,6 +4730,217 @@ mod tests {
 
         let json2 = serde_json::to_string(&result_no_msg).unwrap();
         assert!(json2.contains("\"message\":null"));
+    }
+
+    // ---- cancelling a fetch / pull / push ----
+    //
+    // A REAL cancelled network transfer is not reproducible offline, so these
+    // pin down everything around it that is: that a cancelled operation never
+    // reaches the network at all, that libgit2's generic abort error is
+    // reported as a cancellation rather than a failure, that the registry is
+    // left empty afterwards, and that a cancelled pull leaves the repository
+    // in the state a plain fetch would have.
+
+    use crate::services::cancellation::{CancellationRegistry, CancellationToken};
+    use crate::services::transfer_monitor::OperationProgress;
+
+    /// A monitor wired to a live token, plus the events it emitted.
+    fn cancellable_monitor(
+        operation_id: &str,
+    ) -> (
+        TransferMonitor,
+        CancellationToken,
+        Arc<Mutex<Vec<OperationProgress>>>,
+    ) {
+        let events: Arc<Mutex<Vec<OperationProgress>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_events = Arc::clone(&events);
+        let token = CancellationToken::new();
+        let monitor = TransferMonitor::new(
+            Some(operation_id.to_string()),
+            "Fetching",
+            token.clone(),
+            Arc::new(move |p| sink_events.lock().unwrap().push(p)),
+        );
+        (monitor, token, events)
+    }
+
+    /// The mapping the UI depends on: a cancelled transfer must read as a
+    /// cancellation, not as a timeout and not as a raw libgit2 failure.
+    #[test]
+    fn a_cancelled_transfer_is_reported_as_a_cancellation() {
+        let abort = TransferAbort::default();
+        let raw = || git2::Error::from_str("early EOF");
+
+        // Neither flag: the real error survives untouched.
+        let plain = transfer_failure(&abort, raw(), "Fetch operation timed out");
+        assert!(matches!(plain, LeviathanError::Git(_)));
+
+        abort
+            .timed_out
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let timed_out = transfer_failure(&abort, raw(), "Fetch operation timed out");
+        assert!(matches!(timed_out, LeviathanError::OperationTimeout(_)));
+
+        // Cancellation wins over a deadline that also expired: the user is
+        // told what they did, not what the clock did.
+        abort
+            .cancelled
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let cancelled = transfer_failure(&abort, raw(), "Fetch operation timed out");
+        assert!(matches!(cancelled, LeviathanError::OperationCancelled));
+        assert_eq!(
+            crate::error::ErrorResponse::from(cancelled).code,
+            "OPERATION_CANCELLED",
+            "the frontend keys its 'Cancelled' toast off this code"
+        );
+    }
+
+    /// A cancel that arrives while the fetch is still queued must stop it
+    /// before it opens a socket. The remote here is a URL that would take a
+    /// long time to fail; the test passing instantly is the assertion.
+    #[test]
+    fn a_pre_cancelled_fetch_never_reaches_the_network() {
+        let local = TestRepo::with_initial_commit();
+        local.add_remote("origin", "https://192.0.2.1/unreachable.git");
+
+        let (monitor, token, events) = cancellable_monitor("op-1");
+        token.cancel();
+
+        let err = fetch_internal(&local.path_str(), "origin", false, None, None, monitor)
+            .expect_err("a cancelled fetch must not succeed");
+
+        assert!(matches!(err, LeviathanError::OperationCancelled));
+        assert!(
+            events.lock().unwrap().is_empty(),
+            "nothing transferred, so nothing to report"
+        );
+    }
+
+    /// The same for push: nothing may reach the remote.
+    #[test]
+    fn a_pre_cancelled_push_never_reaches_the_network() {
+        let local = TestRepo::with_initial_commit();
+        local.add_remote("origin", "https://192.0.2.1/unreachable.git");
+
+        let (monitor, token, _events) = cancellable_monitor("op-2");
+        token.cancel();
+
+        let err = push_branch(
+            &local.path_str(),
+            Some("origin".to_string()),
+            None,
+            false,
+            false,
+            false,
+            false,
+            None,
+            monitor,
+        )
+        .expect_err("a cancelled push must not succeed");
+
+        assert!(matches!(err, LeviathanError::OperationCancelled));
+    }
+
+    /// And for the git-CLI push path force push uses — there the child process
+    /// is what has to not be spawned.
+    #[test]
+    fn a_pre_cancelled_cli_push_never_spawns_git() {
+        let local = TestRepo::with_initial_commit();
+        local.add_remote("origin", "https://192.0.2.1/unreachable.git");
+
+        let (monitor, token, _events) = cancellable_monitor("op-3");
+        token.cancel();
+
+        let err = push_via_cli(
+            &local.path_str(),
+            "origin",
+            "main",
+            false,
+            true,
+            false,
+            false,
+            None,
+            &monitor,
+        )
+        .expect_err("a cancelled force push must not succeed");
+
+        assert!(matches!(err, LeviathanError::OperationCancelled));
+    }
+
+    /// A cancelled pull must leave the working tree exactly where it was —
+    /// never half-merged. Cancelling before the fetch is the easy half of
+    /// that; the merge itself is deliberately not interruptible.
+    #[test]
+    fn a_cancelled_pull_leaves_the_working_tree_alone() {
+        let (upstream, local, branch) = pull_fixture();
+        upstream.create_commit("second", &[("b.txt", "b")]);
+        let before = local.head_oid();
+
+        let (monitor, token, _events) = cancellable_monitor("op-4");
+        token.cancel();
+
+        let err = pull_with_monitor(&local, &branch, None, monitor)
+            .expect_err("a cancelled pull must not succeed");
+
+        assert!(matches!(err, LeviathanError::OperationCancelled));
+        assert_eq!(local.head_oid(), before, "HEAD must not have moved");
+        assert!(
+            !local.path.join("b.txt").exists(),
+            "the upstream commit must not have been merged into the tree"
+        );
+        assert_eq!(
+            local.repo().state(),
+            git2::RepositoryState::Clean,
+            "no half-finished merge may be left behind"
+        );
+    }
+
+    /// The registration half of the contract: while a fetch is registered
+    /// `cancel_operation` finds it, and once the operation ends nothing is
+    /// left behind for a later id to collide with.
+    #[tokio::test]
+    async fn cancel_operation_finds_a_registered_operation_and_the_registry_empties() {
+        let registry = CancellationRegistry::default();
+
+        // Nothing registered: this is the state that made every Cancel click a
+        // no-op before this change.
+        assert!(!registry.cancel("op-5"));
+
+        {
+            let guard = registry.guard(Some("op-5".to_string()));
+            assert!(registry.cancel("op-5"), "a registered id is cancellable");
+            assert!(guard.is_cancelled());
+        }
+
+        assert!(
+            registry.is_empty(),
+            "the operation must be deregistered when it ends"
+        );
+        assert!(!registry.cancel("op-5"));
+    }
+
+    /// The guard travels into the blocking task, so the id stays cancellable
+    /// for as long as the work is really running — including after a caller
+    /// that timed out has gone away — and is released when it ends.
+    #[tokio::test]
+    async fn the_registration_outlives_a_caller_that_gave_up() {
+        let registry = CancellationRegistry::default();
+        let guard = registry.guard(Some("op-6".to_string()));
+        let (tx, rx) = std::sync::mpsc::channel::<()>();
+
+        let handle = tokio::task::spawn_blocking(move || {
+            let _guard = guard;
+            rx.recv().ok();
+        });
+
+        assert!(
+            registry.cancel("op-6"),
+            "still cancellable while the work runs"
+        );
+
+        tx.send(()).unwrap();
+        handle.await.unwrap();
+        assert!(registry.is_empty(), "released when the work really ends");
     }
 }
 

--- a/src-tauri/src/services/cancellation.rs
+++ b/src-tauri/src/services/cancellation.rs
@@ -39,10 +39,15 @@ impl Default for CancellationToken {
     }
 }
 
-/// Registry for tracking active operations and their cancellation tokens
-#[derive(Default)]
+/// Registry for tracking active operations and their cancellation tokens.
+///
+/// Cloning shares one map: the registry is Tauri managed state, but the
+/// blocking task that actually runs a fetch/pull/push outlives the command
+/// future that borrowed the `State`, so it needs an owned handle onto the same
+/// table to deregister itself when it really finishes.
+#[derive(Default, Clone)]
 pub struct CancellationRegistry {
-    tokens: Mutex<HashMap<String, CancellationToken>>,
+    tokens: Arc<Mutex<HashMap<String, CancellationToken>>>,
 }
 
 impl CancellationRegistry {
@@ -70,6 +75,81 @@ impl CancellationRegistry {
     pub fn remove(&self, operation_id: &str) {
         if let Ok(mut tokens) = self.tokens.lock() {
             tokens.remove(operation_id);
+        }
+    }
+
+    /// How many operations are currently registered. Test/diagnostic only.
+    pub fn len(&self) -> usize {
+        self.tokens.lock().map(|t| t.len()).unwrap_or(0)
+    }
+
+    /// Whether no operation is currently registered.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Register `operation_id` and hand back a guard that deregisters it again
+    /// when dropped.
+    ///
+    /// A guard rather than a matching `remove` call at the end of the command:
+    /// fetch/pull/push are full of `?` early returns and can fail anywhere
+    /// between the network and the merge, and a leaked registration is not
+    /// harmless — the id would stay cancellable forever, and the frontend
+    /// reuses nothing but still, a stale entry keeps a token alive for the
+    /// life of the process.
+    ///
+    /// `operation_id` is `None` for callers that did not ask for
+    /// cancellation (the background window-focus fetch, an internal fetch).
+    /// The guard is then inert: it registers nothing and its token is never
+    /// cancelled.
+    pub fn guard(&self, operation_id: Option<String>) -> OperationGuard {
+        match operation_id {
+            Some(id) => {
+                let token = self.register(id.clone());
+                OperationGuard {
+                    registry: Some(self.clone()),
+                    operation_id: id,
+                    token,
+                }
+            }
+            None => OperationGuard {
+                registry: None,
+                operation_id: String::new(),
+                token: CancellationToken::new(),
+            },
+        }
+    }
+}
+
+/// Deregisters its operation when dropped — on success, on an early `?`
+/// return, and on a panic unwinding out of the task.
+pub struct OperationGuard {
+    registry: Option<CancellationRegistry>,
+    operation_id: String,
+    token: CancellationToken,
+}
+
+impl OperationGuard {
+    /// The token to hand to the git2 callbacks.
+    pub fn token(&self) -> CancellationToken {
+        self.token.clone()
+    }
+
+    /// The operation id, when this guard actually registered one.
+    pub fn operation_id(&self) -> Option<&str> {
+        self.registry.as_ref().map(|_| self.operation_id.as_str())
+    }
+
+    /// Whether cancellation has been requested for this operation.
+    pub fn is_cancelled(&self) -> bool {
+        self.token.is_cancelled()
+    }
+}
+
+impl Drop for OperationGuard {
+    fn drop(&mut self) {
+        if let Some(registry) = &self.registry {
+            registry.remove(&self.operation_id);
         }
     }
 }
@@ -132,5 +212,69 @@ mod tests {
         registry.remove("op-1");
         let cancelled = registry.cancel("op-1");
         assert!(!cancelled);
+    }
+
+    #[test]
+    fn clones_share_one_table() {
+        let registry = CancellationRegistry::default();
+        let handle = registry.clone();
+        let token = handle.register("op-1".to_string());
+
+        // The clone the blocking task carries must cancel the very operation
+        // the command registered, not a private copy of the map.
+        assert!(registry.cancel("op-1"));
+        assert!(token.is_cancelled());
+    }
+
+    #[test]
+    fn guard_registers_and_deregisters_on_drop() {
+        let registry = CancellationRegistry::default();
+        {
+            let guard = registry.guard(Some("op-1".to_string()));
+            assert_eq!(guard.operation_id(), Some("op-1"));
+            assert!(registry.cancel("op-1"), "the id must be cancellable");
+            assert!(guard.is_cancelled());
+        }
+        assert!(registry.is_empty(), "the guard must deregister on drop");
+        assert!(!registry.cancel("op-1"));
+    }
+
+    #[test]
+    fn guard_deregisters_when_the_operation_fails() {
+        let registry = CancellationRegistry::default();
+        fn run(registry: &CancellationRegistry) -> std::result::Result<(), &'static str> {
+            let _guard = registry.guard(Some("op-1".to_string()));
+            Err("network blew up")
+        }
+        let failed = run(&registry);
+        assert!(failed.is_err());
+        assert!(
+            registry.is_empty(),
+            "an early return must not leak a registration"
+        );
+    }
+
+    #[test]
+    fn guard_deregisters_when_the_operation_panics() {
+        let registry = CancellationRegistry::default();
+        let handle = registry.clone();
+        let panicked = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            let _guard = handle.guard(Some("op-1".to_string()));
+            panic!("boom");
+        }));
+        assert!(panicked.is_err());
+        assert!(
+            registry.is_empty(),
+            "a panic must not leak a registration either"
+        );
+    }
+
+    #[test]
+    fn guard_without_an_id_registers_nothing() {
+        let registry = CancellationRegistry::default();
+        let guard = registry.guard(None);
+        assert_eq!(guard.operation_id(), None);
+        assert!(!guard.is_cancelled());
+        assert!(registry.is_empty());
     }
 }

--- a/src-tauri/src/services/credentials_service.rs
+++ b/src-tauri/src/services/credentials_service.rs
@@ -9,6 +9,8 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, Mutex};
 use std::time::Instant;
 
+use crate::services::transfer_monitor::TransferMonitor;
+
 /// Service name for keychain storage
 const SERVICE_NAME: &str = "leviathan-git";
 
@@ -447,6 +449,32 @@ fn extract_host(url: &str) -> Option<String> {
     None
 }
 
+/// Why a transfer callback aborted the transfer.
+///
+/// Both flags are set at the moment the callback returns false, and are the
+/// ONLY way the error site can tell that abort apart from any other libgit2
+/// failure that merely happened to surface at the same time. Asking the
+/// condition again there instead (has the deadline passed? is the token
+/// cancelled?) relabelled auth failures, protocol errors and disk errors as
+/// "timed out" — see `get_callbacks_with_deadline`.
+#[derive(Clone, Default)]
+pub struct TransferAbort {
+    /// The in-task deadline stopped the transfer.
+    pub timed_out: Arc<AtomicBool>,
+    /// The user cancelled the operation.
+    pub cancelled: Arc<AtomicBool>,
+}
+
+impl TransferAbort {
+    pub fn timed_out(&self) -> bool {
+        self.timed_out.load(Ordering::SeqCst)
+    }
+
+    pub fn cancelled(&self) -> bool {
+        self.cancelled.load(Ordering::SeqCst)
+    }
+}
+
 /// Get fetch options with credential and progress callbacks
 pub fn get_fetch_options<'a>(token: Option<String>) -> git2::FetchOptions<'a> {
     get_fetch_options_with_deadline(token, None).0
@@ -460,16 +488,57 @@ pub fn get_fetch_options_with_deadline<'a>(
     token: Option<String>,
     deadline: Option<std::time::Instant>,
 ) -> (git2::FetchOptions<'a>, Arc<AtomicBool>) {
+    let (opts, abort) =
+        get_fetch_options_with_monitor(token, deadline, TransferMonitor::disabled());
+    (opts, abort.timed_out)
+}
+
+/// Fetch options that also honour a user cancellation and report progress.
+pub fn get_fetch_options_with_monitor<'a>(
+    token: Option<String>,
+    deadline: Option<std::time::Instant>,
+    monitor: TransferMonitor,
+) -> (git2::FetchOptions<'a>, TransferAbort) {
     let mut fetch_opts = git2::FetchOptions::new();
-    let (callbacks, aborted) = get_callbacks_with_deadline(token, deadline);
+    let (callbacks, abort) = get_callbacks_with_monitor(token, deadline, monitor);
     fetch_opts.remote_callbacks(callbacks);
-    (fetch_opts, aborted)
+    (fetch_opts, abort)
 }
 
 /// Get push options with credential and progress callbacks
 pub fn get_push_options<'a>(token: Option<String>) -> git2::PushOptions<'a> {
+    get_push_options_with_monitor(token, TransferMonitor::disabled()).0
+}
+
+/// Push options that honour a user cancellation and report progress.
+///
+/// The cancellation point is `push_negotiation`, which libgit2 calls once the
+/// remote's refs are known and BEFORE a single object is packed or sent —
+/// returning an error there aborts the push with nothing written to the
+/// remote. That is the only abort point available: git2's
+/// `push_transfer_progress` binding always returns 0 to libgit2, so a push
+/// already uploading its pack cannot be stopped from Rust. A cancel that
+/// arrives after that point is therefore honoured on a best-effort basis, and
+/// the push may still land — which is why the frontend reports "cancelled"
+/// only when the command actually returns `OperationCancelled`, and reports
+/// the real success otherwise.
+pub fn get_push_options_with_monitor<'a>(
+    token: Option<String>,
+    monitor: TransferMonitor,
+) -> (git2::PushOptions<'a>, TransferAbort) {
     let mut push_opts = git2::PushOptions::new();
-    let mut callbacks = get_callbacks_with_progress(token);
+    let (mut callbacks, abort) = get_callbacks_with_monitor(token, None, monitor.clone());
+
+    let negotiation_abort = abort.cancelled.clone();
+    callbacks.push_negotiation(move |_updates| {
+        if monitor.is_cancelled() {
+            // Recorded BEFORE the abort, so the error libgit2 raises for it is
+            // already attributable by the time the caller inspects it.
+            negotiation_abort.store(true, Ordering::SeqCst);
+            return Err(git2::Error::from_str("Push cancelled"));
+        }
+        Ok(())
+    });
 
     // Without this, a push the SERVER rejects reports success. libgit2's
     // git_remote_push only errors when the pack fails to unpack; per-reference
@@ -486,7 +555,7 @@ pub fn get_push_options<'a>(token: Option<String>) -> git2::PushOptions<'a> {
     });
 
     push_opts.remote_callbacks(callbacks);
-    push_opts
+    (push_opts, abort)
 }
 
 /// Get remote callbacks with both credential and progress support
@@ -512,16 +581,41 @@ pub fn get_callbacks_with_deadline<'a>(
     token: Option<String>,
     deadline: Option<std::time::Instant>,
 ) -> (RemoteCallbacks<'a>, Arc<AtomicBool>) {
+    let (callbacks, abort) =
+        get_callbacks_with_monitor(token, deadline, TransferMonitor::disabled());
+    (callbacks, abort.timed_out)
+}
+
+/// Same, and additionally honours a user cancellation and reports progress.
+///
+/// The cancellation check sits in the SAME `transfer_progress` callback as the
+/// deadline check, for the same reason: returning false from it is the only
+/// abort point libgit2 offers. The two are recorded on separate flags so the
+/// error site can say which of them stopped the transfer.
+pub fn get_callbacks_with_monitor<'a>(
+    token: Option<String>,
+    deadline: Option<std::time::Instant>,
+    monitor: TransferMonitor,
+) -> (RemoteCallbacks<'a>, TransferAbort) {
     let mut callbacks = CredentialsHelper::new_with_token(token).get_callbacks();
-    let aborted = Arc::new(AtomicBool::new(false));
-    let abort_flag = Arc::clone(&aborted);
+    let abort = TransferAbort::default();
+    let deadline_flag = Arc::clone(&abort.timed_out);
+    let cancel_flag = Arc::clone(&abort.cancelled);
+    let fetch_monitor = monitor.clone();
 
     // Add transfer progress callback
     callbacks.transfer_progress(move |stats| {
+        // Cancellation is checked BEFORE the deadline so a user who pressed
+        // Cancel on an operation that was also about to time out is told what
+        // they did, not what the clock did.
+        if fetch_monitor.is_cancelled() {
+            cancel_flag.store(true, Ordering::SeqCst);
+            return false;
+        }
         if crate::utils::deadline_passed(deadline) {
             // Recorded BEFORE the abort, so the error libgit2 raises for it is
             // already attributable by the time the caller inspects it.
-            abort_flag.store(true, Ordering::SeqCst);
+            deadline_flag.store(true, Ordering::SeqCst);
             return false;
         }
 
@@ -540,6 +634,8 @@ pub fn get_callbacks_with_deadline<'a>(
             );
         }
 
+        fetch_monitor.report(received, total, bytes);
+
         true // Continue the transfer
     });
 
@@ -554,8 +650,12 @@ pub fn get_callbacks_with_deadline<'a>(
         true
     });
 
-    // Add push transfer progress callback
-    callbacks.push_transfer_progress(|current, total, bytes| {
+    // Add push transfer progress callback.
+    //
+    // git2's binding for this one always returns 0 to libgit2, so it CANNOT
+    // abort a push — it only reports. The push cancellation point is
+    // `push_negotiation`, registered in `get_push_options_with_monitor`.
+    callbacks.push_transfer_progress(move |current, total, bytes| {
         if total > 0 {
             let percent = (current as f64 / total as f64) * 100.0;
             tracing::debug!(
@@ -566,9 +666,10 @@ pub fn get_callbacks_with_deadline<'a>(
                 bytes
             );
         }
+        monitor.report(current, total, bytes);
     });
 
-    (callbacks, aborted)
+    (callbacks, abort)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/services/mod.rs
+++ b/src-tauri/src/services/mod.rs
@@ -16,6 +16,7 @@ pub mod keyring_util;
 pub mod loopback_server;
 pub mod oauth;
 pub mod remote_ops;
+pub mod transfer_monitor;
 pub mod update_service;
 pub mod watcher_service;
 
@@ -25,5 +26,6 @@ pub use cancellation::CancellationRegistry;
 pub use credentials_service::CredentialsHelper;
 pub use git_service::GitService;
 pub use remote_ops::{RemoteOp, RemoteOpRegistry};
+pub use transfer_monitor::{OperationProgress, TransferMonitor};
 pub use update_service::{create_update_state, UpdateState};
 pub use watcher_service::WatcherService;

--- a/src-tauri/src/services/transfer_monitor.rs
+++ b/src-tauri/src/services/transfer_monitor.rs
@@ -1,0 +1,273 @@
+//! Cancellation and progress reporting for a network transfer.
+//!
+//! `clone_repository` has always done both: it checks a cancel flag inside
+//! git2's `transfer_progress` callback (the only abort point libgit2 offers)
+//! and emits a progress event from the same place, throttled so a large
+//! transfer does not flood IPC. Fetch, pull and push accepted an
+//! `operation_id` and did neither — nothing was ever registered with the
+//! `CancellationRegistry`, so `cancel_operation` always answered `false`, and
+//! no backend code emitted the `operation-progress` event the frontend
+//! listens for. This module is that behaviour, factored out so all of them
+//! share one implementation.
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+
+use serde::Serialize;
+
+use crate::services::cancellation::CancellationToken;
+
+/// One `operation-progress` event.
+///
+/// `operationId` is the id the FRONTEND generated in
+/// `progress.service.ts::startOperation` and passed into the command, so the
+/// event lands on the row the user is looking at.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationProgress {
+    pub operation_id: String,
+    pub message: String,
+    /// 0-100, or `None` while the remote has not announced a total yet — the
+    /// indicator shows its indeterminate stripe for `None`.
+    pub progress: Option<u8>,
+    pub received_objects: usize,
+    pub total_objects: usize,
+    pub received_bytes: usize,
+}
+
+/// Where a progress event goes. Boxed rather than an `AppHandle` so the
+/// throttling and the percent maths are unit-testable without a Tauri app.
+pub type ProgressSink = Arc<dyn Fn(OperationProgress) + Send + Sync>;
+
+/// Percent of a transfer, or `None` when the total is not known yet.
+fn percent_of(done: usize, total: usize) -> Option<u8> {
+    if total == 0 {
+        return None;
+    }
+    Some(((done.min(total) * 100 / total) as u8).min(100))
+}
+
+/// Cancellation flag plus throttled progress reporting for one transfer.
+///
+/// Cloning shares the throttle state and the token: the same monitor is used
+/// from the git2 callback and from the error site that has to say WHY the
+/// transfer stopped.
+#[derive(Clone)]
+pub struct TransferMonitor {
+    operation_id: Option<String>,
+    message: String,
+    cancel: Option<CancellationToken>,
+    sink: Option<ProgressSink>,
+    /// Last emitted percent, or `usize::MAX` before the first emission so the
+    /// very first callback always reports something.
+    last_percent: Arc<AtomicUsize>,
+}
+
+impl Default for TransferMonitor {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+impl TransferMonitor {
+    /// A monitor that reports nothing and is never cancelled — for callers
+    /// that did not ask for either (the background fetch, the auto-fetch
+    /// service, an internal fetch, and every unit test that only cares about
+    /// the git plumbing).
+    pub fn disabled() -> Self {
+        Self {
+            operation_id: None,
+            message: String::new(),
+            cancel: None,
+            sink: None,
+            last_percent: Arc::new(AtomicUsize::new(usize::MAX)),
+        }
+    }
+
+    /// A monitor that honours `cancel` and reports progress to `sink`.
+    ///
+    /// `operation_id` is `None` when the caller did not pass one, in which
+    /// case no event can be addressed to a row and none is emitted — but the
+    /// token is still honoured.
+    pub fn new(
+        operation_id: Option<String>,
+        message: impl Into<String>,
+        cancel: CancellationToken,
+        sink: ProgressSink,
+    ) -> Self {
+        Self {
+            operation_id,
+            message: message.into(),
+            cancel: Some(cancel),
+            sink: Some(sink),
+            last_percent: Arc::new(AtomicUsize::new(usize::MAX)),
+        }
+    }
+
+    /// The same monitor with a different row message.
+    ///
+    /// The remote a pull or push actually contacts is only known once the
+    /// branch's upstream has been resolved, deeper in than the command that
+    /// built the monitor — this is how the row gets to say "Pulling from
+    /// upstream" rather than a generic "Pulling".
+    pub fn with_message(&self, message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+            ..self.clone()
+        }
+    }
+
+    /// Whether the user asked for this operation to stop.
+    pub fn is_cancelled(&self) -> bool {
+        self.cancel.as_ref().is_some_and(|t| t.is_cancelled())
+    }
+
+    /// Report a transfer snapshot, throttled to one event per whole percent.
+    ///
+    /// Unthrottled this fires for every packet libgit2 receives — tens of
+    /// thousands of IPC messages on a big clone, each one re-rendering the
+    /// progress row. `clone_repository` throttles the same way.
+    pub fn report(&self, done: usize, total: usize, bytes: usize) {
+        let (Some(sink), Some(operation_id)) = (self.sink.as_ref(), self.operation_id.as_ref())
+        else {
+            return;
+        };
+        let progress = percent_of(done, total);
+        // `None` (no total yet) is keyed as 101 so it is distinct from 0% and
+        // still reported exactly once.
+        let key = progress.map_or(101usize, |p| p as usize);
+        if self.last_percent.swap(key, Ordering::Relaxed) == key {
+            return;
+        }
+        sink(OperationProgress {
+            operation_id: operation_id.clone(),
+            message: self.message.clone(),
+            progress,
+            received_objects: done,
+            total_objects: total,
+            received_bytes: bytes,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    fn recording() -> (
+        TransferMonitor,
+        CancellationToken,
+        Arc<Mutex<Vec<OperationProgress>>>,
+    ) {
+        let events: Arc<Mutex<Vec<OperationProgress>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_events = Arc::clone(&events);
+        let token = CancellationToken::new();
+        let monitor = TransferMonitor::new(
+            Some("op-1".to_string()),
+            "Fetching from origin",
+            token.clone(),
+            Arc::new(move |p| sink_events.lock().unwrap().push(p)),
+        );
+        (monitor, token, events)
+    }
+
+    #[test]
+    fn percent_is_none_until_the_total_is_known() {
+        assert_eq!(percent_of(0, 0), None);
+        assert_eq!(percent_of(5, 0), None);
+        assert_eq!(percent_of(0, 10), Some(0));
+        assert_eq!(percent_of(5, 10), Some(50));
+        assert_eq!(percent_of(10, 10), Some(100));
+    }
+
+    /// libgit2 can report more received than total mid-transfer; the bar must
+    /// not run past 100.
+    #[test]
+    fn percent_is_clamped() {
+        assert_eq!(percent_of(30, 10), Some(100));
+    }
+
+    #[test]
+    fn reports_real_counts_for_the_operation_id() {
+        let (monitor, _token, events) = recording();
+        monitor.report(25, 100, 4096);
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(
+            events[0],
+            OperationProgress {
+                operation_id: "op-1".to_string(),
+                message: "Fetching from origin".to_string(),
+                progress: Some(25),
+                received_objects: 25,
+                total_objects: 100,
+                received_bytes: 4096,
+            }
+        );
+    }
+
+    #[test]
+    fn throttles_to_one_event_per_percent() {
+        let (monitor, _token, events) = recording();
+        // 1000 objects, so ten callbacks land inside the same whole percent.
+        for received in 0..10 {
+            monitor.report(received, 1000, received * 100);
+        }
+        monitor.report(50, 1000, 5000);
+
+        let events = events.lock().unwrap();
+        assert_eq!(
+            events.len(),
+            2,
+            "one event for 0% and one for 5%, not one per callback"
+        );
+        assert_eq!(events[0].progress, Some(0));
+        assert_eq!(events[1].progress, Some(5));
+    }
+
+    #[test]
+    fn reports_the_unknown_total_once() {
+        let (monitor, _token, events) = recording();
+        monitor.report(0, 0, 0);
+        monitor.report(0, 0, 0);
+
+        let events = events.lock().unwrap();
+        assert_eq!(events.len(), 1);
+        assert_eq!(events[0].progress, None);
+    }
+
+    #[test]
+    fn a_disabled_monitor_emits_nothing_and_never_cancels() {
+        let monitor = TransferMonitor::disabled();
+        monitor.report(1, 2, 3);
+        assert!(!monitor.is_cancelled());
+    }
+
+    #[test]
+    fn cancellation_is_visible_through_a_clone() {
+        let (monitor, token, _events) = recording();
+        let in_callback = monitor.clone();
+        assert!(!in_callback.is_cancelled());
+        token.cancel();
+        assert!(in_callback.is_cancelled());
+    }
+
+    #[test]
+    fn without_an_operation_id_nothing_is_emitted_but_cancel_still_works() {
+        let events: Arc<Mutex<Vec<OperationProgress>>> = Arc::new(Mutex::new(Vec::new()));
+        let sink_events = Arc::clone(&events);
+        let token = CancellationToken::new();
+        let monitor = TransferMonitor::new(
+            None,
+            "Fetching",
+            token.clone(),
+            Arc::new(move |p| sink_events.lock().unwrap().push(p)),
+        );
+        monitor.report(1, 2, 3);
+        assert!(events.lock().unwrap().is_empty());
+        token.cancel();
+        assert!(monitor.is_cancelled());
+    }
+}

--- a/src/__tests__/app-shell-remote-feedback.test.ts
+++ b/src/__tests__/app-shell-remote-feedback.test.ts
@@ -257,6 +257,129 @@ describe('app-shell remote-operation feedback', () => {
     });
   });
 
+  // ── cancelling a remote operation ────────────────────────────────────────
+  //
+  // Fetch/pull/push advertised cancellation that did not exist: no call site
+  // passed `{cancellable: true}`, so the indicator's Cancel button never
+  // rendered, and no `operationId` reached the backend, so `cancel_operation`
+  // could never find the operation to stop.
+
+  describe('cancellable remote operations', () => {
+    async function progress() {
+      return (await import('../services/progress.service.ts')).progressService;
+    }
+
+    const handlerFor = (op: 'fetch' | 'pull' | 'push') =>
+      `handle${op[0].toUpperCase()}${op.slice(1)}` as 'handleFetch' | 'handlePull' | 'handlePush';
+
+    for (const op of ['fetch', 'pull', 'push'] as const) {
+      it(`${op} runs under a cancellable progress row`, async () => {
+        const service = await progress();
+        const rows: Array<{ id: string; cancellable?: boolean }> = [];
+        const unsubscribe = service.subscribe((ops) => {
+          for (const o of ops) if (!rows.some((r) => r.id === o.id)) rows.push({ ...o });
+        });
+        try {
+          const el = shellOnRepo();
+          await (el as any)[handlerFor(op)]();
+
+          expect(rows.length, `${op} shows a progress row`).to.be.greaterThan(0);
+          expect(
+            rows.every((r) => r.cancellable === true),
+            `${op}'s row must render the Cancel button`,
+          ).to.equal(true);
+        } finally {
+          unsubscribe();
+        }
+      });
+
+      it(`${op} hands the backend the id its Cancel button will use`, async () => {
+        const service = await progress();
+        const ids: string[] = [];
+        const unsubscribe = service.subscribe((ops) => {
+          for (const o of ops) if (!ids.includes(o.id)) ids.push(o.id);
+        });
+        try {
+          const el = shellOnRepo();
+          await (el as any)[handlerFor(op)]();
+
+          const call = invokeCallArgs.find((c) => c.command === op);
+          expect(call, `${op} invoked`).to.not.be.undefined;
+          expect(
+            ids,
+            `${op} must pass the very id the progress row was started with`,
+          ).to.contain(call!.args.operationId);
+        } finally {
+          unsubscribe();
+        }
+      });
+
+      it(`a cancelled ${op} reports "cancelled", not an error`, async () => {
+        failures[op] = { code: 'OPERATION_CANCELLED', message: 'Operation cancelled' };
+        const el = shellOnRepo();
+
+        await (el as any)[handlerFor(op)]();
+
+        const toasts = uiStore.getState().toasts;
+        expect(
+          toasts.filter((t) => t.type === 'error').length,
+          `a cancel the user asked for is not a red ${op} failure`,
+        ).to.equal(0);
+        expect(
+          toasts.some((t) => /cancelled/i.test(t.message)),
+          'the user is told the cancel took effect',
+        ).to.equal(true);
+      });
+
+      it(`a real ${op} failure still shows its error after the cancel path exists`, async () => {
+        failures[op] = { code: 'COMMAND_ERROR', message: 'remote hung up' };
+        const el = shellOnRepo();
+
+        await (el as any)[handlerFor(op)]();
+
+        const errors = uiStore.getState().toasts.filter((t) => t.type === 'error');
+        expect(errors.length, `a genuine ${op} failure is still an error`).to.equal(1);
+        expect(errors[0].message).to.contain('remote hung up');
+      });
+
+      it(`a cancelled ${op} releases the per-repo lock`, async () => {
+        // The lock is what stops a second fetch/pull/push on the same repo.
+        // Leaking it on a cancellation would wedge the repository until the
+        // app restarted, which is worse than not being able to cancel at all.
+        failures[op] = { code: 'OPERATION_CANCELLED', message: 'Operation cancelled' };
+        const el = shellOnRepo();
+
+        await (el as any)[handlerFor(op)]();
+
+        invokeCallArgs.length = 0;
+        delete failures[op];
+        await (el as any)[handlerFor(op)]();
+
+        expect(
+          invokeCallArgs.some((c) => c.command === op),
+          `a retry after a cancelled ${op} must not be refused by a stale lock`,
+        ).to.equal(true);
+      });
+    }
+
+    it('the indicator cancel event reaches the backend cancel command', async () => {
+      const service = await progress();
+      const el = shellOnRepo();
+      const id = service.startOperation('fetch', 'Fetching...', { cancellable: true });
+      invokeCallArgs.length = 0;
+
+      (el as any).handleCancelOperation(new CustomEvent('cancel-operation', { detail: { id } }));
+
+      const cancel = invokeCallArgs.find((c) => c.command === 'cancel_operation');
+      expect(cancel, 'clicking Cancel must reach the backend').to.not.be.undefined;
+      expect(cancel!.args.operationId).to.equal(id);
+      expect(
+        service.getOperations().some((o) => o.id === id),
+        'the row is dismissed immediately',
+      ).to.equal(false);
+    });
+  });
+
   describe('a rejected push offers the recovery the app already implements', () => {
     it('being behind the remote carries a Pull Now action', async () => {
       failures['push'] = {
@@ -399,6 +522,44 @@ describe('app-shell remote-operation feedback', () => {
         uiStore.getState().toasts.some((t) => t.action?.label === 'Force Push'),
         'no unbounded loop through the destructive action',
       ).to.equal(false);
+    });
+
+    it('is cancellable and passes its progress row id to the backend', async () => {
+      mockResponses['plugin:dialog|confirm'] = () => 'Ok';
+      mockResponses['plugin:dialog|message'] = () => 'Ok';
+      const { progressService } = await import('../services/progress.service.ts');
+      const rows: Array<{ id: string; cancellable?: boolean }> = [];
+      const unsubscribe = progressService.subscribe((ops) => {
+        for (const o of ops) if (!rows.some((r) => r.id === o.id)) rows.push({ ...o });
+      });
+      try {
+        const el = shellWithStoreRepo();
+
+        await (el as any).forcePush('/repo/one');
+
+        const push = invokeCallArgs.find((c) => c.command === 'push');
+        expect(push, 'the push runs once confirmed').to.not.be.undefined;
+        expect(
+          rows.some((r) => r.id === push!.args.operationId && r.cancellable === true),
+          'force push must be cancellable through the same row it reports on',
+        ).to.equal(true);
+      } finally {
+        unsubscribe();
+      }
+    });
+
+    it('a cancelled force push is not reported as a failure', async () => {
+      mockResponses['plugin:dialog|confirm'] = () => 'Ok';
+      mockResponses['plugin:dialog|message'] = () => 'Ok';
+      failures['push'] = { code: 'OPERATION_CANCELLED', message: 'Operation cancelled' };
+      const el = shellWithStoreRepo();
+      uiStore.setState({ toasts: [] });
+
+      await (el as any).forcePush('/repo/one');
+
+      const toasts = uiStore.getState().toasts;
+      expect(toasts.filter((t) => t.type === 'error').length).to.equal(0);
+      expect(toasts.some((t) => /cancelled/i.test(t.message))).to.equal(true);
     });
 
     it('force pushing a tag asks first and sends the force flag', async () => {

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -3191,11 +3191,14 @@ export class AppShell extends LitElement {
     );
     if (!confirmed) return;
 
-    const opId = progressService.startOperation('push', 'Force pushing to remote...');
+    const opId = progressService.startOperation('push', 'Force pushing to remote...', {
+      cancellable: true,
+    });
     const result = await gitService.push({
       path: repoPath,
       forceWithLease: true,
       silent: true,
+      operationId: opId,
     });
     if (result.success) {
       progressService.completeOperation(opId);
@@ -3206,7 +3209,9 @@ export class AppShell extends LitElement {
       this.refreshConflictDialogRepo(repoPath);
     } else {
       progressService.failOperation(opId);
-      if (!gitService.isNetworkGateRefusal(result.error)) {
+      if (gitService.isOperationCancelled(result.error)) {
+        showToast('Force push cancelled', 'info');
+      } else if (!gitService.isNetworkGateRefusal(result.error)) {
         // NOT through showErrorWithSuggestion: a force push that is itself
         // rejected would match the same branch that produced this toast and
         // offer Force Push again, an unbounded loop over the one action that
@@ -5069,7 +5074,9 @@ export class AppShell extends LitElement {
 
   private async fetchRepository(): Promise<void> {
     if (!this.activeRepository) return;
-    const opId = progressService.startOperation('fetch', 'Fetching from remote...');
+    const opId = progressService.startOperation('fetch', 'Fetching from remote...', {
+      cancellable: true,
+    });
     // gitService.fetch returns a CommandResult (invokeCommand never throws), so we
     // must inspect result.success — a catch-only path always reported success and
     // the backend emits remote-operation-completed only on success, so failures
@@ -5080,16 +5087,20 @@ export class AppShell extends LitElement {
     // silent: this handler owns the messaging (and the backend's
     // remote-operation-completed event toasts the success). Without it every
     // toolbar fetch stacked two toasts, and every failure two errors.
-    const result = await gitService.fetch({ path: repoPath, silent: true });
+    const result = await gitService.fetch({ path: repoPath, silent: true, operationId: opId });
     if (result.success) {
       progressService.completeOperation(opId);
       this.refreshConflictDialogRepo(repoPath);
     } else {
       progressService.failOperation(opId);
-      // A security-gate refusal already announced itself, and a declined
-      // confirm is the user's own decision — reporting either as a red error
-      // tells them their own click failed.
-      if (!gitService.isNetworkGateRefusal(result.error)) {
+      // A cancel the user asked for is not a failure — say it took effect
+      // rather than showing them a red error for their own click.
+      if (gitService.isOperationCancelled(result.error)) {
+        showToast('Fetch cancelled', 'info');
+      } else if (!gitService.isNetworkGateRefusal(result.error)) {
+        // A security-gate refusal already announced itself, and a declined
+        // confirm is the user's own decision — reporting either as a red error
+        // tells them their own click failed.
         showToast(result.error?.message ?? 'Fetch failed', 'error');
       }
     }
@@ -5119,10 +5130,15 @@ export class AppShell extends LitElement {
   }
 
   private async pullRepository(repoPath: string): Promise<void> {
-    const opId = progressService.startOperation('pull', 'Pulling from remote...');
+    // Cancellable, but only up to the point the merge starts: the backend's
+    // pull aborts during its fetch phase and refuses to begin a merge it
+    // cannot safely stop halfway. See commands/remote.rs::pull_branch.
+    const opId = progressService.startOperation('pull', 'Pulling from remote...', {
+      cancellable: true,
+    });
     // gitService.pull returns a CommandResult (invokeCommand never throws), so we
     // must inspect result.success — the old catch-only path always reported success.
-    const result = await gitService.pull({ path: repoPath, silent: true });
+    const result = await gitService.pull({ path: repoPath, silent: true, operationId: opId });
     if (result.success) {
       progressService.completeOperation(opId);
       // Pinned: a ref-only pull emits no working-tree watcher event, so a
@@ -5147,10 +5163,14 @@ export class AppShell extends LitElement {
       this.refreshConflictDialogRepo(repoPath);
     } else {
       progressService.failOperation(opId);
-      // A security-gate refusal already announced itself, and a declined
-      // confirm is the user's own decision — reporting either as a red error
-      // tells them their own click failed.
-      if (!gitService.isNetworkGateRefusal(result.error)) {
+      if (gitService.isOperationCancelled(result.error)) {
+        // Stopped during the fetch, so nothing was merged — the repository is
+        // exactly where a plain Fetch would have left it.
+        showToast('Pull cancelled', 'info');
+      } else if (!gitService.isNetworkGateRefusal(result.error)) {
+        // A security-gate refusal already announced itself, and a declined
+        // confirm is the user's own decision — reporting either as a red error
+        // tells them their own click failed.
         showToast(result.error?.message ?? 'Pull failed', 'error');
       }
     }
@@ -5169,7 +5189,9 @@ export class AppShell extends LitElement {
 
   private async pushRepository(): Promise<void> {
     if (!this.activeRepository) return;
-    const opId = progressService.startOperation('push', 'Pushing to remote...');
+    const opId = progressService.startOperation('push', 'Pushing to remote...', {
+      cancellable: true,
+    });
     // gitService.push returns a CommandResult (invokeCommand never throws), so we
     // must inspect result.success — a catch-only path always reported success and
     // the backend emits remote-operation-completed only on success, so failures
@@ -5177,16 +5199,19 @@ export class AppShell extends LitElement {
     // Pinned: push is a slow network op; if the user switches tabs while it
     // runs, the refresh must target the repo that pushed, not the active tab.
     const repoPath = this.activeRepository.repository.path;
-    const result = await gitService.push({ path: repoPath, silent: true });
+    const result = await gitService.push({ path: repoPath, silent: true, operationId: opId });
     if (result.success) {
       progressService.completeOperation(opId);
       this.refreshConflictDialogRepo(repoPath);
     } else {
       progressService.failOperation(opId);
-      // A security-gate refusal already announced itself, and a declined
-      // confirm is the user's own decision — reporting either as a red error
-      // tells them their own click failed.
-      if (!gitService.isNetworkGateRefusal(result.error)) {
+      if (gitService.isOperationCancelled(result.error)) {
+        showToast('Push cancelled', 'info');
+      } else if (!gitService.isNetworkGateRefusal(result.error)) {
+        // A security-gate refusal already announced itself, and a declined
+        // confirm is the user's own decision — reporting either as a red error
+        // tells them their own click failed.
+        //
         // Through the suggestion service so a non-fast-forward rejection offers
         // the Pull Now action the app already implements — a plain toast made
         // that recovery unreachable from the only push surface there is.

--- a/src/components/common/__tests__/lv-progress-indicator.test.ts
+++ b/src/components/common/__tests__/lv-progress-indicator.test.ts
@@ -1,0 +1,151 @@
+/**
+ * The progress indicator's Cancel button and transfer counts.
+ *
+ * The Cancel button was unreachable dead code: `startOperation` defaults
+ * `cancellable` to false and no call site passed `{cancellable: true}`, so
+ * `op.cancellable` was never true and the button never rendered. The counts
+ * were likewise never shown, because no backend code emitted the
+ * `operation-progress` event that carries them.
+ */
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: () => Promise.resolve(null),
+  transformCallback: () => 0,
+};
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-progress-indicator.ts';
+import type { LvProgressIndicator } from '../lv-progress-indicator.ts';
+import type { ProgressOperation } from '../../../services/progress.service.ts';
+
+async function indicatorWith(
+  operations: ProgressOperation[],
+): Promise<LvProgressIndicator> {
+  const el = await fixture<LvProgressIndicator>(
+    html`<lv-progress-indicator></lv-progress-indicator>`,
+  );
+  el.operations = operations;
+  await el.updateComplete;
+  return el;
+}
+
+const fetchRow: ProgressOperation = {
+  id: 'op-1',
+  type: 'fetch',
+  message: 'Fetching from origin',
+  progress: 42,
+  cancellable: true,
+};
+
+describe('lv-progress-indicator', () => {
+  describe('cancel button', () => {
+    it('renders for a cancellable operation', async () => {
+      const el = await indicatorWith([fetchRow]);
+      expect(el.shadowRoot!.querySelector('.cancel-btn')).to.exist;
+    });
+
+    it('is absent for an operation that cannot be cancelled', async () => {
+      const el = await indicatorWith([{ ...fetchRow, cancellable: false }]);
+      expect(el.shadowRoot!.querySelector('.cancel-btn')).to.not.exist;
+    });
+
+    it('dispatches cancel-operation with the row id when clicked', async () => {
+      const el = await indicatorWith([fetchRow]);
+      const seen: string[] = [];
+      el.addEventListener('cancel-operation', (e) => {
+        seen.push((e as CustomEvent<{ id: string }>).detail.id);
+      });
+
+      el.shadowRoot!.querySelector<HTMLButtonElement>('.cancel-btn')!.click();
+
+      expect(seen).to.deep.equal(['op-1']);
+    });
+
+    it('cancels only the row whose button was clicked', async () => {
+      const el = await indicatorWith([
+        fetchRow,
+        { id: 'op-2', type: 'push', message: 'Pushing...', cancellable: true },
+      ]);
+      const seen: string[] = [];
+      el.addEventListener('cancel-operation', (e) => {
+        seen.push((e as CustomEvent<{ id: string }>).detail.id);
+      });
+
+      const buttons = el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.cancel-btn');
+      expect(buttons).to.have.length(2);
+      buttons[1].click();
+
+      expect(seen).to.deep.equal(['op-2']);
+    });
+
+    it('bubbles out of the shadow root so app-shell can hear it', async () => {
+      const el = await indicatorWith([fetchRow]);
+      let heard = false;
+      document.addEventListener('cancel-operation', () => {
+        heard = true;
+      }, { once: true });
+
+      el.shadowRoot!.querySelector<HTMLButtonElement>('.cancel-btn')!.click();
+
+      expect(heard, 'the event must be composed and bubbling').to.be.true;
+    });
+  });
+
+  describe('transfer counts', () => {
+    it('shows received and total objects with the transferred size', async () => {
+      const el = await indicatorWith([
+        {
+          ...fetchRow,
+          receivedObjects: 1234,
+          totalObjects: 5000,
+          receivedBytes: 2 * 1024 * 1024,
+        },
+      ]);
+
+      const counts = el.shadowRoot!.querySelector('.progress-counts')!.textContent!.trim();
+      expect(counts).to.contain('objects');
+      expect(counts).to.contain('5,000');
+      expect(counts).to.contain('1,234');
+      expect(counts).to.contain('2.00 MiB');
+    });
+
+    it('omits the total until the remote has announced one', async () => {
+      const el = await indicatorWith([
+        { ...fetchRow, progress: undefined, receivedObjects: 7, totalObjects: 0 },
+      ]);
+
+      const counts = el.shadowRoot!.querySelector('.progress-counts')!.textContent!.trim();
+      expect(counts).to.equal('7 objects');
+    });
+
+    it('shows no counts line before the first progress event', async () => {
+      const el = await indicatorWith([fetchRow]);
+      expect(el.shadowRoot!.querySelector('.progress-counts')).to.not.exist;
+      // The percentage the caller supplied is still shown.
+      expect(el.shadowRoot!.querySelector('.progress-percent-value')!.textContent).to.contain('42');
+    });
+
+    it('renders an indeterminate bar and still shows counts with no percent', async () => {
+      const el = await indicatorWith([
+        { ...fetchRow, progress: undefined, receivedObjects: 12, totalObjects: 0 },
+      ]);
+
+      expect(el.shadowRoot!.querySelector('.progress-fill.indeterminate')).to.exist;
+      expect(el.shadowRoot!.querySelector('.progress-percent-value')).to.not.exist;
+      expect(el.shadowRoot!.querySelector('.progress-counts')).to.exist;
+    });
+
+    it('formats sub-kilobyte transfers in bytes', async () => {
+      const el = await indicatorWith([
+        { ...fetchRow, receivedObjects: 1, totalObjects: 2, receivedBytes: 512 },
+      ]);
+
+      expect(el.shadowRoot!.querySelector('.progress-counts')!.textContent).to.contain('512 B');
+    });
+  });
+
+  it('renders nothing when there are no operations', async () => {
+    const el = await indicatorWith([]);
+    expect(el.shadowRoot!.querySelector('.progress-container')).to.not.exist;
+  });
+});

--- a/src/components/common/lv-progress-indicator.ts
+++ b/src/components/common/lv-progress-indicator.ts
@@ -134,14 +134,50 @@ export class LvProgressIndicator extends LitElement {
       }
 
       .progress-percentage {
+        display: flex;
+        gap: 8px;
         font-size: var(--font-size-xs);
         color: var(--color-text-muted);
         margin-top: 2px;
+      }
+
+      .progress-counts {
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
       }
     `,
   ];
 
   @property({ type: Array }) operations: ProgressOperation[] = [];
+
+  /** Bytes as the transfer line shows them — the units git itself uses. */
+  private formatBytes(bytes: number): string {
+    if (bytes < 1024) return `${bytes} B`;
+    const units = ['KiB', 'MiB', 'GiB'];
+    let value = bytes / 1024;
+    let unit = 0;
+    while (value >= 1024 && unit < units.length - 1) {
+      value /= 1024;
+      unit++;
+    }
+    return `${value.toFixed(value < 10 ? 2 : 1)} ${units[unit]}`;
+  }
+
+  /**
+   * The "1,234 / 5,000 objects · 2.30 MiB" line, or '' when the backend has
+   * not reported any counts for this operation yet (a local operation, or a
+   * transfer the remote has not started).
+   */
+  private transferDetail(op: ProgressOperation): string {
+    const { receivedObjects, totalObjects, receivedBytes } = op;
+    if (receivedObjects === undefined) return '';
+    const objects =
+      totalObjects && totalObjects > 0
+        ? `${receivedObjects.toLocaleString()} / ${totalObjects.toLocaleString()} objects`
+        : `${receivedObjects.toLocaleString()} objects`;
+    return receivedBytes ? `${objects} · ${this.formatBytes(receivedBytes)}` : objects;
+  }
 
   private handleCancel(id: string): void {
     this.dispatchEvent(new CustomEvent('cancel-operation', {
@@ -218,8 +254,11 @@ export class LvProgressIndicator extends LitElement {
                   style="width: ${op.progress ?? 0}%"
                 ></div>
               </div>
-              ${op.progress !== undefined ? html`
-                <div class="progress-percentage">${Math.round(op.progress)}%</div>
+              ${op.progress !== undefined || this.transferDetail(op) ? html`
+                <div class="progress-percentage">
+                  ${op.progress !== undefined ? html`<span class="progress-percent-value">${Math.round(op.progress)}%</span>` : ''}
+                  ${this.transferDetail(op) ? html`<span class="progress-counts">${this.transferDetail(op)}</span>` : ''}
+                </div>
               ` : ''}
             </div>
             ${op.cancellable ? html`
@@ -227,6 +266,7 @@ export class LvProgressIndicator extends LitElement {
                 class="cancel-btn"
                 @click=${() => this.handleCancel(op.id)}
                 title="Cancel"
+                aria-label="Cancel ${op.type}"
               >
                 <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                   <line x1="18" y1="6" x2="6" y2="18"></line>

--- a/src/components/dashboard/__tests__/lv-context-dashboard-remote.test.ts
+++ b/src/components/dashboard/__tests__/lv-context-dashboard-remote.test.ts
@@ -172,4 +172,82 @@ describe('dashboard remote operations', () => {
     ).to.equal(false);
     expect(invoked.some((c) => c.command === 'fetch')).to.equal(false);
   });
+
+  // ── cancellation ─────────────────────────────────────────────────────────
+  //
+  // These are the most visible fetch/pull/push buttons in the app and they
+  // showed no progress row at all, so the whole cancellation flow was
+  // unreachable from them even once the backend supported it.
+
+  describe('cancellation', () => {
+    async function progress() {
+      return (await import('../../../services/progress.service.ts')).progressService;
+    }
+
+    for (const op of ['fetch', 'pull', 'push'] as const) {
+      const handler = `handle${op[0].toUpperCase()}${op.slice(1)}`;
+
+      it(`${op} shows a cancellable row and passes its id to the backend`, async () => {
+        const service = await progress();
+        const rows: Array<{ id: string; cancellable?: boolean }> = [];
+        const unsubscribe = service.subscribe((ops) => {
+          for (const o of ops) if (!rows.some((r) => r.id === o.id)) rows.push({ ...o });
+        });
+        try {
+          const el = await dashboard();
+          await (el as any)[handler]();
+
+          const call = invoked.find((c) => c.command === op);
+          expect(call, `${op} invoked`).to.not.be.undefined;
+          const operationId = (call!.args as { operationId?: string }).operationId;
+          expect(
+            rows.some((r) => r.id === operationId && r.cancellable === true),
+            `${op} must run under a cancellable row the backend can find`,
+          ).to.equal(true);
+        } finally {
+          unsubscribe();
+        }
+      });
+
+      it(`${op} removes its row when it finishes`, async () => {
+        const service = await progress();
+        const el = await dashboard();
+
+        await (el as any)[handler]();
+
+        expect(
+          service.getOperations().length,
+          `${op} must not leave a spinner behind`,
+        ).to.equal(0);
+      });
+
+      it(`a cancelled ${op} says so instead of showing a failure`, async () => {
+        failures.set(op, { code: 'OPERATION_CANCELLED', message: 'Operation cancelled' });
+        const el = await dashboard();
+        uiStore.setState({ toasts: [] });
+
+        await (el as any)[handler]();
+
+        expect(
+          uiStore.getState().toasts.some((t) => t.type === 'error'),
+          `a cancelled ${op} is not a red failure`,
+        ).to.equal(false);
+        expect(toastText()).to.match(/cancelled/i);
+      });
+
+      it(`a genuine ${op} failure is still reported as one`, async () => {
+        failures.set(op, { code: 'COMMAND_ERROR', message: 'remote hung up' });
+        const el = await dashboard();
+        uiStore.setState({ toasts: [] });
+
+        await (el as any)[handler]();
+
+        expect(toastText()).to.contain('remote hung up');
+        expect(
+          (await progress()).getOperations().length,
+          'the row is cleared on failure too',
+        ).to.equal(0);
+      });
+    }
+  });
 });

--- a/src/components/dashboard/lv-context-dashboard.ts
+++ b/src/components/dashboard/lv-context-dashboard.ts
@@ -12,7 +12,8 @@ import { sharedStyles, animationStyles } from '../../styles/shared-styles.ts';
 import { unifiedProfileStore, type AccountConnectionStatus, type ConnectionStatus } from '../../stores/unified-profile.store.ts';
 import { repositoryStore, type OpenRepository } from '../../stores/repository.store.ts';
 import * as unifiedProfileService from '../../services/unified-profile.service.ts';
-import { fetch as gitFetch, pull as gitPull, push as gitPush, getRemoteStatus, isNetworkGateRefusal } from '../../services/git.service.ts';
+import { fetch as gitFetch, pull as gitPull, push as gitPush, getRemoteStatus, isNetworkGateRefusal, isOperationCancelled } from '../../services/git.service.ts';
+import { progressService } from '../../services/progress.service.ts';
 import { showErrorWithSuggestion } from '../../services/error-suggestion.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import {
@@ -738,6 +739,12 @@ export class LvContextDashboard extends LitElement {
     // A security-gate block or a declined confirm already spoke for itself; a
     // red error on top tells the user their own settings failed.
     if (isNetworkGateRefusal(result.error)) return;
+    // Neither is a cancel the user asked for — but it must still be
+    // acknowledged, or the row simply vanishes with no explanation.
+    if (isOperationCancelled(result.error)) {
+      showToast(`${operation[0].toUpperCase()}${operation.slice(1)} cancelled`, 'info');
+      return;
+    }
     showErrorWithSuggestion(result.error?.message ?? '', fallback, {
       operation,
       repoPath,
@@ -756,11 +763,19 @@ export class LvContextDashboard extends LitElement {
     // is active when the network call returns.
     const repoPath = this.activeRepository.repository.path;
     this.isFetching = true;
+    // Cancellable, like every other fetch surface: the row's Cancel button
+    // sends this id back through `cancel_operation`, which is what lets the
+    // backend abort the transfer.
+    const opId = progressService.startOperation('fetch', 'Fetching from remote...', {
+      cancellable: true,
+    });
     try {
-      const result = await gitFetch({ path: repoPath, silent: true });
+      const result = await gitFetch({ path: repoPath, silent: true, operationId: opId });
       if (!result.success) {
+        progressService.failOperation(opId);
         this.reportRemoteFailure(result, 'fetch', 'Fetch failed', repoPath);
       } else {
+        progressService.completeOperation(opId);
         // Refresh repository data after fetch
         this.dispatchEvent(new CustomEvent('repository-refresh', {
           bubbles: true,
@@ -774,6 +789,9 @@ export class LvContextDashboard extends LitElement {
         await this.loadRemoteStatus();
       }
     } finally {
+      // Belt and braces: a throw between start and the branches above would
+      // otherwise leave the row spinning forever.
+      progressService.completeOperation(opId);
       this.isFetching = false;
     }
   }
@@ -791,8 +809,14 @@ export class LvContextDashboard extends LitElement {
     // discard does not produce.
     if (!tryAcquireRefOpOrWarn(repoPath)) return;
     this.isPulling = true;
+    // Cancellable only up to the point the merge starts — see
+    // commands/remote.rs::pull_branch.
+    const opId = progressService.startOperation('pull', 'Pulling from remote...', {
+      cancellable: true,
+    });
     try {
-      const result = await gitPull({ path: repoPath, silent: true });
+      const result = await gitPull({ path: repoPath, silent: true, operationId: opId });
+      progressService.completeOperation(opId);
       if (result.success) {
         this.dispatchEvent(new CustomEvent('repository-refresh', {
           bubbles: true,
@@ -831,6 +855,7 @@ export class LvContextDashboard extends LitElement {
         this.reportRemoteFailure(result, 'pull', 'Pull failed', repoPath);
       }
     } finally {
+      progressService.completeOperation(opId);
       this.isPulling = false;
       releaseRefOp(repoPath);
     }
@@ -853,8 +878,12 @@ export class LvContextDashboard extends LitElement {
     // authorising — and this button could not see a flag private to app-shell.
     if (!this.tryAcquirePushOrWarn(repoPath)) return;
     this.isPushing = true;
+    const opId = progressService.startOperation('push', 'Pushing to remote...', {
+      cancellable: true,
+    });
     try {
-      const result = await gitPush({ path: repoPath, silent: true });
+      const result = await gitPush({ path: repoPath, silent: true, operationId: opId });
+      progressService.completeOperation(opId);
       if (!result.success) {
         this.reportRemoteFailure(result, 'push', 'Push failed', repoPath);
       } else {
@@ -870,6 +899,7 @@ export class LvContextDashboard extends LitElement {
         await this.loadRemoteStatus();
       }
     } finally {
+      progressService.completeOperation(opId);
       this.isPushing = false;
       releasePush(repoPath);
     }

--- a/src/services/__tests__/progress.service.remote-events.test.ts
+++ b/src/services/__tests__/progress.service.remote-events.test.ts
@@ -114,6 +114,89 @@ describe('progress.service backend events', () => {
     progressService.completeOperation(repoB);
   });
 
+  // ---- operation-progress carries the real transfer counts ----
+  //
+  // Nothing in the backend used to emit this event at all, so every
+  // fetch/pull/push row showed an indeterminate stripe with no counts for as
+  // long as it ran.
+
+  it('updates the named row from an operation-progress event', () => {
+    const id = progressService.startOperation('fetch', 'Fetching from remote...', {
+      cancellable: true,
+    });
+
+    emit('operation-progress', {
+      operationId: id,
+      message: 'Fetching from origin',
+      progress: 42,
+      receivedObjects: 420,
+      totalObjects: 1000,
+      receivedBytes: 2048,
+    });
+
+    const [op] = progressService.getOperations();
+    expect(op.message).to.equal('Fetching from origin');
+    expect(op.progress).to.equal(42);
+    expect(op.receivedObjects).to.equal(420);
+    expect(op.totalObjects).to.equal(1000);
+    expect(op.receivedBytes).to.equal(2048);
+
+    progressService.completeOperation(id);
+  });
+
+  it('routes progress to the row it names and no other', () => {
+    const fetching = progressService.startOperation('fetch', 'Fetching...');
+    const pushing = progressService.startOperation('push', 'Pushing...');
+
+    emit('operation-progress', {
+      operationId: pushing,
+      progress: 10,
+      receivedObjects: 5,
+      totalObjects: 50,
+      receivedBytes: 100,
+    });
+
+    const rows = progressService.getOperations();
+    expect(rows.find((op) => op.id === fetching)?.receivedObjects).to.equal(undefined);
+    expect(rows.find((op) => op.id === pushing)?.receivedObjects).to.equal(5);
+
+    progressService.completeOperation(fetching);
+    progressService.completeOperation(pushing);
+  });
+
+  it('notifies subscribers so the indicator re-renders on progress', () => {
+    const id = progressService.startOperation('pull', 'Pulling...');
+    let seen = 0;
+    const unsubscribe = progressService.subscribe(() => {
+      seen++;
+    });
+    const afterSubscribe = seen;
+
+    emit('operation-progress', {
+      operationId: id,
+      progress: 5,
+      receivedObjects: 1,
+      totalObjects: 20,
+      receivedBytes: 64,
+    });
+
+    expect(seen).to.be.greaterThan(afterSubscribe);
+
+    unsubscribe();
+    progressService.completeOperation(id);
+  });
+
+  it('ignores progress for a row that has already gone', () => {
+    const id = progressService.startOperation('fetch', 'Fetching...');
+    progressService.completeOperation(id);
+
+    // A late event from a transfer that has already finished must not
+    // resurrect its row.
+    emit('operation-progress', { operationId: id, progress: 90 });
+
+    expect(progressService.getOperations()).to.have.length(0);
+  });
+
   it('still lets the caller that started a row remove it', () => {
     // The rows are owned by their callers (app-shell completes on success and
     // fails on error, on every branch), which is why nothing else needs to

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -270,6 +270,21 @@ export function isNetworkGateRefusal(error?: { code?: string }): boolean {
   return error?.code === 'BLOCKED' || error?.code === 'CANCELLED';
 }
 
+/**
+ * The user pressed Cancel on the operation's progress row and the backend
+ * really stopped the transfer.
+ *
+ * Not a failure, and deliberately NOT folded into `isNetworkGateRefusal`:
+ * that one means the operation never started and has already been announced,
+ * whereas this one has to say "Fetch cancelled" so the user knows the click
+ * they made took effect. A push that could not be stopped in time still
+ * reports its real success, because the backend only returns this code when it
+ * actually aborted.
+ */
+export function isOperationCancelled(error?: { code?: string }): boolean {
+  return error?.code === 'OPERATION_CANCELLED';
+}
+
 /** Set by the most recent refusal so `blockedResult` can label it. */
 let lastNetworkBlockReason: NetworkBlockReason = 'offline';
 

--- a/src/services/progress.service.ts
+++ b/src/services/progress.service.ts
@@ -16,6 +16,13 @@ export interface ProgressOperation {
   message: string;
   progress?: number; // 0-100, undefined = indeterminate
   cancellable?: boolean;
+  /** Objects transferred so far, from the backend's `operation-progress`
+   *  event. Undefined until the first event arrives. */
+  receivedObjects?: number;
+  /** Objects the remote said there are in total. */
+  totalObjects?: number;
+  /** Bytes transferred so far. */
+  receivedBytes?: number;
 }
 
 export type OperationType = ProgressOperation['type'];
@@ -26,6 +33,9 @@ interface ProgressEvent {
   progress?: number;
   completed?: boolean;
   error?: string;
+  receivedObjects?: number;
+  totalObjects?: number;
+  receivedBytes?: number;
 }
 
 type ProgressListener = (operations: ProgressOperation[]) => void;
@@ -56,7 +66,16 @@ class ProgressService {
   private async setupListeners(): Promise<void> {
     // Listen for progress events from Rust backend
     const unlistenProgress = await listen<ProgressEvent>('operation-progress', (event) => {
-      const { operationId, message, progress, completed, error } = event.payload;
+      const {
+        operationId,
+        message,
+        progress,
+        completed,
+        error,
+        receivedObjects,
+        totalObjects,
+        receivedBytes,
+      } = event.payload;
 
       if (completed || error) {
         this.removeOperation(operationId);
@@ -65,6 +84,12 @@ class ProgressService {
         if (existing) {
           existing.message = message ?? existing.message;
           existing.progress = progress;
+          // Kept on the row rather than folded into the message so the
+          // indicator can format them (and so a later event that carries no
+          // counts — there is none today — would not wipe the last ones).
+          existing.receivedObjects = receivedObjects ?? existing.receivedObjects;
+          existing.totalObjects = totalObjects ?? existing.totalObjects;
+          existing.receivedBytes = receivedBytes ?? existing.receivedBytes;
           this.notifyListeners();
         }
       }

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -187,6 +187,12 @@ export interface FetchCommand {
   /** Suppress the success event a user-initiated fetch emits. Set by the
    *  window-focus background fetch, which must not toast. */
   quiet?: boolean;
+  /** The progress row's id, from `progressService.startOperation`. Registers
+   *  the fetch with the backend cancellation registry so the row's Cancel
+   *  button can stop it, and addresses the `operation-progress` events it
+   *  emits back to that row. Omitted by unattended callers, which have no row
+   *  and must not be cancellable. */
+  operationId?: string;
 }
 
 export interface PullCommand {
@@ -196,6 +202,9 @@ export interface PullCommand {
   rebase?: boolean;
   token?: string;
   timeoutSecs?: number;
+  /** See `FetchCommand.operationId`. A pull can only be cancelled during its
+   *  fetch phase — once the merge or rebase starts it runs to completion. */
+  operationId?: string;
 }
 
 export interface PushCommand {
@@ -208,6 +217,8 @@ export interface PushCommand {
   setUpstream?: boolean;
   token?: string;
   timeoutSecs?: number;
+  /** See `FetchCommand.operationId`. */
+  operationId?: string;
 }
 
 export interface PushToMultipleRemotesCommand {


### PR DESCRIPTION
## Summary

- **Cancel actually works now.** Fetch, pull and push register their operation id with `CancellationRegistry` and check the token inside the git2 callbacks, so the progress row's Cancel button stops the transfer instead of doing nothing. Force push (the git-CLI path) is spawned and polled so its child process can be killed.
- **The Cancel button is reachable.** Every fetch/pull/push/force-push call site now starts a `{cancellable: true}` progress row and passes its id to the backend. The dashboard's Fetch/Pull/Push buttons — the most visible surface — had no progress row at all and now get one.
- **Rows show real numbers.** The backend emits `operation-progress` with received/total objects and bytes from the same callbacks, throttled to one event per whole percent (the way `clone_repository` already does), and the row renders e.g. `1,234 / 5,000 objects · 2.30 MiB`.
- **A cancel reads as a cancel.** A cancelled operation reports "Fetch/Pull/Push cancelled" as an info toast; a genuine failure still shows its error with its existing recovery action, and a push that could not be stopped in time still reports the success it really had. The per-repo lock is released on every path.
- **A cancelled pull cannot leave a half-merged tree.** The fetch phase is the only cancellation point: stopping there leaves exactly what a plain Fetch leaves (remote-tracking refs and FETCH_HEAD), and the merge/rebase is deliberately not interruptible. Documented in `pull_branch` and covered by a test.

## Review finding

`src-tauri/src/commands/remote.rs` — the `fetch`, `pull` and `push` commands accepted an `_operation_id: Option<String>` and never registered it with `CancellationRegistry` (imported but used only by `cancel_operation`), so `cancel_operation` always returned `false`. `src/services/progress.service.ts::startOperation` defaults `cancellable` to false and no call site passed `{cancellable: true}` (`src/app-shell.ts` fetch/pull/push/force-push), so the Cancel button in `src/components/common/lv-progress-indicator.ts` was unreachable dead code. No backend code emitted the `operation-progress` event the progress service listens for, so those rows showed an indeterminate stripe with no counts for the whole transfer. Clone already did all three correctly; this follows that proven pattern — the cancel flag checked inside the git2 `transfer_progress` callback, percent-throttled event emission — factored into `src-tauri/src/services/transfer_monitor.rs` so all four share one implementation.

Additionally, `src/components/dashboard/lv-context-dashboard.ts` — the app's most visible Fetch/Pull/Push buttons — created no progress operation at all, so without touching it the whole flow would still have been unreachable from the main UI.

## Known limitations (deliberate, documented in code)

- git2's `push_transfer_progress` binding always returns 0 to libgit2, so it cannot abort a push. The push cancellation point is `push_negotiation`, which runs before any object is packed or sent; a cancel arriving after that is best-effort, and the command only returns `OperationCancelled` when it really aborted — so the UI never claims a cancel that did not happen.
- The git-CLI force-push path is killable throughout but reports no object counts (its progress is unparsed stderr), so that row stays indeterminate.
- A real cancelled network transfer is not reproducible offline, so the Rust tests pin down everything around it that is deterministic: pre-cancelled fetch/push/CLI-push never reach the network, the abort-flag → `OperationCancelled` mapping, the registry emptying afterwards, and a cancelled pull leaving HEAD, the working tree and the repository state untouched.

## Test plan

- [ ] `npm run lint` — 204 warnings, 0 errors (unchanged baseline)
- [ ] `npm run typecheck` — clean
- [ ] `npm test` — 5379 passed; the only 2 failures are the pre-existing "network gate coverage" timeouts, which fail identically on a stashed working tree
- [ ] `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test --lib` — 2549 passed, 0 failed
- [ ] `npx playwright test e2e/tests/remote-operations.spec.ts` — 50 passed (4 new: a running fetch shows a cancellable row, Cancel invokes `cancel_operation` with that row's id and dismisses the row, push is cancellable too, and the row renders the counts from an emitted `operation-progress`)
- [ ] Manual: start a fetch against a slow remote, confirm the row shows object/byte counts and that Cancel stops it with a "Fetch cancelled" info toast, then confirm a retry is not refused by a stale lock

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_