### PR TITLE
feat: pull requests in the sidebar, create PR from a branch

### DIFF
--- a/e2e/tests/pull-request-sidebar.spec.ts
+++ b/e2e/tests/pull-request-sidebar.spec.ts
@@ -1,0 +1,250 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupTauriMocks, initializeRepositoryStore } from '../fixtures/tauri-mock';
+import { DialogsPage } from '../pages/dialogs.page';
+import { findCommand, startCommandCaptureWithMocks, waitForCommand } from '../fixtures/test-helpers';
+
+/**
+ * E2E for the sidebar's Pull Requests section and the branch context menu's
+ * "Create pull request..." entry.
+ *
+ * Provider mocks have to be in place BEFORE the repository is opened: hosting
+ * provider detection runs once per repository and is cached, exactly as it is
+ * in the app, so these tests stage the mocks between page load and the store
+ * initialisation instead of using setupOpenRepository's one-shot helper.
+ */
+
+const PR_FIXTURE = {
+  number: 42,
+  title: 'Add the pull request sidebar',
+  state: 'open',
+  user: { login: 'octocat', id: 1, avatarUrl: '', name: 'Octo Cat', email: null },
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  mergedAt: null,
+  headRef: 'feature/test',
+  headSha: 'def456abc789',
+  baseRef: 'main',
+  draft: false,
+  mergeable: true,
+  htmlUrl: 'https://github.com/octo/leviathan/pull/42',
+  additions: 10,
+  deletions: 2,
+  changedFiles: 1,
+};
+
+/** Open the app with GitHub detected and the given extra command mocks. */
+async function openWithGitHub(
+  page: Page,
+  overrides: Record<string, unknown> = {},
+): Promise<void> {
+  await setupTauriMocks(page);
+  await page.goto('/');
+  await page.waitForLoadState('domcontentloaded');
+  await startCommandCaptureWithMocks(page, {
+    detect_github_repo: { owner: 'octo', repo: 'leviathan', remoteName: 'origin' },
+    ...overrides,
+  });
+  await initializeRepositoryStore(page);
+}
+
+function prSectionHeader(page: Page) {
+  return page.locator('lv-left-panel .section-header').filter({ hasText: 'Pull Requests' });
+}
+
+function prList(page: Page) {
+  return page.locator('lv-pull-request-list');
+}
+
+test.describe('Pull Requests sidebar section', () => {
+  test('shows the section header for an open repository', async ({ page }) => {
+    await openWithGitHub(page);
+    await expect(prSectionHeader(page)).toBeVisible();
+  });
+
+  test('does not call the provider API until the section is expanded', async ({ page }) => {
+    await openWithGitHub(page, {
+      get_keyring_token: 'gh-token',
+      list_pull_requests: [PR_FIXTURE],
+    });
+
+    // The section starts collapsed, so nothing has been fetched.
+    await expect(prSectionHeader(page)).toBeVisible();
+    expect(await findCommand(page, 'list_pull_requests')).toHaveLength(0);
+
+    await prSectionHeader(page).click();
+    await waitForCommand(page, 'list_pull_requests');
+
+    await expect(prList(page).locator('.pr-item')).toHaveCount(1);
+  });
+
+  test('lists open pull requests with number, title and author', async ({ page }) => {
+    await openWithGitHub(page, {
+      get_keyring_token: 'gh-token',
+      list_pull_requests: [PR_FIXTURE],
+    });
+
+    await prSectionHeader(page).click();
+
+    const item = prList(page).locator('.pr-item').first();
+    await expect(item).toBeVisible();
+    await expect(item).toContainText('Add the pull request sidebar');
+    await expect(item).toContainText('#42');
+    await expect(item).toContainText('Octo Cat');
+    // And the header badge reports the count.
+    await expect(prSectionHeader(page).locator('.count')).toHaveText('1');
+  });
+
+  test('shows an empty state rather than a blank section', async ({ page }) => {
+    await openWithGitHub(page, {
+      get_keyring_token: 'gh-token',
+      list_pull_requests: [],
+    });
+
+    await prSectionHeader(page).click();
+    await expect(prList(page).locator('.empty')).toHaveText(/No open pull requests/);
+  });
+
+  test('offers to connect when the provider is detected but not authenticated', async ({
+    page,
+  }) => {
+    // No keyring token: the default mock returns null for get_keyring_token.
+    await openWithGitHub(page);
+
+    await prSectionHeader(page).click();
+
+    await expect(prList(page)).toContainText('Not connected to GitHub');
+    const connect = prList(page).locator('button', { hasText: 'Connect to GitHub' });
+    await expect(connect).toBeVisible();
+    // An unauthenticated section must not pretend the repository has no PRs.
+    await expect(prList(page).locator('.pr-item')).toHaveCount(0);
+    expect(await findCommand(page, 'list_pull_requests')).toHaveLength(0);
+
+    await connect.click();
+    await expect(new DialogsPage(page).github.dialog).toBeVisible();
+  });
+
+  test('explains a failed load and recovers on retry', async ({ page }) => {
+    await openWithGitHub(page, {
+      get_keyring_token: 'gh-token',
+      list_pull_requests: [PR_FIXTURE],
+    });
+
+    // Fail the first call, succeed afterwards.
+    await page.evaluate(() => {
+      const internals = (window as unknown as {
+        __TAURI_INTERNALS__: { invoke: (c: string, args?: unknown) => Promise<unknown> };
+      }).__TAURI_INTERNALS__;
+      const original = internals.invoke;
+      let failed = false;
+      internals.invoke = async (command: string, args?: unknown) => {
+        if (command === 'list_pull_requests' && !failed) {
+          failed = true;
+          throw new Error('API rate limit exceeded');
+        }
+        return original(command, args);
+      };
+    });
+
+    await prSectionHeader(page).click();
+    await expect(prList(page).locator('.error-notice')).toContainText('API rate limit exceeded');
+
+    await prList(page).locator('button', { hasText: 'Retry' }).click();
+    await expect(prList(page).locator('.pr-item')).toHaveCount(1);
+  });
+
+  test('says why the list is unavailable in offline mode', async ({ page }) => {
+    await openWithGitHub(page, {
+      get_keyring_token: 'gh-token',
+      list_pull_requests: [PR_FIXTURE],
+    });
+
+    await page.evaluate(() => {
+      const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as {
+        settingsStore: { getState: () => { setOfflineMode: (v: boolean) => void } };
+      };
+      stores.settingsStore.getState().setOfflineMode(true);
+    });
+
+    await prSectionHeader(page).click();
+    await expect(prList(page)).toContainText('offline mode');
+    expect(await findCommand(page, 'list_pull_requests')).toHaveLength(0);
+  });
+
+  test('explains when the repository has no supported hosting provider', async ({ page }) => {
+    await setupTauriMocks(page);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    // Every detect_* command returns null in the default mocks.
+    await startCommandCaptureWithMocks(page, {});
+    await initializeRepositoryStore(page);
+
+    await prSectionHeader(page).click();
+    await expect(prList(page)).toContainText(
+      'No GitHub, GitLab, Bitbucket or Azure DevOps remote',
+    );
+  });
+});
+
+test.describe('Branch context menu - Create pull request', () => {
+  test('opens the GitHub create form prefilled with the branch', async ({ page }) => {
+    await openWithGitHub(page, { get_keyring_token: 'gh-token' });
+
+    // "main" is the default mock's checked-out branch and has an upstream.
+    const branchRow = page.locator('lv-branch-list .branch-item').first();
+    await expect(branchRow).toBeVisible();
+    await branchRow.click({ button: 'right' });
+
+    const entry = page
+      .locator('lv-branch-list .context-menu-item')
+      .filter({ hasText: 'Create pull request' });
+    await expect(entry).toBeVisible();
+    await expect(entry).toBeEnabled();
+    await entry.click();
+
+    const dialogs = new DialogsPage(page);
+    await expect(dialogs.github.dialog).toBeVisible();
+    // The create form is showing, with the branch as the head.
+    const head = page.locator('lv-github-dialog input[placeholder="feature-branch"]');
+    await expect(head).toBeVisible();
+    await expect(head).toHaveValue('main');
+  });
+
+  test('is disabled with an explanation for a branch without an upstream', async ({ page }) => {
+    await openWithGitHub(page);
+
+    // The second branch in the default mocks is "feature/test", which has no
+    // upstream. It renders inside its "feature" prefix group, so the row shows
+    // the stripped name.
+    const branchRow = page
+      .locator('lv-branch-list .branch-item')
+      .filter({ has: page.locator('.branch-name', { hasText: /^test$/ }) })
+      .first();
+    await expect(branchRow).toBeVisible();
+    await branchRow.click({ button: 'right' });
+
+    const entry = page
+      .locator('lv-branch-list .context-menu-item')
+      .filter({ hasText: 'Create pull request' });
+    await expect(entry).toBeVisible();
+    await expect(entry).toBeDisabled();
+    await expect(entry).toHaveAttribute('title', /upstream/);
+  });
+
+  test('is disabled when no hosting provider is detected', async ({ page }) => {
+    await setupTauriMocks(page);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await startCommandCaptureWithMocks(page, {});
+    await initializeRepositoryStore(page);
+
+    const branchRow = page.locator('lv-branch-list .branch-item').first();
+    await expect(branchRow).toBeVisible();
+    await branchRow.click({ button: 'right' });
+
+    const entry = page
+      .locator('lv-branch-list .context-menu-item')
+      .filter({ hasText: 'Create pull request' });
+    await expect(entry).toBeDisabled();
+    await expect(entry).toHaveAttribute('title', /No GitHub, GitLab, Bitbucket or Azure DevOps/);
+  });
+});

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -114,6 +114,11 @@ import type { LvProfileManagerDialog } from './components/dialogs/lv-profile-man
 import type { LvReflogDialog } from './components/dialogs/lv-reflog-dialog.ts';
 import type { LvDescribeDialog } from './components/dialogs/lv-describe-dialog.ts';
 import type { LvCompareBranchesDialog } from './components/dialogs/lv-compare-branches-dialog.ts';
+import type { LvGitHubDialog } from './components/dialogs/lv-github-dialog.ts';
+import type { LvGitLabDialog } from './components/dialogs/lv-gitlab-dialog.ts';
+import type { LvBitbucketDialog } from './components/dialogs/lv-bitbucket-dialog.ts';
+import type { LvAzureDevOpsDialog } from './components/dialogs/lv-azure-devops-dialog.ts';
+import type { PullRequestProviderId } from './services/pull-request.service.ts';
 import type { SearchDialogMode } from './components/dialogs/lv-search-dialog.ts';
 import type { LvCleanDialog } from './components/dialogs/lv-clean-dialog.ts';
 import type { LvExportImportDialog } from './components/dialogs/lv-export-import-dialog.ts';
@@ -828,6 +833,10 @@ export class AppShell extends LitElement {
   @query('lv-remote-dialog') private remoteDialog?: LvRemoteDialog;
   @query('lv-repository-health-dialog') private repositoryHealthDialog?: LvRepositoryHealthDialog;
   @query('lv-changelog-dialog') private changelogDialog?: LvChangelogDialog;
+  @query('lv-github-dialog') private githubDialog?: LvGitHubDialog;
+  @query('lv-gitlab-dialog') private gitlabDialog?: LvGitLabDialog;
+  @query('lv-bitbucket-dialog') private bitbucketDialog?: LvBitbucketDialog;
+  @query('lv-azure-devops-dialog') private azureDevOpsDialog?: LvAzureDevOpsDialog;
 
   private unsubscribe?: () => void;
   private unsubscribeUi?: () => void;
@@ -3135,6 +3144,68 @@ export class AppShell extends LitElement {
   private get integrationAttachName(): string {
     return this.integrationContext?.attach ? this.integrationContext.profileName : '';
   }
+
+  /**
+   * "Create pull request..." on a branch in the sidebar.
+   *
+   * Routed to the provider dialog that ALREADY owns the create flow rather
+   * than reimplemented: the dialog holds the form, the account selection, the
+   * create call and its own success/error feedback. All this does is open the
+   * right one on its create tab with the branch prefilled as the source.
+   */
+  private handleCreatePullRequest = async (
+    e: CustomEvent<{
+      provider?: PullRequestProviderId;
+      sourceBranch?: string;
+      baseBranch?: string;
+    }>,
+  ): Promise<void> => {
+    const provider = e.detail?.provider;
+    const sourceBranch = e.detail?.sourceBranch;
+    if (!provider || !sourceBranch) return;
+
+    this.openIntegrationStandalone(provider);
+    // The dialogs are always rendered (only their `open` flag changes), but the
+    // very first open still needs this render to land before the element and
+    // its own update cycle are reachable.
+    await this.updateComplete;
+
+    switch (provider) {
+      case 'github': {
+        const dialog = this.githubDialog;
+        if (!dialog) break;
+        await dialog.updateComplete;
+        dialog.startCreatePullRequest(sourceBranch, e.detail?.baseBranch);
+        return;
+      }
+      case 'gitlab': {
+        const dialog = this.gitlabDialog;
+        if (!dialog) break;
+        await dialog.updateComplete;
+        dialog.startCreateMergeRequest(sourceBranch, e.detail?.baseBranch);
+        return;
+      }
+      case 'bitbucket': {
+        const dialog = this.bitbucketDialog;
+        if (!dialog) break;
+        await dialog.updateComplete;
+        dialog.startCreatePullRequest(sourceBranch, e.detail?.baseBranch);
+        return;
+      }
+      case 'azure-devops': {
+        const dialog = this.azureDevOpsDialog;
+        if (!dialog) break;
+        await dialog.updateComplete;
+        dialog.startCreatePullRequest(sourceBranch, e.detail?.baseBranch);
+        return;
+      }
+    }
+
+    // The dialog is open but could not be reached, so the create form was never
+    // prefilled. Say so rather than leaving the user staring at a blank form
+    // wondering which branch it is about.
+    showToast('Could not open the create form. Fill in the branch manually.', 'error');
+  };
 
   private setIntegrationDialogOpen(type: IntegrationType, open: boolean): void {
     switch (type) {
@@ -5703,6 +5774,11 @@ export class AppShell extends LitElement {
                 }}
                 @compare-branch=${(e: CustomEvent<{ compareRef?: string }>) =>
                   this.compareBranchesDialog?.open(e.detail?.compareRef)}
+                @create-pull-request=${this.handleCreatePullRequest}
+                @open-provider-connection=${(e: CustomEvent<{ provider?: PullRequestProviderId }>) => {
+                  const provider = e.detail?.provider;
+                  if (provider) this.openIntegrationStandalone(provider);
+                }}
               >
                 <lv-left-panel></lv-left-panel>
               </aside>

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -2459,6 +2459,24 @@ export class LvAzureDevOpsDialog extends LitElement {
     `;
   }
 
+  /**
+   * Open the create-pull-request form with `sourceBranch` prefilled as the
+   * source branch.
+   *
+   * The entry point for the sidebar's branch context menu, which deliberately
+   * does NOT build its own create flow: this dialog already owns the form, the
+   * account selection and the create call, so the menu reuses them. `baseBranch`
+   * is only a suggestion and is applied ONLY when the field is still empty, so
+   * a draft the user already typed here is never overwritten.
+   */
+  public startCreatePullRequest(sourceBranch: string, baseBranch?: string): void {
+    this.createPrSource = sourceBranch;
+    if (baseBranch && !this.createPrTarget) {
+      this.createPrTarget = baseBranch;
+    }
+    this.activeTab = 'create-pr';
+  }
+
   render() {
     return html`
       <lv-modal

--- a/src/components/dialogs/lv-bitbucket-dialog.ts
+++ b/src/components/dialogs/lv-bitbucket-dialog.ts
@@ -2116,6 +2116,24 @@ export class LvBitbucketDialog extends LitElement {
     `;
   }
 
+  /**
+   * Open the create-pull-request form with `sourceBranch` prefilled as the
+   * source branch.
+   *
+   * The entry point for the sidebar's branch context menu, which deliberately
+   * does NOT build its own create flow: this dialog already owns the form, the
+   * account selection and the create call, so the menu reuses them. `baseBranch`
+   * is only a suggestion and is applied ONLY when the field is still empty, so
+   * a draft the user already typed here is never overwritten.
+   */
+  public startCreatePullRequest(sourceBranch: string, baseBranch?: string): void {
+    this.createPrSource = sourceBranch;
+    if (baseBranch && !this.createPrDestination) {
+      this.createPrDestination = baseBranch;
+    }
+    this.activeTab = 'create-pr';
+  }
+
   render() {
     return html`
       <lv-modal

--- a/src/components/dialogs/lv-github-dialog.ts
+++ b/src/components/dialogs/lv-github-dialog.ts
@@ -2823,6 +2823,24 @@ export class LvGitHubDialog extends LitElement {
     `;
   }
 
+  /**
+   * Open the create-pull-request form with `sourceBranch` prefilled as the
+   * source branch.
+   *
+   * The entry point for the sidebar's branch context menu, which deliberately
+   * does NOT build its own create flow: this dialog already owns the form, the
+   * account selection and the create call, so the menu reuses them. `baseBranch`
+   * is only a suggestion and is applied ONLY when the field is still empty, so
+   * a draft the user already typed here is never overwritten.
+   */
+  public startCreatePullRequest(sourceBranch: string, baseBranch?: string): void {
+    this.createPrHead = sourceBranch;
+    if (baseBranch && !this.createPrBase) {
+      this.createPrBase = baseBranch;
+    }
+    this.activeTab = 'create-pr';
+  }
+
   private renderCreatePrTab() {
     return html`
       <div class="token-form">

--- a/src/components/dialogs/lv-gitlab-dialog.ts
+++ b/src/components/dialogs/lv-gitlab-dialog.ts
@@ -2164,6 +2164,24 @@ export class LvGitLabDialog extends LitElement {
     `;
   }
 
+  /**
+   * Open the create-merge-request form with `sourceBranch` prefilled as the
+   * source branch.
+   *
+   * The entry point for the sidebar's branch context menu, which deliberately
+   * does NOT build its own create flow: this dialog already owns the form, the
+   * account selection and the create call, so the menu reuses them. `baseBranch`
+   * is only a suggestion and is applied ONLY when the field is still empty, so
+   * a draft the user already typed here is never overwritten.
+   */
+  public startCreateMergeRequest(sourceBranch: string, baseBranch?: string): void {
+    this.createMrSource = sourceBranch;
+    if (baseBranch && !this.createMrTarget) {
+      this.createMrTarget = baseBranch;
+    }
+    this.activeTab = 'create-mr';
+  }
+
   render() {
     return html`
       <lv-modal

--- a/src/components/sidebar/__tests__/lv-branch-list-create-pr.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-create-pr.test.ts
@@ -1,0 +1,248 @@
+/**
+ * Tests for the "Create pull request..." entry on the branch context menu.
+ *
+ * Covers the enabled/disabled conditions (upstream present, provider
+ * detected), the provider-specific label, and the event the entry dispatches
+ * for app-shell to route into the provider dialog's existing create flow.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { LvBranchList } from '../lv-branch-list.ts';
+import { invalidateProviderDetection } from '../../../services/pull-request.service.ts';
+import '../lv-branch-list.ts';
+
+const REPO_PATH = '/test/repo';
+
+interface BranchFields {
+  name: string;
+  shorthand: string;
+  isHead: boolean;
+  isRemote: boolean;
+  upstream: string | null;
+  targetOid: string;
+  isStale: boolean;
+}
+
+function makeBranch(overrides: Partial<BranchFields> = {}): BranchFields {
+  return {
+    name: 'feature/prs',
+    shorthand: 'feature/prs',
+    isHead: false,
+    isRemote: false,
+    upstream: null,
+    targetOid: 'abc123',
+    isStale: false,
+    ...overrides,
+  };
+}
+
+type Provider = 'github' | 'gitlab' | 'none';
+
+function setupMocks(branches: BranchFields[], provider: Provider): void {
+  mockInvoke = async (command: string) => {
+    switch (command) {
+      case 'get_branches':
+        return branches;
+      case 'get_remotes':
+        return [];
+      case 'detect_github_repo':
+        return provider === 'github'
+          ? { owner: 'octo', repo: 'leviathan', remoteName: 'origin' }
+          : null;
+      case 'detect_gitlab_repo':
+        return provider === 'gitlab'
+          ? { instanceUrl: 'https://gitlab.com', projectPath: 'octo/lev', remoteName: 'origin' }
+          : null;
+      case 'detect_ado_repo':
+      case 'detect_bitbucket_repo':
+        return null;
+      default:
+        return null;
+    }
+  };
+}
+
+async function createComponent(
+  branches: BranchFields[],
+  provider: Provider,
+): Promise<LvBranchList> {
+  setupMocks(branches, provider);
+  const el = await fixture<LvBranchList>(
+    html`<lv-branch-list .repositoryPath=${REPO_PATH}></lv-branch-list>`,
+  );
+  for (let i = 0; i < 10; i++) {
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  await el.updateComplete;
+  return el;
+}
+
+/** Open the context menu over `branch` and return the create-request entry. */
+async function openMenuFor(
+  el: LvBranchList,
+  branch: BranchFields,
+): Promise<HTMLButtonElement | undefined> {
+  (el as unknown as { contextMenu: unknown }).contextMenu = {
+    visible: true,
+    x: 0,
+    y: 0,
+    branch,
+  };
+  await el.updateComplete;
+  return Array.from(
+    el.shadowRoot!.querySelectorAll('.context-menu-item'),
+  ).find((b) => /Create (pull|merge) request/.test(b.textContent ?? '')) as
+    | HTMLButtonElement
+    | undefined;
+}
+
+describe('lv-branch-list create pull request entry', () => {
+  beforeEach(() => {
+    invalidateProviderDetection();
+  });
+
+  afterEach(() => {
+    invalidateProviderDetection();
+  });
+
+  it('is enabled for a local branch with an upstream on a detected provider', async () => {
+    const branch = makeBranch({ upstream: 'origin/feature/prs' });
+    const el = await createComponent([branch], 'github');
+
+    const entry = await openMenuFor(el, branch);
+    expect(entry, 'entry present').to.exist;
+    expect(entry!.disabled).to.equal(false);
+    expect(entry!.textContent).to.contain('Create pull request');
+  });
+
+  it('is disabled, and says why, when the branch has no upstream', async () => {
+    const branch = makeBranch({ upstream: null });
+    const el = await createComponent([branch], 'github');
+
+    const entry = await openMenuFor(el, branch);
+    expect(entry!.disabled).to.equal(true);
+    expect(entry!.title).to.contain('upstream');
+  });
+
+  it('is disabled, and says why, when no provider is detected', async () => {
+    const branch = makeBranch({ upstream: 'origin/feature/prs' });
+    const el = await createComponent([branch], 'none');
+
+    const entry = await openMenuFor(el, branch);
+    expect(entry!.disabled).to.equal(true);
+    expect(entry!.title).to.contain('No GitHub, GitLab, Bitbucket or Azure DevOps');
+  });
+
+  it('says "merge request" on GitLab', async () => {
+    const branch = makeBranch({ upstream: 'origin/feature/prs' });
+    const el = await createComponent([branch], 'gitlab');
+
+    const entry = await openMenuFor(el, branch);
+    expect(entry!.textContent).to.contain('Create merge request');
+    expect(entry!.disabled).to.equal(false);
+  });
+
+  it('is offered for the checked-out branch too', async () => {
+    const branch = makeBranch({
+      name: 'main',
+      shorthand: 'main',
+      isHead: true,
+      upstream: 'origin/main',
+    });
+    const el = await createComponent([branch], 'github');
+
+    const entry = await openMenuFor(el, branch);
+    expect(entry, 'entry present on HEAD').to.exist;
+    expect(entry!.disabled).to.equal(false);
+  });
+
+  it('is not offered on a remote branch', async () => {
+    const remote = makeBranch({
+      name: 'origin/feature/prs',
+      shorthand: 'feature/prs',
+      isRemote: true,
+      upstream: null,
+    });
+    const el = await createComponent([remote], 'github');
+
+    const entry = await openMenuFor(el, remote);
+    expect(entry).to.be.undefined;
+  });
+
+  it('dispatches create-pull-request with the branch as the source', async () => {
+    const branch = makeBranch({ upstream: 'origin/feature/prs' });
+    const main = makeBranch({ name: 'main', shorthand: 'main', upstream: 'origin/main' });
+    const el = await createComponent([main, branch], 'github');
+
+    let detail: { provider?: string; sourceBranch?: string; baseBranch?: string } | null = null;
+    el.addEventListener('create-pull-request', (e) => {
+      detail = (e as CustomEvent<typeof detail>).detail;
+    });
+
+    const entry = await openMenuFor(el, branch);
+    entry!.click();
+    await el.updateComplete;
+
+    expect(detail, 'event dispatched').to.not.be.null;
+    expect(detail!.provider).to.equal('github');
+    expect(detail!.sourceBranch).to.equal('feature/prs');
+    // "main" exists locally, so it is suggested as the base.
+    expect(detail!.baseBranch).to.equal('main');
+    // The menu closes after the hand-off.
+    expect(
+      (el as unknown as { contextMenu: { visible: boolean } }).contextMenu.visible,
+    ).to.equal(false);
+  });
+
+  it('suggests no base branch when no conventional trunk exists locally', async () => {
+    const branch = makeBranch({ upstream: 'origin/feature/prs' });
+    const el = await createComponent([branch], 'github');
+
+    let detail: { baseBranch?: string } | null = null;
+    el.addEventListener('create-pull-request', (e) => {
+      detail = (e as CustomEvent<typeof detail>).detail;
+    });
+
+    const entry = await openMenuFor(el, branch);
+    entry!.click();
+    await el.updateComplete;
+
+    expect(detail).to.not.be.null;
+    expect(detail!.baseBranch).to.equal(undefined);
+  });
+
+  it('dispatches nothing when the guard conditions are not met', async () => {
+    const branch = makeBranch({ upstream: null });
+    const el = await createComponent([branch], 'github');
+
+    let fired = 0;
+    el.addEventListener('create-pull-request', () => {
+      fired++;
+    });
+
+    // Bypassing the disabled attribute, as a stale menu surviving a repository
+    // switch would: the handler must refuse on its own.
+    (el as unknown as { contextMenu: unknown }).contextMenu = {
+      visible: true,
+      x: 0,
+      y: 0,
+      branch,
+    };
+    (el as unknown as { handleCreatePullRequest: () => void }).handleCreatePullRequest();
+
+    expect(fired).to.equal(0);
+  });
+});

--- a/src/components/sidebar/__tests__/lv-pull-request-list.test.ts
+++ b/src/components/sidebar/__tests__/lv-pull-request-list.test.ts
@@ -1,0 +1,463 @@
+/**
+ * Tests for lv-pull-request-list — the sidebar's Pull Requests section.
+ *
+ * Covers every state the section can be in (no provider, offline, blocked by
+ * the allowlist, unauthenticated, loading error, empty, populated), the lazy
+ * load contract (nothing is fetched while collapsed), the per-repository
+ * cache, explicit refresh, and click-through to the browser.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+let invokedCommands: string[] = [];
+let invokeCalls: Array<{ command: string; args?: unknown }> = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokedCommands.push(command);
+    invokeCalls.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import { settingsStore } from '../../../stores/settings.store.ts';
+import { unifiedProfileStore } from '../../../stores/unified-profile.store.ts';
+import { invalidateProviderDetection } from '../../../services/pull-request.service.ts';
+import '../lv-pull-request-list.ts';
+import type { LvPullRequestList } from '../lv-pull-request-list.ts';
+
+const REPO_PATH = '/test/repo';
+const OTHER_REPO_PATH = '/test/other-repo';
+
+interface MockOptions {
+  /** Detected GitHub repo, or null for "no provider anywhere". */
+  githubRepo?: { owner: string; repo: string; remoteName: string } | null;
+  /** Keyring answer for the legacy GitHub token. */
+  token?: string | null;
+  /** Pull requests list_pull_requests resolves with. */
+  pullRequests?: unknown[];
+  /** When set, list_pull_requests rejects with this message. */
+  listError?: string;
+}
+
+function setupMocks(options: MockOptions = {}): void {
+  const {
+    githubRepo = { owner: 'octo', repo: 'leviathan', remoteName: 'origin' },
+    token = 'gh-token',
+    pullRequests = [],
+    listError,
+  } = options;
+
+  mockInvoke = async (command: string) => {
+    switch (command) {
+      case 'detect_github_repo':
+        return githubRepo;
+      case 'detect_ado_repo':
+      case 'detect_gitlab_repo':
+      case 'detect_bitbucket_repo':
+        return null;
+      case 'get_keyring_token':
+        return token;
+      case 'list_pull_requests':
+        if (listError) throw new Error(listError);
+        return pullRequests;
+      default:
+        return null;
+    }
+  };
+}
+
+function makePr(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    number: 42,
+    title: 'Add the pull request sidebar',
+    state: 'open',
+    user: { login: 'octocat', id: 1, avatarUrl: '', name: 'Octo Cat', email: null },
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    mergedAt: null,
+    headRef: 'feature/prs',
+    headSha: 'abc123',
+    baseRef: 'main',
+    draft: false,
+    mergeable: true,
+    htmlUrl: 'https://github.com/octo/leviathan/pull/42',
+    additions: 10,
+    deletions: 2,
+    changedFiles: 1,
+    ...overrides,
+  };
+}
+
+async function renderList(
+  expanded = true,
+  repositoryPath = REPO_PATH,
+): Promise<LvPullRequestList> {
+  const el = await fixture<LvPullRequestList>(html`
+    <lv-pull-request-list
+      .repositoryPath=${repositoryPath}
+      .expanded=${expanded}
+    ></lv-pull-request-list>
+  `);
+  await settle(el);
+  return el;
+}
+
+/** Let the element's chained awaits (detect → token → list) resolve. */
+async function settle(el: LvPullRequestList): Promise<void> {
+  for (let i = 0; i < 12; i++) {
+    await el.updateComplete;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  await el.updateComplete;
+}
+
+/** Rendered text with template whitespace collapsed, for prose assertions. */
+function text(el: LvPullRequestList): string {
+  return (el.shadowRoot!.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+/** URLs handed to the Tauri shell plugin by openExternalUrl. */
+function openedUrls(): string[] {
+  return invokeCalls
+    .filter((c) => c.command === 'plugin:shell|open')
+    .map((c) => String((c.args as { path?: string } | undefined)?.path ?? ''));
+}
+
+describe('lv-pull-request-list', () => {
+  beforeEach(() => {
+    // Reset accounts BEFORE the counters: mocha runs the innermost afterEach
+    // first, so a reset there would still reach the previous test's live
+    // element and start one more load.
+    unifiedProfileStore.getState().setAccounts([]);
+    invokedCommands = [];
+    invokeCalls = [];
+    invalidateProviderDetection();
+    settingsStore.getState().setOfflineMode(false);
+    setupMocks();
+  });
+
+  afterEach(() => {
+    settingsStore.getState().setOfflineMode(false);
+    invalidateProviderDetection();
+  });
+
+  // ── Lazy loading ───────────────────────────────────────────────────────
+  describe('lazy loading', () => {
+    it('fetches nothing while the section is collapsed', async () => {
+      const el = await renderList(false);
+      expect(invokedCommands).to.not.include('detect_github_repo');
+      expect(invokedCommands).to.not.include('list_pull_requests');
+      expect(el.shadowRoot!.querySelector('.pr-item')).to.not.exist;
+    });
+
+    it('loads when the section is expanded', async () => {
+      const el = await renderList(false);
+      el.expanded = true;
+      await settle(el);
+
+      expect(invokedCommands).to.include('detect_github_repo');
+      expect(invokedCommands).to.include('list_pull_requests');
+    });
+
+    it('renders nothing at all without a repository path', async () => {
+      const el = await renderList(true, '');
+      expect(el.shadowRoot!.textContent!.trim()).to.equal('');
+      expect(invokedCommands).to.not.include('list_pull_requests');
+    });
+  });
+
+  // ── States ─────────────────────────────────────────────────────────────
+  describe('states', () => {
+    it('lists open pull requests with number, title and author', async () => {
+      setupMocks({ pullRequests: [makePr()] });
+      const el = await renderList();
+
+      const items = el.shadowRoot!.querySelectorAll('.pr-item');
+      expect(items.length).to.equal(1);
+      expect(items[0].textContent).to.contain('Add the pull request sidebar');
+      expect(items[0].textContent).to.contain('#42');
+      expect(items[0].textContent).to.contain('Octo Cat');
+      expect(items[0].textContent).to.contain('feature/prs');
+    });
+
+    it('badges a draft and a conflicting pull request', async () => {
+      setupMocks({
+        pullRequests: [makePr({ draft: true, mergeable: false })],
+      });
+      const el = await renderList();
+
+      const badges = Array.from(el.shadowRoot!.querySelectorAll('.pr-badge')).map(
+        (b) => b.textContent!.trim(),
+      );
+      expect(badges).to.include('Draft');
+      expect(badges).to.include('Conflicts');
+    });
+
+    it('shows an empty state rather than a blank list', async () => {
+      setupMocks({ pullRequests: [] });
+      const el = await renderList();
+
+      expect(el.shadowRoot!.querySelector('.empty')).to.exist;
+      expect(text(el)).to.contain('No open pull requests');
+    });
+
+    it('explains when no hosting provider is detected', async () => {
+      setupMocks({ githubRepo: null });
+      const el = await renderList();
+
+      expect(text(el)).to.contain('No GitHub, GitLab, Bitbucket or Azure DevOps remote');
+      expect(invokedCommands).to.not.include('list_pull_requests');
+    });
+
+    it('offers to connect instead of showing an empty list when not authenticated', async () => {
+      setupMocks({ token: null });
+      const el = await renderList();
+
+      expect(text(el)).to.contain('Not connected to GitHub');
+      const connect = el.shadowRoot!.querySelector('.btn-primary') as HTMLButtonElement;
+      expect(connect).to.exist;
+      expect(connect.textContent).to.contain('Connect to GitHub');
+      // No API call was made without a token.
+      expect(invokedCommands).to.not.include('list_pull_requests');
+    });
+
+    it('dispatches open-provider-connection from the connect button', async () => {
+      setupMocks({ token: null });
+      const el = await renderList();
+
+      let detail: { provider?: string } | null = null;
+      el.addEventListener('open-provider-connection', (e) => {
+        detail = (e as CustomEvent<{ provider: string }>).detail;
+      });
+      (el.shadowRoot!.querySelector('.btn-primary') as HTMLButtonElement).click();
+
+      expect(detail).to.not.be.null;
+      expect(detail!.provider).to.equal('github');
+    });
+
+    it('says why the list is unavailable in offline mode, without calling the API', async () => {
+      settingsStore.getState().setOfflineMode(true);
+      const el = await renderList();
+
+      expect(text(el)).to.contain('unavailable while offline mode is enabled');
+      expect(invokedCommands).to.not.include('list_pull_requests');
+    });
+
+    it('explains an allowlist block rather than showing an empty list', async () => {
+      // A configured allowlist that does not contain api.github.com makes the
+      // shared network gate refuse the provider call with BLOCKED.
+      settingsStore.setState({ remoteAllowlist: ['example.invalid'] });
+      try {
+        const el = await renderList();
+        expect(text(el)).to.contain('allowlist');
+        expect(el.shadowRoot!.querySelector('.pr-item')).to.not.exist;
+      } finally {
+        settingsStore.setState({ remoteAllowlist: [] });
+      }
+    });
+
+    it('shows the error with a retry when the list call fails', async () => {
+      setupMocks({ listError: 'API rate limit exceeded' });
+      const el = await renderList();
+
+      expect(text(el)).to.contain('API rate limit exceeded');
+      const retry = el.shadowRoot!.querySelector('.btn-secondary') as HTMLButtonElement;
+      expect(retry).to.exist;
+      expect(retry.textContent).to.contain('Retry');
+    });
+
+    it('recovers from an error when retry succeeds', async () => {
+      setupMocks({ listError: 'Network unreachable' });
+      const el = await renderList();
+      expect(text(el)).to.contain('Network unreachable');
+
+      setupMocks({ pullRequests: [makePr()] });
+      (el.shadowRoot!.querySelector('.btn-secondary') as HTMLButtonElement).click();
+      await settle(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.pr-item').length).to.equal(1);
+    });
+  });
+
+  // ── Caching and refresh ────────────────────────────────────────────────
+  describe('caching and refresh', () => {
+    it('does not refetch when the section is collapsed and expanded again', async () => {
+      setupMocks({ pullRequests: [makePr()] });
+      const el = await renderList();
+      const firstCalls = invokedCommands.filter((c) => c === 'list_pull_requests').length;
+      expect(firstCalls).to.equal(1);
+
+      el.expanded = false;
+      await settle(el);
+      el.expanded = true;
+      await settle(el);
+
+      const secondCalls = invokedCommands.filter((c) => c === 'list_pull_requests').length;
+      expect(secondCalls).to.equal(1);
+      expect(el.shadowRoot!.querySelectorAll('.pr-item').length).to.equal(1);
+    });
+
+    it('caches per repository and reuses each cached result', async () => {
+      setupMocks({ pullRequests: [makePr()] });
+      const el = await renderList();
+
+      el.repositoryPath = OTHER_REPO_PATH;
+      await settle(el);
+      expect(invokedCommands.filter((c) => c === 'list_pull_requests').length).to.equal(2);
+
+      el.repositoryPath = REPO_PATH;
+      await settle(el);
+      // Back to a repository already loaded: no third call.
+      expect(invokedCommands.filter((c) => c === 'list_pull_requests').length).to.equal(2);
+    });
+
+    it('refetches on an explicit refresh', async () => {
+      setupMocks({ pullRequests: [makePr()] });
+      const el = await renderList();
+      expect(invokedCommands.filter((c) => c === 'list_pull_requests').length).to.equal(1);
+
+      setupMocks({ pullRequests: [makePr({ number: 43, title: 'Second' })] });
+      await el.refresh();
+      await settle(el);
+
+      expect(invokedCommands.filter((c) => c === 'list_pull_requests').length).to.equal(2);
+      expect(text(el)).to.contain('Second');
+    });
+
+    it('retries a failed load when the section is re-expanded', async () => {
+      // An error is not a result, so it must not be cached: re-opening the
+      // section is the obvious "try again" gesture.
+      setupMocks({ listError: 'Network unreachable' });
+      const el = await renderList();
+      expect(text(el)).to.contain('Network unreachable');
+
+      el.expanded = false;
+      await settle(el);
+      setupMocks({ pullRequests: [makePr()] });
+      el.expanded = true;
+      await settle(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.pr-item').length).to.equal(1);
+    });
+
+    it('reloads when an account is connected while showing "not connected"', async () => {
+      setupMocks({ token: null });
+      const el = await renderList();
+      expect(text(el)).to.contain('Not connected to GitHub');
+
+      // Connecting through the dialog the Connect button opens lands as a new
+      // account in the shared store; the section must notice.
+      setupMocks({ token: 'gh-token', pullRequests: [makePr()] });
+      unifiedProfileStore.getState().setAccounts([
+        {
+          id: 'gh-1',
+          name: 'GitHub',
+          integrationType: 'github',
+          config: { type: 'pat' },
+          color: null,
+          cachedUser: null,
+          urlPatterns: [],
+          isDefault: true,
+        },
+      ] as never);
+      await settle(el);
+
+      expect(el.shadowRoot!.querySelectorAll('.pr-item').length).to.equal(1);
+    });
+
+    it('refetches on repository-refresh while expanded', async () => {
+      setupMocks({ pullRequests: [makePr()] });
+      const el = await renderList();
+      expect(invokedCommands.filter((c) => c === 'list_pull_requests').length).to.equal(1);
+
+      window.dispatchEvent(
+        new CustomEvent('repository-refresh', { detail: { repoPath: REPO_PATH } }),
+      );
+      await settle(el);
+
+      expect(invokedCommands.filter((c) => c === 'list_pull_requests').length).to.equal(2);
+    });
+
+    it('does not refetch on repository-refresh while collapsed', async () => {
+      setupMocks({ pullRequests: [makePr()] });
+      const el = await renderList();
+      el.expanded = false;
+      await settle(el);
+
+      window.dispatchEvent(
+        new CustomEvent('repository-refresh', { detail: { repoPath: REPO_PATH } }),
+      );
+      await settle(el);
+
+      expect(invokedCommands.filter((c) => c === 'list_pull_requests').length).to.equal(1);
+    });
+  });
+
+  // ── Count reporting ────────────────────────────────────────────────────
+  describe('count reporting', () => {
+    it('reports the loaded count for the section header badge', async () => {
+      setupMocks({ pullRequests: [makePr(), makePr({ number: 43 })] });
+      const counts: number[] = [];
+      const el = await fixture<LvPullRequestList>(html`
+        <lv-pull-request-list
+          .repositoryPath=${REPO_PATH}
+          .expanded=${true}
+          @pull-request-count-changed=${(e: CustomEvent<{ count: number }>) =>
+            counts.push(e.detail.count)}
+        ></lv-pull-request-list>
+      `);
+      await settle(el);
+
+      expect(counts[counts.length - 1]).to.equal(2);
+    });
+
+    it('reports zero for a state that has no list', async () => {
+      setupMocks({ token: null });
+      const counts: number[] = [];
+      const el = await fixture<LvPullRequestList>(html`
+        <lv-pull-request-list
+          .repositoryPath=${REPO_PATH}
+          .expanded=${true}
+          @pull-request-count-changed=${(e: CustomEvent<{ count: number }>) =>
+            counts.push(e.detail.count)}
+        ></lv-pull-request-list>
+      `);
+      await settle(el);
+
+      expect(counts[counts.length - 1]).to.equal(0);
+    });
+  });
+
+  // ── Click-through ──────────────────────────────────────────────────────
+  describe('click-through', () => {
+    it('opens the pull request in the browser on click', async () => {
+      setupMocks({ pullRequests: [makePr()] });
+      const el = await renderList();
+
+      (el.shadowRoot!.querySelector('.pr-item') as HTMLElement).click();
+      await new Promise((r) => setTimeout(r, 20));
+
+      // openExternalUrl hands the URL to the Tauri shell plugin - the same
+      // route the graph's PR badges take.
+      expect(openedUrls()).to.contain('https://github.com/octo/leviathan/pull/42');
+    });
+
+    it('opens the pull request on Enter', async () => {
+      setupMocks({ pullRequests: [makePr()] });
+      const el = await renderList();
+
+      const item = el.shadowRoot!.querySelector('.pr-item') as HTMLElement;
+      item.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      await new Promise((r) => setTimeout(r, 20));
+
+      expect(openedUrls()).to.contain('https://github.com/octo/leviathan/pull/42');
+    });
+  });
+});

--- a/src/components/sidebar/index.ts
+++ b/src/components/sidebar/index.ts
@@ -4,3 +4,4 @@ export * from './lv-file-status.ts';
 export * from './lv-commit-panel.ts';
 export * from './lv-stash-list.ts';
 export * from './lv-tag-list.ts';
+export * from './lv-pull-request-list.ts';

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -8,6 +8,11 @@ import { sweepRepoScopedDialogs } from '../../utils/repo-scoped-dialogs.ts';
 import { showErrorWithSuggestion } from '../../services/error-suggestion.service.ts';
 import { dragDropService, type DragItem } from '../../services/drag-drop.service.ts';
 import { settingsStore } from '../../stores/settings.store.ts';
+import {
+  detectPullRequestProvider,
+  invalidateProviderDetection,
+  type PullRequestProviderTarget,
+} from '../../services/pull-request.service.ts';
 import { repositoryStore } from '../../stores/repository.store.ts';
 import { fuzzyScore } from '../../utils/fuzzy-search.ts';
 import '../dialogs/lv-branch-cleanup-dialog.ts';
@@ -651,6 +656,22 @@ export class LvBranchList extends LitElement {
    */
   @state() private cleanupCheckFailed = false;
 
+  /**
+   * The hosting provider backing this repository, once resolved, and null when
+   * resolution finished and found none. `providerResolved` is what tells those
+   * two apart -- "not detected" and "not looked yet" must not both disable the
+   * create-request entry with the same explanation.
+   *
+   * Resolved eagerly (per repository, through the cache in
+   * pull-request.service that the sidebar's Pull Requests section shares) and
+   * NOT on menu open: the `detect_*_repo` commands only read this repository's
+   * own remote configuration, so they cost no network call, and an entry that
+   * flips from disabled to enabled under the user's cursor is worse than one
+   * that is simply right when the menu appears.
+   */
+  @state() private prProvider: PullRequestProviderTarget | null = null;
+  @state() private prProviderResolved = false;
+
   @query('lv-branch-cleanup-dialog') private branchCleanupDialog!: LvBranchCleanupDialog;
 
   private static readonly HIDDEN_BRANCHES_STORAGE_PREFIX = 'lv-hidden-branches:';
@@ -707,6 +728,7 @@ export class LvBranchList extends LitElement {
       });
     });
     await this.loadBranches();
+    void this.detectProvider();
   }
 
   disconnectedCallback(): void {
@@ -723,6 +745,9 @@ export class LvBranchList extends LitElement {
 
   private handleRepositoryRefresh = (): void => {
     this.loadBranches();
+    // Adding or re-pointing a remote changes the answer, and a stale "no
+    // provider" would silently keep the create-request entry disabled.
+    void this.detectProvider(true);
   };
 
   private handleExternalCleanupOpen = (): void => {
@@ -779,8 +804,118 @@ export class LvBranchList extends LitElement {
       // survive the rebind and delete repo A's branch inside repo B.
       this.contextMenu = { ...this.contextMenu, visible: false };
       this.loadHiddenBranches();
+      // Clear before the await: the previous repository's provider must never
+      // label -- or enable -- a menu opened over this one's branches.
+      this.prProvider = null;
+      this.prProviderResolved = false;
       await this.loadBranches();
+      await this.detectProvider();
     }
+  }
+
+  /**
+   * Resolve the hosting provider for the bound repository.
+   *
+   * `force` re-detects instead of reading the shared cache, for the case where
+   * the repository's remotes may have just changed.
+   */
+  private async detectProvider(force = false): Promise<void> {
+    const loadedPath = this.repositoryPath;
+    if (!loadedPath) {
+      this.prProvider = null;
+      this.prProviderResolved = false;
+      return;
+    }
+    if (force) invalidateProviderDetection(loadedPath);
+    let target: PullRequestProviderTarget | null = null;
+    try {
+      target = await detectPullRequestProvider(loadedPath, { force });
+    } catch {
+      // Detection is best-effort: a failure leaves the entry disabled with the
+      // "no provider" explanation rather than breaking the menu. Nothing the
+      // user asked for has failed here, so there is nothing to report.
+      target = null;
+    }
+    // A tab switch while detection was in flight: the result belongs to the
+    // repository it was requested for, not whichever one is bound now.
+    if (this.repositoryPath !== loadedPath) return;
+    this.prProvider = target;
+    this.prProviderResolved = true;
+  }
+
+  /**
+   * Label for the create-request entry. GitLab calls them merge requests, and
+   * saying "pull request" there would name a thing GitLab does not have.
+   */
+  private get createRequestLabel(): string {
+    return this.prProvider?.provider === 'gitlab'
+      ? 'Create merge request...'
+      : 'Create pull request...';
+  }
+
+  /**
+   * Why the create-request entry is disabled, or null when it is enabled.
+   *
+   * An upstream is required because every provider opens the request from a
+   * branch that already exists on the remote -- without one there is nothing
+   * on the server to open it from.
+   */
+  private createRequestBlockedReason(branch: Branch): string | null {
+    if (!this.prProviderResolved) return 'Checking for a hosting provider...';
+    if (!this.prProvider) {
+      return 'No GitHub, GitLab, Bitbucket or Azure DevOps remote was detected for this repository';
+    }
+    if (!branch.upstream) {
+      return `Push ${branch.shorthand} and set its upstream first`;
+    }
+    return null;
+  }
+
+  /**
+   * A base branch to prefill the provider's create form with: the first
+   * conventional trunk that exists locally, and nothing when none does.
+   *
+   * A SUGGESTION only -- the dialog applies it just to an empty field, and the
+   * user can change it there. Derived from the branches already loaded, so it
+   * costs no extra call; the repository's real default branch is only known to
+   * the remote.
+   */
+  private suggestBaseBranch(sourceBranch: string): string | undefined {
+    const localNames = new Set(
+      this.localBranchGroups.flatMap((group) => group.branches.map((b) => b.shorthand)),
+    );
+    return ['main', 'master', 'develop', 'trunk'].find(
+      (name) => name !== sourceBranch && localNames.has(name),
+    );
+  }
+
+  /**
+   * Hand the branch off to the provider dialog's existing create form.
+   *
+   * Dispatched rather than handled here on purpose: the four provider dialogs
+   * already own the create flow (form, account selection, API call, feedback),
+   * and app-shell hosts them. Listener: `@create-pull-request` on app-shell's
+   * left-panel aside.
+   */
+  private handleCreatePullRequest(): void {
+    const branch = this.contextMenu.branch;
+    const provider = this.prProvider;
+    // Re-checked at click time, not just in the disabled binding: the provider
+    // is resolved asynchronously and the menu can outlive a repository switch.
+    if (!branch || branch.isRemote || !branch.upstream || !provider) return;
+
+    this.contextMenu = { ...this.contextMenu, visible: false };
+    this.dispatchEvent(
+      new CustomEvent('create-pull-request', {
+        bubbles: true,
+        composed: true,
+        detail: {
+          provider: provider.provider,
+          sourceBranch: branch.shorthand,
+          baseBranch: this.suggestBaseBranch(branch.shorthand),
+        },
+      }),
+    );
   }
 
   private get hiddenBranchesStorageKey(): string {
@@ -2195,6 +2330,7 @@ export class LvBranchList extends LitElement {
     const branch = this.contextMenu.branch;
     const isLocal = !branch.isRemote;
     const isHead = branch.isHead;
+    const createRequestBlocked = isLocal ? this.createRequestBlockedReason(branch) : null;
 
     return html`
       <div
@@ -2243,6 +2379,24 @@ export class LvBranchList extends LitElement {
               <line x1="23" y1="11" x2="17" y2="11"></line>
             </svg>
             Track this branch
+          </button>
+        ` : ''}
+
+        ${isLocal ? html`
+          <button
+            class="context-menu-item"
+            role="menuitem"
+            ?disabled=${createRequestBlocked !== null}
+            title=${createRequestBlocked ?? `Open a ${this.prProvider?.itemNoun ?? 'pull request'} for ${branch.shorthand} on ${this.prProvider?.providerName ?? 'the remote'}`}
+            @click=${this.handleCreatePullRequest}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
+              <circle cx="18" cy="18" r="3"></circle>
+              <circle cx="6" cy="6" r="3"></circle>
+              <path d="M13 6h3a2 2 0 0 1 2 2v7"></path>
+              <line x1="6" y1="9" x2="6" y2="21"></line>
+            </svg>
+            ${this.createRequestLabel}
           </button>
         ` : ''}
 

--- a/src/components/sidebar/lv-left-panel.ts
+++ b/src/components/sidebar/lv-left-panel.ts
@@ -5,7 +5,9 @@ import { repositoryStore } from '../../stores/index.ts';
 import './lv-branch-list.ts';
 import './lv-stash-list.ts';
 import './lv-tag-list.ts';
+import './lv-pull-request-list.ts';
 import './lv-gitflow-panel.ts';
+import type { LvPullRequestList } from './lv-pull-request-list.ts';
 
 /**
  * Left panel container component
@@ -139,6 +141,7 @@ export class LvLeftPanel extends LitElement {
   @state() private repositoryPath: string | null = null;
   @state() private stashCount: number = 0;
   @state() private tagCount: number = 0;
+  @state() private pullRequestCount: number = 0;
   @state() private expandedSections = new Set<string>(['branches']);
 
   private unsubscribe?: () => void;
@@ -169,6 +172,7 @@ export class LvLeftPanel extends LitElement {
     const branchesExpanded = this.expandedSections.has('branches');
     const stashesExpanded = this.expandedSections.has('stashes');
     const tagsExpanded = this.expandedSections.has('tags');
+    const pullRequestsExpanded = this.expandedSections.has('pull-requests');
     const gitflowExpanded = this.expandedSections.has('gitflow');
 
     return html`
@@ -249,6 +253,40 @@ export class LvLeftPanel extends LitElement {
         </div>
       </section>
 
+      <!-- Pull Requests Section - collapsed by default ON PURPOSE. Its content
+           is the only sidebar section backed by a REMOTE API (GitHub / GitLab /
+           Bitbucket / Azure DevOps), so it loads only once the user expands it:
+           the child's .expanded property is its lazy-load trigger, and nothing
+           is fetched at app start. It keeps its own per-repository cache, so
+           collapsing and re-expanding costs no further API calls. -->
+      <section class="section refs-section ${pullRequestsExpanded ? '' : 'collapsed'}">
+        <header class="section-header" @click=${() => this.toggleSection('pull-requests')}>
+          ${this.renderChevron(pullRequestsExpanded)}
+          <span class="title">Pull Requests</span>
+          ${this.pullRequestCount > 0 ? html`<span class="count">${this.pullRequestCount}</span>` : ''}
+          ${pullRequestsExpanded ? html`
+            <button
+              class="section-action"
+              title="Refresh pull requests"
+              aria-label="Refresh pull requests"
+              @click=${this.handleRefreshPullRequests}
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="23 4 23 10 17 10"></polyline>
+                <path d="M20.49 15a9 9 0 1 1-2.12-9.36L23 10"></path>
+              </svg>
+            </button>
+          ` : ''}
+        </header>
+        <div class="section-content">
+          <lv-pull-request-list
+            .repositoryPath=${this.repositoryPath}
+            .expanded=${pullRequestsExpanded}
+            @pull-request-count-changed=${this.handlePullRequestCountChanged}
+          ></lv-pull-request-list>
+        </div>
+      </section>
+
       <!-- Git Flow Section -->
       <section class="section refs-section ${gitflowExpanded ? '' : 'collapsed'}">
         <header class="section-header" @click=${() => this.toggleSection('gitflow')}>
@@ -318,6 +356,23 @@ export class LvLeftPanel extends LitElement {
 
   private handleTagCountChanged(e: CustomEvent<{ count: number }>): void {
     this.tagCount = e.detail.count;
+  }
+
+  private handlePullRequestCountChanged(e: CustomEvent<{ count: number }>): void {
+    this.pullRequestCount = e.detail.count;
+  }
+
+  /**
+   * Explicit refresh of the pull request list. Called directly on the child
+   * rather than dispatched as an event, because this element would be the only
+   * possible listener - an event would just be a longer way to reach the same
+   * instance.
+   */
+  private handleRefreshPullRequests(e: Event): void {
+    // The button sits inside the header that toggles the section.
+    e.stopPropagation();
+    const list = this.renderRoot.querySelector('lv-pull-request-list') as LvPullRequestList | null;
+    void list?.refresh();
   }
 
   private handleCreateTag(e: Event): void {

--- a/src/components/sidebar/lv-pull-request-list.ts
+++ b/src/components/sidebar/lv-pull-request-list.ts
@@ -1,0 +1,587 @@
+/**
+ * Pull Requests sidebar section.
+ *
+ * Lists the OPEN pull/merge requests for the active repository's detected
+ * hosting provider. Deliberately read-only: clicking a row opens the request in
+ * the browser, which is exactly what clicking a PR badge on a graph row already
+ * does (`lv-graph-canvas.handleClick`), so the two surfaces behave the same.
+ *
+ * Loading is lazy and cached. The provider APIs are real network calls behind
+ * the offline/allowlist gate, so this element fetches ONLY when its section is
+ * expanded, keeps the result per repository, and refetches only on an explicit
+ * refresh or a `repository-refresh`. Nothing happens at app start while the
+ * section is collapsed — which is its default.
+ */
+
+import { LitElement, html, css, nothing } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { repeat } from 'lit/directives/repeat.js';
+import { sharedStyles, buttonStyles } from '../../styles/shared-styles.ts';
+import { settingsStore } from '../../stores/settings.store.ts';
+import { unifiedProfileStore } from '../../stores/unified-profile.store.ts';
+import { openExternalUrl } from '../../utils/external-link.ts';
+import {
+  detectPullRequestProvider,
+  getProviderToken,
+  invalidateProviderDetection,
+  listOpenPullRequests,
+  type PullRequestProviderTarget,
+  type SidebarPullRequest,
+} from '../../services/pull-request.service.ts';
+
+/**
+ * Every state this section can be in. They are mutually exclusive and each one
+ * renders something the user can act on — an empty list is never used to stand
+ * in for "not connected", "offline" or "failed".
+ */
+type ListState =
+  | 'idle'
+  | 'loading'
+  | 'no-provider'
+  | 'offline'
+  | 'blocked'
+  | 'unauthenticated'
+  | 'error'
+  | 'ready';
+
+/** What a completed load produced, cached per repository path. */
+interface CacheEntry {
+  state: ListState;
+  target: PullRequestProviderTarget | null;
+  pullRequests: SidebarPullRequest[];
+  errorMessage: string | null;
+}
+
+@customElement('lv-pull-request-list')
+export class LvPullRequestList extends LitElement {
+  static styles = [
+    sharedStyles,
+    buttonStyles,
+    css`
+      :host {
+        display: block;
+      }
+
+      .pr-list {
+        list-style: none;
+        margin: 0;
+        padding: 0;
+      }
+
+      /* Full-bleed row inside a scrolling list: draw the shared keyboard focus
+         ring inside the row so the scroll container cannot clip it. */
+      .pr-item {
+        --lv-focus-ring-offset: -2px;
+        display: flex;
+        align-items: flex-start;
+        gap: 6px;
+        padding: 3px 12px;
+        cursor: pointer;
+        font-size: var(--font-size-sm);
+      }
+
+      .pr-item:hover {
+        background: var(--color-bg-hover);
+      }
+
+      .pr-icon {
+        width: 14px;
+        height: 14px;
+        flex-shrink: 0;
+        margin-top: 2px;
+        color: var(--color-success);
+      }
+
+      .pr-icon.draft {
+        color: var(--color-text-muted);
+      }
+
+      .pr-body {
+        min-width: 0;
+        flex: 1;
+      }
+
+      .pr-title {
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .pr-meta {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .pr-number {
+        font-family: var(--font-family-mono);
+      }
+
+      .pr-badge {
+        flex-shrink: 0;
+        padding: 0 4px;
+        border-radius: var(--radius-sm);
+        border: 1px solid var(--color-border);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+      }
+
+      .pr-badge.conflicts {
+        border-color: var(--color-error);
+        color: var(--color-error);
+      }
+
+      .notice {
+        display: flex;
+        flex-direction: column;
+        align-items: flex-start;
+        gap: var(--spacing-sm);
+        padding: var(--spacing-sm) 12px;
+        font-size: var(--font-size-sm);
+        color: var(--color-text-muted);
+      }
+
+      .notice.error-notice {
+        color: var(--color-error);
+      }
+
+      .notice-message {
+        overflow-wrap: anywhere;
+      }
+
+      .empty {
+        padding: 4px 12px;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+        font-style: italic;
+      }
+
+      .loading {
+        padding: 4px 12px;
+        font-size: var(--font-size-sm);
+        color: var(--color-text-muted);
+      }
+
+      /* Compact variant of the shared .btn for the sidebar's tighter rhythm. */
+      .btn-sm {
+        padding: 2px var(--spacing-sm);
+        font-size: var(--font-size-xs);
+        cursor: pointer;
+        border: 1px solid var(--color-border);
+      }
+
+      .repo-label {
+        padding: 2px 12px;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+    `,
+  ];
+
+  @property({ type: String }) repositoryPath: string = '';
+
+  /**
+   * True while the host section is expanded. This is the lazy-load trigger:
+   * the element fetches nothing until it flips true, so a collapsed section
+   * costs no provider API calls at app start.
+   */
+  @property({ type: Boolean }) expanded: boolean = false;
+
+  @state() private listState: ListState = 'idle';
+  @state() private target: PullRequestProviderTarget | null = null;
+  @state() private pullRequests: SidebarPullRequest[] = [];
+  @state() private errorMessage: string | null = null;
+
+  /**
+   * Completed loads, keyed by repository path. Switching tabs back and forth
+   * must not re-hit the provider API: the sidebar is not a live view of the
+   * remote, and each call is rate-limited and gated.
+   */
+  private cache = new Map<string, CacheEntry>();
+
+  /**
+   * Per-path load generation. lv-left-panel keeps ONE instance of this element
+   * across repository tabs and only rebinds `.repositoryPath`, and Lit does not
+   * await an async `updated()` — so a fast A→B→A switch starts overlapping
+   * loads with nothing sequencing them. Same shape as lv-tag-list.tagsLoadSeq.
+   */
+  private loadSeq = new Map<string, number>();
+
+  /** Ids of the connected integration accounts, as last seen. */
+  private accountSignature = '';
+  private unsubscribeAccounts?: () => void;
+
+  connectedCallback(): void {
+    super.connectedCallback();
+    window.addEventListener('repository-refresh', this.handleRepositoryRefresh);
+
+    // Connecting an account from the "Connect to ..." button opens a dialog
+    // that this element never hears back from. Without this subscription the
+    // section kept saying "Not connected" after a successful sign-in, which is
+    // a dead end: the one action it offers appears to do nothing. The account
+    // set is the signal the sign-in actually landed (and that a disconnect
+    // happened, which must put the Connect button back).
+    this.accountSignature = this.readAccountSignature();
+    this.unsubscribeAccounts = unifiedProfileStore.subscribe(() => {
+      const signature = this.readAccountSignature();
+      if (signature === this.accountSignature) return;
+      this.accountSignature = signature;
+      if (!this.repositoryPath) return;
+      this.cache.delete(this.repositoryPath);
+      if (this.expanded) void this.load();
+    });
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    window.removeEventListener('repository-refresh', this.handleRepositoryRefresh);
+    this.unsubscribeAccounts?.();
+    this.unsubscribeAccounts = undefined;
+  }
+
+  private readAccountSignature(): string {
+    return unifiedProfileStore
+      .getState()
+      .accounts.map((a) => a.id)
+      .join(',');
+  }
+
+  /**
+   * An app-level refresh invalidates the cached list AND the cached provider
+   * detection (a remote may have just been added or re-pointed). The refetch
+   * only happens while expanded — a collapsed section reloads when it is next
+   * opened, which is the whole point of loading lazily.
+   */
+  private handleRepositoryRefresh = (e: Event): void => {
+    const repoPath =
+      (e as CustomEvent<{ repoPath?: string }>).detail?.repoPath ?? this.repositoryPath;
+    if (!repoPath) return;
+    this.cache.delete(repoPath);
+    invalidateProviderDetection(repoPath);
+    if (repoPath !== this.repositoryPath) return;
+    if (this.expanded) {
+      void this.load();
+    } else {
+      // Drop the stale rows now so re-expanding cannot show the previous
+      // result for a heartbeat before the fresh load lands.
+      this.applyState({
+        state: 'idle',
+        target: null,
+        pullRequests: [],
+        errorMessage: null,
+      });
+    }
+  };
+
+  updated(changedProperties: Map<string, unknown>): void {
+    const repoChanged = changedProperties.has('repositoryPath');
+    if (!repoChanged && !changedProperties.has('expanded')) return;
+    // Deferred by a microtask on purpose: setting reactive state synchronously
+    // inside updated() makes Lit schedule a second update from within the
+    // first, which it warns about. One microtask is imperceptible here.
+    queueMicrotask(() => {
+      if (repoChanged) {
+        // Show the NEW repository's cached result (or nothing): the previous
+        // repo's rows are live "open in browser" targets pointing at a
+        // different project.
+        const cached = this.repositoryPath ? this.cache.get(this.repositoryPath) : undefined;
+        this.applyState(
+          cached ?? { state: 'idle', target: null, pullRequests: [], errorMessage: null },
+        );
+      }
+      if (this.expanded) void this.load();
+    });
+  }
+
+  /** Reload from the provider, ignoring any cached result. */
+  public async refresh(): Promise<void> {
+    if (this.repositoryPath) {
+      this.cache.delete(this.repositoryPath);
+      invalidateProviderDetection(this.repositoryPath);
+    }
+    await this.load();
+  }
+
+  private applyState(entry: CacheEntry): void {
+    this.listState = entry.state;
+    this.target = entry.target;
+    this.pullRequests = entry.pullRequests;
+    this.errorMessage = entry.errorMessage;
+    this.dispatchEvent(
+      new CustomEvent('pull-request-count-changed', {
+        // Only a loaded list has a meaningful count; every other state must
+        // clear the header badge rather than leave the last repo's number on it.
+        detail: { count: entry.state === 'ready' ? entry.pullRequests.length : 0 },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private async load(): Promise<void> {
+    if (!this.repositoryPath || !this.expanded) return;
+
+    // Captured before the awaits so a mid-flight tab switch still resolves this
+    // result against the repository it was loaded FROM.
+    const loadedPath = this.repositoryPath;
+    const cached = this.cache.get(loadedPath);
+    if (cached) {
+      this.applyState(cached);
+      return;
+    }
+
+    const seq = (this.loadSeq.get(loadedPath) ?? 0) + 1;
+    this.loadSeq.set(loadedPath, seq);
+    /** Latest load for this path AND this path is still the bound one. */
+    const isFresh = (): boolean =>
+      this.loadSeq.get(loadedPath) === seq && this.repositoryPath === loadedPath;
+
+    this.listState = 'loading';
+    this.errorMessage = null;
+
+    const settle = (entry: CacheEntry): void => {
+      if (!isFresh()) return;
+      // A failure is not a result, so it is NOT cached: re-opening the section
+      // is a natural "try again", and it cannot loop because collapsing and
+      // re-expanding is a deliberate gesture. Every other state is cached and
+      // has its own way out - Try again for offline and allowlist, the account
+      // subscription above for "not connected", and a repository-refresh or
+      // the section's refresh button for all of them.
+      if (entry.state !== 'error') {
+        this.cache.set(loadedPath, entry);
+      }
+      this.applyState(entry);
+    };
+
+    try {
+      const target = await detectPullRequestProvider(loadedPath);
+      if (!isFresh()) return;
+      if (!target) {
+        settle({ state: 'no-provider', target: null, pullRequests: [], errorMessage: null });
+        return;
+      }
+
+      // Checked here rather than only reacting to the gate's BLOCKED refusal so
+      // the message can name the actual reason. `invokeProviderCommand` refuses
+      // silently for background callers like this one, so an unexplained empty
+      // list is the alternative.
+      if (settingsStore.getState().offlineMode) {
+        settle({ state: 'offline', target, pullRequests: [], errorMessage: null });
+        return;
+      }
+
+      const token = await getProviderToken(target);
+      if (!isFresh()) return;
+      if (!token) {
+        settle({ state: 'unauthenticated', target, pullRequests: [], errorMessage: null });
+        return;
+      }
+
+      const result = await listOpenPullRequests(target, token);
+      if (!isFresh()) return;
+
+      if (result.success) {
+        settle({
+          state: 'ready',
+          target,
+          pullRequests: result.data ?? [],
+          errorMessage: null,
+        });
+        return;
+      }
+
+      // The security gate refuses silently for provider calls (see
+      // invokeProviderCommand), so this branch has to say so itself.
+      if (result.error?.code === 'BLOCKED') {
+        settle({ state: 'blocked', target, pullRequests: [], errorMessage: null });
+        return;
+      }
+
+      settle({
+        state: 'error',
+        target,
+        pullRequests: [],
+        errorMessage: result.error?.message ?? `Failed to load ${target.itemNounPlural}`,
+      });
+    } catch (err) {
+      if (!isFresh()) return;
+      settle({
+        state: 'error',
+        target: this.target,
+        pullRequests: [],
+        errorMessage: err instanceof Error ? err.message : 'Failed to load pull requests',
+      });
+    }
+  }
+
+  private handleOpen(pr: SidebarPullRequest): void {
+    void openExternalUrl(pr.url);
+  }
+
+  private handleItemKeydown(e: KeyboardEvent, pr: SidebarPullRequest): void {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      this.handleOpen(pr);
+    }
+  }
+
+  /** Ask the host to open this provider's dialog so the user can connect. */
+  private handleConnect(): void {
+    if (!this.target) return;
+    this.dispatchEvent(
+      new CustomEvent('open-provider-connection', {
+        detail: { provider: this.target.provider },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+  }
+
+  private renderRetry(label = 'Retry') {
+    return html`
+      <button class="btn btn-secondary btn-sm" @click=${() => void this.refresh()}>
+        ${label}
+      </button>
+    `;
+  }
+
+  private renderBody() {
+    const noun = this.target?.itemNounPlural ?? 'pull requests';
+
+    switch (this.listState) {
+      case 'idle':
+        // Only reachable while collapsed (the section loads on expand), so it
+        // renders nothing rather than a state the user can never see.
+        return nothing;
+
+      case 'loading':
+        return html`<div class="loading">Loading ${noun}...</div>`;
+
+      case 'no-provider':
+        return html`
+          <div class="notice">
+            <span class="notice-message">
+              No GitHub, GitLab, Bitbucket or Azure DevOps remote was detected for this
+              repository.
+            </span>
+          </div>
+        `;
+
+      case 'offline':
+        return html`
+          <div class="notice">
+            <span class="notice-message">
+              ${this.target?.itemNounTitle ?? 'Pull requests'} are unavailable while offline
+              mode is enabled. Disable it in Settings &gt; Security.
+            </span>
+            ${this.renderRetry('Try again')}
+          </div>
+        `;
+
+      case 'blocked':
+        return html`
+          <div class="notice">
+            <span class="notice-message">
+              ${this.target?.providerName ?? 'This provider'} is not in your remote allowlist,
+              so its ${noun} cannot be loaded. Update the allowlist in Settings &gt; Security.
+            </span>
+            ${this.renderRetry('Try again')}
+          </div>
+        `;
+
+      case 'unauthenticated':
+        return html`
+          <div class="notice">
+            <span class="notice-message">
+              Not connected to ${this.target?.providerName ?? 'this provider'}. Connect an
+              account to see this repository's ${noun}.
+            </span>
+            <button class="btn btn-primary btn-sm" @click=${this.handleConnect}>
+              Connect to ${this.target?.providerName ?? 'provider'}
+            </button>
+          </div>
+        `;
+
+      case 'error':
+        return html`
+          <div class="notice error-notice">
+            <span class="notice-message">${this.errorMessage ?? `Failed to load ${noun}`}</span>
+            ${this.renderRetry()}
+          </div>
+        `;
+
+      case 'ready':
+        if (this.pullRequests.length === 0) {
+          return html`<div class="empty">No open ${noun}</div>`;
+        }
+        return html`
+          ${this.target
+            ? html`<div class="repo-label" title=${this.target.repoLabel}>
+                ${this.target.repoLabel}
+              </div>`
+            : nothing}
+          <ul class="pr-list" role="list">
+            ${repeat(
+              this.pullRequests,
+              (pr) => pr.key,
+              (pr) => html`
+                <li
+                  class="pr-item"
+                  role="listitem"
+                  tabindex="0"
+                  title="${pr.title} (${pr.sourceBranch} → ${pr.targetBranch}) - opens in your browser"
+                  @click=${() => this.handleOpen(pr)}
+                  @keydown=${(e: KeyboardEvent) => this.handleItemKeydown(e, pr)}
+                >
+                  <svg
+                    class="pr-icon ${pr.draft ? 'draft' : ''}"
+                    viewBox="0 0 24 24"
+                    fill="none"
+                    stroke="currentColor"
+                    stroke-width="2"
+                    aria-hidden="true"
+                  >
+                    <circle cx="18" cy="18" r="3"></circle>
+                    <circle cx="6" cy="6" r="3"></circle>
+                    <path d="M13 6h3a2 2 0 0 1 2 2v7"></path>
+                    <line x1="6" y1="9" x2="6" y2="21"></line>
+                  </svg>
+                  <div class="pr-body">
+                    <div class="pr-title">${pr.title}</div>
+                    <div class="pr-meta">
+                      <span class="pr-number">#${pr.number}</span>
+                      ${pr.author ? html`<span>${pr.author}</span>` : nothing}
+                      <span>${pr.sourceBranch} → ${pr.targetBranch}</span>
+                    </div>
+                  </div>
+                  ${pr.draft ? html`<span class="pr-badge">Draft</span>` : nothing}
+                  ${pr.status
+                    ? html`<span class="pr-badge conflicts">${pr.status}</span>`
+                    : nothing}
+                </li>
+              `,
+            )}
+          </ul>
+        `;
+    }
+  }
+
+  render() {
+    if (!this.repositoryPath) return nothing;
+    return this.renderBody();
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lv-pull-request-list': LvPullRequestList;
+  }
+}

--- a/src/services/pull-request.service.ts
+++ b/src/services/pull-request.service.ts
@@ -1,0 +1,372 @@
+/**
+ * Shared hosting-provider pull/merge request access for the sidebar.
+ *
+ * The four provider dialogs (`lv-github-dialog` and friends) each own a full
+ * account picker, connection flow and create form. This module is deliberately
+ * NOT another copy of that: it is the thin, read-only slice the sidebar needs —
+ * "which provider is this repository on", "what token do we have for it", and
+ * "list its open requests" — normalised into one shape so the sidebar renders
+ * one list instead of four.
+ *
+ * Everything here routes through `git.service`, so the provider network calls
+ * stay behind the same offline-mode / allowlist gate as every other provider
+ * call (see `invokeProviderCommand`). The `detect_*_repo` commands are NOT
+ * gated: they only read the repository's own remote configuration and make no
+ * network call.
+ */
+
+import * as gitService from './git.service.ts';
+import type {
+  DetectedAdoRepo,
+  DetectedBitbucketRepo,
+  DetectedGitHubRepo,
+  DetectedGitLabRepo,
+} from './git.service.ts';
+import type { CommandResult } from '../types/api.types.ts';
+import * as credentialService from './credential.service.ts';
+import {
+  getAccountById,
+  getActiveProfilePreferredAccount,
+  unifiedProfileStore,
+} from '../stores/unified-profile.store.ts';
+import * as unifiedProfileService from './unified-profile.service.ts';
+
+/** The hosting providers that can back the sidebar's request list. */
+export type PullRequestProviderId = 'github' | 'gitlab' | 'bitbucket' | 'azure-devops';
+
+/** A detected provider plus the coordinates its API calls need. */
+export interface PullRequestProviderTarget {
+  provider: PullRequestProviderId;
+  /** Display name, e.g. "GitLab". */
+  providerName: string;
+  /** "pull request" everywhere except GitLab, which calls them merge requests. */
+  itemNoun: string;
+  /** Plural of {@link itemNoun}. */
+  itemNounPlural: string;
+  /** Title-case plural used for headings, e.g. "Merge Requests". */
+  itemNounTitle: string;
+  /** Human label for the detected repository, e.g. "owner/repo". */
+  repoLabel: string;
+  github?: DetectedGitHubRepo;
+  gitlab?: DetectedGitLabRepo;
+  bitbucket?: DetectedBitbucketRepo;
+  ado?: DetectedAdoRepo;
+}
+
+/** One open request, normalised across the four providers. */
+export interface SidebarPullRequest {
+  /** Stable identity for list keying: provider id + number. */
+  key: string;
+  /** The number the provider shows the user (`number` / `iid` / `id`). */
+  number: number;
+  title: string;
+  /** Display name or login of whoever opened it; empty when unknown. */
+  author: string;
+  /** Web URL, opened in the browser on click. */
+  url: string;
+  sourceBranch: string;
+  targetBranch: string;
+  draft: boolean;
+  /**
+   * Short merge/review status, ONLY where the provider's existing list command
+   * already returns one (GitHub's `mergeable`, GitLab's `mergeStatus`). Null
+   * everywhere else rather than invented — the alternative would be a second
+   * API round trip per row.
+   */
+  status: string | null;
+}
+
+/** Number of open requests fetched for the sidebar list. */
+const SIDEBAR_PAGE_SIZE = 30;
+
+/**
+ * Provider detection cache, keyed by repository path.
+ *
+ * Detection reads the repo's remotes over IPC (four commands), and both the
+ * sidebar list and the branch context menu need the answer. Caching it keeps
+ * the context menu's "Create pull request…" entry from having to resolve
+ * asynchronously under the user's cursor, and keeps an expanded list section
+ * from re-detecting on every refresh.
+ */
+const detectionCache = new Map<string, PullRequestProviderTarget | null>();
+/** In-flight detections, so concurrent callers share one round of IPC. */
+const detectionInFlight = new Map<string, Promise<PullRequestProviderTarget | null>>();
+
+/**
+ * Forget cached detection. Called when a repository's remotes may have changed
+ * (a `repository-refresh`), because adding or re-pointing `origin` changes the
+ * answer and a stale "no provider" would silently disable the menu entry.
+ */
+export function invalidateProviderDetection(repoPath?: string): void {
+  if (repoPath) {
+    detectionCache.delete(repoPath);
+    detectionInFlight.delete(repoPath);
+  } else {
+    detectionCache.clear();
+    detectionInFlight.clear();
+  }
+}
+
+/** Strip `refs/heads/` from an Azure DevOps ref name for display. */
+function shortRef(refName: string): string {
+  return refName.replace(/^refs\/heads\//, '');
+}
+
+/**
+ * Which hosting provider backs this repository, or null when none is detected.
+ *
+ * Order matches `detectRepositoryIntegration` in git.service so the two never
+ * disagree about a repo that somehow matches more than one provider.
+ */
+export async function detectPullRequestProvider(
+  repoPath: string,
+  options?: { force?: boolean },
+): Promise<PullRequestProviderTarget | null> {
+  if (!repoPath) return null;
+  if (options?.force) {
+    detectionCache.delete(repoPath);
+    detectionInFlight.delete(repoPath);
+  } else {
+    if (detectionCache.has(repoPath)) return detectionCache.get(repoPath) ?? null;
+    const pending = detectionInFlight.get(repoPath);
+    if (pending) return pending;
+  }
+
+  const run = (async (): Promise<PullRequestProviderTarget | null> => {
+    const [github, ado, gitlab, bitbucket] = await Promise.all([
+      gitService.detectGitHubRepo(repoPath),
+      gitService.detectAdoRepo(repoPath),
+      gitService.detectGitLabRepo(repoPath),
+      gitService.detectBitbucketRepo(repoPath),
+    ]);
+
+    let target: PullRequestProviderTarget | null = null;
+    if (github.success && github.data) {
+      target = {
+        provider: 'github',
+        providerName: 'GitHub',
+        itemNoun: 'pull request',
+        itemNounPlural: 'pull requests',
+        itemNounTitle: 'Pull Requests',
+        repoLabel: `${github.data.owner}/${github.data.repo}`,
+        github: github.data,
+      };
+    } else if (ado.success && ado.data) {
+      target = {
+        provider: 'azure-devops',
+        providerName: 'Azure DevOps',
+        itemNoun: 'pull request',
+        itemNounPlural: 'pull requests',
+        itemNounTitle: 'Pull Requests',
+        repoLabel: `${ado.data.project}/${ado.data.repository}`,
+        ado: ado.data,
+      };
+    } else if (gitlab.success && gitlab.data) {
+      target = {
+        provider: 'gitlab',
+        providerName: 'GitLab',
+        itemNoun: 'merge request',
+        itemNounPlural: 'merge requests',
+        itemNounTitle: 'Merge Requests',
+        repoLabel: gitlab.data.projectPath,
+        gitlab: gitlab.data,
+      };
+    } else if (bitbucket.success && bitbucket.data) {
+      target = {
+        provider: 'bitbucket',
+        providerName: 'Bitbucket',
+        itemNoun: 'pull request',
+        itemNounPlural: 'pull requests',
+        itemNounTitle: 'Pull Requests',
+        repoLabel: `${bitbucket.data.workspace}/${bitbucket.data.repoSlug}`,
+        bitbucket: bitbucket.data,
+      };
+    }
+
+    detectionCache.set(repoPath, target);
+    return target;
+  })();
+
+  detectionInFlight.set(repoPath, run);
+  try {
+    return await run;
+  } finally {
+    detectionInFlight.delete(repoPath);
+  }
+}
+
+/**
+ * The token the sidebar should use for this provider, or null when the user
+ * has not connected an account for it.
+ *
+ * Mirrors each dialog's own `getSelectedAccountToken()`: the profile's
+ * preferred account first (falling back to the global default), refreshed when
+ * an OAuth access token is near expiry. GitHub and Azure DevOps additionally
+ * fall back to their legacy single-account credential, exactly as their dialogs
+ * do, so a user who never migrated is not told they are disconnected.
+ */
+export async function getProviderToken(
+  target: PullRequestProviderTarget,
+): Promise<string | null> {
+  // Every provider dialog loads the unified profiles before reading accounts.
+  // The sidebar can ask earlier than that -- before the app's own
+  // initialisation has finished, or while a profile migration is pending -- and
+  // an unloaded store would report a connected user as "not connected".
+  if (unifiedProfileStore.getState().accounts.length === 0) {
+    await unifiedProfileService.loadUnifiedProfiles();
+  }
+
+  switch (target.provider) {
+    case 'github': {
+      // getGitHubToken() already resolves account-then-legacy for GitHub.
+      const result = await gitService.getGitHubToken();
+      return result.success ? (result.data ?? null) : null;
+    }
+    case 'gitlab': {
+      const account = getActiveProfilePreferredAccount('gitlab');
+      if (!account) return null;
+      // Refresh against the instance the ACCOUNT was created on, never the
+      // detected repo's instance — same guard as lv-gitlab-dialog.
+      const stored = getAccountById(account.id);
+      const instanceUrl =
+        stored?.config.type === 'gitlab' ? stored.config.instanceUrl : undefined;
+      return credentialService.getFreshAccountToken(
+        'gitlab',
+        account.id,
+        'gitlab',
+        instanceUrl || undefined,
+      );
+    }
+    case 'bitbucket': {
+      const account = getActiveProfilePreferredAccount('bitbucket');
+      if (!account) return null;
+      return credentialService.getFreshAccountToken('bitbucket', account.id, 'bitbucket');
+    }
+    case 'azure-devops': {
+      const account = getActiveProfilePreferredAccount('azure-devops');
+      const token = account
+        ? await credentialService.getFreshAccountToken('azure-devops', account.id, 'azure')
+        : null;
+      return token ?? (await credentialService.AzureDevOpsCredentials.getToken());
+    }
+  }
+}
+
+/**
+ * Open requests for a detected provider, normalised.
+ *
+ * Returns the raw `CommandResult` shape so callers can tell the security
+ * gate's refusal (`BLOCKED`) apart from a real API failure — the gate stays
+ * silent for provider calls, so the caller has to explain it in place.
+ */
+export async function listOpenPullRequests(
+  target: PullRequestProviderTarget,
+  token: string | null,
+): Promise<CommandResult<SidebarPullRequest[]>> {
+  switch (target.provider) {
+    case 'github': {
+      const repo = target.github!;
+      const result = await gitService.listPullRequests(
+        repo.owner,
+        repo.repo,
+        'open',
+        SIDEBAR_PAGE_SIZE,
+        1,
+        token,
+      );
+      if (!result.success) return { success: false, error: result.error };
+      return {
+        success: true,
+        data: (result.data ?? []).map((pr) => ({
+          key: `github-${pr.number}`,
+          number: pr.number,
+          title: pr.title,
+          author: pr.user?.name || pr.user?.login || '',
+          url: pr.htmlUrl,
+          sourceBranch: pr.headRef,
+          targetBranch: pr.baseRef,
+          draft: pr.draft,
+          // `mergeable` is null until GitHub finishes computing it; only an
+          // explicit false is a real conflict signal.
+          status: pr.mergeable === false ? 'Conflicts' : null,
+        })),
+      };
+    }
+    case 'azure-devops': {
+      const repo = target.ado!;
+      const result = await gitService.listAdoPullRequests(
+        repo.organization,
+        repo.project,
+        repo.repository,
+        'active',
+        SIDEBAR_PAGE_SIZE,
+        token,
+      );
+      if (!result.success) return { success: false, error: result.error };
+      return {
+        success: true,
+        data: (result.data ?? []).map((pr) => ({
+          key: `ado-${pr.pullRequestId}`,
+          number: pr.pullRequestId,
+          title: pr.title,
+          author: pr.createdBy?.displayName || '',
+          url: pr.url,
+          sourceBranch: shortRef(pr.sourceRefName),
+          targetBranch: shortRef(pr.targetRefName),
+          draft: pr.isDraft,
+          status: null,
+        })),
+      };
+    }
+    case 'gitlab': {
+      const repo = target.gitlab!;
+      const result = await gitService.listGitLabMergeRequests(
+        repo.instanceUrl,
+        repo.projectPath,
+        'opened',
+        SIDEBAR_PAGE_SIZE,
+        token,
+      );
+      if (!result.success) return { success: false, error: result.error };
+      return {
+        success: true,
+        data: (result.data ?? []).map((mr) => ({
+          key: `gitlab-${mr.iid}`,
+          number: mr.iid,
+          title: mr.title,
+          author: mr.author?.name || mr.author?.username || '',
+          url: mr.webUrl,
+          sourceBranch: mr.sourceBranch,
+          targetBranch: mr.targetBranch,
+          draft: mr.draft,
+          status: mr.mergeStatus === 'cannot_be_merged' ? 'Conflicts' : null,
+        })),
+      };
+    }
+    case 'bitbucket': {
+      const repo = target.bitbucket!;
+      const result = await gitService.listBitbucketPullRequests(
+        repo.workspace,
+        repo.repoSlug,
+        'OPEN',
+        SIDEBAR_PAGE_SIZE,
+        token,
+      );
+      if (!result.success) return { success: false, error: result.error };
+      return {
+        success: true,
+        data: (result.data ?? []).map((pr) => ({
+          key: `bitbucket-${pr.id}`,
+          number: pr.id,
+          title: pr.title,
+          author: pr.author?.displayName || pr.author?.username || '',
+          url: pr.url,
+          sourceBranch: pr.sourceBranch,
+          targetBranch: pr.destinationBranch,
+          draft: false,
+          status: null,
+        })),
+      };
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a collapsible **Pull Requests** section to the left panel that lists the open pull/merge requests for the repository's detected provider (GitHub, GitLab, Bitbucket, Azure DevOps), with title, number, author, source → target branch, and draft/conflict badges where the provider's existing list command already reports them. Clicking a row opens it in the browser — the same thing clicking a PR badge on a graph row already does.
- Loads lazily: nothing is fetched at app start or while the section is collapsed. Results are cached per repository, and refetched only from the section's refresh button or a `repository-refresh`.
- Every state is explained instead of being shown as an empty list: no provider detected, provider detected but not connected (with a **Connect to …** button that opens that provider's dialog, and an automatic reload once the account lands), offline mode, remote-allowlist block, loading, empty ("No open pull requests"), and a failure with **Retry**.
- Adds **Create pull request…** (Create merge request… on GitLab) to the branch context menu, enabled only for a local branch that has an upstream on a detected provider and disabled with the reason otherwise. It opens the provider dialog's **existing** create form with the branch prefilled as the source — no second create-PR implementation.
- New `src/services/pull-request.service.ts` normalises provider detection, token resolution and the four providers' list commands behind one shape, and shares its detection cache between the sidebar section and the branch menu.

## Review finding

Pull requests were almost invisible in the main UI. PR badges were painted on graph rows (`src/components/graph/lv-graph-canvas.ts:1718-1815`, with the `GraphPullRequest` type in `src/graph/virtual-scroll.ts:48`), and the full provider dialogs (`src/components/dialogs/lv-github-dialog.ts`, `lv-gitlab-dialog.ts`, `lv-bitbucket-dialog.ts`, `lv-azure-devops-dialog.ts`) were reachable only from the command palette — there was no list of open PRs in the sidebar (`src/components/sidebar/lv-left-panel.ts`) and no "Create pull request" on a branch (`src/components/sidebar/lv-branch-list.ts`). This PR adds both, reusing the existing `detect_*_repo` / `list_*_pull_requests` commands and the dialogs' own create flow rather than duplicating either, and respecting the offline-mode/allowlist gate that `invokeProviderCommand` applies to provider APIs (`src/services/git.service.ts:226`).

Note on scope: the sidebar shows the merge/review signal the list commands already return (GitHub's `mergeable`, GitLab's `mergeStatus`, plus draft). Per-PR CI status would need an extra API round trip per row, so it is deliberately not fetched.

## Test plan

- [ ] `npm run lint` — 0 errors, 204 warnings (unchanged from `origin/main`)
- [ ] `npm run typecheck` — clean
- [ ] `npm test` — 5529 passed; the only 2 failures are the pre-existing `network gate coverage` timeouts, verified to fail identically on the unmodified tree
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` — clean (no Rust changed)
- [ ] `npx playwright test e2e/tests/pull-request-sidebar.spec.ts` — 11 passed; plus `github-dialog.spec.ts` (27) and `accessibility.spec.ts` (6) still green
- [ ] Manual: open a GitHub repo, expand **Pull Requests** — with no account it offers Connect; after connecting, the list appears and a row opens the PR in the browser. Right-click a branch with an upstream → **Create pull request…** opens the GitHub dialog's create form with that branch as the head.
- [ ] Manual: enable Settings → Security → Offline mode and expand the section — it says why the list is unavailable rather than showing an empty list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_