### PR TITLE
feat: add branch and submodule options to the clone dialog

### DIFF
--- a/e2e/pages/dialogs.page.ts
+++ b/e2e/pages/dialogs.page.ts
@@ -48,6 +48,8 @@ export class CloneDialogPage extends BaseDialog {
   readonly browseButton: Locator;
   readonly cloneButton: Locator;
   readonly progressBar: Locator;
+  readonly branchInput: Locator;
+  readonly submodulesCheckbox: Locator;
 
   constructor(page: Page) {
     super(page, 'lv-clone-dialog');
@@ -61,6 +63,20 @@ export class CloneDialogPage extends BaseDialog {
     // Clone button inside the dialog - use locator within the dialog to avoid matching welcome screen button
     this.cloneButton = page.locator('lv-clone-dialog').getByRole('button', { name: 'Clone', exact: true });
     this.progressBar = this.dialog.locator('.progress-bar, progress');
+    // Role selectors, not CSS: two lv-clone-dialog instances are mounted (the
+    // toolbar's and the shell's) and only the open one is in the
+    // accessibility tree, so a CSS id match is ambiguous while a role match is
+    // not.
+    this.branchInput = page.getByRole('textbox', { name: /^Branch/ });
+    this.submodulesCheckbox = page.getByRole('checkbox', { name: /Clone submodules/i });
+  }
+
+  async fillBranch(branch: string): Promise<void> {
+    await this.branchInput.fill(branch);
+  }
+
+  async checkSubmodules(): Promise<void> {
+    await this.submodulesCheckbox.check();
   }
 
   async fillUrl(url: string): Promise<void> {

--- a/e2e/tests/clone-options.spec.ts
+++ b/e2e/tests/clone-options.spec.ts
@@ -1,0 +1,185 @@
+import { test, expect } from '@playwright/test';
+import { setupTauriMocks, emptyRepository } from '../fixtures/tauri-mock';
+import { AppPage } from '../pages/app.page';
+import { DialogsPage } from '../pages/dialogs.page';
+import {
+  startCommandCapture,
+  findCommand,
+  waitForCommand,
+  injectCommandMock,
+  injectCommandError,
+} from '../fixtures/test-helpers';
+
+/**
+ * E2E: the clone dialog's branch and submodule options.
+ *
+ * The backend has always accepted a `branch`, but the dialog sent only url,
+ * path, depth, filter and singleBranch — so cloning any branch other than the
+ * remote's default was impossible from the UI. And with no recursive clone on
+ * the backend, a cloned superproject left every submodule directory empty.
+ */
+
+const clonedRepo = {
+  path: '/home/user/projects/proj',
+  name: 'proj',
+  isValid: true,
+  isBare: false,
+  headRef: 'develop',
+};
+
+const oneSubmodule = [
+  {
+    name: 'libs/vendor',
+    path: 'libs/vendor',
+    url: 'https://example.com/vendor.git',
+    headOid: null,
+    branch: null,
+    initialized: false,
+    status: 'uninitialized',
+  },
+];
+
+test.describe('Clone Dialog - branch and submodule options', () => {
+  let app: AppPage;
+  let dialogs: DialogsPage;
+
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMocks(page, emptyRepository());
+    app = new AppPage(page);
+    dialogs = new DialogsPage(page);
+    await app.goto();
+    await injectCommandMock(page, {
+      clone_repository: clonedRepo,
+      get_submodules: [],
+      update_submodules: null,
+    });
+    await app.cloneButton.click();
+    await dialogs.clone.waitForOpen();
+  });
+
+  test('offers the branch field and the submodule checkbox', async () => {
+    await expect(dialogs.clone.branchInput).toBeVisible();
+    await expect(dialogs.clone.submodulesCheckbox).toBeVisible();
+    await expect(dialogs.clone.submodulesCheckbox).not.toBeChecked();
+  });
+
+  test('passes the requested branch to clone_repository', async ({ page }) => {
+    await dialogs.clone.fillUrl('https://example.com/group/proj.git');
+    await dialogs.clone.fillPath('/home/user/projects');
+    await dialogs.clone.fillBranch('develop');
+
+    await startCommandCapture(page);
+    await dialogs.clone.clone();
+    await waitForCommand(page, 'clone_repository');
+
+    const args = (await findCommand(page, 'clone_repository'))[0].args as { branch?: string };
+    expect(args.branch).toBe('develop');
+  });
+
+  test('sends no branch when the field is left empty', async ({ page }) => {
+    await dialogs.clone.fillUrl('https://example.com/group/proj.git');
+    await dialogs.clone.fillPath('/home/user/projects');
+
+    await startCommandCapture(page);
+    await dialogs.clone.clone();
+    await waitForCommand(page, 'clone_repository');
+
+    const args = (await findCommand(page, 'clone_repository'))[0].args as { branch?: string };
+    expect(args.branch).toBeUndefined();
+  });
+
+  test('reports a branch that does not exist on the remote', async ({ page }) => {
+    await dialogs.clone.fillUrl('https://example.com/group/proj.git');
+    await dialogs.clone.fillPath('/home/user/projects');
+    await dialogs.clone.fillBranch('no-such-branch');
+
+    await injectCommandError(
+      page,
+      'clone_repository',
+      "Remote branch no-such-branch not found in upstream origin",
+    );
+    await dialogs.clone.clone();
+
+    const errorMessage = page.locator('lv-clone-dialog .error-message');
+    await expect(errorMessage).toBeVisible();
+    await expect(errorMessage).toContainText('no-such-branch');
+    await expect(dialogs.clone.dialog).toBeVisible();
+  });
+
+  test('clones submodules after the clone finishes when asked', async ({ page }) => {
+    await injectCommandMock(page, { get_submodules: oneSubmodule });
+
+    await dialogs.clone.fillUrl('https://example.com/group/proj.git');
+    await dialogs.clone.fillPath('/home/user/projects');
+    await dialogs.clone.checkSubmodules();
+
+    await startCommandCapture(page);
+    await dialogs.clone.clone();
+    await waitForCommand(page, 'update_submodules');
+
+    const args = (await findCommand(page, 'update_submodules'))[0].args as {
+      path?: string;
+      init?: boolean;
+      recursive?: boolean;
+    };
+    expect(args.path).toBe(clonedRepo.path);
+    expect(args.init).toBe(true);
+    expect(args.recursive).toBe(true);
+
+    // The submodule phase ran AFTER the clone, against the new repository.
+    const commands = (await findCommand(page, 'clone_repository')).length;
+    expect(commands).toBeGreaterThanOrEqual(1);
+
+    // Everything succeeded, so the dialog closes on its own.
+    await expect(dialogs.clone.dialog).toBeHidden();
+  });
+
+  test('does not run the submodule phase when the box is unchecked', async ({ page }) => {
+    await injectCommandMock(page, { get_submodules: oneSubmodule });
+
+    await dialogs.clone.fillUrl('https://example.com/group/proj.git');
+    await dialogs.clone.fillPath('/home/user/projects');
+
+    await startCommandCapture(page);
+    await dialogs.clone.clone();
+    await waitForCommand(page, 'clone_repository');
+    await expect(dialogs.clone.dialog).toBeHidden();
+
+    expect(await findCommand(page, 'update_submodules')).toHaveLength(0);
+  });
+
+  test('a submodule failure is reported as a partial success, not a failed clone', async ({
+    page,
+  }) => {
+    await injectCommandMock(page, { get_submodules: oneSubmodule });
+    await injectCommandError(page, 'update_submodules', 'authentication required');
+
+    await dialogs.clone.fillUrl('https://example.com/group/proj.git');
+    await dialogs.clone.fillPath('/home/user/projects');
+    await dialogs.clone.checkSubmodules();
+    await dialogs.clone.clone();
+
+    // A toast, because opening the cloned repository tears the welcome
+    // screen — and the dialog it hosts — down.
+    const warning = page.locator('.toast.warning', { hasText: /submodules were not/i });
+    await expect(warning).toBeVisible();
+    await expect(warning).toContainText('authentication required');
+    // The clone itself succeeded, so nothing says it failed.
+    await expect(page.locator('lv-clone-dialog .error-message')).toHaveCount(0);
+
+    // And the repository the user asked for is open regardless.
+    const opened = await page.evaluate(() => {
+      const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as
+        | {
+            repositoryStore: {
+              getState: () => { openRepositories: { repository: { path: string } }[] };
+            };
+          }
+        | undefined;
+      return (
+        stores?.repositoryStore.getState().openRepositories.map((r) => r.repository.path) ?? []
+      );
+    });
+    expect(opened).toContain(clonedRepo.path);
+  });
+});

--- a/src/components/dialogs/__tests__/lv-clone-dialog-options.test.ts
+++ b/src/components/dialogs/__tests__/lv-clone-dialog-options.test.ts
@@ -1,0 +1,501 @@
+/**
+ * The clone dialog's branch and submodule options.
+ *
+ * The backend's clone command accepts and validates a `branch`, but the dialog
+ * never sent one, so cloning anything other than the remote's default branch
+ * was impossible from the UI. There is also no recursive clone on the backend,
+ * so a superproject cloned here left every submodule directory empty and the
+ * user had to find the palette-only Submodules dialog afterwards.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invoked: { command: string; args?: Record<string, unknown> }[] = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invoked.push({ command, args: args as Record<string, unknown> });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+(globalThis as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+  convertCallback: (callback: unknown, once: boolean) => {
+    void once;
+    void callback;
+    return 0;
+  },
+  unregisterListener: (_event: string, _eventId: number) => {},
+};
+
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-clone-dialog.ts';
+import type { LvCloneDialog } from '../lv-clone-dialog.ts';
+import { settingsStore } from '../../../stores/settings.store.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
+import { repositoryStore } from '../../../stores/index.ts';
+
+interface CloneInternals {
+  url: string;
+  destination: string;
+  repoName: string;
+  branch: string;
+  cloneSubmodules: boolean;
+  submodulePhase: boolean;
+  isCloning: boolean;
+  isComplete: boolean;
+  error: string;
+  progressText: string;
+  handleClone: () => Promise<void>;
+  handleModalClose: () => void;
+}
+
+function internals(el: LvCloneDialog): CloneInternals {
+  return el as unknown as CloneInternals;
+}
+
+/** The args Tauri nests under the command's parameter name. */
+function argsOf(command: string): Record<string, unknown> | undefined {
+  const call = invoked.find((c) => c.command === command);
+  if (!call) return undefined;
+  const nested = call.args?.args as Record<string, unknown> | undefined;
+  return nested ?? call.args;
+}
+
+async function flush(): Promise<void> {
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+}
+
+/**
+ * Poll until `predicate` holds. The clone path awaits credential lookups and
+ * dynamic imports before it reaches the submodule phase, so a fixed number of
+ * ticks is not a reliable way to observe a phase that is deliberately left
+ * pending.
+ */
+async function waitFor(predicate: () => boolean, what: string): Promise<void> {
+  for (let i = 0; i < 300; i++) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 10));
+  }
+  throw new Error(`Timed out waiting for ${what}`);
+}
+
+const clonedRepo = {
+  path: '/dest/repo',
+  name: 'repo',
+  isValid: true,
+  isBare: false,
+  headRef: 'main',
+};
+
+const submodule = {
+  name: 'libs/vendor',
+  path: 'libs/vendor',
+  url: 'https://example.com/vendor.git',
+  headOid: null,
+  branch: null,
+  initialized: false,
+  status: 'uninitialized',
+};
+
+function toastMessages(): string[] {
+  return uiStore.getState().toasts.map((t) => t.message);
+}
+
+describe('lv-clone-dialog branch and submodule options', () => {
+  let el: LvCloneDialog;
+
+  beforeEach(async () => {
+    invoked.length = 0;
+    mockInvoke = () => Promise.resolve(null);
+    settingsStore.getState().setDefaultClonePath('');
+    settingsStore.setState({ offlineMode: false, confirmNetworkOps: false });
+    uiStore.setState({ toasts: [] });
+    repositoryStore.setState({ openRepositories: [], activeIndex: -1 });
+
+    el = await fixture<LvCloneDialog>(html`<lv-clone-dialog></lv-clone-dialog>`);
+  });
+
+  // ── Fields ───────────────────────────────────────────────────────────────
+  describe('fields', () => {
+    it('renders an optional Branch field', () => {
+      const input = el.shadowRoot!.querySelector('#branch') as HTMLInputElement;
+      expect(input, 'the branch field must exist').to.exist;
+      expect(input.type).to.equal('text');
+      expect(input.placeholder.toLowerCase()).to.contain('default');
+    });
+
+    it('renders a Clone submodules checkbox', () => {
+      const box = el.shadowRoot!.querySelector('#clone-submodules') as HTMLInputElement;
+      expect(box, 'the submodule checkbox must exist').to.exist;
+      expect(box.type).to.equal('checkbox');
+      expect(box.checked, 'submodules are opt-in').to.be.false;
+    });
+
+    it('disables both new controls while a clone is in flight', async () => {
+      internals(el).isCloning = true;
+      await el.updateComplete;
+
+      const branch = el.shadowRoot!.querySelector('#branch') as HTMLInputElement;
+      const box = el.shadowRoot!.querySelector('#clone-submodules') as HTMLInputElement;
+      expect(branch.disabled).to.be.true;
+      expect(box.disabled).to.be.true;
+    });
+
+    it('tracks typing in the branch field', async () => {
+      const input = el.shadowRoot!.querySelector('#branch') as HTMLInputElement;
+      input.value = 'release/2.0';
+      input.dispatchEvent(new Event('input'));
+      await el.updateComplete;
+
+      expect(internals(el).branch).to.equal('release/2.0');
+    });
+
+    it('clears both new fields on reset', async () => {
+      const state = internals(el);
+      state.branch = 'develop';
+      state.cloneSubmodules = true;
+
+      (el as unknown as { reset: () => void }).reset();
+
+      expect(state.branch).to.equal('');
+      expect(state.cloneSubmodules).to.be.false;
+    });
+  });
+
+  // ── Branch passed through ────────────────────────────────────────────────
+  describe('branch', () => {
+    beforeEach(() => {
+      mockInvoke = (command) => {
+        if (command === 'clone_repository') return Promise.resolve(clonedRepo);
+        return Promise.resolve(null);
+      };
+    });
+
+    it('sends the requested branch to clone_repository', async () => {
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.branch = '  develop  ';
+
+      await state.handleClone();
+      await flush();
+
+      expect(argsOf('clone_repository')?.branch, 'the branch is trimmed and sent').to.equal(
+        'develop',
+      );
+    });
+
+    it('omits branch entirely when the field is left empty', async () => {
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.branch = '   ';
+
+      await state.handleClone();
+      await flush();
+
+      const args = argsOf('clone_repository');
+      expect(args, 'the clone still runs').to.exist;
+      expect(args!.branch, 'an empty branch means the remote default').to.be.undefined;
+    });
+
+    it('rejects a branch the backend would refuse, without a round trip', async () => {
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.branch = '--upload-pack=evil';
+
+      await state.handleClone();
+      await el.updateComplete;
+
+      const error = el.shadowRoot!.querySelector('.error-message');
+      expect(error, 'the refusal is shown inline').to.exist;
+      expect(error!.textContent).to.contain('Branch name');
+      expect(
+        invoked.some((c) => c.command === 'clone_repository'),
+        'a branch the backend rejects is never sent',
+      ).to.be.false;
+      expect(state.isCloning, 'the dialog stays usable').to.be.false;
+    });
+
+    it('surfaces the backend error when the branch does not exist', async () => {
+      mockInvoke = (command) => {
+        if (command === 'clone_repository') {
+          return Promise.reject({
+            code: 'COMMAND_ERROR',
+            message: "Remote branch nope not found in upstream origin",
+          });
+        }
+        return Promise.resolve(null);
+      };
+
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.branch = 'nope';
+
+      await state.handleClone();
+      await el.updateComplete;
+
+      const error = el.shadowRoot!.querySelector('.error-message');
+      expect(error, 'a missing branch must be reported').to.exist;
+      expect(error!.textContent).to.contain('Remote branch nope not found');
+    });
+  });
+
+  // ── Submodule phase ──────────────────────────────────────────────────────
+  describe('submodules', () => {
+    it('does not touch the submodule commands when the box is unchecked', async () => {
+      mockInvoke = (command) => {
+        if (command === 'clone_repository') return Promise.resolve(clonedRepo);
+        return Promise.resolve(null);
+      };
+
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.cloneSubmodules = false;
+
+      await state.handleClone();
+      await flush();
+
+      expect(invoked.some((c) => c.command === 'get_submodules')).to.be.false;
+      expect(invoked.some((c) => c.command === 'update_submodules')).to.be.false;
+    });
+
+    it('initialises and updates submodules against the new repository', async () => {
+      mockInvoke = (command) => {
+        if (command === 'clone_repository') return Promise.resolve(clonedRepo);
+        if (command === 'get_submodules') return Promise.resolve([submodule]);
+        return Promise.resolve(null);
+      };
+
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.repoName = 'repo';
+      state.cloneSubmodules = true;
+
+      await state.handleClone();
+      await flush();
+
+      const update = argsOf('update_submodules');
+      expect(update, 'the submodule phase must run after a successful clone').to.exist;
+      expect(update!.path, 'it runs against the cloned repository').to.equal('/dest/repo');
+      expect(update!.init, 'uninitialised submodules must be initialised').to.be.true;
+      expect(update!.recursive, 'nested submodules are cloned too').to.be.true;
+    });
+
+    it('skips the update — and its network gate — when there are no submodules', async () => {
+      mockInvoke = (command) => {
+        if (command === 'clone_repository') return Promise.resolve(clonedRepo);
+        if (command === 'get_submodules') return Promise.resolve([]);
+        return Promise.resolve(null);
+      };
+
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.cloneSubmodules = true;
+
+      await state.handleClone();
+      await flush();
+
+      expect(invoked.some((c) => c.command === 'get_submodules')).to.be.true;
+      expect(
+        invoked.some((c) => c.command === 'update_submodules'),
+        'nothing to update means nothing to ask the user about',
+      ).to.be.false;
+    });
+
+    it('shows the submodule step in the dialog progress', async () => {
+      let releaseUpdate: ((value: unknown) => void) | null = null;
+      mockInvoke = (command) => {
+        if (command === 'clone_repository') return Promise.resolve(clonedRepo);
+        if (command === 'get_submodules') return Promise.resolve([submodule]);
+        if (command === 'update_submodules') {
+          return new Promise((resolve) => {
+            releaseUpdate = resolve;
+          });
+        }
+        return Promise.resolve(null);
+      };
+
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.cloneSubmodules = true;
+
+      const pending = state.handleClone();
+      await waitFor(() => state.submodulePhase, 'the submodule phase to start');
+      await el.updateComplete;
+
+      expect(state.submodulePhase, 'the phase is active').to.be.true;
+      const progress = el.shadowRoot!.querySelector('.progress-text');
+      expect(progress, 'progress stays visible during the submodule phase').to.exist;
+      expect(progress!.textContent).to.contain('submodule');
+
+      (releaseUpdate as ((value: unknown) => void) | null)?.(null);
+      await pending;
+      await flush();
+    });
+
+    it('reports a submodule failure as a partial success, not a failed clone', async () => {
+      mockInvoke = (command) => {
+        if (command === 'clone_repository') return Promise.resolve(clonedRepo);
+        if (command === 'get_submodules') return Promise.resolve([submodule]);
+        if (command === 'update_submodules') {
+          return Promise.reject({ code: 'COMMAND_ERROR', message: 'authentication required' });
+        }
+        return Promise.resolve(null);
+      };
+
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.cloneSubmodules = true;
+
+      await state.handleClone();
+      await flush();
+      await el.updateComplete;
+
+      // A toast, not an inline banner: opening the cloned repository can tear
+      // this dialog down with the welcome screen that hosts it.
+      const toasts = uiStore.getState().toasts;
+      const warning = toasts.find((t) => t.type === 'warning');
+      expect(warning, 'the partial failure must be reported').to.exist;
+      expect(warning!.message).to.contain('cloned');
+      expect(warning!.message).to.contain('authentication required');
+
+      expect(
+        el.shadowRoot!.querySelector('.error-message'),
+        'the clone itself did NOT fail',
+      ).to.not.exist;
+      expect(state.error, 'and nothing claims the clone failed').to.equal('');
+
+      const repos = repositoryStore.getState().openRepositories;
+      expect(
+        repos.some((r) => r.repository.path === '/dest/repo'),
+        'the cloned repository stays open',
+      ).to.be.true;
+    });
+
+    it('closes the dialog after a submodule failure rather than trapping it', async () => {
+      mockInvoke = (command) => {
+        if (command === 'clone_repository') return Promise.resolve(clonedRepo);
+        if (command === 'get_submodules') return Promise.resolve([submodule]);
+        if (command === 'update_submodules') {
+          return Promise.reject({ code: 'COMMAND_ERROR', message: 'boom' });
+        }
+        return Promise.resolve(null);
+      };
+
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.cloneSubmodules = true;
+
+      el.open();
+      await el.updateComplete;
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.cloneSubmodules = true;
+
+      await state.handleClone();
+      // The close is scheduled on the same 500ms timer a clean clone uses.
+      await waitFor(() => {
+        const modal = el.shadowRoot!.querySelector('lv-modal') as HTMLElement & { open: boolean };
+        return !modal.open;
+      }, 'the dialog to close after the failed submodule phase');
+
+      expect(state.isCloning, 'and the dialog is reusable').to.be.false;
+    });
+
+    it('a gate refusal on the submodule update is not shown as a failure', async () => {
+      settingsStore.setState({ offlineMode: true });
+      mockInvoke = (command) => {
+        if (command === 'clone_repository') return Promise.resolve(clonedRepo);
+        if (command === 'get_submodules') return Promise.resolve([submodule]);
+        return Promise.resolve(null);
+      };
+
+      try {
+        const state = internals(el);
+        state.url = 'https://example.com/user/repo.git';
+        state.destination = '/dest';
+        state.cloneSubmodules = true;
+
+        await state.handleClone();
+        await flush();
+        await el.updateComplete;
+
+        expect(
+          uiStore.getState().toasts.some((t) => t.message.includes('submodules were not')),
+          'the gate already explained itself',
+        ).to.be.false;
+        expect(state.error, 'and the clone did not fail').to.equal('');
+      } finally {
+        settingsStore.setState({ offlineMode: false });
+      }
+    });
+
+    it('closing during the submodule phase keeps the repository and reports later', async () => {
+      let releaseUpdate: ((value: unknown) => void) | null = null;
+      mockInvoke = (command) => {
+        if (command === 'clone_repository') return Promise.resolve(clonedRepo);
+        if (command === 'get_submodules') return Promise.resolve([submodule]);
+        if (command === 'update_submodules') {
+          return new Promise((resolve) => {
+            releaseUpdate = resolve;
+          });
+        }
+        return Promise.resolve(null);
+      };
+
+      const state = internals(el);
+      state.url = 'https://example.com/user/repo.git';
+      state.destination = '/dest';
+      state.repoName = 'repo';
+      state.cloneSubmodules = true;
+
+      const pending = state.handleClone();
+      await waitFor(() => state.submodulePhase, 'the submodule phase to start');
+      await el.updateComplete;
+
+      // Escape / the x / the footer button while submodules are still running.
+      state.handleModalClose();
+      await el.updateComplete;
+
+      const modal = el.shadowRoot!.querySelector('lv-modal') as HTMLElement & { open: boolean };
+      expect(modal.open, 'the dialog closes rather than blocking on submodules').to.be.false;
+      expect(
+        invoked.some((c) => c.command === 'cancel_clone'),
+        'the clone already succeeded, so nothing may cancel it',
+      ).to.be.false;
+      expect(
+        repositoryStore
+          .getState()
+          .openRepositories.some((r) => r.repository.path === '/dest/repo'),
+        'the cloned repository is kept',
+      ).to.be.true;
+
+      (releaseUpdate as ((value: unknown) => void) | null)?.(null);
+      await pending;
+      await waitFor(
+        () => toastMessages().some((m) => m.includes('submodule')),
+        'the background phase to report',
+      );
+
+      expect(
+        toastMessages().some((m) => m.includes('submodule')),
+        'the detached phase reports its outcome in a toast',
+      ).to.be.true;
+    });
+  });
+});

--- a/src/components/dialogs/lv-clone-dialog.ts
+++ b/src/components/dialogs/lv-clone-dialog.ts
@@ -6,8 +6,15 @@
 import { LitElement, html, css } from 'lit';
 import { customElement, state, query } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
-import { isNetworkGateRefusal, cloneRepository, cancelClone } from '../../services/git.service.ts';
+import {
+  isNetworkGateRefusal,
+  cloneRepository,
+  cancelClone,
+  getSubmodules,
+  updateSubmodules,
+} from '../../services/git.service.ts';
 import { openCloneDestinationDialog } from '../../services/dialog.service.ts';
+import { showToast } from '../../services/notification.service.ts';
 import { repositoryStore } from '../../stores/index.ts';
 import { settingsStore } from '../../stores/settings.store.ts';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
@@ -140,6 +147,11 @@ export class LvCloneDialog extends LitElement {
         font-size: var(--font-size-sm);
       }
 
+      .field-hint {
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+      }
+
       .btn {
         padding: var(--spacing-sm) var(--spacing-lg);
         border-radius: var(--radius-md);
@@ -183,6 +195,9 @@ export class LvCloneDialog extends LitElement {
   @state() private depth: number | null = null;
   @state() private filter: string | null = null;
   @state() private singleBranch = false;
+  /** Empty means "whatever the remote's HEAD points at" -- the default branch. */
+  @state() private branch = '';
+  @state() private cloneSubmodules = false;
   @state() private isCloning = false;
   /**
    * The clone SUCCEEDED and the dialog is in its brief close delay.
@@ -197,6 +212,14 @@ export class LvCloneDialog extends LitElement {
   @state() private isComplete = false;
   /** Set while a cancellation request is in flight, so Cancel cannot be spammed. */
   @state() private isCancelling = false;
+  /**
+   * The clone itself is done and the submodules are being fetched.
+   *
+   * The phase runs against the repository that is ALREADY in the store and
+   * open, so nothing here may report a failure as a failed clone, and
+   * dismissing the dialog must leave that repository alone.
+   */
+  @state() private submodulePhase = false;
   @state() private progress = 0;
   @state() private progressText = '';
   @state() private error = '';
@@ -204,6 +227,18 @@ export class LvCloneDialog extends LitElement {
   @query('lv-modal') private modal!: LvModal;
 
   private unlistenProgress?: UnlistenFn;
+
+  /**
+   * Identifies the submodule phase currently owned by this dialog session.
+   *
+   * The submodule update has no cancellation handle, so a dismissed dialog
+   * leaves the phase running. Bumping this on every reset makes that orphaned
+   * run report through a toast instead of writing progress into -- or closing
+   * -- the session that replaced it.
+   */
+  private submoduleRunId = 0;
+  /** The dialog was dismissed while the submodule phase was still running. */
+  private submoduleDetached = false;
 
   public open(): void {
     // A clone already in flight owns this component; reset() would
@@ -225,6 +260,7 @@ export class LvCloneDialog extends LitElement {
     this.isCloning = false;
     this.isCancelling = false;
     this.isComplete = false;
+    this.submodulePhase = false;
     this.cleanupListener();
   }
 
@@ -240,12 +276,18 @@ export class LvCloneDialog extends LitElement {
     this.destination = '';
     this.repoName = '';
     this.depth = null;
+    this.branch = '';
+    this.cloneSubmodules = false;
     this.isCloning = false;
     this.isCancelling = false;
     this.isComplete = false;
+    this.submodulePhase = false;
     this.progress = 0;
     this.progressText = '';
     this.error = '';
+    // Any submodule phase still running belongs to the session being thrown
+    // away: it must report through a toast rather than into this one.
+    this.submoduleRunId += 1;
     this.cleanupListener();
   }
 
@@ -266,6 +308,12 @@ export class LvCloneDialog extends LitElement {
     const input = e.target as HTMLInputElement;
     const value = input.value.trim();
     this.depth = value ? parseInt(value, 10) || null : null;
+    this.error = '';
+  }
+
+  private handleBranchChange(e: Event): void {
+    const input = e.target as HTMLInputElement;
+    this.branch = input.value;
     this.error = '';
   }
 
@@ -318,6 +366,15 @@ export class LvCloneDialog extends LitElement {
       return;
     }
 
+    // Mirrors the backend's own check (commands/repository.rs clone_repository)
+    // so the user is told before a round trip; the backend keeps rejecting
+    // these regardless of what the dialog sends.
+    const branch = this.branch.trim();
+    if (branch && (branch.startsWith('-') || /[\r\n]/.test(branch))) {
+      this.error = "Branch name must not start with '-' or contain line breaks";
+      return;
+    }
+
     this.isCloning = true;
     this.progress = 0;
     this.progressText = 'Starting clone...';
@@ -346,6 +403,7 @@ export class LvCloneDialog extends LitElement {
       const result = await cloneRepository({
         url: this.url.trim(),
         path: fullPath,
+        ...(branch ? { branch } : {}),
         ...(this.depth !== null ? { depth: this.depth } : {}),
         ...(this.filter ? { filter: this.filter } : {}),
         ...(this.singleBranch ? { singleBranch: true } : {}),
@@ -356,9 +414,17 @@ export class LvCloneDialog extends LitElement {
         this.progressText = 'Clone complete!';
         this.isComplete = true;
 
-        // Add the repository to the store
+        // Add the repository to the store FIRST: the submodule phase below runs
+        // against a repository that is already open, so however that phase
+        // ends the user keeps the clone they asked for.
         const store = repositoryStore.getState();
         store.addRepository(result.data);
+
+        if (this.cloneSubmodules) {
+          // 'detached' means the dialog was dismissed during the phase, or
+          // reset into a new session: closing it here would yank that one shut.
+          if ((await this.runSubmodulePhase(result.data.path)) !== 'close') return;
+        }
 
         // Close dialog after a brief delay
         setTimeout(() => {
@@ -385,6 +451,131 @@ export class LvCloneDialog extends LitElement {
     }
   }
 
+  /**
+   * Fetch the freshly cloned repository's submodules.
+   *
+   * There is no recursive clone on the backend, so this reuses the ordinary
+   * submodule commands against the new repository. The clone has already
+   * succeeded by the time this runs: every failure here is a PARTIAL success
+   * and is reported as such.
+   *
+   * Returns what the caller should do with the dialog: `close` it as usual, or
+   * leave it alone because it is no longer this run's to close.
+   */
+  private async runSubmodulePhase(repoPath: string): Promise<'close' | 'detached'> {
+    const runId = ++this.submoduleRunId;
+    this.submoduleDetached = false;
+    this.submodulePhase = true;
+    this.progress = 100;
+    this.progressText = 'Checking for submodules...';
+
+    const name = this.repoName || repoPath;
+
+    // Listed first so a repository without submodules never reaches the
+    // network gate: prompting to confirm a network operation that has nothing
+    // to fetch would be a confirm for no reason.
+    const listed = await getSubmodules(repoPath);
+    if (!listed.success) {
+      return this.reportSubmoduleFailure(
+        runId,
+        listed.error?.message ?? 'the submodule list could not be read',
+      );
+    }
+
+    const count = listed.data?.length ?? 0;
+    if (count === 0) {
+      if (!this.isDetached(runId)) {
+        this.progressText = 'No submodules to clone.';
+        this.submodulePhase = false;
+        return 'close';
+      }
+      return 'detached';
+    }
+
+    const label = count === 1 ? '1 submodule' : `${count} submodules`;
+    if (!this.isDetached(runId)) {
+      this.progressText = `Cloning ${label}...`;
+    }
+
+    const updated = await updateSubmodules(repoPath, { init: true, recursive: true });
+
+    if (updated.success) {
+      if (this.isDetached(runId)) {
+        // The dialog is gone, so the only place left to say this is a toast.
+        showToast(`Cloned ${label} into ${name}.`, 'success');
+        return 'detached';
+      }
+      this.progressText = `Cloned ${label}.`;
+      this.submodulePhase = false;
+      return 'close';
+    }
+
+    if (isNetworkGateRefusal(updated.error)) {
+      // The gate already explained a block, and a declined confirm is the
+      // user's own decision, so neither is reported again. The clone itself
+      // stands either way.
+      if (this.isDetached(runId)) return 'detached';
+      this.progressText = 'Submodules were not cloned.';
+      this.submodulePhase = false;
+      return 'close';
+    }
+
+    return this.reportSubmoduleFailure(
+      runId,
+      updated.error?.message ?? 'the submodules could not be cloned',
+    );
+  }
+
+  /**
+   * True once `runId`'s phase has lost the dialog: either the user dismissed
+   * it, or the dialog was reset into a new session while the phase ran. Such a
+   * phase must not write progress into — or close — the dialog it no longer
+   * owns; it reports through a toast instead.
+   */
+  private isDetached(runId: number): boolean {
+    return this.submoduleDetached || runId !== this.submoduleRunId;
+  }
+
+  /**
+   * Report a submodule failure WITHOUT claiming the clone failed: the
+   * repository is on disk, in the store, and open.
+   *
+   * A toast rather than an inline banner, because opening the cloned
+   * repository can tear this dialog down with the welcome screen that hosts
+   * it — an inline message would then be shown to nobody, which is exactly the
+   * silent error path this must not become.
+   */
+  private reportSubmoduleFailure(runId: number, message: string): 'close' | 'detached' {
+    showToast(
+      `The repository was cloned, but its submodules were not: ${message}. Use Submodules to retry.`,
+      'warning',
+      10000,
+    );
+
+    if (this.isDetached(runId)) return 'detached';
+
+    this.submodulePhase = false;
+    this.progressText = '';
+    return 'close';
+  }
+
+  /**
+   * Dismiss the dialog while submodules are still being fetched.
+   *
+   * The clone has already succeeded and the repository is open, so this closes
+   * the dialog and lets the phase finish in the background rather than leaving
+   * a half-cloned working tree behind. The phase reports its outcome in a
+   * toast once it lands.
+   */
+  private handleDetachSubmodules(): void {
+    this.submoduleDetached = true;
+    showToast(
+      'Repository opened. Its submodules are still being cloned in the background.',
+      'info',
+    );
+    this.close();
+  }
+
   private handleModalClose(): void {
     // A clone in flight must not be abandoned behind a hidden dialog: lv-modal
     // sets open=false BEFORE dispatching, so re-assert it and route Escape, the
@@ -395,6 +586,14 @@ export class LvCloneDialog extends LitElement {
     if (this.isCloning && !this.isComplete) {
       this.modal.open = true;
       void this.handleCancelClone();
+      return;
+    }
+
+    // The clone is done and only submodules are outstanding. Cancelling the
+    // clone here would be wrong (there is nothing left to cancel) and reset()
+    // alone would leave the phase writing into a discarded session.
+    if (this.submodulePhase) {
+      this.handleDetachSubmodules();
       return;
     }
 
@@ -432,7 +631,13 @@ export class LvCloneDialog extends LitElement {
   }
 
   private get canClone(): boolean {
-    return Boolean(this.url.trim() && this.destination.trim() && !this.isCloning);
+    // `isComplete` is checked as well as `isCloning`: the submodule phase and
+    // the partial-success warning both release `isCloning` while the clone
+    // that already landed in this destination is finished, and a second clone
+    // into the same path could only fail.
+    return Boolean(
+      this.url.trim() && this.destination.trim() && !this.isCloning && !this.isComplete,
+    );
   }
 
   render() {
@@ -480,6 +685,21 @@ export class LvCloneDialog extends LitElement {
           </div>
 
           <div class="field">
+            <label for="branch">Branch (optional)</label>
+            <input
+              id="branch"
+              type="text"
+              placeholder="Leave empty for the default branch"
+              .value=${this.branch}
+              @input=${this.handleBranchChange}
+              ?disabled=${this.isCloning}
+            />
+            <div class="field-hint">
+              Clones and checks out this branch instead of the one the remote points at.
+            </div>
+          </div>
+
+          <div class="field">
             <label for="depth">Shallow clone depth (optional)</label>
             <input
               id="depth"
@@ -517,11 +737,26 @@ export class LvCloneDialog extends LitElement {
             <label for="single-branch" style="margin:0">Single branch only</label>
           </div>
 
+          <div class="field" style="flex-direction:row;align-items:center;gap:8px">
+            <input
+              type="checkbox"
+              id="clone-submodules"
+              .checked=${this.cloneSubmodules}
+              @change=${(e: Event) => {
+                this.cloneSubmodules = (e.target as HTMLInputElement).checked;
+              }}
+              ?disabled=${this.isCloning}
+            />
+            <label for="clone-submodules" style="margin:0">
+              Clone submodules (fetched after the clone finishes)
+            </label>
+          </div>
+
           ${this.fullPath
             ? html`<div class="repo-name-preview">Full path: ${this.fullPath}</div>`
             : ''}
 
-          ${this.isCloning
+          ${this.isCloning || this.submodulePhase
             ? html`
                 <div class="progress-section">
                   <div class="progress-text">${this.progressText}</div>
@@ -540,19 +775,31 @@ export class LvCloneDialog extends LitElement {
         <div slot="footer">
           <button
             class="btn btn-secondary"
-            @click=${this.isCloning && !this.isComplete ? this.handleCancelClone : this.close}
+            @click=${this.submodulePhase
+              ? this.handleDetachSubmodules
+              : this.isCloning && !this.isComplete
+                ? this.handleCancelClone
+                : this.close}
             ?disabled=${this.isCancelling}
           >
-            ${this.isCloning && !this.isComplete
-              ? (this.isCancelling ? 'Cancelling…' : 'Cancel Clone')
-              : 'Cancel'}
+            ${this.submodulePhase
+              ? 'Close'
+              : this.isCloning && !this.isComplete
+                ? (this.isCancelling ? 'Cancelling…' : 'Cancel Clone')
+                : 'Cancel'}
           </button>
           <button
             class="btn btn-primary"
             @click=${this.handleClone}
             ?disabled=${!this.canClone}
           >
-            ${this.isCloning ? 'Cloning...' : 'Clone'}
+            ${this.submodulePhase
+              ? 'Cloning submodules...'
+              : this.isComplete
+                ? 'Done'
+                : this.isCloning
+                  ? 'Cloning...'
+                  : 'Clone'}
           </button>
         </div>
       </lv-modal>

--- a/src/types/api.types.ts
+++ b/src/types/api.types.ts
@@ -27,7 +27,15 @@ export interface OpenRepositoryCommand {
 export interface CloneRepositoryCommand {
   url: string;
   path: string;
-  bare?: boolean;
+  /*
+   * The backend also accepts `bare`, and it is deliberately NOT declared here.
+   * A bare clone has no working tree, and nothing in this app branches on
+   * `Repository.isBare`: staging, the diff, file status and the commit panel
+   * would all be operating on a repository that cannot have any of them. Until
+   * the UI can present a bare repository honestly, offering the option would
+   * only produce a broken window.
+   */
+  /** Clone and check out this branch instead of the remote's default. */
   branch?: string;
   token?: string;
   depth?: number;


### PR DESCRIPTION
## Summary

- **Branch field.** The clone dialog now offers an optional "Branch", so a user can clone and check out any branch instead of only the remote's default. Empty still means the default branch; a value is trimmed and sent as `branch`. There is no backend command to list a remote's branches without cloning (nothing in `src-tauri` runs `ls-remote`), so it is a free-text field — and the backend's error ("Remote branch X not found in upstream origin") surfaces in the dialog's existing error banner.
- **Client-side validation mirrors the backend.** `clone_repository` rejects a branch starting with `-` or containing a line break (`src-tauri/src/commands/repository.rs:474-480`); the dialog refuses the same input inline before spending a round trip, and the backend keeps rejecting it regardless of what the dialog sends.
- **"Clone submodules" checkbox.** There is no recursive clone anywhere on the backend, so this reuses the existing submodule commands against the newly cloned repository: `get_submodules` first (so a repository with no submodules never reaches the network gate and never prompts for a network confirm), then `update_submodules` with `init` and `recursive`. No new Rust command was needed. The step is visible in the dialog's progress ("Checking for submodules…", "Cloning N submodules…").
- **Partial failure is reported as partial.** The repository is added to the store *before* the submodule phase runs, so it opens and stays open however that phase ends. A submodule failure never sets the red "the clone failed" banner; it reports "The repository was cloned, but its submodules were not: … Use Submodules to retry." in a warning toast. A toast rather than an inline message deliberately: opening the cloned repository tears down the welcome screen that hosts one of the two clone-dialog instances, so an inline banner would frequently be shown to nobody.
- **Cancellation stays coherent.** While submodules are fetching, the footer offers **Close** (and Escape / the ×  route to the same place) instead of firing `cancel_clone` at a clone that already succeeded. Closing leaves a complete, usable clone and lets the phase finish in the background, where it reports through a toast. A phase whose dialog has since been reset into a new clone session reports the same way instead of writing into — or closing — that session.

## Review finding

`src/components/dialogs/lv-clone-dialog.ts` sent only `url`, `path`, `depth`, `filter` and `singleBranch` to the clone command, while `clone_repository` in `src-tauri/src/commands/repository.rs:454-480` accepts and validates `branch` and `bare`, and `src/types/api.types.ts:26-34` already declared both — two supported options were unreachable from the UI. Separately there is no recursive submodule clone anywhere in the backend (`grep recurse src-tauri/src/commands/repository.rs` finds nothing), so cloning a superproject left empty submodule directories and the user had to find the palette-only Submodules dialog afterwards.

**Decision on `bare`: dropped from the TypeScript type, not exposed.** Investigated before choosing. A bare clone has no working tree, and *nothing in the app branches on `Repository.isBare`* — `grep isBare src/` finds only the type declaration (`src/types/git.types.ts:9`, `src/services/git.service.ts:2942`) and test fixtures; no component, store or panel reads it. Opening a bare repository today therefore drives staging, the diff, file status and the commit panel at a repository that cannot have any of them (`git2`'s `statuses()` refuses on a bare repo). Per the brief's "do not expose an option that produces a broken app state", `bare?: boolean` is removed from `CloneRepositoryCommand` with a comment explaining why; the backend parameter is untouched and simply unused by the UI. (`InitRepositoryCommand.bare`, which the init dialog does use, is deliberately left alone — that is a separate pre-existing surface and outside this PR's scope.)

## Test plan

- [ ] Unit: `src/components/dialogs/__tests__/lv-clone-dialog-options.test.ts` — fields present and disabled during a clone; branch trimmed and passed through; branch omitted when empty; flag-like branch refused inline without a round trip; backend "branch not found" surfaced; submodule commands untouched when unchecked; `update_submodules` called with `init`/`recursive` against the cloned path; update skipped when there are no submodules; the phase visible in progress; a failure reported as a warning toast with the repository still open and no error banner; the dialog closes rather than trapping; a gate refusal not reported twice; closing mid-phase keeps the repository, does not fire `cancel_clone`, and reports later in a toast.
- [ ] E2E: `e2e/tests/clone-options.spec.ts` — the two new controls are offered; `branch` reaches `clone_repository` (and is absent when empty); a non-existent branch shows the dialog error; `update_submodules` runs after a successful clone with the right arguments and the dialog then closes; no submodule phase when unchecked; a submodule failure shows the warning toast, no error banner, and the repository is in `openRepositories`.
- [ ] Ran: `npm run lint` (0 errors, 204 pre-existing warnings — unchanged), `npm run typecheck`, `npm test` (5351 passed; the only 2 failures are the two known pre-existing "network gate coverage" timeouts, verified failing identically with these changes stashed), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` (clean; no Rust changed), and the CLAUDE.md snake_case check (no new matches).
- [ ] E2E run on an isolated dev-server port: `clone-options.spec.ts` + `clone-auth.spec.ts` (11 passed) and `dialogs.spec.ts` + `welcome.spec.ts` (81 passed) as a regression check on the shared clone dialog page object.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_