### PR TITLE
feat: sign-off and co-author trailers in the commit panel

### DIFF
--- a/e2e/tests/commit-panel.spec.ts
+++ b/e2e/tests/commit-panel.spec.ts
@@ -643,3 +643,225 @@ test.describe('Commit Panel - UI Outcome Verification', () => {
     await expect(rightPanel.commitMessage).toHaveValue('existing draft message');
   });
 });
+
+test.describe('Commit Panel - Trailers', () => {
+  let rightPanel: RightPanelPage;
+
+  const stagedFile = [
+    { path: 'src/main.ts', status: 'modified', isStaged: true, isConflicted: false },
+  ];
+
+  const commitBy = (
+    oid: string,
+    summary: string,
+    author: { name: string; email: string },
+    body: string | null = null
+  ) => ({
+    oid,
+    shortId: oid.slice(0, 7),
+    message: body ? `${summary}\n\n${body}` : summary,
+    summary,
+    body,
+    author: { ...author, timestamp: Date.now() / 1000 },
+    committer: { ...author, timestamp: Date.now() / 1000 },
+    parentIds: [],
+    timestamp: Date.now() / 1000,
+  });
+
+  test('sign off adds a Signed-off-by trailer to the committed message', async ({ page }) => {
+    rightPanel = new RightPanelPage(page);
+    await setupOpenRepository(page, withStagedFiles(stagedFile));
+
+    await startCommandCaptureWithMocks(page, {
+      create_commit: { oid: 'signed-1', shortId: 'signed1', summary: 'feat: signed' },
+    });
+
+    await rightPanel.commitMessage.fill('feat: signed work');
+    await page.locator('lv-commit-panel .signoff-toggle input').check();
+
+    // The panel says exactly what will be added before the commit is made.
+    const preview = page.locator('lv-commit-panel .trailers-preview');
+    await expect(preview).toBeVisible();
+    await expect(preview).toContainText('Signed-off-by: Test User <test@example.com>');
+
+    await rightPanel.commitButton.click();
+    await waitForCommand(page, 'create_commit');
+
+    const commits = await findCommand(page, 'create_commit');
+    expect(commits.length).toBe(1);
+    expect((commits[0].args as { message: string }).message).toBe(
+      'feat: signed work\n\nSigned-off-by: Test User <test@example.com>'
+    );
+  });
+
+  test('turning sign off back off removes only its own trailer', async ({ page }) => {
+    rightPanel = new RightPanelPage(page);
+    await setupOpenRepository(page, withStagedFiles(stagedFile));
+
+    await startCommandCaptureWithMocks(page, {
+      create_commit: { oid: 'unsigned-1', shortId: 'unsign1', summary: 'feat: unsigned' },
+    });
+
+    const body = page.locator('lv-commit-panel .description-input');
+    await rightPanel.commitMessage.fill('feat: hand written');
+    await body.fill('A body the user wrote.\n\nRefs: #42');
+
+    const signOff = page.locator('lv-commit-panel .signoff-toggle input');
+    await signOff.check();
+    await expect(page.locator('lv-commit-panel .trailers-preview')).toBeVisible();
+    await signOff.uncheck();
+    await expect(page.locator('lv-commit-panel .trailers-preview')).toHaveCount(0);
+
+    await rightPanel.commitButton.click();
+    await waitForCommand(page, 'create_commit');
+
+    const commits = await findCommand(page, 'create_commit');
+    expect((commits[0].args as { message: string }).message).toBe(
+      'feat: hand written\n\nA body the user wrote.\n\nRefs: #42'
+    );
+  });
+
+  test('a recent author can be added as a co-author and reaches the commit', async ({ page }) => {
+    rightPanel = new RightPanelPage(page);
+    await setupOpenRepository(page, {
+      ...withStagedFiles(stagedFile),
+      commits: [
+        commitBy('aaa1111', 'earlier work', { name: 'Grace Hopper', email: 'grace@example.com' }),
+        commitBy('bbb2222', 'older work', { name: 'Test User', email: 'test@example.com' }),
+      ],
+    });
+
+    await startCommandCaptureWithMocks(page, {
+      create_commit: { oid: 'coauth-1', shortId: 'coauth1', summary: 'feat: paired' },
+    });
+
+    await rightPanel.commitMessage.fill('feat: paired work');
+    await page.locator('lv-commit-panel .coauthor-btn').click();
+
+    const suggestion = page.locator('lv-commit-panel .coauthor-suggestion', {
+      hasText: 'grace@example.com',
+    });
+    await expect(suggestion).toBeVisible();
+    // The committer themselves is never offered as their own co-author.
+    await expect(
+      page.locator('lv-commit-panel .coauthor-suggestion', { hasText: 'test@example.com' })
+    ).toHaveCount(0);
+
+    await suggestion.click();
+
+    const preview = page.locator('lv-commit-panel .trailers-preview');
+    await expect(preview).toContainText('Co-authored-by: Grace Hopper <grace@example.com>');
+
+    await rightPanel.commitButton.click();
+    await waitForCommand(page, 'create_commit');
+
+    const commits = await findCommand(page, 'create_commit');
+    expect((commits[0].args as { message: string }).message).toBe(
+      'feat: paired work\n\nCo-authored-by: Grace Hopper <grace@example.com>'
+    );
+  });
+
+  test('a co-author can be typed in, removed, and refused when duplicated', async ({ page }) => {
+    rightPanel = new RightPanelPage(page);
+    await setupOpenRepository(page, withStagedFiles(stagedFile));
+
+    await rightPanel.commitMessage.fill('feat: manual co-author');
+    await page.locator('lv-commit-panel .coauthor-btn').click();
+
+    const input = page.locator('lv-commit-panel .coauthor-input');
+    const add = page.locator('lv-commit-panel .coauthor-add-btn');
+
+    // A malformed entry is refused with an explanation, not silently dropped.
+    await input.fill('grace@example.com');
+    await add.click();
+    await expect(page.locator('lv-commit-panel .coauthor-error')).toContainText(
+      'not a valid co-author'
+    );
+
+    await input.fill('Grace Hopper <grace@example.com>');
+    await add.click();
+    await expect(page.locator('lv-commit-panel .trailer-line')).toHaveCount(1);
+
+    // Adding the same person again is a no-op that says so.
+    await input.fill('G. Hopper <GRACE@example.com>');
+    await add.click();
+    await expect(page.locator('lv-commit-panel .coauthor-error')).toContainText(
+      'already a co-author'
+    );
+    await expect(page.locator('lv-commit-panel .trailer-line')).toHaveCount(1);
+
+    // Close the dropdown, which floats over the preview beneath it.
+    await page.locator('lv-commit-panel .coauthor-btn').click();
+    await expect(page.locator('lv-commit-panel .coauthor-dropdown')).toHaveCount(0);
+
+    await page.locator('lv-commit-panel .trailer-remove').click();
+    await expect(page.locator('lv-commit-panel .trailers-preview')).toHaveCount(0);
+  });
+
+  test('amending a commit that already has trailers does not duplicate them', async ({ page }) => {
+    rightPanel = new RightPanelPage(page);
+    await setupOpenRepository(page, {
+      commits: [
+        commitBy(
+          'ccc3333',
+          'fix: already signed',
+          { name: 'Test User', email: 'test@example.com' },
+          'Body.\n\nSigned-off-by: Test User <test@example.com>\nCo-authored-by: Grace Hopper <grace@example.com>'
+        ),
+      ],
+    });
+
+    await startCommandCaptureWithMocks(page, {
+      create_commit: { oid: 'amend-1', shortId: 'amend1', summary: 'fix: already signed' },
+    });
+
+    await page.locator('lv-commit-panel label', { hasText: /amend/i }).first().click();
+
+    // The existing footer is shown as panel state instead of being re-appended.
+    await expect(page.locator('lv-commit-panel .signoff-toggle input')).toBeChecked();
+    const preview = page.locator('lv-commit-panel .trailers-preview');
+    await expect(preview).toContainText('Signed-off-by: Test User <test@example.com>');
+    await expect(preview).toContainText('Co-authored-by: Grace Hopper <grace@example.com>');
+    await expect(page.locator('lv-commit-panel .description-input')).toHaveValue('Body.');
+
+    await rightPanel.commitButton.click();
+    await waitForCommand(page, 'create_commit');
+
+    const commits = await findCommand(page, 'create_commit');
+    const message = (commits[0].args as { message: string }).message;
+    expect(message).toBe(
+      'fix: already signed\n\nBody.\n\nSigned-off-by: Test User <test@example.com>\n' +
+        'Co-authored-by: Grace Hopper <grace@example.com>'
+    );
+    expect(message.match(/Signed-off-by/g)).toHaveLength(1);
+    expect(message.match(/Co-authored-by/g)).toHaveLength(1);
+  });
+
+  test('without a git identity the sign-off control explains itself', async ({ page }) => {
+    rightPanel = new RightPanelPage(page);
+    await setupOpenRepository(page, withStagedFiles(stagedFile));
+
+    await injectCommandMock(page, {
+      get_user_identity: { name: null, email: null, nameIsGlobal: false, emailIsGlobal: false },
+    });
+
+    // Reload the identity the way applying a profile would.
+    await page.locator('lv-commit-panel').evaluate(async (el) => {
+      const panel = el as HTMLElement & {
+        loadAuthorName: () => Promise<void>;
+        updateComplete: Promise<unknown>;
+      };
+      await panel.loadAuthorName();
+      await panel.updateComplete;
+    });
+
+    await expect(page.locator('lv-commit-panel .signoff-toggle input')).toBeDisabled();
+    const hint = page.locator('lv-commit-panel .trailer-hint');
+    await expect(hint).toBeVisible();
+    await expect(hint).toContainText('No git identity configured');
+
+    // The warning leads somewhere: it opens the Git Configuration dialog.
+    await hint.locator('button').click();
+    await expect(page.locator('lv-config-dialog lv-modal[open]')).toBeVisible();
+  });
+});

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -1799,6 +1799,7 @@ export class AppShell extends LitElement {
     window.addEventListener('trigger-pull', this.handleTriggerPull);
     window.addEventListener('force-delete-branch', this.handleForceDeleteBranch as EventListener);
     window.addEventListener('open-settings', this.handleOpenSettings);
+    window.addEventListener('open-git-config', this.handleOpenGitConfig);
     window.addEventListener('trigger-abort', this.handleTriggerAbort);
     window.addEventListener('force-push', this.handleForcePush);
     window.addEventListener('force-push-tag', this.handleForcePushTag);
@@ -1959,6 +1960,7 @@ export class AppShell extends LitElement {
     window.removeEventListener('trigger-pull', this.handleTriggerPull);
     window.removeEventListener('force-delete-branch', this.handleForceDeleteBranch as EventListener);
     window.removeEventListener('open-settings', this.handleOpenSettings);
+    window.removeEventListener('open-git-config', this.handleOpenGitConfig);
     window.removeEventListener('trigger-abort', this.handleTriggerAbort);
     window.removeEventListener('force-push', this.handleForcePush);
     window.removeEventListener('force-push-tag', this.handleForcePushTag);
@@ -3060,6 +3062,15 @@ export class AppShell extends LitElement {
 
   private handleOpenSettings = (): void => {
     this.showSettings = true;
+  };
+
+  /**
+   * Open the Git Configuration dialog — where user.name/user.email are set.
+   * Dispatched by the commit panel when there is no identity to sign off with,
+   * so the warning it shows leads somewhere.
+   */
+  private handleOpenGitConfig = (): void => {
+    this.showConfig = true;
   };
 
   // True while any integration dialog is open.

--- a/src/components/dialogs/lv-settings-dialog.ts
+++ b/src/components/dialogs/lv-settings-dialog.ts
@@ -332,6 +332,7 @@ export class LvSettingsDialog extends LitElement {
   @state() private confirmNetworkOps = false;
   @state() private remoteAllowlist: string[] = [];
   @state() private autoStashOnCheckout = false;
+  @state() private alwaysSignOff = false;
   @state() private staleBranchDays = 90;
   @state() private networkOperationTimeout = 300;
 
@@ -530,6 +531,7 @@ export class LvSettingsDialog extends LitElement {
     this.confirmNetworkOps = settings.confirmNetworkOps;
     this.remoteAllowlist = settings.remoteAllowlist;
     this.autoStashOnCheckout = settings.autoStashOnCheckout;
+    this.alwaysSignOff = settings.alwaysSignOff;
     this.staleBranchDays = settings.staleBranchDays;
     this.networkOperationTimeout = settings.networkOperationTimeout;
     this.autoFetchInterval = settings.autoFetchInterval;
@@ -909,6 +911,10 @@ export class LvSettingsDialog extends LitElement {
       case 'autoStashOnCheckout':
         this.autoStashOnCheckout = value;
         store.setAutoStashOnCheckout(value);
+        break;
+      case 'alwaysSignOff':
+        this.alwaysSignOff = value;
+        store.setAlwaysSignOff(value);
         break;
       case 'fetchOnFocus':
         this.fetchOnFocus = value;
@@ -1522,6 +1528,14 @@ export class LvSettingsDialog extends LitElement {
               <span class="setting-description">Automatically stash and re-apply changes when switching branches</span>
             </div>
             ${this.renderToggle(this.autoStashOnCheckout, 'autoStashOnCheckout')}
+          </div>
+
+          <div class="setting-row">
+            <div class="setting-label">
+              <span class="setting-name">Always Sign Off Commits</span>
+              <span class="setting-description">Start each new commit message with Sign off enabled, adding a Signed-off-by trailer</span>
+            </div>
+            ${this.renderToggle(this.alwaysSignOff, 'alwaysSignOff')}
           </div>
 
           <div class="setting-row">

--- a/src/components/sidebar/__tests__/lv-commit-panel-trailers.test.ts
+++ b/src/components/sidebar/__tests__/lv-commit-panel-trailers.test.ts
@@ -1,0 +1,576 @@
+/**
+ * Tests for the commit panel's trailer affordances: Sign off and Co-authors.
+ *
+ * The bar is what reaches `create_commit`: the composed message must carry the
+ * exact trailers the panel promises, once each, in the footer.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeHistory: Array<{ command: string; args?: unknown }> = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+(globalThis as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+  convertCallback: (callback: unknown, once: boolean) => { void once; void callback; return 0; },
+  unregisterListener: (_event: string, _eventId: number) => {},
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import { repositoryStore } from '../../../stores/repository.store.ts';
+import { settingsStore } from '../../../stores/settings.store.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
+import type { LvCommitPanel } from '../lv-commit-panel.ts';
+import '../lv-commit-panel.ts';
+
+const REPO_PATH = '/test/repo';
+
+const IDENTITY = { name: 'Ada Lovelace', email: 'ada@example.com' };
+
+interface PanelInternals {
+  summary: string;
+  description: string;
+  signOff: boolean;
+  coAuthors: Array<{ name: string; email: string }>;
+  coAuthorInput: string;
+  coAuthorError: string | null;
+  suggestionsError: string | null;
+  conventionalMode: boolean;
+  selectedType: string;
+  scope: string;
+  amend: boolean;
+  identityName: string;
+  identityEmail: string;
+  identityLoaded: boolean;
+  showCoAuthors: boolean;
+  visibleSuggestions: Array<{ name: string; email: string }>;
+  buildCommitMessage: () => string;
+  handleCommit: () => Promise<void>;
+  handleAddCoAuthor: () => void;
+  handleRemoveCoAuthor: (coAuthor: { name: string; email: string }) => void;
+  handleCoAuthorsToggle: (e: Event) => void;
+  loadCoAuthorSuggestions: () => Promise<void>;
+  fetchLastCommitMessage: () => Promise<void>;
+  handleAmendToggle: (e: Event) => Promise<void>;
+}
+
+function commitOf(summary: string, body: string | null) {
+  return {
+    oid: 'abc123def456',
+    shortId: 'abc123d',
+    message: body ? `${summary}\n\n${body}` : summary,
+    summary,
+    body,
+    author: { name: 'Ada Lovelace', email: 'ada@example.com', timestamp: 0 },
+    committer: { name: 'Ada Lovelace', email: 'ada@example.com', timestamp: 0 },
+    parentIds: [],
+    timestamp: 0,
+  };
+}
+
+let identity: { name: string | null; email: string | null } | null = IDENTITY;
+let history: unknown[] = [commitOf('Last commit message', 'Some body text')];
+
+function setupDefaultMocks(): void {
+  mockInvoke = async (command: string) => {
+    switch (command) {
+      case 'list_templates':
+        return [];
+      case 'get_conventional_types':
+        return [
+          { typeName: 'feat', description: 'A new feature', emoji: null },
+          { typeName: 'fix', description: 'A bug fix', emoji: null },
+        ];
+      case 'get_commit_template':
+        return null;
+      case 'get_user_identity':
+        return identity;
+      case 'is_ai_available':
+        return false;
+      case 'get_commit_history':
+        return history;
+      case 'create_commit':
+        return { shortId: 'new123', oid: 'new123456', summary: 'test commit' };
+      default:
+        return null;
+    }
+  };
+}
+
+function setupStore(): void {
+  repositoryStore.getState().addRepository({
+    path: REPO_PATH,
+    name: 'test-repo',
+    isValid: true,
+    isBare: false,
+    headRef: null,
+    detachedHeadOid: null,
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  });
+}
+
+async function renderCommitPanel(stagedCount = 1): Promise<LvCommitPanel> {
+  const el = await fixture<LvCommitPanel>(
+    html`<lv-commit-panel .repositoryPath=${REPO_PATH} .stagedCount=${stagedCount}></lv-commit-panel>`
+  );
+  await new Promise((r) => setTimeout(r, 100));
+  await el.updateComplete;
+  return el;
+}
+
+function internals(el: LvCommitPanel): PanelInternals {
+  return el as unknown as PanelInternals;
+}
+
+describe('lv-commit-panel trailers', () => {
+  beforeEach(() => {
+    invokeHistory.length = 0;
+    identity = IDENTITY;
+    history = [commitOf('Last commit message', 'Some body text')];
+    localStorage.removeItem('leviathan-commit-history');
+    settingsStore.getState().setAlwaysSignOff(false);
+    setupDefaultMocks();
+    setupStore();
+  });
+
+  afterEach(() => {
+    repositoryStore.getState().reset();
+    settingsStore.getState().setAlwaysSignOff(false);
+  });
+
+  // ── Sign off ───────────────────────────────────────────────────────────
+  describe('sign off', () => {
+    it('renders a sign-off toggle, off by default', async () => {
+      const el = await renderCommitPanel();
+      const checkbox = el.shadowRoot!.querySelector(
+        '.signoff-toggle input'
+      ) as HTMLInputElement;
+      expect(checkbox).to.exist;
+      expect(checkbox.checked).to.be.false;
+      expect(checkbox.disabled).to.be.false;
+    });
+
+    it('appends Signed-off-by with the repository identity', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.summary = 'fix: a bug';
+      const checkbox = el.shadowRoot!.querySelector('.signoff-toggle input') as HTMLInputElement;
+      checkbox.click();
+      await el.updateComplete;
+
+      expect(panel.signOff).to.be.true;
+      expect(panel.buildCommitMessage()).to.equal(
+        'fix: a bug\n\nSigned-off-by: Ada Lovelace <ada@example.com>'
+      );
+    });
+
+    it('shows the trailer that will be added', async () => {
+      const el = await renderCommitPanel();
+      internals(el).summary = 'fix: a bug';
+      (el.shadowRoot!.querySelector('.signoff-toggle input') as HTMLInputElement).click();
+      await el.updateComplete;
+
+      const preview = el.shadowRoot!.querySelector('.trailers-preview');
+      expect(preview).to.exist;
+      expect(preview!.textContent).to.contain('Signed-off-by: Ada Lovelace <ada@example.com>');
+    });
+
+    it('removes exactly its own trailer when toggled off, leaving the message intact', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.summary = 'fix: a bug';
+      panel.description = 'A hand-written body.\n\nRefs: #42';
+      const checkbox = el.shadowRoot!.querySelector('.signoff-toggle input') as HTMLInputElement;
+
+      checkbox.click();
+      await el.updateComplete;
+      expect(panel.buildCommitMessage()).to.equal(
+        'fix: a bug\n\nA hand-written body.\n\nRefs: #42\nSigned-off-by: Ada Lovelace <ada@example.com>'
+      );
+
+      checkbox.click();
+      await el.updateComplete;
+      expect(panel.buildCommitMessage()).to.equal(
+        'fix: a bug\n\nA hand-written body.\n\nRefs: #42'
+      );
+    });
+
+    it('disables the toggle and explains itself when no identity is configured', async () => {
+      identity = { name: null, email: null };
+      const el = await renderCommitPanel();
+      await el.updateComplete;
+
+      const checkbox = el.shadowRoot!.querySelector('.signoff-toggle input') as HTMLInputElement;
+      expect(checkbox.disabled, 'the toggle is not armable').to.be.true;
+
+      const hint = el.shadowRoot!.querySelector('.trailer-hint');
+      expect(hint, 'the panel says why').to.exist;
+      expect(hint!.textContent).to.contain('No git identity configured');
+    });
+
+    it('never writes a broken trailer when the identity is missing', async () => {
+      identity = { name: null, email: null };
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.summary = 'fix: a bug';
+      panel.signOff = true;
+      await el.updateComplete;
+
+      expect(panel.buildCommitMessage()).to.equal('fix: a bug');
+      expect(el.shadowRoot!.querySelector('.trailers-preview')).to.not.exist;
+    });
+
+    it('reports a rejected sign-off instead of silently ignoring it', async () => {
+      identity = { name: null, email: null };
+      const el = await renderCommitPanel();
+      uiStore.setState({ toasts: [] });
+
+      const checkbox = el.shadowRoot!.querySelector('.signoff-toggle input') as HTMLInputElement;
+      // Bypass the disabled attribute the way a programmatic toggle would.
+      checkbox.disabled = false;
+      checkbox.checked = true;
+      checkbox.dispatchEvent(new Event('change'));
+      await el.updateComplete;
+
+      expect(internals(el).signOff).to.be.false;
+      const errors = uiStore.getState().toasts.filter((t) => t.type === 'error');
+      expect(errors.length).to.equal(1);
+      expect(errors[0].message).to.contain('No git identity');
+    });
+
+    it('opens the git config dialog from the hint', async () => {
+      identity = { name: null, email: null };
+      const el = await renderCommitPanel();
+      await el.updateComplete;
+
+      let opened = false;
+      const listener = (): void => { opened = true; };
+      window.addEventListener('open-git-config', listener);
+      (el.shadowRoot!.querySelector('.trailer-hint button') as HTMLButtonElement).click();
+      window.removeEventListener('open-git-config', listener);
+
+      expect(opened).to.be.true;
+    });
+
+    it('starts armed when "always sign off" is enabled', async () => {
+      settingsStore.getState().setAlwaysSignOff(true);
+      const el = await renderCommitPanel();
+      await el.updateComplete;
+      expect(internals(el).signOff).to.be.true;
+    });
+  });
+
+  // ── Co-authors ─────────────────────────────────────────────────────────
+  describe('co-authors', () => {
+    it('adds a manually entered co-author', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.summary = 'feat: pair work';
+      panel.coAuthorInput = 'Grace Hopper <grace@example.com>';
+      panel.handleAddCoAuthor();
+      await el.updateComplete;
+
+      expect(panel.coAuthors).to.deep.equal([
+        { name: 'Grace Hopper', email: 'grace@example.com' },
+      ]);
+      expect(panel.buildCommitMessage()).to.equal(
+        'feat: pair work\n\nCo-authored-by: Grace Hopper <grace@example.com>'
+      );
+      expect(panel.coAuthorInput, 'the box is cleared for the next one').to.equal('');
+    });
+
+    it('rejects a malformed entry with an explanation', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.coAuthorInput = 'grace@example.com';
+      panel.handleAddCoAuthor();
+      await el.updateComplete;
+
+      expect(panel.coAuthors).to.deep.equal([]);
+      expect(panel.coAuthorError).to.contain('not a valid co-author');
+    });
+
+    it('adding the same co-author twice is a no-op and says so', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.coAuthorInput = 'Grace Hopper <grace@example.com>';
+      panel.handleAddCoAuthor();
+      panel.coAuthorInput = 'G. Hopper <GRACE@example.com>';
+      panel.handleAddCoAuthor();
+      await el.updateComplete;
+
+      expect(panel.coAuthors).to.have.lengthOf(1);
+      expect(panel.coAuthorError).to.contain('already a co-author');
+    });
+
+    it('removes a co-author', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.summary = 'feat: pair work';
+      panel.coAuthorInput = 'Grace Hopper <grace@example.com>';
+      panel.handleAddCoAuthor();
+      await el.updateComplete;
+
+      panel.handleRemoveCoAuthor({ name: 'Grace Hopper', email: 'grace@example.com' });
+      await el.updateComplete;
+
+      expect(panel.coAuthors).to.deep.equal([]);
+      expect(panel.buildCommitMessage()).to.equal('feat: pair work');
+    });
+
+    it('suggests recent commit authors, excluding yourself', async () => {
+      history = [
+        commitOf('one', null),
+        { ...commitOf('two', null), author: { name: 'Grace Hopper', email: 'grace@example.com', timestamp: 0 } },
+        { ...commitOf('three', null), author: { name: 'Grace H', email: 'GRACE@example.com', timestamp: 0 } },
+        { ...commitOf('four', null), author: { name: 'Alan Turing', email: 'alan@example.com', timestamp: 0 } },
+      ];
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      await panel.loadCoAuthorSuggestions();
+      await el.updateComplete;
+
+      expect(panel.visibleSuggestions.map((s) => s.email)).to.deep.equal([
+        'grace@example.com',
+        'alan@example.com',
+      ]);
+    });
+
+    it('drops a suggestion once it has been added', async () => {
+      history = [
+        { ...commitOf('two', null), author: { name: 'Grace Hopper', email: 'grace@example.com', timestamp: 0 } },
+      ];
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      await panel.loadCoAuthorSuggestions();
+      panel.coAuthorInput = 'Grace Hopper <grace@example.com>';
+      panel.handleAddCoAuthor();
+      await el.updateComplete;
+
+      expect(panel.visibleSuggestions).to.deep.equal([]);
+    });
+
+    it('surfaces a failure to read recent authors', async () => {
+      const el = await renderCommitPanel();
+      mockInvoke = async (command: string) => {
+        if (command === 'get_commit_history') {
+          throw { code: 'COMMAND_ERROR', message: 'HEAD is unborn' };
+        }
+        return null;
+      };
+      const panel = internals(el);
+      await panel.loadCoAuthorSuggestions();
+      await el.updateComplete;
+
+      expect(panel.suggestionsError).to.contain('HEAD is unborn');
+      const error = el.shadowRoot!.querySelector('.coauthor-error');
+      // The dropdown is closed, so open it to see the message.
+      expect(error === null || error.textContent!.includes('HEAD is unborn')).to.be.true;
+    });
+  });
+
+  // ── Composition ────────────────────────────────────────────────────────
+  describe('message composition', () => {
+    it('places the footer after a conventional-commit subject and body', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.conventionalMode = true;
+      panel.selectedType = 'feat';
+      panel.scope = 'auth';
+      panel.summary = 'add SSO';
+      panel.description = 'Why this matters.';
+      panel.signOff = true;
+      panel.coAuthorInput = 'Grace Hopper <grace@example.com>';
+      panel.handleAddCoAuthor();
+      await el.updateComplete;
+
+      expect(panel.buildCommitMessage()).to.equal(
+        'feat(auth): add SSO\n\nWhy this matters.\n\n' +
+          'Signed-off-by: Ada Lovelace <ada@example.com>\n' +
+          'Co-authored-by: Grace Hopper <grace@example.com>'
+      );
+    });
+
+    it('composes with a template body that already ends in a trailer', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.summary = 'chore: from template';
+      panel.description = 'Body from the template.\n\nRefs: PROJ-1';
+      panel.signOff = true;
+      await el.updateComplete;
+
+      expect(panel.buildCommitMessage()).to.equal(
+        'chore: from template\n\nBody from the template.\n\n' +
+          'Refs: PROJ-1\nSigned-off-by: Ada Lovelace <ada@example.com>'
+      );
+    });
+
+    it('sends the composed message to create_commit', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.summary = 'feat: shipped';
+      panel.signOff = true;
+      panel.coAuthorInput = 'Grace Hopper <grace@example.com>';
+      panel.handleAddCoAuthor();
+      await el.updateComplete;
+
+      invokeHistory.length = 0;
+      await panel.handleCommit();
+
+      const call = invokeHistory.find((h) => h.command === 'create_commit');
+      expect(call, 'create_commit ran').to.exist;
+      expect((call!.args as { message: string }).message).to.equal(
+        'feat: shipped\n\nSigned-off-by: Ada Lovelace <ada@example.com>\n' +
+          'Co-authored-by: Grace Hopper <grace@example.com>'
+      );
+    });
+
+    it('clears co-authors after a successful commit', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.summary = 'feat: shipped';
+      panel.signOff = true;
+      panel.coAuthorInput = 'Grace Hopper <grace@example.com>';
+      panel.handleAddCoAuthor();
+      await el.updateComplete;
+
+      await panel.handleCommit();
+      await el.updateComplete;
+
+      expect(panel.coAuthors).to.deep.equal([]);
+      expect(panel.signOff, 'falls back to the standing preference').to.be.false;
+    });
+  });
+
+  // ── Amend ──────────────────────────────────────────────────────────────
+  describe('amend', () => {
+    it('adopts the amended commit trailers instead of duplicating them', async () => {
+      history = [
+        commitOf(
+          'fix: earlier commit',
+          'Body.\n\nSigned-off-by: Ada Lovelace <ada@example.com>\n' +
+            'Co-authored-by: Grace Hopper <grace@example.com>'
+        ),
+      ];
+      const el = await renderCommitPanel(0);
+      const panel = internals(el);
+      panel.amend = true;
+      await panel.fetchLastCommitMessage();
+      await el.updateComplete;
+
+      expect(panel.signOff, 'the sign-off is reflected in the control').to.be.true;
+      expect(panel.coAuthors).to.deep.equal([
+        { name: 'Grace Hopper', email: 'grace@example.com' },
+      ]);
+      expect(panel.description, 'the footer is lifted out of the body').to.equal('Body.');
+
+      const message = panel.buildCommitMessage();
+      expect(message).to.equal(
+        'fix: earlier commit\n\nBody.\n\nSigned-off-by: Ada Lovelace <ada@example.com>\n' +
+          'Co-authored-by: Grace Hopper <grace@example.com>'
+      );
+      expect(message.match(/Signed-off-by/g)).to.have.lengthOf(1);
+      expect(message.match(/Co-authored-by/g)).to.have.lengthOf(1);
+    });
+
+    it('leaves a sign-off by somebody else in the message body', async () => {
+      history = [
+        commitOf('fix: earlier commit', 'Signed-off-by: Grace Hopper <grace@example.com>'),
+      ];
+      const el = await renderCommitPanel(0);
+      const panel = internals(el);
+      panel.amend = true;
+      await panel.fetchLastCommitMessage();
+      await el.updateComplete;
+
+      expect(panel.signOff).to.be.false;
+      expect(panel.description).to.equal('Signed-off-by: Grace Hopper <grace@example.com>');
+      expect(panel.buildCommitMessage()).to.equal(
+        'fix: earlier commit\n\nSigned-off-by: Grace Hopper <grace@example.com>'
+      );
+    });
+
+    it('restores the draft trailers when amend is switched off', async () => {
+      history = [
+        commitOf('fix: earlier commit', 'Co-authored-by: Grace Hopper <grace@example.com>'),
+      ];
+      const el = await renderCommitPanel(1);
+      const panel = internals(el);
+      panel.summary = 'my own draft';
+      panel.coAuthorInput = 'Alan Turing <alan@example.com>';
+      panel.handleAddCoAuthor();
+      await el.updateComplete;
+
+      const checkbox = el.shadowRoot!.querySelector('.amend-toggle input') as HTMLInputElement;
+      checkbox.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+      expect(panel.coAuthors.map((c) => c.email)).to.deep.equal([
+        'alan@example.com',
+        'grace@example.com',
+      ]);
+
+      checkbox.click();
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      expect(panel.summary).to.equal('my own draft');
+      expect(panel.coAuthors.map((c) => c.email)).to.deep.equal(['alan@example.com']);
+    });
+  });
+
+  // ── Repository switching ───────────────────────────────────────────────
+  describe('repository switching', () => {
+    it('drops the previous repository identity and co-authors', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.coAuthorInput = 'Grace Hopper <grace@example.com>';
+      panel.handleAddCoAuthor();
+      panel.signOff = true;
+      await el.updateComplete;
+
+      identity = { name: 'Second Repo User', email: 'second@example.com' };
+      el.repositoryPath = '/test/other-repo';
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 50));
+      await el.updateComplete;
+
+      expect(panel.coAuthors).to.deep.equal([]);
+      expect(panel.signOff).to.be.false;
+      expect(panel.identityEmail).to.equal('second@example.com');
+    });
+
+    it('restores the trailers of a cached draft when switching back', async () => {
+      const el = await renderCommitPanel();
+      const panel = internals(el);
+      panel.summary = 'draft for repo one';
+      panel.coAuthorInput = 'Grace Hopper <grace@example.com>';
+      panel.handleAddCoAuthor();
+      panel.signOff = true;
+      await el.updateComplete;
+
+      el.repositoryPath = '/test/other-repo';
+      await el.updateComplete;
+      el.repositoryPath = REPO_PATH;
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 50));
+
+      expect(panel.summary).to.equal('draft for repo one');
+      expect(panel.signOff).to.be.true;
+      expect(panel.coAuthors.map((c) => c.email)).to.deep.equal(['grace@example.com']);
+    });
+  });
+});

--- a/src/components/sidebar/__tests__/lv-commit-panel.test.ts
+++ b/src/components/sidebar/__tests__/lv-commit-panel.test.ts
@@ -723,7 +723,7 @@ describe('lv-commit-panel', () => {
       const internal = el as unknown as {
         summary: string;
         description: string;
-        draftCache: Map<string, { summary: string; description: string; conventionalMode: boolean; selectedType: string; scope: string }>;
+        draftCache: Map<string, { summary: string; description: string; conventionalMode: boolean; selectedType: string; scope: string; signOff: boolean; coAuthors: Array<{ name: string; email: string }> }>;
       };
 
       // Pre-populate cache
@@ -733,6 +733,8 @@ describe('lv-commit-panel', () => {
         conventionalMode: false,
         selectedType: 'feat',
         scope: '',
+        signOff: false,
+        coAuthors: [],
       });
 
       el.repositoryPath = '/other/repo';

--- a/src/components/sidebar/lv-commit-panel.ts
+++ b/src/components/sidebar/lv-commit-panel.ts
@@ -5,11 +5,22 @@ import * as gitService from '../../services/git.service.ts';
 import * as aiService from '../../services/ai.service.ts';
 import { showToast } from '../../services/notification.service.ts';
 import { showPrompt } from '../../services/dialog.service.ts';
-import { repositoryStore } from '../../stores/index.ts';
+import { repositoryStore, settingsStore } from '../../stores/index.ts';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type { CommitTemplate, ConventionalType } from '../../services/git.service.ts';
 import type { Commit } from '../../types/git.types.ts';
 import { RefLockController, tryAcquireRefOpOrWarn, releaseRefOp } from '../../utils/ref-lock.ts';
+import {
+  adoptTrailers,
+  applyTrailers,
+  coAuthoredByTrailer,
+  formatTrailer,
+  parseCoAuthorInput,
+  sameCoAuthor,
+  signedOffByTrailer,
+  type CoAuthor,
+  type Trailer,
+} from '../../utils/commit-trailers.ts';
 
 /**
  * Commit panel component
@@ -639,6 +650,204 @@ export class LvCommitPanel extends LitElement {
         font-size: var(--font-size-xs);
         text-align: center;
       }
+
+      /* Trailers (Signed-off-by / Co-authored-by) */
+      .signoff-toggle {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-xs);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary);
+        cursor: pointer;
+        user-select: none;
+      }
+
+      .signoff-toggle input {
+        margin: 0;
+      }
+
+      .signoff-toggle.disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .coauthor-wrapper {
+        position: relative;
+      }
+
+      .coauthor-btn {
+        padding: 2px var(--spacing-xs);
+        background: transparent;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-xs);
+        cursor: pointer;
+        transition: all var(--transition-fast);
+      }
+
+      .coauthor-btn:hover {
+        background: var(--color-bg-hover);
+        color: var(--color-text-primary);
+      }
+
+      .coauthor-dropdown {
+        position: absolute;
+        top: calc(100% + 4px);
+        left: 0;
+        z-index: 100;
+        width: 280px;
+        max-height: 260px;
+        overflow-y: auto;
+        background: var(--color-bg-primary);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+      }
+
+      .coauthor-dropdown-header {
+        padding: var(--spacing-xs) var(--spacing-sm);
+        border-bottom: 1px solid var(--color-border);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary);
+      }
+
+      .coauthor-entry {
+        display: flex;
+        gap: var(--spacing-xs);
+        padding: var(--spacing-xs) var(--spacing-sm);
+        border-bottom: 1px solid var(--color-border);
+      }
+
+      .coauthor-input {
+        flex: 1;
+        min-width: 0;
+        padding: var(--spacing-xs);
+        background: var(--color-bg-primary);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-primary);
+        font-size: var(--font-size-xs);
+      }
+
+      .coauthor-input:focus {
+        outline: none;
+        border-color: var(--color-primary);
+      }
+
+      .coauthor-add-btn {
+        padding: 2px var(--spacing-xs);
+        background: transparent;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-secondary);
+        font-size: var(--font-size-xs);
+        cursor: pointer;
+      }
+
+      .coauthor-add-btn:hover {
+        background: var(--color-bg-hover);
+        color: var(--color-text-primary);
+      }
+
+      .coauthor-suggestion {
+        display: block;
+        width: 100%;
+        padding: var(--spacing-xs) var(--spacing-sm);
+        background: transparent;
+        border: none;
+        border-bottom: 1px solid var(--color-border);
+        color: var(--color-text-primary);
+        font-size: var(--font-size-xs);
+        text-align: left;
+        cursor: pointer;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+
+      .coauthor-suggestion:hover {
+        background: var(--color-bg-hover);
+      }
+
+      .coauthor-suggestion .suggestion-email {
+        color: var(--color-text-muted);
+      }
+
+      .coauthor-empty {
+        padding: var(--spacing-sm);
+        color: var(--color-text-muted);
+        font-size: var(--font-size-xs);
+        text-align: center;
+      }
+
+      .coauthor-error {
+        padding: var(--spacing-xs) var(--spacing-sm);
+        color: var(--color-error);
+        font-size: var(--font-size-xs);
+      }
+
+      .trailers-preview {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        padding: var(--spacing-xs);
+        border: 1px dashed var(--color-border);
+        border-radius: var(--radius-sm);
+        font-size: var(--font-size-xs);
+      }
+
+      .trailers-title {
+        color: var(--color-text-muted);
+      }
+
+      .trailer-line {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-xs);
+        font-family: var(--font-mono);
+        color: var(--color-text-secondary);
+        word-break: break-all;
+      }
+
+      .trailer-remove {
+        margin-left: auto;
+        padding: 0 4px;
+        background: transparent;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        color: var(--color-text-muted);
+        font-size: 10px;
+        cursor: pointer;
+        flex-shrink: 0;
+      }
+
+      .trailer-remove:hover {
+        color: var(--color-error);
+        border-color: var(--color-error);
+      }
+
+      .trailer-hint {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-xs);
+        flex-wrap: wrap;
+        padding: var(--spacing-xs);
+        background: var(--color-warning-bg);
+        border-radius: var(--radius-sm);
+        color: var(--color-warning);
+        font-size: var(--font-size-xs);
+      }
+
+      .trailer-hint button {
+        padding: 1px 6px;
+        background: transparent;
+        border: 1px solid currentColor;
+        border-radius: var(--radius-sm);
+        color: inherit;
+        font-size: var(--font-size-xs);
+        cursor: pointer;
+      }
     `,
   ];
 
@@ -680,9 +889,35 @@ export class LvCommitPanel extends LitElement {
   @state() private currentBranch: string = '';
   private cachedAuthor: string = '';
 
+  // Trailer state (Signed-off-by / Co-authored-by)
+  @state() private signOff: boolean = false;
+  @state() private coAuthors: CoAuthor[] = [];
+  @state() private showCoAuthors: boolean = false;
+  @state() private coAuthorInput: string = '';
+  @state() private coAuthorError: string | null = null;
+  @state() private authorSuggestions: CoAuthor[] = [];
+  @state() private loadingSuggestions: boolean = false;
+  @state() private suggestionsError: string | null = null;
+  /**
+   * The identity the commit will actually be authored with.
+   *
+   * `get_user_identity` resolves user.name/user.email *with repository
+   * context*, the same way libgit2 does when it signs the commit — so it
+   * honours system/global/local precedence and the conditional includes a bare
+   * `--global --get` would miss, and it picks up whatever a unified profile
+   * wrote into this repository's config. Signing off with anything else would
+   * put a name in the footer that the commit is not authored by.
+   */
+  @state() private identityName: string = '';
+  @state() private identityEmail: string = '';
+  /** False until the first identity lookup finishes, so the hint isn't flashed. */
+  @state() private identityLoaded: boolean = false;
+
   // Store original input before amend pre-population
   private originalSummary: string = '';
   private originalDescription: string = '';
+  private originalSignOff: boolean = false;
+  private originalCoAuthors: CoAuthor[] = [];
 
   // AI state
   @state() private aiAvailable: boolean = false;
@@ -713,7 +948,7 @@ export class LvCommitPanel extends LitElement {
   private readonly HISTORY_MAX_ENTRIES = 20;
 
   // Per-repo draft cache: preserves commit form state when switching repos
-  private draftCache = new Map<string, { summary: string; description: string; conventionalMode: boolean; selectedType: string; scope: string }>();
+  private draftCache = new Map<string, { summary: string; description: string; conventionalMode: boolean; selectedType: string; scope: string; signOff: boolean; coAuthors: CoAuthor[] }>();
 
   private boundHandleTriggerAmend = this.handleTriggerAmend.bind(this);
   private boundHandleAiSettingsChanged = () => this.checkAiAvailability();
@@ -733,6 +968,9 @@ export class LvCommitPanel extends LitElement {
     await this.loadGitTemplate();
     await this.checkAiAvailability();
     await this.loadAuthorName();
+    // "Always sign off" seeds a fresh draft; it never overrides a choice the
+    // user made on the draft in front of them.
+    this.signOff = settingsStore.getState().alwaysSignOff;
     this._onDocumentClick = this._onDocumentClick.bind(this);
     document.addEventListener('click', this._onDocumentClick);
 
@@ -789,6 +1027,8 @@ export class LvCommitPanel extends LitElement {
           conventionalMode: this.conventionalMode,
           selectedType: this.selectedType,
           scope: this.scope,
+          signOff: this.signOff,
+          coAuthors: this.coAuthors,
         });
       }
 
@@ -800,12 +1040,16 @@ export class LvCommitPanel extends LitElement {
         this.conventionalMode = draft.conventionalMode;
         this.selectedType = draft.selectedType;
         this.scope = draft.scope;
+        this.signOff = draft.signOff;
+        this.coAuthors = draft.coAuthors;
       } else {
         this.summary = '';
         this.description = '';
         this.conventionalMode = false;
         this.selectedType = 'feat';
         this.scope = '';
+        this.signOff = settingsStore.getState().alwaysSignOff;
+        this.coAuthors = [];
       }
 
       // Clear transient state
@@ -814,6 +1058,18 @@ export class LvCommitPanel extends LitElement {
       this.generationError = null;
       this.amend = false;
       this.lastCommit = null;
+      this.showCoAuthors = false;
+      this.coAuthorInput = '';
+      this.coAuthorError = null;
+      this.suggestionsError = null;
+      // Suggestions and the sign-off identity both belong to the repository, so
+      // neither may survive a tab switch: signing off as the previous repo's
+      // identity would write a footer the commit is not authored by.
+      this.authorSuggestions = [];
+      this.identityName = '';
+      this.identityEmail = '';
+      this.identityLoaded = false;
+      void this.loadAuthorName();
     }
   }
 
@@ -849,20 +1105,29 @@ export class LvCommitPanel extends LitElement {
         this.showHistory = false;
       }
     }
+    if (this.showCoAuthors) {
+      const path = e.composedPath();
+      const isInside = path.some(
+        (el) => el instanceof HTMLElement && (el.classList?.contains('coauthor-wrapper'))
+      );
+      if (!isInside) {
+        this.showCoAuthors = false;
+      }
+    }
   }
 
   private handleTriggerAmend(e: Event): void {
     const event = e as CustomEvent<{ commit: Commit }>;
     if (event.detail?.commit) {
       // Store original input before pre-populating
-      this.originalSummary = this.summary;
-      this.originalDescription = this.description;
+      this.snapshotDraftForAmend();
 
       // Enable amend mode and populate with commit message
       this.amend = true;
       this.lastCommit = event.detail.commit;
       this.summary = event.detail.commit.summary;
       this.description = event.detail.commit.body ?? '';
+      this.adoptTrailersFromDescription();
 
       // Focus the summary input
       this.updateComplete.then(() => {
@@ -966,10 +1231,39 @@ export class LvCommitPanel extends LitElement {
 
   private async loadAuthorName(): Promise<void> {
     if (!this.repositoryPath) return;
+    const requestedFor = this.repositoryPath;
     const result = await gitService.getUserIdentity(this.repositoryPath);
+    // A slow lookup for a repo the user has since tabbed away from must not
+    // overwrite the identity of the repo now on screen.
+    if (this.repositoryPath !== requestedFor) return;
     if (result.success && result.data?.name) {
       this.cachedAuthor = result.data.name;
     }
+    if (result.success) {
+      this.identityName = result.data?.name ?? '';
+      this.identityEmail = result.data?.email ?? '';
+    } else {
+      this.identityName = '';
+      this.identityEmail = '';
+    }
+    this.identityLoaded = true;
+  }
+
+  /** True once we know the commit will carry a real `Name <email>`. */
+  private get hasIdentity(): boolean {
+    return this.identityName.trim().length > 0 && this.identityEmail.trim().length > 0;
+  }
+
+  /** The trailers the current controls will append to the message. */
+  private get pendingTrailers(): Trailer[] {
+    const trailers: Trailer[] = [];
+    if (this.signOff && this.hasIdentity) {
+      trailers.push(signedOffByTrailer(this.identityName, this.identityEmail));
+    }
+    for (const coAuthor of this.coAuthors) {
+      trailers.push(coAuthoredByTrailer(coAuthor));
+    }
+    return trailers;
   }
 
   expandTemplateVariables(content: string): string {
@@ -1052,7 +1346,154 @@ export class LvCommitPanel extends LitElement {
       summary = `${this.selectedType}${scopePart}: ${summary}`;
     }
 
-    return this.description ? `${summary}\n\n${this.description}` : summary;
+    const message = this.description ? `${summary}\n\n${this.description}` : summary;
+
+    // Trailers belong in the footer: a blank line after the body, one per line,
+    // never repeated. With no trailers armed the message is returned untouched,
+    // so a hand-formatted message is never reflowed by a feature that is off.
+    return applyTrailers(message, this.pendingTrailers);
+  }
+
+  private handleSignOffToggle(e: Event): void {
+    const target = e.target as HTMLInputElement;
+    // Without an identity the trailer would read `Signed-off-by:  <>`. Refuse,
+    // and say why — the checkbox is disabled, but a keyboard or programmatic
+    // toggle must not slip past it either.
+    if (target.checked && !this.hasIdentity) {
+      target.checked = false;
+      this.signOff = false;
+      showToast(
+        'No git identity configured — set user.name and user.email to sign off',
+        'error'
+      );
+      return;
+    }
+    this.signOff = target.checked;
+  }
+
+  private handleCoAuthorsToggle(e: Event): void {
+    e.stopPropagation();
+    this.showCoAuthors = !this.showCoAuthors;
+    this.coAuthorError = null;
+    if (this.showCoAuthors) {
+      void this.loadCoAuthorSuggestions();
+    }
+  }
+
+  /**
+   * Recent distinct commit authors in this repository, newest first — the
+   * people you are most likely to be pairing with. Read from the commit history
+   * that is already available rather than a bespoke backend command.
+   */
+  private async loadCoAuthorSuggestions(): Promise<void> {
+    if (!this.repositoryPath || this.loadingSuggestions) return;
+
+    this.loadingSuggestions = true;
+    this.suggestionsError = null;
+    try {
+      const result = await gitService.getCommitHistory({
+        path: this.repositoryPath,
+        limit: 100,
+        allBranches: true,
+      });
+
+      if (!result.success) {
+        this.suggestionsError = result.error?.message ?? 'Could not read recent commit authors';
+        this.authorSuggestions = [];
+        return;
+      }
+
+      const seen = new Set<string>();
+      const suggestions: CoAuthor[] = [];
+      for (const commit of result.data ?? []) {
+        const name = commit.author?.name?.trim();
+        const email = commit.author?.email?.trim();
+        if (!name || !email) continue;
+        const key = email.toLowerCase();
+        if (seen.has(key)) continue;
+        seen.add(key);
+        suggestions.push({ name, email });
+        if (suggestions.length >= 20) break;
+      }
+      this.authorSuggestions = suggestions;
+    } catch (err) {
+      this.suggestionsError = err instanceof Error ? err.message : 'Could not read recent commit authors';
+      this.authorSuggestions = [];
+    } finally {
+      this.loadingSuggestions = false;
+    }
+  }
+
+  /** Suggestions minus yourself and anyone already added. */
+  private get visibleSuggestions(): CoAuthor[] {
+    const own = this.identityEmail.trim().toLowerCase();
+    return this.authorSuggestions.filter(
+      (s) =>
+        s.email.trim().toLowerCase() !== own &&
+        !this.coAuthors.some((c) => sameCoAuthor(c, s))
+    );
+  }
+
+  private addCoAuthor(coAuthor: CoAuthor): boolean {
+    if (this.coAuthors.some((c) => sameCoAuthor(c, coAuthor))) {
+      // Adding the same co-author twice is a no-op — say so rather than
+      // leaving the click looking broken.
+      this.coAuthorError = `${coAuthor.email} is already a co-author`;
+      return false;
+    }
+    this.coAuthors = [...this.coAuthors, coAuthor];
+    this.coAuthorError = null;
+    return true;
+  }
+
+  private handleCoAuthorInput(e: Event): void {
+    this.coAuthorInput = (e.target as HTMLInputElement).value;
+    this.coAuthorError = null;
+  }
+
+  private handleAddCoAuthor(): void {
+    const { coAuthor, error } = parseCoAuthorInput(this.coAuthorInput);
+    if (!coAuthor) {
+      this.coAuthorError = error ?? 'Invalid co-author';
+      return;
+    }
+    if (this.addCoAuthor(coAuthor)) {
+      this.coAuthorInput = '';
+    }
+  }
+
+  private handleCoAuthorKeyDown(e: KeyboardEvent): void {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      e.stopPropagation();
+      this.handleAddCoAuthor();
+    }
+  }
+
+  private handleRemoveCoAuthor(coAuthor: CoAuthor): void {
+    this.coAuthors = this.coAuthors.filter((c) => !sameCoAuthor(c, coAuthor));
+    this.coAuthorError = null;
+  }
+
+  /**
+   * Take over the trailers of a message being amended, so the controls show
+   * what is already in the footer instead of the panel appending a second copy
+   * of it. Only what the UI can represent is lifted out of the text.
+   */
+  private adoptTrailersFromDescription(): void {
+    const identity = this.hasIdentity
+      ? { name: this.identityName, email: this.identityEmail }
+      : null;
+    // The description has already had the subject split off, so its only
+    // paragraph may legitimately be the trailer block.
+    const adopted = adoptTrailers(this.description, identity, { allowSingleParagraph: true });
+    this.description = adopted.message;
+    if (adopted.signedOff) this.signOff = true;
+    for (const coAuthor of adopted.coAuthors) {
+      if (!this.coAuthors.some((c) => sameCoAuthor(c, coAuthor))) {
+        this.coAuthors = [...this.coAuthors, coAuthor];
+      }
+    }
   }
 
   private get canCommit(): boolean {
@@ -1082,17 +1523,33 @@ export class LvCommitPanel extends LitElement {
 
     if (this.amend) {
       // Store current input before pre-populating
-      this.originalSummary = this.summary;
-      this.originalDescription = this.description;
+      this.snapshotDraftForAmend();
 
       // Fetch last commit and pre-populate message
       await this.fetchLastCommitMessage();
     } else {
       // Restore original input when toggling off
-      this.summary = this.originalSummary;
-      this.description = this.originalDescription;
+      this.restoreDraftAfterAmend();
       this.lastCommit = null;
     }
+  }
+
+  /**
+   * Remember the draft the amend pre-population is about to overwrite —
+   * trailers included, since amend adopts the amended commit's own footer.
+   */
+  private snapshotDraftForAmend(): void {
+    this.originalSummary = this.summary;
+    this.originalDescription = this.description;
+    this.originalSignOff = this.signOff;
+    this.originalCoAuthors = this.coAuthors;
+  }
+
+  private restoreDraftAfterAmend(): void {
+    this.summary = this.originalSummary;
+    this.description = this.originalDescription;
+    this.signOff = this.originalSignOff;
+    this.coAuthors = this.originalCoAuthors;
   }
 
   private async fetchLastCommitMessage(): Promise<void> {
@@ -1108,6 +1565,7 @@ export class LvCommitPanel extends LitElement {
         this.lastCommit = result.data[0];
         this.summary = this.lastCommit.summary;
         this.description = this.lastCommit.body ?? '';
+        this.adoptTrailersFromDescription();
         return;
       }
 
@@ -1315,6 +1773,15 @@ export class LvCommitPanel extends LitElement {
           this.lastCommit = null;
           this.originalSummary = '';
           this.originalDescription = '';
+          // Co-authors belong to the commit that was just made, not to the next
+          // one; sign-off falls back to the user's standing preference.
+          this.coAuthors = [];
+          this.signOff = settingsStore.getState().alwaysSignOff;
+          this.originalSignOff = this.signOff;
+          this.originalCoAuthors = [];
+          this.showCoAuthors = false;
+          this.coAuthorInput = '';
+          this.coAuthorError = null;
 
           // Clear success message after a delay
           setTimeout(() => {
@@ -1366,8 +1833,87 @@ export class LvCommitPanel extends LitElement {
     }
   }
 
+  /**
+   * The footer the commit will carry, with a control to take each line back
+   * out. Without it the only way to know what `create_commit` is about to
+   * receive would be to make the commit and read it back.
+   */
+  private renderTrailersPreview() {
+    const trailers = this.pendingTrailers;
+    if (trailers.length === 0) return nothing;
+
+    return html`
+      <div class="trailers-preview" role="status" aria-label="Trailers added to this commit">
+        <span class="trailers-title">Trailers</span>
+        ${trailers.map((trailer) => {
+          const coAuthor = this.coAuthors.find(
+            (c) => formatTrailer(coAuthoredByTrailer(c)) === formatTrailer(trailer)
+          );
+          return html`
+            <div class="trailer-line">
+              <span>${formatTrailer(trailer)}</span>
+              <button
+                class="trailer-remove"
+                title=${coAuthor ? `Remove ${coAuthor.email}` : 'Turn off sign-off'}
+                @click=${() => (coAuthor ? this.handleRemoveCoAuthor(coAuthor) : (this.signOff = false))}
+              >
+                ✕
+              </button>
+            </div>
+          `;
+        })}
+      </div>
+    `;
+  }
+
+  private renderCoAuthorDropdown() {
+    return html`
+      <div class="coauthor-dropdown">
+        <div class="coauthor-dropdown-header">Add co-author</div>
+        <div class="coauthor-entry">
+          <input
+            type="text"
+            class="coauthor-input"
+            placeholder="Name &lt;email@example.com&gt;"
+            .value=${this.coAuthorInput}
+            @input=${this.handleCoAuthorInput}
+            @keydown=${this.handleCoAuthorKeyDown}
+          />
+          <button class="coauthor-add-btn" @click=${this.handleAddCoAuthor}>Add</button>
+        </div>
+        ${this.coAuthorError
+          ? html`<div class="coauthor-error" role="alert">${this.coAuthorError}</div>`
+          : nothing}
+        ${this.loadingSuggestions
+          ? html`<div class="coauthor-empty">Loading recent authors...</div>`
+          : this.suggestionsError
+            ? html`<div class="coauthor-error" role="alert">${this.suggestionsError}</div>`
+            : this.visibleSuggestions.length > 0
+              ? this.visibleSuggestions.map(
+                  (suggestion) => html`
+                    <button
+                      class="coauthor-suggestion"
+                      title="${suggestion.name} <${suggestion.email}>"
+                      @click=${() => this.addCoAuthor(suggestion)}
+                    >
+                      ${suggestion.name}
+                      <span class="suggestion-email">&lt;${suggestion.email}&gt;</span>
+                    </button>
+                  `
+                )
+              : html`<div class="coauthor-empty">No other recent authors in this repository</div>`}
+      </div>
+    `;
+  }
+
+  /** Open the Git Configuration dialog, where user.name/user.email live. */
+  private handleOpenGitConfig(): void {
+    window.dispatchEvent(new CustomEvent('open-git-config'));
+  }
+
   render() {
     const summaryOverLimit = this.summary.length > this.SUMMARY_LIMIT;
+    const identityMissing = this.identityLoaded && !this.hasIdentity;
 
     return html`
       <div class="header">
@@ -1604,7 +2150,44 @@ export class LvCommitPanel extends LitElement {
           />
           Conventional
         </label>
+
+        <label
+          class="signoff-toggle ${identityMissing ? 'disabled' : ''}"
+          title=${identityMissing
+            ? 'No git identity configured — set user.name and user.email to sign off'
+            : this.hasIdentity
+              ? `Add Signed-off-by: ${this.identityName} <${this.identityEmail}>`
+              : 'Add a Signed-off-by trailer using your git identity'}
+        >
+          <input
+            type="checkbox"
+            .checked=${this.signOff}
+            ?disabled=${identityMissing}
+            @change=${this.handleSignOffToggle}
+          />
+          Sign off
+        </label>
+
+        <div class="coauthor-wrapper">
+          <button
+            class="coauthor-btn"
+            @click=${this.handleCoAuthorsToggle}
+            title="Add Co-authored-by trailers"
+          >
+            Co-authors${this.coAuthors.length > 0 ? ` (${this.coAuthors.length})` : ''}
+          </button>
+          ${this.showCoAuthors ? this.renderCoAuthorDropdown() : nothing}
+        </div>
       </div>
+
+      ${identityMissing ? html`
+        <div class="trailer-hint" role="status">
+          <span>No git identity configured, so commits cannot be signed off.</span>
+          <button @click=${this.handleOpenGitConfig}>Configure identity</button>
+        </div>
+      ` : nothing}
+
+      ${this.renderTrailersPreview()}
 
       ${this.error ? html`<div class="error">${this.error}</div>` : nothing}
       ${this.success ? html`<div class="success">${this.success}</div>` : nothing}

--- a/src/stores/__tests__/settings.store.test.ts
+++ b/src/stores/__tests__/settings.store.test.ts
@@ -76,6 +76,12 @@ describe('settings.store', () => {
       expect(settingsStore.getState().autoStashOnCheckout).to.be.true;
     });
 
+    it('should not always sign off by default', () => {
+      // Sign-off is a project requirement, not a universal one: defaulting it
+      // on would add a trailer to every commit message unasked.
+      expect(settingsStore.getState().alwaysSignOff).to.be.false;
+    });
+
     it('should have 90 stale branch days by default', () => {
       expect(settingsStore.getState().staleBranchDays).to.equal(90);
     });
@@ -227,6 +233,11 @@ describe('settings.store', () => {
     it('should set auto stash on checkout', () => {
       settingsStore.getState().setAutoStashOnCheckout(true);
       expect(settingsStore.getState().autoStashOnCheckout).to.be.true;
+    });
+
+    it('should set always sign off', () => {
+      settingsStore.getState().setAlwaysSignOff(true);
+      expect(settingsStore.getState().alwaysSignOff).to.be.true;
     });
 
     it('should set stale branch days', () => {

--- a/src/stores/settings.store.ts
+++ b/src/stores/settings.store.ts
@@ -40,6 +40,7 @@ export interface SettingsState {
   confirmBeforeDiscard: boolean;
   openLastRepository: boolean;
   autoStashOnCheckout: boolean; // Automatically stash/pop when switching branches
+  alwaysSignOff: boolean; // Start every new commit message with Sign off enabled
 
   // Branch settings
   staleBranchDays: number; // Days without commits before a branch is considered stale (0 = disabled)
@@ -76,6 +77,7 @@ export interface SettingsState {
   setConfirmBeforeDiscard: (confirm: boolean) => void;
   setOpenLastRepository: (open: boolean) => void;
   setAutoStashOnCheckout: (enabled: boolean) => void;
+  setAlwaysSignOff: (enabled: boolean) => void;
   setStaleBranchDays: (days: number) => void;
   setNetworkOperationTimeout: (timeout: number) => void;
   setOfflineMode: (enabled: boolean) => void;
@@ -111,6 +113,9 @@ const defaultSettings = {
   // checkout auto-stashed, so `false` here would silently change behaviour for
   // every existing user — turning a seamless branch switch into a refusal.
   autoStashOnCheckout: true,
+  // Defaults OFF: sign-off is a project requirement, not a universal one, and
+  // adding a trailer nobody asked for would rewrite every commit message.
+  alwaysSignOff: false,
   staleBranchDays: 90,
   networkOperationTimeout: 300,
   offlineMode: false,
@@ -194,6 +199,8 @@ export const settingsStore = createStore<SettingsState>()(
       setOpenLastRepository: (openLastRepository) => set({ openLastRepository }),
 
       setAutoStashOnCheckout: (autoStashOnCheckout) => set({ autoStashOnCheckout }),
+
+      setAlwaysSignOff: (alwaysSignOff) => set({ alwaysSignOff }),
 
       setStaleBranchDays: (staleBranchDays) => set({ staleBranchDays }),
 

--- a/src/utils/__tests__/commit-trailers.test.ts
+++ b/src/utils/__tests__/commit-trailers.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Tests for commit message trailer composition.
+ *
+ * Trailers are a footer, not free text: git only recognises them in the last
+ * paragraph, one per line, after a blank line. These tests pin the rules that
+ * make a `Signed-off-by:`/`Co-authored-by:` line actually count.
+ */
+
+import { expect } from '@open-wc/testing';
+import {
+  adoptTrailers,
+  applyTrailers,
+  coAuthoredByTrailer,
+  composeMessage,
+  formatIdentity,
+  formatTrailer,
+  mergeTrailers,
+  parseCoAuthorInput,
+  parseIdentityValue,
+  sameCoAuthor,
+  signedOffByTrailer,
+  splitTrailers,
+  type Trailer,
+} from '../commit-trailers.ts';
+
+const ME = { name: 'Ada Lovelace', email: 'ada@example.com' };
+const PAIR = { name: 'Grace Hopper', email: 'grace@example.com' };
+
+describe('commit-trailers', () => {
+  describe('formatting', () => {
+    it('formats an identity as Name <email>', () => {
+      expect(formatIdentity('Ada Lovelace', 'ada@example.com')).to.equal(
+        'Ada Lovelace <ada@example.com>'
+      );
+    });
+
+    it('trims stray whitespace out of the identity', () => {
+      expect(formatIdentity('  Ada  ', ' ada@example.com ')).to.equal('Ada <ada@example.com>');
+    });
+
+    it('formats a trailer line as Token: value', () => {
+      expect(formatTrailer(signedOffByTrailer(ME.name, ME.email))).to.equal(
+        'Signed-off-by: Ada Lovelace <ada@example.com>'
+      );
+      expect(formatTrailer(coAuthoredByTrailer(PAIR))).to.equal(
+        'Co-authored-by: Grace Hopper <grace@example.com>'
+      );
+    });
+  });
+
+  describe('composeMessage', () => {
+    it('separates the footer from the body with exactly one blank line', () => {
+      const message = composeMessage('feat: add login\n\nSome body text', [
+        signedOffByTrailer(ME.name, ME.email),
+      ]);
+      expect(message).to.equal(
+        'feat: add login\n\nSome body text\n\nSigned-off-by: Ada Lovelace <ada@example.com>'
+      );
+    });
+
+    it('collapses trailing blank lines in the body rather than stacking them', () => {
+      const message = composeMessage('subject\n\nbody\n\n\n', [coAuthoredByTrailer(PAIR)]);
+      expect(message).to.equal('subject\n\nbody\n\nCo-authored-by: Grace Hopper <grace@example.com>');
+    });
+
+    it('puts one trailer per line', () => {
+      const message = composeMessage('subject', [
+        signedOffByTrailer(ME.name, ME.email),
+        coAuthoredByTrailer(PAIR),
+      ]);
+      expect(message.split('\n').slice(-2)).to.deep.equal([
+        'Signed-off-by: Ada Lovelace <ada@example.com>',
+        'Co-authored-by: Grace Hopper <grace@example.com>',
+      ]);
+    });
+
+    it('returns the body untouched when there are no trailers', () => {
+      expect(composeMessage('subject\n\nbody', [])).to.equal('subject\n\nbody');
+    });
+  });
+
+  describe('splitTrailers', () => {
+    it('splits a trailing trailer paragraph off the body', () => {
+      const { body, trailers } = splitTrailers(
+        'subject\n\nbody\n\nSigned-off-by: Ada Lovelace <ada@example.com>'
+      );
+      expect(body).to.equal('subject\n\nbody');
+      expect(trailers).to.deep.equal([
+        { token: 'Signed-off-by', value: 'Ada Lovelace <ada@example.com>' },
+      ]);
+    });
+
+    it('never reads the subject line as a trailer', () => {
+      // A one-line message is the subject, even when it is shaped like one.
+      const { body, trailers } = splitTrailers('Signed-off-by: Ada Lovelace <ada@example.com>');
+      expect(trailers).to.deep.equal([]);
+      expect(body).to.equal('Signed-off-by: Ada Lovelace <ada@example.com>');
+    });
+
+    it('reads a lone paragraph as trailers when the subject was already split off', () => {
+      const { body, trailers } = splitTrailers('Co-authored-by: Grace Hopper <grace@example.com>', {
+        allowSingleParagraph: true,
+      });
+      expect(body).to.equal('');
+      expect(trailers).to.have.lengthOf(1);
+    });
+
+    it('leaves a mixed final paragraph alone rather than rewriting it', () => {
+      const message = 'subject\n\nSee: the docs\nand also this prose line';
+      const { body, trailers } = splitTrailers(message);
+      expect(trailers).to.deep.equal([]);
+      expect(body).to.equal(message);
+    });
+
+    it('ignores trailer-looking lines that are not in the last paragraph', () => {
+      const message = 'subject\n\nSigned-off-by: Ada Lovelace <ada@example.com>\n\nreal body';
+      const { trailers } = splitTrailers(message);
+      expect(trailers).to.deep.equal([]);
+    });
+  });
+
+  describe('mergeTrailers', () => {
+    it('drops an exact duplicate', () => {
+      const merged = mergeTrailers(
+        [coAuthoredByTrailer(PAIR)],
+        [coAuthoredByTrailer(PAIR)]
+      );
+      expect(merged).to.have.lengthOf(1);
+    });
+
+    it('treats token and value case-insensitively when de-duplicating', () => {
+      const existing: Trailer[] = [
+        { token: 'co-authored-by', value: 'Grace Hopper <GRACE@example.com>' },
+      ];
+      const merged = mergeTrailers(existing, [coAuthoredByTrailer(PAIR)]);
+      expect(merged).to.have.lengthOf(1);
+    });
+
+    it('keeps distinct trailers in order', () => {
+      const merged = mergeTrailers(
+        [signedOffByTrailer(ME.name, ME.email)],
+        [coAuthoredByTrailer(PAIR)]
+      );
+      expect(merged.map(formatTrailer)).to.deep.equal([
+        'Signed-off-by: Ada Lovelace <ada@example.com>',
+        'Co-authored-by: Grace Hopper <grace@example.com>',
+      ]);
+    });
+  });
+
+  describe('applyTrailers', () => {
+    it('returns the message byte-for-byte when nothing is armed', () => {
+      const message = 'subject\n\nbody with  odd   spacing\n\n\n';
+      expect(applyTrailers(message, [])).to.equal(message);
+    });
+
+    it('appends the footer to a body-less message', () => {
+      expect(applyTrailers('fix: typo', [signedOffByTrailer(ME.name, ME.email)])).to.equal(
+        'fix: typo\n\nSigned-off-by: Ada Lovelace <ada@example.com>'
+      );
+    });
+
+    it('composes with a conventional-commit subject', () => {
+      const message = applyTrailers('feat(auth): add SSO\n\nWhy this matters.', [
+        signedOffByTrailer(ME.name, ME.email),
+        coAuthoredByTrailer(PAIR),
+      ]);
+      expect(message).to.equal(
+        'feat(auth): add SSO\n\nWhy this matters.\n\n' +
+          'Signed-off-by: Ada Lovelace <ada@example.com>\n' +
+          'Co-authored-by: Grace Hopper <grace@example.com>'
+      );
+    });
+
+    it('does not duplicate a trailer the message already carries (amend)', () => {
+      const existing =
+        'fix: bug\n\nBody.\n\nSigned-off-by: Ada Lovelace <ada@example.com>';
+      const message = applyTrailers(existing, [signedOffByTrailer(ME.name, ME.email)]);
+      expect(message).to.equal(existing);
+      expect(message.match(/Signed-off-by/g)).to.have.lengthOf(1);
+    });
+
+    it('joins the existing footer instead of starting a second one', () => {
+      // `Refs: #42` is already a trailer paragraph, so the new line belongs in
+      // it — a blank line between them would split the footer in two.
+      const message = applyTrailers('fix: bug\n\nRefs: #42', [coAuthoredByTrailer(PAIR)]);
+      expect(message).to.equal(
+        'fix: bug\n\nRefs: #42\nCo-authored-by: Grace Hopper <grace@example.com>'
+      );
+    });
+
+    it('keeps the footer as one paragraph when a trailer is added twice over', () => {
+      const once = applyTrailers('subject', [coAuthoredByTrailer(PAIR)]);
+      const twice = applyTrailers(once, [coAuthoredByTrailer(PAIR)]);
+      expect(twice).to.equal(once);
+    });
+  });
+
+  describe('parseIdentityValue / parseCoAuthorInput', () => {
+    it('parses Name <email>', () => {
+      expect(parseIdentityValue('Grace Hopper <grace@example.com>')).to.deep.equal(PAIR);
+    });
+
+    it('rejects a value without an email', () => {
+      expect(parseIdentityValue('Grace Hopper')).to.equal(null);
+    });
+
+    it('rejects a value without a name', () => {
+      expect(parseIdentityValue('<grace@example.com>')).to.equal(null);
+    });
+
+    it('explains what is wrong instead of silently dropping the entry', () => {
+      const empty = parseCoAuthorInput('   ');
+      expect(empty.coAuthor).to.equal(undefined);
+      expect(empty.error).to.contain('Name <email');
+
+      const bare = parseCoAuthorInput('grace@example.com');
+      expect(bare.coAuthor).to.equal(undefined);
+      expect(bare.error).to.contain('not a valid co-author');
+    });
+
+    it('accepts a well-formed entry', () => {
+      expect(parseCoAuthorInput('  Grace Hopper <grace@example.com> ').coAuthor).to.deep.equal(PAIR);
+    });
+  });
+
+  describe('sameCoAuthor', () => {
+    it('matches on email, ignoring case and display name', () => {
+      expect(sameCoAuthor(PAIR, { name: 'G. Hopper', email: 'GRACE@Example.com' })).to.be.true;
+      expect(sameCoAuthor(PAIR, ME)).to.be.false;
+    });
+  });
+
+  describe('adoptTrailers', () => {
+    it('lifts co-authors out of an existing message', () => {
+      const adopted = adoptTrailers(
+        'Body text.\n\nCo-authored-by: Grace Hopper <grace@example.com>',
+        ME,
+        { allowSingleParagraph: true }
+      );
+      expect(adopted.coAuthors).to.deep.equal([PAIR]);
+      expect(adopted.message).to.equal('Body text.');
+      expect(adopted.signedOff).to.be.false;
+    });
+
+    it('recognises a sign-off by the current identity', () => {
+      const adopted = adoptTrailers('Signed-off-by: Ada Lovelace <ada@example.com>', ME, {
+        allowSingleParagraph: true,
+      });
+      expect(adopted.signedOff).to.be.true;
+      expect(adopted.message).to.equal('');
+    });
+
+    it('keeps a sign-off by somebody else in the message', () => {
+      // There is no control that could put it back, so removing it would lose it.
+      const adopted = adoptTrailers('Signed-off-by: Grace Hopper <grace@example.com>', ME, {
+        allowSingleParagraph: true,
+      });
+      expect(adopted.signedOff).to.be.false;
+      expect(adopted.message).to.equal('Signed-off-by: Grace Hopper <grace@example.com>');
+    });
+
+    it('keeps unrelated trailers and adopts only what the UI can show', () => {
+      const adopted = adoptTrailers(
+        'Body.\n\nRefs: #42\nCo-authored-by: Grace Hopper <grace@example.com>',
+        ME,
+        { allowSingleParagraph: true }
+      );
+      expect(adopted.coAuthors).to.deep.equal([PAIR]);
+      expect(adopted.message).to.equal('Body.\n\nRefs: #42');
+    });
+
+    it('de-duplicates a co-author listed twice', () => {
+      const adopted = adoptTrailers(
+        'Co-authored-by: Grace Hopper <grace@example.com>\n' +
+          'Co-authored-by: G. Hopper <GRACE@example.com>',
+        ME,
+        { allowSingleParagraph: true }
+      );
+      expect(adopted.coAuthors).to.have.lengthOf(1);
+    });
+
+    it('leaves a message with no footer completely alone', () => {
+      const adopted = adoptTrailers('Just a body.', ME, { allowSingleParagraph: true });
+      expect(adopted.message).to.equal('Just a body.');
+      expect(adopted.coAuthors).to.deep.equal([]);
+      expect(adopted.signedOff).to.be.false;
+    });
+
+    it('cannot adopt a sign-off when there is no identity to compare against', () => {
+      const adopted = adoptTrailers('Signed-off-by: Ada Lovelace <ada@example.com>', null, {
+        allowSingleParagraph: true,
+      });
+      expect(adopted.signedOff).to.be.false;
+      expect(adopted.message).to.equal('Signed-off-by: Ada Lovelace <ada@example.com>');
+    });
+  });
+});

--- a/src/utils/commit-trailers.ts
+++ b/src/utils/commit-trailers.ts
@@ -1,0 +1,240 @@
+/**
+ * Commit message trailers (`Signed-off-by:`, `Co-authored-by:`).
+ *
+ * Git treats trailers as a *footer*: the last paragraph of the message, one
+ * `Token: value` per line, separated from the body by a blank line. Everything
+ * here is pure string work so the composition rules can be tested on their own
+ * and reused by the commit panel for both fresh commits and amends.
+ */
+
+export interface Trailer {
+  token: string;
+  value: string;
+}
+
+export interface CoAuthor {
+  name: string;
+  email: string;
+}
+
+export const SIGNED_OFF_BY = 'Signed-off-by';
+export const CO_AUTHORED_BY = 'Co-authored-by';
+
+/**
+ * One trailer line. Git's own parser is looser (it accepts folded continuation
+ * lines and a mixed block), but recognising *less* is the safe direction: an
+ * unrecognised paragraph is simply left in the body untouched instead of being
+ * rewritten.
+ */
+const TRAILER_LINE = /^([A-Za-z][A-Za-z0-9-]*)[ \t]*:[ \t]*(\S.*?)[ \t\r]*$/;
+
+/** `Name <email>` as it appears in a trailer value. */
+const IDENTITY_VALUE = /^(.*?)\s*<([^<>]+)>$/;
+
+/** Deliberately permissive: git does not validate emails either. */
+const EMAIL = /^[^\s<>@]+@[^\s<>@]+$/;
+
+/** Render one trailer as the line that goes in the message. */
+export function formatTrailer(trailer: Trailer): string {
+  return `${trailer.token}: ${trailer.value}`;
+}
+
+/**
+ * Identity key for de-duplication. Trailer tokens are case-insensitive in git
+ * (`git interpret-trailers` matches them that way), and so are email domains
+ * in practice — GitHub attributes co-authors by email regardless of case.
+ */
+export function trailerKey(trailer: Trailer): string {
+  return `${trailer.token.toLowerCase()}:${trailer.value.trim().toLowerCase()}`;
+}
+
+/** `Name <email>`, the shape both trailers require. */
+export function formatIdentity(name: string, email: string): string {
+  return `${name.trim()} <${email.trim()}>`;
+}
+
+export function signedOffByTrailer(name: string, email: string): Trailer {
+  return { token: SIGNED_OFF_BY, value: formatIdentity(name, email) };
+}
+
+export function coAuthoredByTrailer(coAuthor: CoAuthor): Trailer {
+  return { token: CO_AUTHORED_BY, value: formatIdentity(coAuthor.name, coAuthor.email) };
+}
+
+/** Two identities are the same person when their emails match, case-insensitively. */
+export function sameCoAuthor(a: CoAuthor, b: CoAuthor): boolean {
+  return a.email.trim().toLowerCase() === b.email.trim().toLowerCase();
+}
+
+/** Parse a trailer value of the form `Name <email>`. Returns null otherwise. */
+export function parseIdentityValue(value: string): CoAuthor | null {
+  const match = IDENTITY_VALUE.exec(value.trim());
+  if (!match) return null;
+  const name = match[1].trim();
+  const email = match[2].trim();
+  if (!name || !EMAIL.test(email)) return null;
+  return { name, email };
+}
+
+/**
+ * Parse what the user typed into the co-author box.
+ *
+ * Returns an error string rather than throwing so the caller always has
+ * something concrete to show: a silently ignored entry is the worst outcome.
+ */
+export function parseCoAuthorInput(input: string): { coAuthor?: CoAuthor; error?: string } {
+  const trimmed = input.trim();
+  if (!trimmed) {
+    return { error: 'Enter a co-author as: Name <email@example.com>' };
+  }
+  const coAuthor = parseIdentityValue(trimmed);
+  if (!coAuthor) {
+    return { error: `"${trimmed}" is not a valid co-author. Use: Name <email@example.com>` };
+  }
+  return { coAuthor };
+}
+
+export interface SplitMessage {
+  /** The message without its trailer footer (trailing blank lines removed). */
+  body: string;
+  /** The trailers found in the footer, in the order they appear. */
+  trailers: Trailer[];
+}
+
+export interface SplitOptions {
+  /**
+   * Allow the *only* paragraph to be the trailer block. Off by default because
+   * in a full commit message that paragraph is the subject line — `git` never
+   * reads the subject as a trailer. Turn it on when parsing a message body that
+   * has already had its subject split off.
+   */
+  allowSingleParagraph?: boolean;
+}
+
+/**
+ * Split a commit message into its body and its trailer footer.
+ *
+ * The footer is only recognised when the last paragraph consists *entirely* of
+ * trailer lines; otherwise the message is returned untouched with no trailers,
+ * so a hand-written footer that merely looks close to one is never rewritten.
+ */
+export function splitTrailers(message: string, options: SplitOptions = {}): SplitMessage {
+  const lines = message.split('\n');
+
+  let end = lines.length;
+  while (end > 0 && lines[end - 1].trim() === '') end--;
+  if (end === 0) return { body: message, trailers: [] };
+
+  let start = end;
+  while (start > 0 && lines[start - 1].trim() !== '') start--;
+
+  if (start === 0 && !options.allowSingleParagraph) {
+    // The last paragraph is also the first — that is the subject, not a footer.
+    return { body: message, trailers: [] };
+  }
+
+  const block = lines.slice(start, end);
+  const trailers: Trailer[] = [];
+  for (const line of block) {
+    const match = TRAILER_LINE.exec(line);
+    if (!match) return { body: message, trailers: [] };
+    trailers.push({ token: match[1], value: match[2] });
+  }
+
+  const body = lines.slice(0, start).join('\n').replace(/\n+$/, '');
+  return { body, trailers };
+}
+
+/**
+ * Append `additions` to `existing`, skipping any that are already present.
+ * Adding the same co-author twice is a no-op.
+ */
+export function mergeTrailers(existing: Trailer[], additions: Trailer[]): Trailer[] {
+  const seen = new Set(existing.map(trailerKey));
+  const merged = [...existing];
+  for (const trailer of additions) {
+    const key = trailerKey(trailer);
+    if (seen.has(key)) continue;
+    seen.add(key);
+    merged.push(trailer);
+  }
+  return merged;
+}
+
+/** Join a body and a trailer footer with exactly one blank line between them. */
+export function composeMessage(body: string, trailers: Trailer[]): string {
+  const trimmedBody = body.replace(/\n+$/, '');
+  if (trailers.length === 0) return trimmedBody;
+  const footer = trailers.map(formatTrailer).join('\n');
+  return trimmedBody ? `${trimmedBody}\n\n${footer}` : footer;
+}
+
+/**
+ * Add trailers to a message: existing footer trailers are kept in place, new
+ * ones are appended after them, and duplicates are dropped.
+ *
+ * With nothing to add the message is returned byte-for-byte unchanged — a
+ * user's hand-formatted message is never reflowed by a feature they aren't
+ * using.
+ */
+export function applyTrailers(message: string, additions: Trailer[]): string {
+  if (additions.length === 0) return message;
+  const { body, trailers } = splitTrailers(message);
+  return composeMessage(body, mergeTrailers(trailers, additions));
+}
+
+export interface AdoptedTrailers {
+  /** The message with the adopted trailer lines removed. */
+  message: string;
+  /** Co-authors found in the footer. */
+  coAuthors: CoAuthor[];
+  /** True when the footer already signs off as `identity`. */
+  signedOff: boolean;
+}
+
+/**
+ * Take over the trailers of an existing message (an amend) so the panel's
+ * controls show the real state instead of silently re-adding what is already
+ * there.
+ *
+ * Only trailers the UI can represent are removed from the text: co-authors, and
+ * a sign-off by `identity`. Anything else — including a sign-off by somebody
+ * else — stays in the message untouched, because dropping a line the user has
+ * no control to restore would lose it.
+ */
+export function adoptTrailers(
+  message: string,
+  identity: CoAuthor | null,
+  options: SplitOptions = {},
+): AdoptedTrailers {
+  const { body, trailers } = splitTrailers(message, options);
+  if (trailers.length === 0) {
+    return { message, coAuthors: [], signedOff: false };
+  }
+
+  const coAuthors: CoAuthor[] = [];
+  const kept: Trailer[] = [];
+  let signedOff = false;
+
+  for (const trailer of trailers) {
+    const token = trailer.token.toLowerCase();
+    const parsed = parseIdentityValue(trailer.value);
+
+    if (token === CO_AUTHORED_BY.toLowerCase() && parsed) {
+      if (!coAuthors.some((c) => sameCoAuthor(c, parsed))) coAuthors.push(parsed);
+      continue;
+    }
+    if (
+      token === SIGNED_OFF_BY.toLowerCase() &&
+      parsed &&
+      identity &&
+      sameCoAuthor(parsed, identity)
+    ) {
+      signedOff = true;
+      continue;
+    }
+    kept.push(trailer);
+  }
+
+  return { message: composeMessage(body, kept), coAuthors, signedOff };
+}


### PR DESCRIPTION
## Summary

- **Sign off** appends `Signed-off-by: Name <email>` using the identity the commit will actually be authored with — `get_user_identity` resolves `user.name`/`user.email` *with repository context* (system → global → local → worktree, conditional includes), so a unified profile applied to this repository wins over the global config. With no identity configured the control is disabled, explains itself, and offers a button that opens Git Configuration instead of writing `Signed-off-by:  <>`.
- **Co-authors** appends one `Co-authored-by:` line per person. Suggestions come from the recent distinct commit authors of the current repository via the existing `get_commit_history` command (no new Rust command); a co-author can also be typed in as `Name <email>`. Adding the same person twice is a refused no-op ("already a co-author"), a malformed entry is rejected with an explanation, and each co-author can be removed again.
- **Trailer correctness**: trailers are composed as a real footer — blank line after the body, one per line, joined to an existing footer paragraph rather than starting a second one, de-duplicated case-insensitively by token and email. With nothing armed the message is passed through byte-for-byte, so a hand-formatted message is never reflowed. Composition is a separate pure module (`src/utils/commit-trailers.ts`).
- **Amend** adopts the amended commit's own trailers into the controls (sign-off ticked, co-authors listed, footer lifted out of the body) instead of appending a second copy; a sign-off by somebody else stays in the message, since no control could put it back.
- **Visible state**: the panel lists the exact trailer lines that will be added, each with a control to take it back out, and the composed message — not the textarea — is what reaches `create_commit`.
- Optional per-user preference **"Always Sign Off Commits"** seeds each new draft (settings row included); it seeds a fresh draft only and never overrides a choice the user made on the draft in front of them.

## Review finding

`src/components/sidebar/lv-commit-panel.ts` (1,633 lines) offered message templates, conventional-commit mode and amend, but there was no way to add a `Signed-off-by:` trailer (DCO sign-off, mandatory in many OSS projects) or a `Co-authored-by:` trailer (standard in GitHub Desktop and used by GitHub for co-author attribution). Neither string appeared anywhere in `src/` or `src-tauri/src/` outside a hooks test fixture (`src-tauri/src/commands/hooks.rs:1214`). This PR adds both, sourcing the sign-off identity from the same place the commit does (`get_user_identity`, `src-tauri/src/commands/config.rs:287`) so it matches per-repository profile overrides, and wires a new `open-git-config` window event with its listener in `src/app-shell.ts`.

## Test plan

- [ ] `npm run lint` — 0 errors, 204 warnings (unchanged from baseline)
- [ ] `npm run typecheck` — clean
- [ ] `npm test` — 5395 passed; the only 2 failures are the pre-existing "network gate coverage" timeouts, confirmed to fail identically with these source changes stashed
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` — clean (no Rust changed)
- [ ] `npx playwright test e2e/tests/commit-panel.spec.ts` — 41 passed, including 6 new trailer tests asserting the exact message reaching `create_commit`
- [ ] Manual: tick Sign off and check the preview line and the committed message; add a co-author from the suggestion list and by hand; try adding the same one twice; amend a commit that already carries both trailers and confirm neither is duplicated; unset `user.email` and confirm the control disables and points at Git Configuration

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_