### PR TITLE
fix: harden the webview Content-Security-Policy

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -46,6 +46,12 @@ The findings below were manually verified against source code. Some original fin
 | **MEDIUM** | No security scanning in CI | Added `security-audit` job with `npm audit` and `cargo audit`. |
 | **MEDIUM** | Vulnerable `brace-expansion@5.0.3` | Updated via `npm audit fix` to patched version. |
 
+### ✅ CSP hardening follow-up
+
+| # | Finding | Fix |
+|---|---------|-----|
+| **MEDIUM** | CSP was missing `object-src`, `base-uri`, `frame-src` and `form-action`, and allowed the webview to connect to any `https:` host — a large exfiltration surface next to the (intentional) `$HOME/**` filesystem scope | Added `object-src 'none'`, `base-uri 'self'`, `frame-src 'none'`, `form-action 'self'`. Narrowed `connect-src` to `'self'`: the webview makes no remote requests (no `fetch`/XHR/`WebSocket`/`EventSource` to a remote host in `src/`, no `@tauri-apps/plugin-http`) — every provider API call, OAuth token exchange, updater check and AI request runs in Rust via `reqwest`. Dropped `http://127.0.0.1` from both `img-src` and `connect-src`: the OAuth loopback server is a Rust `TcpListener` and the authorize URL opens in the system browser, so the webview never talks to loopback. `img-src` keeps `https:` on purpose — avatar URLs come from the provider APIs at runtime and self-hosted GitHub/GitLab/Bitbucket/Azure DevOps/OIDC instances make the host unknowable at build time. Full per-directive rationale and a regression test live in `src-tauri/tests/csp_policy.rs` (`tauri.conf.json` cannot carry comments — the `config-json5` feature is not enabled). |
+
 ---
 
 ## 0. CRITICAL - Security & Memory Issues

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -25,7 +25,7 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http://127.0.0.1; connect-src 'self' https: http://127.0.0.1; font-src 'self' data:"
+      "csp": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-src 'none'; form-action 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:"
     }
   },
   "bundle": {

--- a/src-tauri/tests/csp_policy.rs
+++ b/src-tauri/tests/csp_policy.rs
@@ -1,0 +1,221 @@
+//! Content-Security-Policy regression test for `tauri.conf.json`.
+//!
+//! `tauri.conf.json` must stay strict JSON — the `config-json5` feature is not
+//! enabled in this dependency graph (no `json5` crate in `Cargo.lock`), so a
+//! `//` comment in that file makes the build fail. This test file is therefore
+//! where the CSP is documented: it pins every directive and explains why each
+//! one has the value it has, so a future edit that loosens the policy fails
+//! here instead of silently shipping.
+//!
+//! A CSP violation is only ever visible at runtime in the webview console. The
+//! Playwright suite runs against the Vite dev server, which serves the app
+//! WITHOUT the Tauri CSP, so E2E can never catch a regression here. This test
+//! is the only automated guard.
+//!
+//! ## Directive rationale
+//!
+//! * `default-src 'self'` — fallback for every directive not listed below.
+//!   Everything the webview loads is bundled by Vite and served from the app's
+//!   own origin.
+//!
+//! * `base-uri 'self'` — an injected `<base href>` would silently re-target
+//!   every relative URL in the document. Nothing in the app sets a `<base>`
+//!   tag, so pinning this costs nothing.
+//!
+//! * `object-src 'none'` — there is no `<object>`, `<embed>` or `<applet>` in
+//!   the app. Plugin content is a classic script-execution bypass.
+//!
+//! * `frame-src 'none'` — the app contains no `<iframe>` anywhere in `src/`.
+//!   NOTE: `frame-ancestors` is deliberately NOT set. Tauri applies the CSP as
+//!   a response header on Windows/macOS but injects it as a `<meta>` tag on
+//!   Linux, and `frame-ancestors` is ignored (with a console warning) in a
+//!   `<meta>` policy.
+//!
+//! * `form-action 'self'` — the app has no `<form>` elements at all; every
+//!   dialog submits through Tauri IPC. This stops an injected form from
+//!   POSTing scraped data to a remote endpoint.
+//!
+//! * `script-src 'self' 'wasm-unsafe-eval'` — `'wasm-unsafe-eval'` is required
+//!   by Shiki (`src/utils/shiki-highlighter.ts`), whose Oniguruma regex engine
+//!   is WebAssembly. Shiki's language grammars are dynamically imported as
+//!   local Vite chunks, so they are covered by `'self'`. No inline scripts.
+//!
+//! * `style-src 'self' 'unsafe-inline'` — Lit components apply per-element
+//!   inline `style=` attributes and fall back to injected `<style>` elements
+//!   where constructable stylesheets are unavailable. Removing
+//!   `'unsafe-inline'` would need a nonce/hash pipeline the build does not
+//!   have; left as-is deliberately.
+//!
+//! * `img-src 'self' data: https:` — `data:` covers image diffs, which are
+//!   base64 payloads returned by Rust (`src/components/panels/lv-image-diff.ts`
+//!   builds `data:<mime>;base64,...`). The broad `https:` is REQUIRED and must
+//!   not be narrowed to an allowlist: avatar URLs are supplied by the provider
+//!   APIs at runtime and the app supports self-hosted instances, so the host is
+//!   not knowable at build time. Evidence:
+//!   - `src/components/common/lv-avatar.ts` and `src/graph/canvas-renderer.ts`
+//!     load `https://www.gravatar.com/avatar/...` (opt-in; when the Gravatar
+//!     setting is off no network request is made at all).
+//!   - `src/components/dialogs/lv-github-dialog.ts` renders
+//!     `<img src="${user.avatarUrl}">` from the GitHub API — `avatars.
+//!     githubusercontent.com` for github.com, but an arbitrary host for GitHub
+//!     Enterprise Server.
+//!   - `src/components/dialogs/lv-gitlab-dialog.ts` and
+//!     `lv-bitbucket-dialog.ts` do the same with `user.avatarUrl`; GitLab
+//!     avatars come from the configured instance (self-hosted GitLab is a
+//!     first-class option) and Bitbucket avatars from Atlassian CDN hosts.
+//!   - `src/components/dialogs/lv-azure-devops-dialog.ts` maps
+//!     `user.imageUrl`, which is served by the configured Azure DevOps
+//!     organisation (or a self-hosted server).
+//!   - `src/components/dialogs/lv-oidc-dialog.ts` renders the OIDC `picture`
+//!     claim, i.e. whatever host the user's identity provider returns.
+//!
+//!   `http://127.0.0.1` was removed: nothing loads an image over loopback.
+//!
+//! * `connect-src 'self'` — the webview makes NO remote requests. There is no
+//!   `fetch()`, `XMLHttpRequest`, `EventSource` or `WebSocket` to a remote host
+//!   anywhere in `src/` (the only `fetch` calls are `gitService.fetch(...)`,
+//!   i.e. `git fetch` over IPC), and `@tauri-apps/plugin-http` is not a
+//!   dependency. Every provider API call, OAuth token exchange, updater check
+//!   and AI request is made in Rust with `reqwest`. `http://127.0.0.1` was
+//!   removed too: the OAuth loopback server
+//!   (`src-tauri/src/services/loopback_server.rs`) is a Rust `TcpListener` and
+//!   the authorize URL is opened in the SYSTEM browser via the shell plugin
+//!   (`src/services/oauth.service.ts`), so the webview never talks to it; local
+//!   AI endpoints (Ollama / LM Studio) and the local MCP server are likewise
+//!   reached only from Rust, with the frontend going through `invokeCommand`.
+//!
+//!   Tauri's own IPC uses `fetch()` to `ipc://localhost` (macOS/Linux) or
+//!   `http://ipc.localhost` (Windows) and falls back to `window.ipc.postMessage`
+//!   when that request is blocked. Neither origin was allowed by the previous
+//!   policy either (`https:` and `http://127.0.0.1` do not match them), so the
+//!   app already runs on the postMessage transport and this change does not
+//!   alter that. Adding `ipc: http://ipc.localhost` here would switch the whole
+//!   app to the custom-protocol transport — a real behaviour change, and
+//!   deliberately out of scope for a CSP hardening change.
+//!
+//! * `font-src 'self' data:` — only bundled and inlined fonts; no remote font
+//!   CDN is referenced from `index.html` or any stylesheet.
+//!
+//! ## Accepted risk (unchanged by this file)
+//!
+//! `src-tauri/capabilities/default.json` grants `fs:` permissions over
+//! `$HOME/**`. That is intentional for a Git client — repositories live
+//! anywhere under the home directory — and is documented in `CODE_REVIEW.md`.
+//! The CSP above is the defence-in-depth layer around it.
+
+use std::collections::BTreeMap;
+
+/// The CSP exactly as it must appear in `tauri.conf.json`, split into
+/// `directive -> sources`.
+fn expected_directives() -> BTreeMap<&'static str, Vec<&'static str>> {
+    BTreeMap::from([
+        ("default-src", vec!["'self'"]),
+        ("base-uri", vec!["'self'"]),
+        ("object-src", vec!["'none'"]),
+        ("frame-src", vec!["'none'"]),
+        ("form-action", vec!["'self'"]),
+        ("script-src", vec!["'self'", "'wasm-unsafe-eval'"]),
+        ("style-src", vec!["'self'", "'unsafe-inline'"]),
+        ("img-src", vec!["'self'", "data:", "https:"]),
+        ("connect-src", vec!["'self'"]),
+        ("font-src", vec!["'self'", "data:"]),
+    ])
+}
+
+fn csp_from_config() -> String {
+    let raw = include_str!("../tauri.conf.json");
+    let config: serde_json::Value =
+        serde_json::from_str(raw).expect("tauri.conf.json must be valid strict JSON");
+    config["app"]["security"]["csp"]
+        .as_str()
+        .expect("app.security.csp must be a string in tauri.conf.json")
+        .to_string()
+}
+
+fn parse_csp(csp: &str) -> BTreeMap<String, Vec<String>> {
+    csp.split(';')
+        .map(str::trim)
+        .filter(|part| !part.is_empty())
+        .map(|part| {
+            let mut tokens = part.split_whitespace();
+            let name = tokens.next().expect("non-empty directive").to_string();
+            (name, tokens.map(str::to_string).collect::<Vec<_>>())
+        })
+        .collect()
+}
+
+#[test]
+fn csp_matches_documented_policy() {
+    let actual = parse_csp(&csp_from_config());
+    let expected = expected_directives();
+
+    for (directive, sources) in &expected {
+        let actual_sources = actual.get(*directive).unwrap_or_else(|| {
+            panic!(
+                "CSP directive `{directive}` is missing from tauri.conf.json. \
+                 See the module docs in src-tauri/tests/csp_policy.rs for why it is there."
+            )
+        });
+        assert_eq!(
+            actual_sources, sources,
+            "CSP directive `{directive}` changed. If the change is intentional, update \
+             src-tauri/tests/csp_policy.rs AND the rationale in its module docs."
+        );
+    }
+
+    let unexpected: Vec<_> = actual
+        .keys()
+        .filter(|name| !expected.contains_key(name.as_str()))
+        .collect();
+    assert!(
+        unexpected.is_empty(),
+        "Undocumented CSP directive(s) {unexpected:?} in tauri.conf.json — add them to \
+         src-tauri/tests/csp_policy.rs with a rationale."
+    );
+}
+
+#[test]
+fn csp_does_not_allow_arbitrary_remote_connections() {
+    let actual = parse_csp(&csp_from_config());
+    let connect = actual
+        .get("connect-src")
+        .expect("connect-src must be set explicitly, not inherited from default-src");
+
+    // The webview makes no remote requests; all outbound HTTP is Rust/reqwest.
+    // A bare `https:` here would restore an unrestricted exfiltration channel.
+    for source in connect {
+        assert!(
+            source == "'self'",
+            "connect-src gained `{source}`. The webview does not make remote requests \
+             (no fetch/XHR/WebSocket/EventSource to a remote host in src/, and no \
+             @tauri-apps/plugin-http). Adding a remote source re-opens an exfiltration path."
+        );
+    }
+}
+
+#[test]
+fn csp_blocks_plugin_and_frame_content() {
+    let actual = parse_csp(&csp_from_config());
+    for directive in ["object-src", "frame-src"] {
+        assert_eq!(
+            actual.get(directive).map(Vec::as_slice),
+            Some(["'none'".to_string()].as_slice()),
+            "`{directive}` must stay 'none' — the app contains no <object>/<embed>/<iframe>."
+        );
+    }
+}
+
+#[test]
+fn csp_is_applied_at_all() {
+    // A `null`/absent csp disables the policy entirely, which is how this
+    // finding started life (see CODE_REVIEW.md).
+    let csp = csp_from_config();
+    assert!(
+        !csp.trim().is_empty(),
+        "app.security.csp must not be empty — an empty policy is the same as no policy."
+    );
+    assert!(
+        !csp.contains("'unsafe-eval'"),
+        "script-src must never allow 'unsafe-eval'; Shiki only needs 'wasm-unsafe-eval'."
+    );
+}


### PR DESCRIPTION
## Summary

- Adds the CSP directives that were simply missing and cost nothing: `object-src 'none'`, `base-uri 'self'`, `frame-src 'none'`, `form-action 'self'`.
- Narrows `connect-src` from `'self' https: http://127.0.0.1` to `'self'` — the webview makes **no** remote requests; all outbound HTTP is Rust/`reqwest`.
- Drops `http://127.0.0.1` from `img-src` too — nothing loads an image over loopback.
- Keeps `img-src ... https:` **on purpose** (self-hosted provider avatars), with the evidence recorded in code.
- Because `tauri.conf.json` cannot carry comments, the per-directive rationale lives in a new regression test, `src-tauri/tests/csp_policy.rs`, which pins the policy and fails loudly if a future edit loosens it.

Before / after:

```
- default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https: http://127.0.0.1; connect-src 'self' https: http://127.0.0.1; font-src 'self' data:
+ default-src 'self'; base-uri 'self'; object-src 'none'; frame-src 'none'; form-action 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: https:; connect-src 'self'; font-src 'self' data:
```

## Review finding

`src-tauri/tauri.conf.json` set a CSP with no `object-src`, `base-uri`, `frame-src` or `form-action`, and allowed the renderer to connect to any `https:` host. Combined with the broad `$HOME/**` filesystem capability in `src-tauri/capabilities/default.json` (which includes `fs:allow-remove` and `fs:allow-write-text-file`), any renderer-side injection had a large blast radius: read/write/delete anywhere under the user's home **and** exfiltrate to any https host. The code is careful today (one `innerHTML`, at `src/components/dialogs/lv-command-palette.ts:716`, fed by a correct `escapeHtml` in `src/utils/fuzzy-search.ts`), so this is defence in depth, not an active exploit.

### Evidence gathered from the code

**Nothing legitimately iframes, embeds or submits a form.** `grep` over `src/` and `index.html` returns zero hits for `<iframe`, `<object`, `<embed`, `<applet`, `<form` and `<base`. So `frame-src 'none'`, `object-src 'none'`, `form-action 'self'` and `base-uri 'self'` are free.

**`connect-src` — the webview does not make remote requests.** `grep` over `src/` for `fetch(`, `XMLHttpRequest`, `EventSource`, `new WebSocket`, `sendBeacon`, `axios` finds only three call sites, all of which are `gitService.fetch(...)` (i.e. `git fetch` over Tauri IPC): `src/components/dialogs/lv-remote-dialog.ts:634`, `src/components/dialogs/lv-workspace-manager-dialog.ts:950`, `src/app-shell.ts:5083`. `@tauri-apps/plugin-http` is not in `package.json`. Every provider API call, OAuth token exchange, updater check, AI request and MCP status read goes through `invokeCommand` into Rust, which uses `reqwest` (`src-tauri/Cargo.toml`). This is what makes the self-hosted-instance concern moot: a user's self-hosted GitLab / Bitbucket / Azure DevOps / OIDC endpoint, and their custom Ollama / LM Studio endpoint, are contacted from Rust, which no CSP applies to. So `connect-src 'self'` cannot break them.

**`http://127.0.0.1` is not needed by the webview.** The OAuth loopback server is a Rust `TcpListener` (`src-tauri/src/services/loopback_server.rs:107`), and `src/services/oauth.service.ts:253` opens the authorize URL in the **system browser** via `@tauri-apps/plugin-shell`; the callback lands on the Rust listener, never in the webview. Local AI endpoints (`src-tauri/src/services/ai/mod.rs`) and the local MCP server (`src-tauri/src/services/ai/mcp/server.rs`) are likewise only reached from Rust — `src/services/local-ai.service.ts` and `src/services/mcp.service.ts` only use `invokeCommand`/`listenToEvent`, and `lv-settings-dialog.ts` merely displays the port as text.

**`img-src` — `https:` must stay.** Avatar hosts cannot be enumerated at build time because provider APIs supply the URL and self-hosted instances are first-class:
- `src/components/common/lv-avatar.ts:70` and `src/graph/canvas-renderer.ts:542` build `https://www.gravatar.com/avatar/...` (Gravatar is opt-in and gated — `canvas-renderer.ts:40`, `lv-graph-canvas.ts:956` — when off, no request is made).
- `src/components/dialogs/lv-github-dialog.ts:2148` renders ``'&lt;img src="${user.avatarUrl}"&gt;'`` straight from the GitHub API (`avatars.githubusercontent.com` for github.com, an arbitrary host for GitHub Enterprise Server).
- `src/components/dialogs/lv-gitlab-dialog.ts:1683` and `src/components/dialogs/lv-bitbucket-dialog.ts:1664` do the same with `user.avatarUrl` (GitLab avatars come from the configured instance; Bitbucket from Atlassian CDN hosts).
- `src/components/dialogs/lv-azure-devops-dialog.ts` maps `user.imageUrl`, served by the configured Azure DevOps organisation or a self-hosted server.
- `src/components/dialogs/lv-oidc-dialog.ts:819` renders the OIDC `picture` claim — whatever host the user's IdP returns.

Narrowing this to an allowlist would break avatars for every self-hosted user, which is exactly the "worse than a loose one" failure mode. `data:` is still needed for image diffs (`src/components/panels/lv-image-diff.ts:588` builds `data:<mime>;base64,...`).

**Untouched on purpose.** `script-src` keeps `'wasm-unsafe-eval'` (Shiki's Oniguruma engine is WebAssembly — `src/utils/shiki-highlighter.ts`; its grammars are local Vite chunks covered by `'self'`). `style-src` keeps `'unsafe-inline'` (Lit inline `style=` attributes and its `<style>` fallback; removing it needs a nonce/hash pipeline the build does not have). `frame-ancestors` is deliberately **not** added: Tauri sends the CSP as a response header on Windows/macOS but injects it as a `<meta>` tag on Linux, where `frame-ancestors` is ignored with a console warning.

**Accepted risk, unchanged here:** the `$HOME/**` `fs:` scope in `src-tauri/capabilities/default.json` stays as-is. A Git client legitimately needs it (repos live anywhere under `$HOME`, and the inline file editor writes directly), and the decision is already documented in `CODE_REVIEW.md` and in the capability's own `description`. This PR is the defence-in-depth layer around it.

**Incidental finding, not changed:** Tauri's own IPC uses `fetch()` to `ipc://localhost` (macOS/Linux) or `http://ipc.localhost` (Windows) and silently falls back to `window.ipc.postMessage` when that request is blocked. Neither origin matched the **previous** policy either (`https:` and `http://127.0.0.1` do not cover them), so the app already runs on the postMessage transport and this PR does not change that. Adding `ipc: http://ipc.localhost` would switch the whole app to the custom-protocol transport — a real behaviour change, deliberately out of scope. Noted in `src-tauri/tests/csp_policy.rs` for whoever wants to pick it up.

## Test plan

- [ ] **A CSP regression cannot be caught by E2E, and this PR does not pretend otherwise.** Playwright runs against the Vite dev server, which serves the app *without* the Tauri CSP (Tauri only injects the policy for the assets it serves in a bundled build), so a broken directive would not fail a single spec. The conclusions above are therefore reasoned from the code, and pinned by a Rust test rather than a browser test.
- [ ] New `src-tauri/tests/csp_policy.rs` (4 tests) parses the CSP out of `tauri.conf.json` and asserts the exact directive set, that `connect-src` contains only `'self'`, that `object-src`/`frame-src` are `'none'`, and that `'unsafe-eval'` never appears. It also carries the full per-directive rationale as module docs, since the JSON file cannot hold comments. `cargo test --test csp_policy` → 4 passed.
- [ ] `npm run lint` → 0 errors, 204 warnings (unchanged baseline). `npm run typecheck` → clean.
- [ ] `npm test` → 5334 passed, 2 failed; the 2 are the pre-existing `network-gate-coverage.test.ts` timeouts on `origin/main` and reproduce with the file run alone.
- [ ] `cargo fmt --check` clean; `cargo clippy --all-targets -- -D warnings` clean.
- [ ] Full Playwright suite on an isolated port: 1339 passed, 3 skipped, 16 failed under 3 parallel workers on a loaded machine; the two affected spec files (`bitbucket-dialog.spec.ts`, `blame-view.spec.ts`) re-run alone give 23/23 passed, so those were load flake, and neither file touches anything this PR changes.
- [ ] Reviewer check worth doing by hand: run a bundled build (`npm run tauri:build`, or `tauri dev` with `frontendDist` rather than `devUrl`), open the webview devtools, and confirm the console is free of `Refused to ...` CSP messages while signing in to a provider, viewing the graph with Gravatar enabled, and opening an image diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_