### PR TITLE
feat: follow OS high contrast for the graph colour scheme

### DIFF
--- a/e2e/tests/forced-colors.spec.ts
+++ b/e2e/tests/forced-colors.spec.ts
@@ -1,0 +1,97 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupOpenRepository } from '../fixtures/tauri-mock';
+
+// =========================================================================
+// Forced colors / high contrast
+//
+// The commit graph is painted into a <canvas>, so Windows High Contrast Mode
+// cannot recolor it — the app has to pick the high-contrast palette itself.
+// It does that automatically while the user has not pinned a scheme, and stops
+// the moment they choose one in Settings.
+// =========================================================================
+
+/** The scheme the store applied, as the graph renderer reads it. */
+function appliedScheme(page: Page): Promise<string | null> {
+  return page.evaluate(() => document.documentElement.getAttribute('data-graph-scheme'));
+}
+
+function storedScheme(page: Page): Promise<{ scheme: string; auto: boolean }> {
+  return page.evaluate(() => {
+    const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as {
+      settingsStore: {
+        getState: () => { graphColorScheme: string; graphColorSchemeAuto: boolean };
+      };
+    };
+    const state = stores.settingsStore.getState();
+    return { scheme: state.graphColorScheme, auto: state.graphColorSchemeAuto };
+  });
+}
+
+async function openSettings(page: Page): Promise<void> {
+  await page.keyboard.press('Meta+,');
+  await expect(page.locator('lv-settings-dialog')).toBeVisible();
+}
+
+function schemeSelect(page: Page) {
+  return page.locator('lv-settings-dialog select[aria-label="Graph color scheme"]');
+}
+
+function autoNote(page: Page) {
+  return page.locator('lv-settings-dialog [data-testid="graph-scheme-auto-note"]');
+}
+
+test.describe('Forced colors', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+  });
+
+  test('switches the graph to the high-contrast palette when forced colors turn on', async ({
+    page,
+  }) => {
+    expect(await appliedScheme(page)).toBe('default');
+
+    await page.emulateMedia({ forcedColors: 'active' });
+
+    await expect.poll(() => appliedScheme(page)).toBe('high-contrast');
+    expect(await storedScheme(page)).toEqual({ scheme: 'high-contrast', auto: true });
+  });
+
+  test('reverts to the default palette when forced colors turn off again', async ({ page }) => {
+    await page.emulateMedia({ forcedColors: 'active' });
+    await expect.poll(() => appliedScheme(page)).toBe('high-contrast');
+
+    await page.emulateMedia({ forcedColors: 'none' });
+
+    await expect.poll(() => appliedScheme(page)).toBe('default');
+    expect(await storedScheme(page)).toEqual({ scheme: 'default', auto: true });
+  });
+
+  test('Settings says the scheme is automatic, and picking one pins it', async ({ page }) => {
+    await page.emulateMedia({ forcedColors: 'active' });
+    await expect.poll(() => appliedScheme(page)).toBe('high-contrast');
+
+    await openSettings(page);
+    await expect(autoNote(page)).toHaveText('Auto (high contrast)');
+    await expect(schemeSelect(page)).toHaveValue('high-contrast');
+
+    await schemeSelect(page).selectOption('pastel');
+
+    await expect(autoNote(page)).toHaveCount(0);
+    await expect.poll(() => appliedScheme(page)).toBe('pastel');
+    expect(await storedScheme(page)).toEqual({ scheme: 'pastel', auto: false });
+
+    // A pinned choice survives the OS setting changing underneath it.
+    await page.emulateMedia({ forcedColors: 'none' });
+    await page.emulateMedia({ forcedColors: 'active' });
+
+    await expect(schemeSelect(page)).toHaveValue('pastel');
+    expect(await appliedScheme(page)).toBe('pastel');
+  });
+
+  test('shows no automatic note while the OS is not forcing colors', async ({ page }) => {
+    await openSettings(page);
+
+    await expect(schemeSelect(page)).toHaveValue('default');
+    await expect(autoNote(page)).toHaveCount(0);
+  });
+});

--- a/src/components/dialogs/__tests__/lv-settings-dialog-contrast.test.ts
+++ b/src/components/dialogs/__tests__/lv-settings-dialog-contrast.test.ts
@@ -1,0 +1,172 @@
+/**
+ * Settings Dialog — automatic high-contrast graph scheme
+ *
+ * The commit graph is painted into a <canvas>, so the OS cannot recolor it.
+ * When forced-colors / prefers-contrast is on, the store auto-selects the
+ * high-contrast palette; the Settings row has to say so, and picking a scheme
+ * by hand has to pin it and stop the automatic behaviour.
+ */
+
+import { expect, fixture, html } from '@open-wc/testing';
+
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+const mockInvoke: MockInvoke = async (command: string) => {
+  if (command === 'plugin:notification|is_permission_granted') return false;
+
+  switch (command) {
+    case 'get_ai_providers':
+      return [];
+    case 'get_app_version':
+      return '0.1.0';
+    case 'get_settings':
+      return {};
+    case 'get_system_capabilities':
+      return { hasGpu: false, gpuName: null, totalRam: 8 };
+    case 'get_downloaded_models':
+    case 'get_available_models':
+    case 'get_available_diff_tools':
+    case 'get_available_merge_tools':
+    case 'list_diff_tools':
+      return [];
+    case 'get_local_model_status':
+      return { loaded: false, modelId: null };
+    case 'get_mcp_status':
+      return { servers: [], totalTools: 0 };
+    case 'get_merge_tool_config':
+      return { toolName: null, toolCmd: null };
+    case 'get_diff_tool':
+      return { tool: null, cmd: null, prompt: false };
+    default:
+      return null;
+  }
+};
+
+let nextCallbackId = 1;
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: mockInvoke,
+  // The dialog subscribes to model-download events on connect; without this the
+  // Tauri event shim throws outside the test.
+  transformCallback: () => nextCallbackId++,
+};
+
+(globalThis as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+  unregisterListener: () => {},
+};
+
+// Import AFTER setting up the mock
+import '../lv-settings-dialog.ts';
+import type { LvSettingsDialog } from '../lv-settings-dialog.ts';
+import { settingsStore } from '../../../stores/settings.store.ts';
+
+describe('lv-settings-dialog graph color scheme under forced colors', () => {
+  let el: LvSettingsDialog;
+
+  const noteEl = (): Element | null =>
+    el.shadowRoot?.querySelector('[data-testid="graph-scheme-auto-note"]') ?? null;
+
+  const schemeSelect = (): HTMLSelectElement => {
+    const select = el.shadowRoot?.querySelector<HTMLSelectElement>(
+      'select[aria-label="Graph color scheme"]'
+    );
+    if (!select) throw new Error('graph color scheme select not found');
+    return select;
+  };
+
+  beforeEach(async () => {
+    settingsStore.getState().resetToDefaults();
+    settingsStore.getState().applySystemContrast(false);
+    el = await fixture<LvSettingsDialog>(html`<lv-settings-dialog></lv-settings-dialog>`);
+    await el.updateComplete;
+  });
+
+  afterEach(() => {
+    settingsStore.getState().resetToDefaults();
+    settingsStore.getState().applySystemContrast(false);
+  });
+
+  it('shows no auto note while the OS is not asking for high contrast', () => {
+    expect(noteEl()).to.be.null;
+    expect(schemeSelect().value).to.equal('default');
+  });
+
+  it('says the scheme is automatic when the OS is in high contrast', async () => {
+    settingsStore.getState().applySystemContrast(true);
+    await el.updateComplete;
+
+    expect(noteEl(), 'the row explains why the palette changed').to.not.be.null;
+    expect(noteEl()?.textContent?.trim()).to.equal('Auto (high contrast)');
+    expect(schemeSelect().value).to.equal('high-contrast');
+    expect(
+      el.shadowRoot?.textContent,
+      'the description explains the canvas cannot be recolored by the OS'
+    ).to.contain('Following your system high contrast setting');
+  });
+
+  it('picking a scheme by hand pins it and drops the auto note', async () => {
+    settingsStore.getState().applySystemContrast(true);
+    await el.updateComplete;
+    expect(noteEl()).to.not.be.null;
+
+    const select = schemeSelect();
+    select.value = 'pastel';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await el.updateComplete;
+
+    expect(settingsStore.getState().graphColorScheme).to.equal('pastel');
+    expect(settingsStore.getState().graphColorSchemeAuto, 'the choice is pinned').to.be.false;
+    expect(noteEl(), 'no longer automatic').to.be.null;
+  });
+
+  it('keeps the pinned choice when the OS contrast setting changes again', async () => {
+    const select = schemeSelect();
+    select.value = 'vibrant';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await el.updateComplete;
+
+    settingsStore.getState().applySystemContrast(true);
+    await el.updateComplete;
+
+    expect(settingsStore.getState().graphColorScheme).to.equal('vibrant');
+    expect(schemeSelect().value).to.equal('vibrant');
+    expect(noteEl()).to.be.null;
+  });
+
+  it('reverts to the default scheme when the OS setting turns off', async () => {
+    settingsStore.getState().applySystemContrast(true);
+    await el.updateComplete;
+    expect(schemeSelect().value).to.equal('high-contrast');
+
+    settingsStore.getState().applySystemContrast(false);
+    await el.updateComplete;
+
+    expect(schemeSelect().value).to.equal('default');
+    expect(noteEl()).to.be.null;
+  });
+
+  it('dispatches settings-changed when the scheme is changed by hand', async () => {
+    let fired = false;
+    window.addEventListener('settings-changed', () => { fired = true; }, { once: true });
+
+    const select = schemeSelect();
+    select.value = 'monochrome';
+    select.dispatchEvent(new Event('change', { bubbles: true }));
+    await el.updateComplete;
+
+    expect(fired).to.be.true;
+  });
+
+  it('stops mirroring the store once the dialog is disconnected', async () => {
+    el.remove();
+    await el.updateComplete;
+
+    settingsStore.getState().applySystemContrast(true);
+
+    expect(
+      (el as unknown as { graphColorSchemeAuto: boolean; systemHighContrast: boolean })
+        .systemHighContrast,
+      'the subscription is torn down with the dialog'
+    ).to.be.false;
+  });
+});

--- a/src/components/dialogs/lv-settings-dialog.ts
+++ b/src/components/dialogs/lv-settings-dialog.ts
@@ -289,6 +289,32 @@ export class LvSettingsDialog extends LitElement {
         border-radius: 2px;
       }
 
+      .auto-scheme-note {
+        display: inline-flex;
+        align-items: center;
+        gap: 4px;
+        padding: 1px 6px;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm, 4px);
+        font-size: 11px;
+        color: var(--color-text-secondary);
+        white-space: nowrap;
+      }
+
+      /* Forced colors would flatten every swatch to the same system color,
+         turning the palette preview into a row of identical squares. These
+         squares ARE the information, so opt them out and outline them. */
+      @media (forced-colors: active) {
+        .color-swatch {
+          forced-color-adjust: none;
+          border: 1px solid CanvasText;
+        }
+
+        .auto-scheme-note {
+          border-color: CanvasText;
+        }
+      }
+
       .scheme-option {
         display: flex;
         align-items: center;
@@ -322,6 +348,8 @@ export class LvSettingsDialog extends LitElement {
   @state() private fontSize: FontSize = 'medium';
   @state() private density: Density = 'comfortable';
   @state() private graphColorScheme: GraphColorScheme = 'default';
+  @state() private graphColorSchemeAuto = true;
+  @state() private systemHighContrast = false;
   @state() private defaultBranchName = 'main';
   @state() private defaultClonePath = '';
   @state() private showAvatars = true;
@@ -393,9 +421,18 @@ export class LvSettingsDialog extends LitElement {
   private mergeToolWriteToken = 0;
   private diffToolWriteToken = 0;
 
+  private settingsUnsubscribe: (() => void) | null = null;
+
   connectedCallback(): void {
     super.connectedCallback();
     this.loadSettings();
+    // The graph colour scheme can change underneath an open dialog when the OS
+    // high-contrast setting flips, so mirror it from the store.
+    this.settingsUnsubscribe = settingsStore.subscribe((state) => {
+      this.graphColorScheme = state.graphColorScheme;
+      this.graphColorSchemeAuto = state.graphColorSchemeAuto;
+      this.systemHighContrast = state.systemHighContrast;
+    });
     this.loadVersion();
     this.loadAiProviders();
     this.loadExternalToolsConfig();
@@ -406,6 +443,8 @@ export class LvSettingsDialog extends LitElement {
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    this.settingsUnsubscribe?.();
+    this.settingsUnsubscribe = null;
     this.downloadProgressUnlisten?.();
     this.downloadCompleteUnlisten?.();
     this.downloadErrorUnlisten?.();
@@ -418,6 +457,10 @@ export class LvSettingsDialog extends LitElement {
     // selects once their options exist.
     this.syncSelectValue('#merge-tool-select', this.mergeToolName);
     this.syncSelectValue('#diff-tool-select', this.diffToolName);
+    // Same hazard: the graph scheme select and its options render in one
+    // update, and the automatic high-contrast scheme is a value that is only
+    // ever set before the options exist.
+    this.syncSelectValue('#graph-scheme-select', this.graphColorScheme);
   }
 
   private syncSelectValue(selector: string, value: string | null): void {
@@ -520,6 +563,8 @@ export class LvSettingsDialog extends LitElement {
     this.fontSize = settings.fontSize;
     this.density = settings.density;
     this.graphColorScheme = settings.graphColorScheme;
+    this.graphColorSchemeAuto = settings.graphColorSchemeAuto;
+    this.systemHighContrast = settings.systemHighContrast;
     this.defaultBranchName = settings.defaultBranchName;
     this.defaultClonePath = settings.defaultClonePath;
     this.showAvatars = settings.showAvatars;
@@ -562,7 +607,10 @@ export class LvSettingsDialog extends LitElement {
   private handleGraphColorSchemeChange(e: Event): void {
     const select = e.target as HTMLSelectElement;
     this.graphColorScheme = select.value as GraphColorScheme;
+    // Picking a scheme by hand pins it — the OS high-contrast watcher stops
+    // overriding it from here on.
     settingsStore.getState().setGraphColorScheme(this.graphColorScheme);
+    this.graphColorSchemeAuto = settingsStore.getState().graphColorSchemeAuto;
     window.dispatchEvent(new CustomEvent('settings-changed'));
   }
 
@@ -1274,10 +1322,22 @@ export class LvSettingsDialog extends LitElement {
           <div class="setting-row">
             <div class="setting-label">
               <span class="setting-name">Graph Color Scheme</span>
-              <span class="setting-description">Color palette for branch lanes</span>
+              <span class="setting-description">
+                ${this.graphColorSchemeAuto && this.systemHighContrast
+                  ? 'Following your system high contrast setting — the graph is drawn on a canvas, so it cannot be recolored by the OS. Choose a scheme to override.'
+                  : 'Color palette for branch lanes'}
+              </span>
             </div>
             <div style="display: flex; align-items: center; gap: 8px;">
-              <select .value=${this.graphColorScheme} @change=${this.handleGraphColorSchemeChange}>
+              ${this.graphColorSchemeAuto && this.systemHighContrast
+                ? html`<span class="auto-scheme-note" data-testid="graph-scheme-auto-note">Auto (high contrast)</span>`
+                : ''}
+              <select
+                id="graph-scheme-select"
+                aria-label="Graph color scheme"
+                .value=${this.graphColorScheme}
+                @change=${this.handleGraphColorSchemeChange}
+              >
                 ${getGraphColorSchemes().map(scheme => html`
                   <option value=${scheme.id}>${scheme.name}</option>
                 `)}

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -491,6 +491,52 @@ export class LvGraphCanvas extends LitElement {
         background: var(--color-primary);
         opacity: 0.5;
       }
+
+      /* ===========================================================
+         Forced colors (Windows High Contrast Mode)
+         The graph itself is canvas pixels the OS cannot recolor —
+         that is handled by auto-selecting the high-contrast palette
+         in settings.store.ts. This block only keeps the DOM chrome
+         around the canvas usable: focus rings and the states that
+         are otherwise shown by a custom background alone.
+         =========================================================== */
+      @media (forced-colors: active) {
+        canvas:focus,
+        canvas:focus-visible {
+          outline: 3px solid Highlight;
+          outline-offset: -3px;
+        }
+
+        .toolbar-btn:focus-visible,
+        .export-menu-item:focus-visible,
+        .branch-item:focus-within {
+          outline: 2px solid Highlight;
+          outline-offset: -2px;
+        }
+
+        .toolbar-btn.active,
+        .toolbar-btn:hover,
+        .branch-item:hover,
+        .export-menu-item:hover,
+        .branch-panel-actions button:hover {
+          background: Highlight;
+          color: HighlightText;
+        }
+
+        /* The minimap is a canvas overlay: forced colors leaves its pixels
+           alone, so give it a real edge and full opacity instead of the
+           translucent seam that disappears against a forced background. */
+        .minimap-canvas {
+          opacity: 1;
+          border-left: 1px solid CanvasText;
+        }
+
+        .resize-handle:hover,
+        .resize-handle.dragging {
+          background: Highlight;
+          opacity: 1;
+        }
+      }
     `,
   ];
 
@@ -972,7 +1018,11 @@ export class LvGraphCanvas extends LitElement {
       this.scheduleRender();
     });
 
-    // Listen for theme changes via data-theme attribute
+    // Listen for theme changes via data-theme attribute, and for graph colour
+    // scheme changes via data-graph-scheme — the lane colours live in CSS
+    // variables the canvas only re-reads through setTheme(), so without this
+    // the palette (including the automatic high-contrast switch) would not
+    // reach the already-painted graph.
     this.themeObserver = new MutationObserver(() => {
       this.renderer?.setTheme(getThemeFromCSS());
       this.rebuildMinimapDots();
@@ -980,7 +1030,7 @@ export class LvGraphCanvas extends LitElement {
     });
     this.themeObserver.observe(document.documentElement, {
       attributes: true,
-      attributeFilter: ['data-theme'],
+      attributeFilter: ['data-theme', 'data-graph-scheme'],
     });
 
     // Also listen for system theme changes

--- a/src/stores/__tests__/settings.store.test.ts
+++ b/src/stores/__tests__/settings.store.test.ts
@@ -1,5 +1,11 @@
 import { expect } from '@open-wc/testing';
-import { settingsStore, getGraphColorSchemes } from '../settings.store.ts';
+import {
+  settingsStore,
+  getGraphColorSchemes,
+  migrateSettings,
+  watchSystemContrast,
+} from '../settings.store.ts';
+import type { SettingsState } from '../settings.store.ts';
 
 describe('settings.store', () => {
   beforeEach(() => {
@@ -467,6 +473,189 @@ describe('settings.store', () => {
       rehydrate();
 
       expect(settingsStore.getState().wordWrap, 'a real setting is not clobbered').to.be.true;
+    });
+  });
+
+  describe('system high contrast (forced colors)', () => {
+    afterEach(() => {
+      // Leave the store the way the real environment reports it.
+      settingsStore.getState().resetToDefaults();
+      settingsStore.getState().applySystemContrast(false);
+    });
+
+    it('auto-selects the high-contrast palette when the OS asks for it', () => {
+      settingsStore.getState().applySystemContrast(true);
+
+      expect(settingsStore.getState().graphColorScheme).to.equal('high-contrast');
+      expect(settingsStore.getState().systemHighContrast).to.be.true;
+      expect(settingsStore.getState().graphColorSchemeAuto, 'still automatic').to.be.true;
+      expect(document.documentElement.getAttribute('data-graph-scheme')).to.equal('high-contrast');
+    });
+
+    it('reverts to the default palette when the OS setting turns off again', () => {
+      settingsStore.getState().applySystemContrast(true);
+      settingsStore.getState().applySystemContrast(false);
+
+      expect(settingsStore.getState().graphColorScheme).to.equal('default');
+      expect(settingsStore.getState().systemHighContrast).to.be.false;
+      expect(document.documentElement.getAttribute('data-graph-scheme')).to.equal('default');
+    });
+
+    it('a scheme picked by the user pins it and survives a contrast change', () => {
+      settingsStore.getState().setGraphColorScheme('vibrant');
+      expect(settingsStore.getState().graphColorSchemeAuto, 'picking pins the choice').to.be.false;
+
+      settingsStore.getState().applySystemContrast(true);
+
+      expect(settingsStore.getState().graphColorScheme, 'the choice wins').to.equal('vibrant');
+      expect(settingsStore.getState().systemHighContrast, 'but the OS state is tracked').to.be.true;
+
+      settingsStore.getState().applySystemContrast(false);
+      expect(settingsStore.getState().graphColorScheme).to.equal('vibrant');
+    });
+
+    it('keeps following the OS again after a reset to defaults', () => {
+      settingsStore.getState().setGraphColorScheme('pastel');
+      settingsStore.getState().applySystemContrast(true);
+      expect(settingsStore.getState().graphColorScheme).to.equal('pastel');
+
+      settingsStore.getState().resetToDefaults();
+
+      expect(settingsStore.getState().graphColorSchemeAuto).to.be.true;
+      expect(settingsStore.getState().graphColorScheme, 'reset re-reads the OS').to.equal(
+        'high-contrast'
+      );
+    });
+
+    describe('watchSystemContrast', () => {
+      interface FakeQuery {
+        media: string;
+        matches: boolean;
+        listeners: Set<() => void>;
+        addEventListener: (type: string, fn: () => void) => void;
+        removeEventListener: (type: string, fn: () => void) => void;
+      }
+
+      let originalMatchMedia: typeof window.matchMedia;
+      let queries: Map<string, FakeQuery>;
+
+      const makeQuery = (media: string): FakeQuery => ({
+        media,
+        matches: false,
+        listeners: new Set<() => void>(),
+        addEventListener(_type, fn) {
+          this.listeners.add(fn);
+        },
+        removeEventListener(_type, fn) {
+          this.listeners.delete(fn);
+        },
+      });
+
+      const fire = (media: string, matches: boolean): void => {
+        const q = queries.get(media);
+        if (!q) throw new Error(`no query registered for ${media}`);
+        q.matches = matches;
+        q.listeners.forEach((fn) => fn());
+      };
+
+      beforeEach(() => {
+        originalMatchMedia = window.matchMedia;
+        queries = new Map();
+        window.matchMedia = ((media: string) => {
+          let q = queries.get(media);
+          if (!q) {
+            q = makeQuery(media);
+            queries.set(media, q);
+          }
+          return q as unknown as MediaQueryList;
+        }) as typeof window.matchMedia;
+      });
+
+      afterEach(() => {
+        window.matchMedia = originalMatchMedia;
+      });
+
+      it('watches both forced-colors and prefers-contrast', () => {
+        const stop = watchSystemContrast();
+
+        expect([...queries.keys()]).to.have.members([
+          '(forced-colors: active)',
+          '(prefers-contrast: more)',
+        ]);
+
+        stop();
+      });
+
+      it('applies the palette on either query matching, and on later changes', () => {
+        const stop = watchSystemContrast();
+        expect(settingsStore.getState().graphColorScheme).to.equal('default');
+
+        fire('(prefers-contrast: more)', true);
+        expect(settingsStore.getState().graphColorScheme).to.equal('high-contrast');
+
+        fire('(prefers-contrast: more)', false);
+        expect(settingsStore.getState().graphColorScheme).to.equal('default');
+
+        fire('(forced-colors: active)', true);
+        expect(settingsStore.getState().graphColorScheme).to.equal('high-contrast');
+
+        stop();
+      });
+
+      it('applies immediately when the OS is already in high contrast at startup', () => {
+        queries.set('(forced-colors: active)', {
+          ...makeQuery('(forced-colors: active)'),
+          matches: true,
+        });
+
+        const stop = watchSystemContrast();
+
+        expect(settingsStore.getState().graphColorScheme).to.equal('high-contrast');
+        stop();
+      });
+
+      it('stops listening once disposed', () => {
+        const stop = watchSystemContrast();
+        stop();
+
+        fire('(forced-colors: active)', true);
+
+        expect(settingsStore.getState().graphColorScheme).to.equal('default');
+      });
+    });
+  });
+
+  describe('migrateSettings', () => {
+    it('leaves existing users who never picked a scheme on automatic', () => {
+      const migrated = migrateSettings(
+        { graphColorScheme: 'default', theme: 'light' } as Partial<SettingsState>,
+        3
+      );
+
+      expect(migrated.graphColorSchemeAuto).to.be.true;
+      expect(migrated.theme, 'unrelated settings are untouched').to.equal('light');
+    });
+
+    it('treats a stored non-default scheme as a deliberate choice and pins it', () => {
+      const migrated = migrateSettings({ graphColorScheme: 'pastel' } as Partial<SettingsState>, 3);
+
+      expect(migrated.graphColorSchemeAuto).to.be.false;
+      expect(migrated.graphColorScheme).to.equal('pastel');
+    });
+
+    it('treats a state with no stored scheme at all as automatic', () => {
+      const migrated = migrateSettings({}, 1);
+
+      expect(migrated.graphColorSchemeAuto).to.be.true;
+    });
+
+    it('does not re-run the rule for state already at the current version', () => {
+      const migrated = migrateSettings(
+        { graphColorScheme: 'default', graphColorSchemeAuto: false } as Partial<SettingsState>,
+        4
+      );
+
+      expect(migrated.graphColorSchemeAuto, 'a pinned default stays pinned').to.be.false;
     });
   });
 });

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -28,6 +28,14 @@ export interface SettingsState {
   showCommitSize: boolean;
   graphRowHeight: number;
   graphColorScheme: GraphColorScheme;
+  // False once the user picks a scheme themselves. While true the scheme
+  // follows the OS: high contrast / forced colours select the high-contrast
+  // palette, and turning them off puts it back to the default palette.
+  graphColorSchemeAuto: boolean;
+  // Whether the OS currently reports forced colours or a preference for more
+  // contrast. Derived from matchMedia at startup and on every change, never a
+  // user setting.
+  systemHighContrast: boolean;
 
   // Diff settings
   diffContextLines: number;
@@ -62,6 +70,7 @@ export interface SettingsState {
   setFontFamily: (family: string) => void;
   setDensity: (density: Density) => void;
   setGraphColorScheme: (scheme: GraphColorScheme) => void;
+  applySystemContrast: (highContrast: boolean) => void;
   setDefaultBranchName: (name: string) => void;
   setDefaultRemoteName: (name: string) => void;
   setDefaultClonePath: (path: string) => void;
@@ -98,6 +107,7 @@ const defaultSettings = {
   showCommitSize: true,
   graphRowHeight: 40,
   graphColorScheme: 'default' as GraphColorScheme,
+  graphColorSchemeAuto: true,
   diffContextLines: 3,
   // Defaults OFF: until it was wired up nothing read this, and the diff view's
   // own copy — the only word wrap anyone has ever seen — defaulted to off.
@@ -140,10 +150,36 @@ function adoptLegacyDiffWordWrap(state: SettingsState): void {
   state.setWordWrap(legacy === 'true');
 }
 
+/**
+ * Persisted-state migration. Exported so the version-to-version rules can be
+ * tested directly instead of through localStorage.
+ */
+export function migrateSettings(persisted: unknown, fromVersion: number): SettingsState {
+  const state = { ...((persisted ?? {}) as Partial<SettingsState>) };
+  if (fromVersion < 2) {
+    state.autoStashOnCheckout = true;
+  }
+  if (fromVersion < 3) {
+    state.wordWrap = false;
+  }
+  if (fromVersion < 4) {
+    // The whole settings object is persisted the moment anything at all
+    // changes, so the presence of `graphColorScheme` says nothing about whether
+    // the user chose it. A value other than the default is the only evidence of
+    // a deliberate choice: pin those, and leave everyone else — including every
+    // user who never touched the setting — on the new automatic behaviour.
+    state.graphColorSchemeAuto = (state.graphColorScheme ?? 'default') === 'default';
+  }
+  return state as SettingsState;
+}
+
 export const settingsStore = createStore<SettingsState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       ...defaultSettings,
+      // Re-derived from matchMedia on every startup, so whatever was persisted
+      // for it is irrelevant.
+      systemHighContrast: false,
 
       setTheme: (theme) => {
         set({ theme });
@@ -162,9 +198,26 @@ export const settingsStore = createStore<SettingsState>()(
         applyDensity(density);
       },
 
+      // Choosing a scheme in Settings pins it: the OS high-contrast watcher
+      // must never overwrite a deliberate choice.
       setGraphColorScheme: (graphColorScheme) => {
-        set({ graphColorScheme });
+        set({ graphColorScheme, graphColorSchemeAuto: false });
         applyGraphColorScheme(graphColorScheme);
+      },
+
+      applySystemContrast: (systemHighContrast) => {
+        set({ systemHighContrast });
+        const state = get();
+        if (!state.graphColorSchemeAuto) return;
+        const next: GraphColorScheme = systemHighContrast
+          ? 'high-contrast'
+          : defaultSettings.graphColorScheme;
+        if (next !== state.graphColorScheme) {
+          set({ graphColorScheme: next });
+        }
+        // Applied even when the scheme is unchanged: this also runs at startup,
+        // where the palette variables have not been written to the document yet.
+        applyGraphColorScheme(next);
       },
 
       setDefaultBranchName: (defaultBranchName) => set({ defaultBranchName }),
@@ -208,16 +261,20 @@ export const settingsStore = createStore<SettingsState>()(
       setShowNativeNotifications: (showNativeNotifications) => set({ showNativeNotifications }),
 
       resetToDefaults: () => {
-        set(defaultSettings);
+        // The OS contrast reading is not a preference, so a reset re-reads it
+        // rather than clearing it — and re-applies the auto scheme from it.
+        const { systemHighContrast } = get();
+        set({ ...defaultSettings, systemHighContrast });
         applyTheme(defaultSettings.theme);
         applyFontSize(defaultSettings.fontSize);
         applyDensity(defaultSettings.density);
         applyGraphColorScheme(defaultSettings.graphColorScheme);
+        get().applySystemContrast(systemHighContrast);
       },
     }),
     {
       name: 'leviathan-settings',
-      version: 3,
+      version: 4,
       // Changing a default only affects installs with no persisted state.
       // zustand's default merge is a shallow `{...defaults, ...persisted}`, and
       // the whole settings object is persisted the moment the user changes
@@ -228,16 +285,7 @@ export const settingsStore = createStore<SettingsState>()(
       // has only ever experienced auto-stashing. `wordWrap` has exactly the same
       // story: it was persisted but never read, so a persisted value is not a
       // user choice either and is dropped in favour of the diff view's own key.
-      migrate: (persisted: unknown, fromVersion: number) => {
-        const state = { ...((persisted ?? {}) as Partial<SettingsState>) };
-        if (fromVersion < 2) {
-          state.autoStashOnCheckout = true;
-        }
-        if (fromVersion < 3) {
-          state.wordWrap = false;
-        }
-        return state as SettingsState;
-      },
+      migrate: migrateSettings,
       onRehydrateStorage: () => (state) => {
         if (state) {
           applyTheme(state.theme);
@@ -362,6 +410,34 @@ export function getGraphColorSchemes(): { id: GraphColorScheme; name: string; co
   ];
 }
 
+/**
+ * The queries that mean "this user needs maximum contrast". Forced colours is
+ * Windows High Contrast Mode; prefers-contrast covers the equivalent settings
+ * on macOS/Linux and browser-level increased-contrast preferences.
+ */
+const HIGH_CONTRAST_QUERIES = ['(forced-colors: active)', '(prefers-contrast: more)'];
+
+/**
+ * Follow the OS contrast setting for the graph colour scheme.
+ *
+ * The commit graph is painted into a <canvas>, so forced-colors can't recolour
+ * it the way it recolours DOM — the app has to pick a high-contrast palette
+ * itself. Only applies while the scheme is on "auto"; the moment the user picks
+ * a scheme in Settings this becomes a no-op for the palette (it still tracks
+ * `systemHighContrast` so the UI can explain itself).
+ *
+ * Returns a disposer that removes the listeners.
+ */
+export function watchSystemContrast(): () => void {
+  const queries = HIGH_CONTRAST_QUERIES.map((q) => window.matchMedia(q));
+  const update = (): void => {
+    settingsStore.getState().applySystemContrast(queries.some((q) => q.matches));
+  };
+  queries.forEach((q) => q.addEventListener('change', update));
+  update();
+  return () => queries.forEach((q) => q.removeEventListener('change', update));
+}
+
 // Listen for system theme changes
 if (typeof window !== 'undefined') {
   window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
@@ -370,4 +446,7 @@ if (typeof window !== 'undefined') {
       applyTheme('system');
     }
   });
+
+  // Listen for system contrast changes (Windows High Contrast Mode et al.)
+  watchSystemContrast();
 }

--- a/src/styles/shared-styles.ts
+++ b/src/styles/shared-styles.ts
@@ -104,6 +104,32 @@ export const sharedStyles = css`
   .attach-breadcrumb strong {
     color: var(--color-text-primary);
   }
+
+  /* ===========================================================
+     Forced colors (Windows High Contrast Mode)
+     The OS replaces author colors with its own palette, which
+     silently drops focus rings and any state shown only through a
+     custom background. Restate them with system color keywords.
+     =========================================================== */
+  @media (forced-colors: active) {
+    :focus-visible,
+    input:focus-visible,
+    textarea:focus-visible,
+    select:focus-visible {
+      outline: 2px solid Highlight;
+      outline-offset: 2px;
+    }
+
+    /* Disabled state is conveyed by opacity, which forced colors does not
+       adjust — a faded-but-still-forced color reads as enabled. */
+    button:disabled,
+    .btn:disabled,
+    .input:disabled {
+      opacity: 1;
+      color: GrayText;
+      border-color: GrayText;
+    }
+  }
 `;
 
 /**


### PR DESCRIPTION
## Summary

- The commit graph auto-switches to the **High Contrast** palette when the OS reports `forced-colors: active` (Windows High Contrast Mode) or `prefers-contrast: more`, and reverts to the default palette when that turns off again — no hunting through Settings.
- Choosing a scheme in Settings **pins** it: the OS watcher never overrides a deliberate choice, in either direction.
- While automatic selection is driving the palette, the Settings row says so — an "Auto (high contrast)" tag next to the select plus a description explaining that the graph is a canvas the OS cannot recolour, and that picking a scheme overrides it.
- The graph now repaints when the palette changes: `lv-graph-canvas` observes `data-graph-scheme` as well as `data-theme`, without which the lane colours (manual *or* automatic) never reached the already-painted canvas.
- A tight `@media (forced-colors: active)` block keeps the DOM chrome legible under forced colours: focus rings and hover/active states restated with system colour keywords, and the palette preview swatches opted out with `forced-color-adjust: none` so they don't flatten into identical squares.

### Auto vs. user-pinned — how it is represented

`graphColorSchemeAuto` (default `true`) is an explicit persisted flag; `setGraphColorScheme()` sets it to `false`, so any manual change pins the scheme. `applySystemContrast(highContrast)` only touches the palette while the flag is true, and picks `high-contrast` or the default scheme — since "auto" means the user never chose anything, the revert target is unambiguously the default. A separate non-preference field, `systemHighContrast`, tracks what the OS currently reports (re-derived from `matchMedia` on every startup) so the UI can explain itself even when the scheme is pinned.

Persisted-state migration to version 4: the whole settings object is written the moment *anything* changes, so the mere presence of `graphColorScheme` proves nothing. A stored value other than `default` is the only evidence of a deliberate choice, so those users are migrated to `graphColorSchemeAuto: false` and keep exactly the scheme they picked; everyone else — including every existing user who never touched the setting — gets the new automatic behaviour. `resetToDefaults()` returns to auto and immediately re-reads the OS.

## Review finding

The commit graph is drawn into a `<canvas>` (`src/graph/canvas-renderer.ts`), so Windows High Contrast Mode and `forced-colors: active` have no effect on it — the OS cannot recolour pixels the app paints itself. A `high-contrast` graph colour scheme already existed (`src/stores/settings.store.ts`, one of the `GraphColorScheme` values) but the user had to find and select it by hand, even though the store already watched `prefers-color-scheme` with `matchMedia` right next to it. This adds the equivalent contrast watcher (`watchSystemContrast()` in `src/stores/settings.store.ts`), the auto/pinned distinction with its migration, the Settings indication in `src/components/dialogs/lv-settings-dialog.ts`, the repaint wiring in `src/components/graph/lv-graph-canvas.ts`, and forced-colours CSS in `src/styles/shared-styles.ts` plus the two components above.

Note: the forced-colours CSS is deliberately kept in self-contained, clearly commented blocks appended at the end of each style sheet so it merges cleanly alongside the parallel focus-ring/reduced-motion work rather than fighting over the same lines.

## Test plan

- [ ] `npm run lint` — 0 errors, 204 pre-existing warnings (unchanged)
- [ ] `npm run typecheck` — clean
- [ ] `npm test` — 5353 passed; the only 2 failures are the known pre-existing `network-gate-coverage` timeouts, which fail identically on a clean `origin/main` checkout
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` — clean (no Rust changes)
- [ ] New unit tests in `src/stores/__tests__/settings.store.test.ts`: auto-select on match, revert on unmatch, a user pin winning and surviving contrast changes, reset returning to auto, `watchSystemContrast` wiring against a mocked `matchMedia` (both queries, later changes, already-on at startup, disposal), and the version-4 migration rules
- [ ] New component tests in `src/components/dialogs/__tests__/lv-settings-dialog-contrast.test.ts`: the auto note appears/disappears, manual selection pins and drops the note, the pinned value survives a contrast change, `settings-changed` still dispatches, and the store subscription is torn down on disconnect
- [ ] New E2E in `e2e/tests/forced-colors.spec.ts` using `page.emulateMedia({ forcedColors: 'active' })`: the applied `data-graph-scheme` switches to `high-contrast` and back to `default`, and Settings shows the auto note until a scheme is picked. Ran with `e2e/tests/graph.spec.ts`, `e2e/tests/dialogs.spec.ts` and `e2e/tests/settings-external-tools.spec.ts` — 92 passed.
- [ ] Manual check: turn Windows High Contrast Mode (or a browser increased-contrast setting) on and off with the graph visible; the lanes repaint immediately, and picking any scheme in Settings stops that happening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_