### PR TITLE
feat: open repositories by dropping a folder, and scan a folder for them

### DIFF
--- a/e2e/pages/app.page.ts
+++ b/e2e/pages/app.page.ts
@@ -24,6 +24,7 @@ export class AppPage {
   readonly openButton: Locator;
   readonly cloneButton: Locator;
   readonly initButton: Locator;
+  readonly scanButton: Locator;
 
   // Recent repositories
   readonly recentSection: Locator;
@@ -59,6 +60,7 @@ export class AppPage {
     this.openButton = this.welcomeScreen.locator('.action-btn', { hasText: 'Open' });
     this.cloneButton = this.welcomeScreen.locator('.action-btn', { hasText: 'Clone' });
     this.initButton = this.welcomeScreen.locator('.action-btn', { hasText: 'Init' });
+    this.scanButton = this.welcomeScreen.locator('.action-btn', { hasText: 'Scan' });
 
     // Recent repos
     this.recentSection = this.welcomeScreen.locator('.recent-section');

--- a/e2e/tests/welcome.spec.ts
+++ b/e2e/tests/welcome.spec.ts
@@ -2,7 +2,14 @@ import { test, expect } from '@playwright/test';
 import { setupTauriMocks, emptyRepository } from '../fixtures/tauri-mock';
 import { AppPage } from '../pages/app.page';
 import { DialogsPage } from '../pages/dialogs.page';
-import { startCommandCapture, findCommand, waitForCommand, injectCommandError } from '../fixtures/test-helpers';
+import {
+  startCommandCapture,
+  startCommandCaptureWithMocks,
+  findCommand,
+  waitForCommand,
+  injectCommandError,
+  injectCommandMock,
+} from '../fixtures/test-helpers';
 
 test.describe('Welcome Screen', () => {
   let app: AppPage;
@@ -724,5 +731,259 @@ test.describe('Welcome Screen - recent repository rows', () => {
     await expect(app.recentItems).toHaveCount(1);
     await expect(app.recentItems.first()).toContainText('repo2');
     expect(await findCommand(page, 'open_repository')).toHaveLength(0);
+  });
+});
+
+/** Repository payload shaped like the backend's `Repository`. */
+function repositoryPayload(path: string) {
+  return {
+    path,
+    name: path.split('/').pop(),
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+function scanResultPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    root: '/code',
+    repositories: [
+      { path: '/code/alpha', name: 'alpha', isBare: false },
+      { path: '/code/beta', name: 'beta', isBare: false },
+    ],
+    scannedDirectories: 12,
+    truncated: false,
+    cancelled: false,
+    ...overrides,
+  };
+}
+
+/** Fire one of the webview's OS drag/drop events through the Tauri mock. */
+async function emitDragEvent(
+  page: import('@playwright/test').Page,
+  event: 'tauri://drag-enter' | 'tauri://drag-over' | 'tauri://drag-leave' | 'tauri://drag-drop',
+  paths: string[] = []
+): Promise<void> {
+  await page.evaluate(
+    ({ name, dropped }) => {
+      const emit = (window as unknown as {
+        __EMIT_TAURI_EVENT__: (event: string, payload: unknown) => void;
+      }).__EMIT_TAURI_EVENT__;
+      emit(name, { paths: dropped, position: { x: 20, y: 20 } });
+    },
+    { name: event, dropped: paths }
+  );
+}
+
+test.describe('Welcome Screen - scan for repositories', () => {
+  let app: AppPage;
+
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMocks(page, emptyRepository());
+    app = new AppPage(page);
+    await app.goto();
+    await expect(app.welcomeScreen).toBeVisible();
+  });
+
+  test('scans the chosen folder and opens the selected repository', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {
+      'plugin:dialog|open': '/code',
+      scan_for_repositories: scanResultPayload(),
+      open_repository: repositoryPayload('/code/alpha'),
+      get_repository_info: repositoryPayload('/code/alpha'),
+    });
+
+    await app.scanButton.click();
+
+    const dialog = page.locator('lv-scan-repositories-dialog');
+    await expect(dialog.locator('.result-item')).toHaveCount(2);
+    await expect(dialog.locator('.results-toolbar')).toContainText('2 repositories');
+
+    const scanCalls = await findCommand(page, 'scan_for_repositories');
+    expect((scanCalls[0].args as { path: string }).path).toBe('/code');
+
+    // Nothing is opened until the user picks something.
+    const openSelected = dialog.getByRole('button', { name: /Open selected/ });
+    await expect(openSelected).toBeDisabled();
+
+    await dialog.locator('.result-item').first().locator('input[type="checkbox"]').check();
+    await expect(openSelected).toBeEnabled();
+    await openSelected.click();
+
+    // The repository really opens: the welcome screen gives way to the repo view.
+    await expect(app.welcomeScreen).not.toBeVisible({ timeout: 10000 });
+    const openCalls = await findCommand(page, 'open_repository');
+    expect((openCalls[0].args as { path: string }).path).toBe('/code/alpha');
+  });
+
+  test('reports a folder with no repositories in it', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {
+      'plugin:dialog|open': '/code',
+      scan_for_repositories: scanResultPayload({ repositories: [], scannedDirectories: 40 }),
+    });
+
+    await app.scanButton.click();
+
+    const dialog = page.locator('lv-scan-repositories-dialog');
+    await expect(dialog.locator('.explanation')).toContainText('No Git repositories were found');
+    await expect(dialog.locator('.notice')).toContainText('40');
+    await expect(dialog.locator('.result-item')).toHaveCount(0);
+  });
+
+  test('surfaces a scan failure', async ({ page }) => {
+    await injectCommandMock(page, { 'plugin:dialog|open': '/code' });
+    await injectCommandError(page, 'scan_for_repositories', '/code no longer exists');
+
+    await app.scanButton.click();
+
+    const dialog = page.locator('lv-scan-repositories-dialog');
+    await expect(dialog.locator('.error-message')).toContainText('no longer exists');
+  });
+
+  test('does not open the scan dialog when the folder picker is cancelled', async ({ page }) => {
+    await injectCommandMock(page, { 'plugin:dialog|open': null });
+
+    await app.scanButton.click();
+
+    // The element is always mounted in the shell; a cancelled picker must
+    // leave it closed (and so invisible), not open it on an empty folder.
+    await expect(page.locator('lv-scan-repositories-dialog .body')).not.toBeVisible();
+  });
+});
+
+test.describe('Welcome Screen - dropping a folder on the window', () => {
+  let app: AppPage;
+
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMocks(page, emptyRepository());
+    app = new AppPage(page);
+    await app.goto();
+    await expect(app.welcomeScreen).toBeVisible();
+  });
+
+  test('shows a drop affordance while a folder is dragged over the window', async ({ page }) => {
+    await emitDragEvent(page, 'tauri://drag-enter', ['/code/alpha']);
+    await expect(app.welcomeScreen.locator('.drop-overlay')).toBeVisible();
+    await expect(app.welcomeScreen.locator('.drop-overlay')).toContainText('Drop a folder');
+
+    await emitDragEvent(page, 'tauri://drag-leave');
+    await expect(app.welcomeScreen.locator('.drop-overlay')).toHaveCount(0);
+  });
+
+  test('opens a dropped repository', async ({ page }) => {
+    await startCommandCaptureWithMocks(page, {
+      classify_repository_path: {
+        path: '/code/alpha',
+        name: 'alpha',
+        exists: true,
+        isDirectory: true,
+        isRepository: true,
+        isBare: false,
+      },
+      open_repository: repositoryPayload('/code/alpha'),
+      get_repository_info: repositoryPayload('/code/alpha'),
+    });
+
+    await emitDragEvent(page, 'tauri://drag-enter', ['/code/alpha']);
+    await expect(app.welcomeScreen.locator('.drop-overlay')).toBeVisible();
+    await emitDragEvent(page, 'tauri://drag-drop', ['/code/alpha']);
+
+    await expect(app.welcomeScreen).not.toBeVisible({ timeout: 10000 });
+    const openCalls = await findCommand(page, 'open_repository');
+    expect((openCalls[0].args as { path: string }).path).toBe('/code/alpha');
+  });
+
+  test('offers a scan or an init for a dropped folder that is not a repository', async ({
+    page,
+  }) => {
+    await startCommandCaptureWithMocks(page, {
+      classify_repository_path: {
+        path: '/projects',
+        name: 'projects',
+        exists: true,
+        isDirectory: true,
+        isRepository: false,
+        isBare: false,
+      },
+      scan_for_repositories: scanResultPayload({ root: '/projects' }),
+    });
+
+    await emitDragEvent(page, 'tauri://drag-drop', ['/projects']);
+
+    const dialog = page.locator('lv-scan-repositories-dialog');
+    await expect(dialog.locator('.explanation')).toContainText('not a Git repository');
+    // The drop affordance goes away as soon as the drop lands.
+    await expect(app.welcomeScreen.locator('.drop-overlay')).toHaveCount(0);
+
+    await dialog.getByRole('button', { name: 'Scan it for repositories' }).click();
+    await expect(dialog.locator('.result-item')).toHaveCount(2);
+    const scanCalls = await findCommand(page, 'scan_for_repositories');
+    expect((scanCalls[0].args as { path: string }).path).toBe('/projects');
+  });
+
+  test('offers to initialize a dropped folder that is not a repository', async ({ page }) => {
+    await injectCommandMock(page, {
+      classify_repository_path: {
+        path: '/projects/new-thing',
+        name: 'new-thing',
+        exists: true,
+        isDirectory: true,
+        isRepository: false,
+        isBare: false,
+      },
+    });
+
+    await emitDragEvent(page, 'tauri://drag-drop', ['/projects/new-thing']);
+
+    const dialog = page.locator('lv-scan-repositories-dialog');
+    await dialog.getByRole('button', { name: 'Initialize a repository here' }).click();
+
+    // The init dialog takes over, pre-filled with the dropped folder.
+    await expect(page.getByRole('dialog', { name: 'Initialize Repository' })).toBeVisible();
+    await expect(page.getByRole('textbox', { name: /Repository Location/i })).toHaveValue(
+      '/projects/new-thing'
+    );
+  });
+
+  test('reports a dropped path that is gone', async ({ page }) => {
+    await injectCommandMock(page, {
+      classify_repository_path: {
+        path: '/code/gone',
+        name: 'gone',
+        exists: false,
+        isDirectory: false,
+        isRepository: false,
+        isBare: false,
+      },
+    });
+
+    await emitDragEvent(page, 'tauri://drag-drop', ['/code/gone']);
+
+    await expect(page.locator('.toast')).toContainText('no longer exists');
+    await expect(app.welcomeScreen).toBeVisible();
+  });
+
+  test('reports a dropped repository that cannot be opened', async ({ page }) => {
+    await injectCommandMock(page, {
+      classify_repository_path: {
+        path: '/code/locked',
+        name: 'locked',
+        exists: true,
+        isDirectory: true,
+        isRepository: true,
+        isBare: false,
+      },
+    });
+    await injectCommandError(page, 'open_repository', 'permission denied');
+
+    await emitDragEvent(page, 'tauri://drag-drop', ['/code/locked']);
+
+    await expect(page.locator('.toast')).toContainText('permission denied');
+    await expect(app.welcomeScreen).toBeVisible();
   });
 });

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -51,6 +51,7 @@ pub mod profiles;
 pub mod reflog;
 pub mod refs;
 pub mod remote;
+pub mod repo_scan;
 pub mod repository;
 pub mod rewrite;
 pub mod search;

--- a/src-tauri/src/commands/repo_scan.rs
+++ b/src-tauri/src/commands/repo_scan.rs
@@ -1,0 +1,680 @@
+//! Repository discovery.
+//!
+//! Two entry points, both used by the "open by dropping a folder on the
+//! window" and "scan a folder for repositories" flows:
+//!
+//! * [`classify_repository_path`] — what IS this path? The drop handler needs
+//!   to tell "gone", "a file", "a plain directory" and "a repository" apart so
+//!   it can report each case instead of showing one generic failure.
+//! * [`scan_for_repositories`] — walk a directory tree looking for
+//!   repositories. Bounded on every axis (depth, visited directories, results)
+//!   and cancellable, because the natural thing for a user to pick is their
+//!   home directory and a naive full walk of that would hang the app.
+
+use std::path::Path;
+use std::sync::atomic::{AtomicBool, Ordering};
+
+use tauri::{command, AppHandle, Emitter};
+
+use crate::error::{LeviathanError, Result};
+
+/// How deep below the chosen folder the scan looks, by default.
+///
+/// 4 covers the usual layouts (`~/code/<repo>`, `~/code/<org>/<repo>`,
+/// `~/dev/<lang>/<org>/<repo>`) without walking a whole home directory.
+pub const DEFAULT_MAX_DEPTH: usize = 4;
+
+/// Hard ceiling on the requested depth. A caller asking for more is clamped
+/// rather than rejected — the scan stays bounded whatever the UI sends.
+pub const MAX_ALLOWED_DEPTH: usize = 8;
+
+/// Most repositories reported from a single scan. Beyond this the result is
+/// flagged `truncated` so the UI can tell the user to narrow the folder.
+pub const MAX_RESULTS: usize = 200;
+
+/// Most directories visited before the walk gives up. Also reported as
+/// `truncated`; it is the backstop for a tree that is wide rather than deep.
+pub const MAX_VISITED_DIRECTORIES: usize = 20_000;
+
+/// Emit a progress event at most every this many directories, so a big scan
+/// does not flood the webview with IPC traffic.
+const PROGRESS_EVERY: usize = 50;
+
+/// Directory names never descended into.
+///
+/// Two groups: dependency/build output that can hold thousands of entries (and
+/// whose vendored copies are not repositories the user means to open), and OS
+/// directories that are slow or refuse access. Hidden directories are skipped
+/// separately by name prefix.
+const SKIPPED_DIRECTORY_NAMES: &[&str] = &[
+    "node_modules",
+    "target",
+    "dist",
+    "build",
+    "out",
+    "bin",
+    "obj",
+    "vendor",
+    "venv",
+    "__pycache__",
+    "Pods",
+    "Carthage",
+    "DerivedData",
+    "Library",
+    "Applications",
+    "System",
+    "AppData",
+    "Windows",
+    "Program Files",
+    "Program Files (x86)",
+    "$RECYCLE.BIN",
+    "System Volume Information",
+];
+
+/// A repository found by a scan.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct DiscoveredRepository {
+    pub path: String,
+    pub name: String,
+    pub is_bare: bool,
+}
+
+/// The outcome of a scan. `truncated` and `cancelled` are reported rather than
+/// turned into an error: the repositories found before the limit are still
+/// worth showing.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RepositoryScanResult {
+    pub root: String,
+    pub repositories: Vec<DiscoveredRepository>,
+    pub scanned_directories: usize,
+    pub truncated: bool,
+    pub cancelled: bool,
+}
+
+/// Progress event payload, emitted as `repository-scan-progress`.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RepositoryScanProgress {
+    pub scanned_directories: usize,
+    pub found: usize,
+    pub current_path: String,
+}
+
+/// What a dropped (or picked) path actually is.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct PathClassification {
+    pub path: String,
+    pub name: String,
+    pub exists: bool,
+    pub is_directory: bool,
+    pub is_repository: bool,
+    pub is_bare: bool,
+}
+
+/// Bounds for one walk. Separated from the command so the tests can drive the
+/// walk directly with small limits.
+#[derive(Debug, Clone, Copy)]
+pub struct ScanOptions {
+    pub max_depth: usize,
+    pub max_results: usize,
+    pub max_visited_directories: usize,
+}
+
+impl Default for ScanOptions {
+    fn default() -> Self {
+        Self {
+            max_depth: DEFAULT_MAX_DEPTH,
+            max_results: MAX_RESULTS,
+            max_visited_directories: MAX_VISITED_DIRECTORIES,
+        }
+    }
+}
+
+/// Set when the user cancels the in-flight scan.
+///
+/// One flag is enough: the scan dialog runs a single scan at a time and blocks
+/// further input while it is running. Cleared at the start of every scan so a
+/// stale cancellation cannot kill the next one — the same shape as
+/// `CLONE_CANCELLED` in `commands::repository`.
+static SCAN_CANCELLED: AtomicBool = AtomicBool::new(false);
+
+/// Request cancellation of the in-flight repository scan.
+#[command]
+pub async fn cancel_repository_scan() -> Result<()> {
+    SCAN_CANCELLED.store(true, Ordering::SeqCst);
+    Ok(())
+}
+
+/// Last path segment, falling back to the whole path for a root directory.
+fn display_name(path: &Path) -> String {
+    path.file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| path.display().to_string())
+}
+
+/// True when `dir` is the working directory of a repository.
+///
+/// `.git` is checked with `symlink_metadata` rather than `is_dir` because a
+/// linked worktree and a submodule both store a `.git` FILE pointing at the
+/// real git directory — treating those as "not a repository" would hide every
+/// worktree from the scan.
+fn is_worktree_repository(dir: &Path) -> bool {
+    dir.join(".git").symlink_metadata().is_ok()
+}
+
+/// True when `dir` looks like a bare repository (`HEAD` + `objects/` +
+/// `refs/`). Checked structurally rather than by opening it with git2: the
+/// scan visits thousands of directories and must not pay for a repository
+/// open on each one.
+fn is_bare_repository(dir: &Path) -> bool {
+    dir.join("HEAD").is_file() && dir.join("objects").is_dir() && dir.join("refs").is_dir()
+}
+
+/// Classify a directory as a repository, if it is one.
+fn as_repository(dir: &Path) -> Option<DiscoveredRepository> {
+    let is_bare = if is_worktree_repository(dir) {
+        false
+    } else if is_bare_repository(dir) {
+        true
+    } else {
+        return None;
+    };
+    Some(DiscoveredRepository {
+        path: dir.display().to_string(),
+        name: display_name(dir),
+        is_bare,
+    })
+}
+
+/// True for a directory the walk must not descend into.
+///
+/// Hidden directories are skipped wholesale: `.git` itself, and the caches
+/// (`.cache`, `.venv`, `.gradle`, `.cargo`, …) that make a home-directory scan
+/// crawl. A repository whose own name starts with a dot is still reachable
+/// when the user picks it directly — the root is never filtered.
+fn should_skip_directory(name: &str) -> bool {
+    name.starts_with('.') || SKIPPED_DIRECTORY_NAMES.contains(&name)
+}
+
+/// Walk `root` looking for repositories.
+///
+/// Iterative (no recursion, so a deep tree cannot blow the stack), never
+/// follows symlinks (`file_type()` reports the LINK, and a link is skipped
+/// before it is either descended into or reported — a `~/link -> ~` loop would
+/// otherwise walk forever), and stops at the first repository on a branch
+/// instead of descending into its working tree.
+pub fn scan_directory_for_repositories(
+    root: &Path,
+    options: ScanOptions,
+    cancelled: &AtomicBool,
+    mut on_progress: impl FnMut(&RepositoryScanProgress),
+) -> RepositoryScanResult {
+    let mut result = RepositoryScanResult {
+        root: root.display().to_string(),
+        repositories: Vec::new(),
+        scanned_directories: 0,
+        truncated: false,
+        cancelled: false,
+    };
+
+    // The chosen folder may itself be a repository — the most likely case when
+    // it arrives from a drop. Report it and do not walk its working tree.
+    if let Some(repo) = as_repository(root) {
+        result.repositories.push(repo);
+        result.scanned_directories = 1;
+        return result;
+    }
+
+    let mut stack: Vec<(std::path::PathBuf, usize)> = vec![(root.to_path_buf(), 0)];
+
+    while let Some((dir, depth)) = stack.pop() {
+        if cancelled.load(Ordering::SeqCst) {
+            result.cancelled = true;
+            break;
+        }
+        if result.scanned_directories >= options.max_visited_directories {
+            result.truncated = true;
+            break;
+        }
+
+        result.scanned_directories += 1;
+        if result.scanned_directories.is_multiple_of(PROGRESS_EVERY) {
+            on_progress(&RepositoryScanProgress {
+                scanned_directories: result.scanned_directories,
+                found: result.repositories.len(),
+                current_path: dir.display().to_string(),
+            });
+        }
+
+        // A directory that cannot be read (permission denied, removed while
+        // the scan ran) is skipped, not fatal: one unreadable folder must not
+        // throw away every repository found around it.
+        let Ok(entries) = std::fs::read_dir(&dir) else {
+            continue;
+        };
+
+        for entry in entries.flatten() {
+            let Ok(file_type) = entry.file_type() else {
+                continue;
+            };
+            // Symlinks are never followed, in either direction: not descended
+            // into, and not reported as a found repository.
+            if file_type.is_symlink() || !file_type.is_dir() {
+                continue;
+            }
+
+            let child = entry.path();
+            let name = entry.file_name().to_string_lossy().to_string();
+
+            if let Some(repo) = as_repository(&child) {
+                if result.repositories.len() >= options.max_results {
+                    result.truncated = true;
+                    return result;
+                }
+                result.repositories.push(repo);
+                // Do not descend into a repository: its submodules and vendored
+                // copies are not what the user asked for.
+                continue;
+            }
+
+            if should_skip_directory(&name) {
+                continue;
+            }
+            if depth + 1 < options.max_depth {
+                stack.push((child, depth + 1));
+            }
+        }
+    }
+
+    // Deterministic order regardless of the filesystem's own iteration order,
+    // so the same folder always lists the same way.
+    result.repositories.sort_by(|a, b| a.path.cmp(&b.path));
+    result
+}
+
+/// Classify a path so the caller can tell the user exactly what is wrong with
+/// it (gone, a file, a plain folder) instead of a single generic failure.
+#[command]
+pub async fn classify_repository_path(path: String) -> Result<PathClassification> {
+    let candidate = std::path::PathBuf::from(&path);
+    let name = display_name(&candidate);
+
+    // symlink_metadata first so a dangling symlink reports as "gone" rather
+    // than erroring out.
+    let metadata = std::fs::metadata(&candidate).ok();
+    let exists = metadata.is_some();
+    let is_directory = metadata.as_ref().is_some_and(|m| m.is_dir());
+
+    let repository = if is_directory {
+        as_repository(&candidate)
+    } else {
+        None
+    };
+
+    Ok(PathClassification {
+        path,
+        name,
+        exists,
+        is_directory,
+        is_repository: repository.is_some(),
+        is_bare: repository.is_some_and(|r| r.is_bare),
+    })
+}
+
+/// Reject a scan root that is gone or is not a folder, naming which it is —
+/// "no repositories found" would be a lie for a path that never existed.
+fn validate_scan_root(root: &Path) -> Result<()> {
+    if !root.exists() {
+        return Err(LeviathanError::InvalidPath(format!(
+            "{} no longer exists",
+            root.display()
+        )));
+    }
+    if !root.is_dir() {
+        return Err(LeviathanError::InvalidPath(format!(
+            "{} is not a folder",
+            root.display()
+        )));
+    }
+    Ok(())
+}
+
+/// Scan `path` for git repositories, emitting `repository-scan-progress`
+/// while it runs.
+#[command]
+pub async fn scan_for_repositories(
+    app: AppHandle,
+    path: String,
+    max_depth: Option<usize>,
+) -> Result<RepositoryScanResult> {
+    let root = std::path::PathBuf::from(&path);
+    validate_scan_root(&root)?;
+
+    // A cancellation requested against a previous scan must not kill this one.
+    SCAN_CANCELLED.store(false, Ordering::SeqCst);
+
+    let options = ScanOptions {
+        max_depth: max_depth
+            .unwrap_or(DEFAULT_MAX_DEPTH)
+            .clamp(1, MAX_ALLOWED_DEPTH),
+        ..ScanOptions::default()
+    };
+
+    // The walk is blocking filesystem work; running it inline would stall an
+    // async worker for the whole scan.
+    tokio::task::spawn_blocking(move || {
+        scan_directory_for_repositories(&root, options, &SCAN_CANCELLED, |progress| {
+            let _ = app.emit("repository-scan-progress", progress.clone());
+        })
+    })
+    .await
+    .map_err(|e| LeviathanError::OperationFailed(format!("Repository scan failed: {}", e)))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use std::path::PathBuf;
+
+    use tempfile::TempDir;
+
+    /// Create `dir` and give it a `.git` directory, so the scan sees a
+    /// repository without paying for a real git2 init.
+    fn make_repo(root: &Path, relative: &str) -> PathBuf {
+        let dir = root.join(relative);
+        fs::create_dir_all(dir.join(".git")).unwrap();
+        dir
+    }
+
+    fn scan(root: &Path, options: ScanOptions) -> RepositoryScanResult {
+        let flag = AtomicBool::new(false);
+        scan_directory_for_repositories(root, options, &flag, |_| {})
+    }
+
+    fn paths(result: &RepositoryScanResult) -> Vec<String> {
+        result.repositories.iter().map(|r| r.path.clone()).collect()
+    }
+
+    #[test]
+    fn finds_repositories_at_several_depths() {
+        let tmp = TempDir::new().unwrap();
+        let a = make_repo(tmp.path(), "a");
+        let b = make_repo(tmp.path(), "org/b");
+        fs::create_dir_all(tmp.path().join("empty")).unwrap();
+
+        let result = scan(tmp.path(), ScanOptions::default());
+
+        assert_eq!(
+            paths(&result),
+            {
+                let mut expected = vec![a.display().to_string(), b.display().to_string()];
+                expected.sort();
+                expected
+            },
+            "both repositories are reported, sorted by path"
+        );
+        assert!(!result.truncated);
+        assert!(!result.cancelled);
+    }
+
+    #[test]
+    fn stops_at_the_depth_limit() {
+        let tmp = TempDir::new().unwrap();
+        make_repo(tmp.path(), "one/two/three/deep");
+
+        let shallow = scan(
+            tmp.path(),
+            ScanOptions {
+                max_depth: 2,
+                ..ScanOptions::default()
+            },
+        );
+        assert!(
+            shallow.repositories.is_empty(),
+            "a repository below the depth limit is not reported"
+        );
+
+        let deep = scan(
+            tmp.path(),
+            ScanOptions {
+                max_depth: 5,
+                ..ScanOptions::default()
+            },
+        );
+        assert_eq!(deep.repositories.len(), 1, "raising the limit finds it");
+    }
+
+    #[test]
+    fn does_not_descend_into_a_repository() {
+        let tmp = TempDir::new().unwrap();
+        let outer = make_repo(tmp.path(), "outer");
+        make_repo(&outer, "vendor-copy");
+
+        let result = scan(tmp.path(), ScanOptions::default());
+
+        assert_eq!(
+            paths(&result),
+            vec![outer.display().to_string()],
+            "the nested copy inside a repository's working tree is not listed"
+        );
+    }
+
+    #[test]
+    fn skips_heavy_and_hidden_directories() {
+        let tmp = TempDir::new().unwrap();
+        make_repo(tmp.path(), "node_modules/dep");
+        make_repo(tmp.path(), "target/debug/thing");
+        make_repo(tmp.path(), ".cache/thing");
+        let real = make_repo(tmp.path(), "real");
+
+        let result = scan(tmp.path(), ScanOptions::default());
+
+        assert_eq!(
+            paths(&result),
+            vec![real.display().to_string()],
+            "only the repository outside the ignored directories is reported"
+        );
+    }
+
+    #[test]
+    fn reports_a_bare_repository() {
+        let tmp = TempDir::new().unwrap();
+        let bare = tmp.path().join("mirror.git");
+        fs::create_dir_all(bare.join("objects")).unwrap();
+        fs::create_dir_all(bare.join("refs")).unwrap();
+        fs::write(bare.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+        let result = scan(tmp.path(), ScanOptions::default());
+
+        assert_eq!(result.repositories.len(), 1);
+        assert!(result.repositories[0].is_bare);
+        assert_eq!(result.repositories[0].name, "mirror.git");
+    }
+
+    #[test]
+    fn reports_the_root_itself_when_it_is_a_repository() {
+        let tmp = TempDir::new().unwrap();
+        let repo = make_repo(tmp.path(), "repo");
+        make_repo(&repo, "nested");
+
+        let result = scan(&repo, ScanOptions::default());
+
+        assert_eq!(paths(&result), vec![repo.display().to_string()]);
+    }
+
+    #[test]
+    fn caps_the_number_of_results() {
+        let tmp = TempDir::new().unwrap();
+        for i in 0..6 {
+            make_repo(tmp.path(), &format!("repo{}", i));
+        }
+
+        let result = scan(
+            tmp.path(),
+            ScanOptions {
+                max_results: 3,
+                ..ScanOptions::default()
+            },
+        );
+
+        assert_eq!(result.repositories.len(), 3);
+        assert!(result.truncated, "hitting the cap is reported as truncated");
+    }
+
+    #[test]
+    fn caps_the_number_of_visited_directories() {
+        let tmp = TempDir::new().unwrap();
+        for i in 0..10 {
+            fs::create_dir_all(tmp.path().join(format!("plain{}", i))).unwrap();
+        }
+
+        let result = scan(
+            tmp.path(),
+            ScanOptions {
+                max_visited_directories: 3,
+                ..ScanOptions::default()
+            },
+        );
+
+        assert!(result.truncated);
+        assert!(result.scanned_directories <= 3);
+    }
+
+    #[test]
+    fn stops_when_cancelled() {
+        let tmp = TempDir::new().unwrap();
+        make_repo(tmp.path(), "a/b");
+
+        let flag = AtomicBool::new(true);
+        let result =
+            scan_directory_for_repositories(tmp.path(), ScanOptions::default(), &flag, |_| {});
+
+        assert!(result.cancelled);
+        assert!(result.repositories.is_empty());
+    }
+
+    #[test]
+    fn reports_progress_for_a_wide_tree() {
+        let tmp = TempDir::new().unwrap();
+        for i in 0..PROGRESS_EVERY + 5 {
+            fs::create_dir_all(tmp.path().join(format!("plain{}", i))).unwrap();
+        }
+
+        let flag = AtomicBool::new(false);
+        let mut seen = Vec::new();
+        scan_directory_for_repositories(tmp.path(), ScanOptions::default(), &flag, |p| {
+            seen.push(p.scanned_directories)
+        });
+
+        assert!(
+            !seen.is_empty(),
+            "a scan crossing the progress interval emits at least one update"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn does_not_follow_symlinks() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = TempDir::new().unwrap();
+        let real = make_repo(tmp.path(), "outside/real");
+        let inside = tmp.path().join("inside");
+        fs::create_dir_all(&inside).unwrap();
+        // A link to a repository, and a link back to the scan root: following
+        // either would list a repository twice or loop forever.
+        symlink(&real, inside.join("link-to-repo")).unwrap();
+        symlink(tmp.path(), inside.join("link-to-root")).unwrap();
+
+        let result = scan(&inside, ScanOptions::default());
+
+        assert!(
+            result.repositories.is_empty(),
+            "symlinked repositories are neither followed nor reported"
+        );
+    }
+
+    #[tokio::test]
+    async fn classify_reports_a_missing_path() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("gone");
+
+        let info = classify_repository_path(missing.display().to_string())
+            .await
+            .unwrap();
+
+        assert!(!info.exists);
+        assert!(!info.is_directory);
+        assert!(!info.is_repository);
+        assert_eq!(info.name, "gone");
+    }
+
+    #[tokio::test]
+    async fn classify_reports_a_file() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("notes.txt");
+        fs::write(&file, "hello").unwrap();
+
+        let info = classify_repository_path(file.display().to_string())
+            .await
+            .unwrap();
+
+        assert!(info.exists);
+        assert!(!info.is_directory);
+        assert!(!info.is_repository);
+    }
+
+    #[tokio::test]
+    async fn classify_separates_plain_directories_from_repositories() {
+        let tmp = TempDir::new().unwrap();
+        let plain = tmp.path().join("plain");
+        fs::create_dir_all(&plain).unwrap();
+        let repo = make_repo(tmp.path(), "repo");
+
+        let plain_info = classify_repository_path(plain.display().to_string())
+            .await
+            .unwrap();
+        assert!(plain_info.is_directory);
+        assert!(!plain_info.is_repository);
+
+        let repo_info = classify_repository_path(repo.display().to_string())
+            .await
+            .unwrap();
+        assert!(repo_info.is_directory);
+        assert!(repo_info.is_repository);
+        assert!(!repo_info.is_bare);
+        assert_eq!(repo_info.name, "repo");
+    }
+
+    #[test]
+    fn scan_root_must_exist_and_be_a_folder() {
+        let tmp = TempDir::new().unwrap();
+        let file = tmp.path().join("notes.txt");
+        fs::write(&file, "hello").unwrap();
+
+        let missing = validate_scan_root(&tmp.path().join("gone")).unwrap_err();
+        assert!(
+            missing.to_string().contains("no longer exists"),
+            "got: {missing}"
+        );
+
+        let not_a_folder = validate_scan_root(&file).unwrap_err();
+        assert!(
+            not_a_folder.to_string().contains("is not a folder"),
+            "got: {not_a_folder}"
+        );
+
+        assert!(validate_scan_root(tmp.path()).is_ok());
+    }
+
+    #[test]
+    fn requested_depth_is_clamped_to_the_ceiling() {
+        let clamped = 10_000_usize.clamp(1, MAX_ALLOWED_DEPTH);
+        assert_eq!(clamped, MAX_ALLOWED_DEPTH);
+        assert_eq!(0_usize.clamp(1, MAX_ALLOWED_DEPTH), 1);
+    }
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -303,6 +303,9 @@ pub fn run() {
         })
         .invoke_handler(tauri::generate_handler![
             commands::repository::open_repository,
+            commands::repo_scan::classify_repository_path,
+            commands::repo_scan::scan_for_repositories,
+            commands::repo_scan::cancel_repository_scan,
             commands::repository::clone_repository,
             commands::repository::cancel_clone,
             commands::repository::init_repository,

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -92,6 +92,8 @@ import './components/dialogs/lv-azure-devops-dialog.ts';
 import './components/dialogs/lv-profile-manager-dialog.ts';
 import './components/dialogs/lv-migration-dialog.ts';
 import './components/dialogs/lv-workspace-manager-dialog.ts';
+import './components/dialogs/lv-scan-repositories-dialog.ts';
+import './components/dialogs/lv-init-dialog.ts';
 import './components/dialogs/lv-hooks-dialog.ts';
 import './components/dialogs/lv-create-tag-dialog.ts';
 import './components/dialogs/lv-create-branch-dialog.ts';
@@ -165,6 +167,10 @@ import { embeddingIndexService } from './services/embedding-index.service.ts';
 import { initOAuthListener } from './services/oauth.service.ts';
 import * as localAiService from './services/local-ai.service.ts';
 import { emit, type UnlistenFn } from '@tauri-apps/api/event';
+import {
+  startRepositoryDropListener,
+  REPOSITORY_SCAN_OFFER_EVENT,
+} from './services/window-drop.service.ts';
 
 /**
  * Main application shell component
@@ -790,6 +796,15 @@ export class AppShell extends LitElement {
 
   // Migration dialog
   @state() private showMigrationDialog = false;
+
+  // Scan-for-repositories dialog, opened from the welcome screen's Scan
+  // action and from a dropped folder that is not a repository.
+  @state() private showRepositoryScan = false;
+  @state() private repositoryScanPath = '';
+  @state() private repositoryScanMode: 'scan' | 'offer' = 'scan';
+  /** True while an OS drag is over the window, so the welcome screen can
+   *  show its drop affordance. */
+  @state() private fileDragActive = false;
 
   // Workspace Manager dialog
   @state() private showWorkspaceManager = false;
@@ -1830,6 +1845,10 @@ export class AppShell extends LitElement {
     this.addEventListener('rebase-complete', this.handleRebaseComplete);
     this.addEventListener('show-commit', this.handleShowCommitEvent);
     window.addEventListener('settings-changed', this.handleSettingsChanged);
+    window.addEventListener(REPOSITORY_SCAN_OFFER_EVENT, this.handleRepositoryScanOffer);
+    // OS folder drops open repositories from anywhere in the app, not just
+    // the welcome screen.
+    void this.setupWindowDropListener();
 
     // Load vim mode from keyboard service
     this.vimMode = keyboardService.isVimMode();
@@ -1986,6 +2005,9 @@ export class AppShell extends LitElement {
     this.removeEventListener('rebase-complete', this.handleRebaseComplete);
     this.removeEventListener('show-commit', this.handleShowCommitEvent);
     window.removeEventListener('settings-changed', this.handleSettingsChanged);
+    window.removeEventListener(REPOSITORY_SCAN_OFFER_EVENT, this.handleRepositoryScanOffer);
+    this.dropUnlisten?.();
+    this.dropUnlisten = undefined;
     gitService.cleanupRemoteOperationListeners();
     // Clean up auto-fetch
     this.autoFetchUnsubscribe?.();
@@ -3078,6 +3100,60 @@ export class AppShell extends LitElement {
   private handleOpenSettings = (): void => {
     this.showSettings = true;
   };
+
+  /** Unlisten for the webview's OS drag/drop events. */
+  private dropUnlisten?: UnlistenFn;
+
+  /** Open the scan dialog on a folder the user picked (welcome screen). */
+  private handleOpenRepositoryScan = (e: Event): void => {
+    const detail = (e as CustomEvent<{ path?: string; mode?: 'scan' | 'offer' }>).detail;
+    if (!detail?.path) return;
+    this.repositoryScanPath = detail.path;
+    this.repositoryScanMode = detail.mode ?? 'scan';
+    this.showRepositoryScan = true;
+  };
+
+  /**
+   * A folder dropped on the window is not a repository: offer to scan it or to
+   * initialize one there. Fired on `window` by the drop service, which has no
+   * component of its own.
+   */
+  private handleRepositoryScanOffer = (e: Event): void => {
+    const detail = (e as CustomEvent<{ path?: string }>).detail;
+    if (!detail?.path) return;
+    this.repositoryScanPath = detail.path;
+    this.repositoryScanMode = 'offer';
+    this.showRepositoryScan = true;
+  };
+
+  /**
+   * Hand a folder to the init dialog. Only one init dialog is mounted at a
+   * time: the welcome screen owns it while no repository is open, the shell
+   * owns it once one is.
+   */
+  private handleInitializeRepositoryRequest = async (e: Event): Promise<void> => {
+    const path = (e as CustomEvent<{ path?: string }>).detail?.path;
+    this.showRepositoryScan = false;
+    await this.updateComplete;
+    const welcome = this.renderRoot.querySelector('lv-welcome');
+    if (welcome) {
+      welcome.openInitDialog(path);
+      return;
+    }
+    const initDialog = this.renderRoot.querySelector('lv-init-dialog');
+    if (initDialog) {
+      initDialog.open(path);
+      return;
+    }
+    showToast('Could not open the Initialize Repository dialog', 'error');
+  };
+
+  /** Start listening for folders dropped onto the window. */
+  private async setupWindowDropListener(): Promise<void> {
+    this.dropUnlisten = await startRepositoryDropListener((active) => {
+      this.fileDragActive = active;
+    });
+  }
 
   // True while any integration dialog is open.
   private get integrationDialogOpen(): boolean {
@@ -5902,8 +5978,10 @@ export class AppShell extends LitElement {
             </footer>
           `
         : html`<lv-welcome
+            .dragActive=${this.fileDragActive}
             @open-workspace-manager=${() => { this.showWorkspaceManager = true; }}
             @open-profile-manager=${() => { this.showProfileManager = true; }}
+            @open-repository-scan=${this.handleOpenRepositoryScan}
           ></lv-welcome>`}
 
       ${this.showSettings
@@ -6435,6 +6513,20 @@ export class AppShell extends LitElement {
         @close=${() => { this.showWorkspaceManager = false; }}
         @open-repo-file=${this.handleWorkspaceOpenRepoFile}
       ></lv-workspace-manager-dialog>
+
+      <lv-scan-repositories-dialog
+        ?open=${this.showRepositoryScan}
+        .scanPath=${this.repositoryScanPath}
+        .mode=${this.repositoryScanMode}
+        @close=${() => { this.showRepositoryScan = false; }}
+        @initialize-repository=${this.handleInitializeRepositoryRequest}
+      ></lv-scan-repositories-dialog>
+
+      ${this.activeRepository
+        // The welcome screen mounts its own init dialog, so this one exists
+        // only while a repository is open — never two at once.
+        ? html`<lv-init-dialog></lv-init-dialog>`
+        : ''}
 
       ${this.activeRepository ? html`
         <lv-hooks-dialog

--- a/src/components/dialogs/__tests__/lv-scan-repositories-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-scan-repositories-dialog.test.ts
@@ -1,0 +1,376 @@
+/**
+ * Tests for the "Scan for Repositories" dialog: the results list the user
+ * picks from, the offer step for a dropped folder that is not a repository,
+ * and the failure paths (scan error, open error, cancellation).
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
+const mockResponses: Record<string, (args: Record<string, unknown>) => unknown> = {};
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCallArgs.push({ command, args: args || {} });
+    const handler = mockResponses[command];
+    try {
+      return Promise.resolve(handler ? handler(args || {}) : null);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  transformCallback: () => cbId++,
+};
+(globalThis as Record<string, unknown>).__TAURI_EVENT_PLUGIN_INTERNALS__ = {
+  unregisterListener: () => {},
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-scan-repositories-dialog.ts';
+import type { LvScanRepositoriesDialog } from '../lv-scan-repositories-dialog.ts';
+import { repositoryStore, uiStore } from '../../../stores/index.ts';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+function scanResult(overrides: Record<string, unknown> = {}) {
+  return {
+    root: '/code',
+    repositories: [
+      { path: '/code/alpha', name: 'alpha', isBare: false },
+      { path: '/code/beta', name: 'beta', isBare: false },
+    ],
+    scannedDirectories: 12,
+    truncated: false,
+    cancelled: false,
+    ...overrides,
+  };
+}
+
+function mockRepoPayload(path: string) {
+  return {
+    path,
+    name: path.split('/').pop(),
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+async function waitUntil(predicate: () => boolean, what: string): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  throw new Error(`timed out waiting for ${what}`);
+}
+
+async function openDialog(
+  el: LvScanRepositoriesDialog,
+  mode: 'scan' | 'offer',
+  path = '/code',
+): Promise<void> {
+  el.scanPath = path;
+  el.mode = mode;
+  el.open = true;
+  await el.updateComplete;
+}
+
+function query<T extends Element>(el: LvScanRepositoriesDialog, selector: string): T | null {
+  return el.shadowRoot!.querySelector<T>(selector);
+}
+
+/** Lit interpolation leaves newlines between values; compare on one line. */
+function text(el: LvScanRepositoriesDialog, selector: string): string {
+  return (query(el, selector)?.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function allText(el: LvScanRepositoriesDialog): string {
+  return (el.shadowRoot?.textContent ?? '').replace(/\s+/g, ' ').trim();
+}
+
+function queryAll<T extends Element>(el: LvScanRepositoriesDialog, selector: string): T[] {
+  return Array.from(el.shadowRoot!.querySelectorAll<T>(selector));
+}
+
+function buttonWithText(el: LvScanRepositoriesDialog, text: string): HTMLButtonElement {
+  const match = queryAll<HTMLButtonElement>(el, 'button').find((b) =>
+    (b.textContent ?? '').trim().includes(text),
+  );
+  if (!match) throw new Error(`no button containing "${text}"`);
+  return match;
+}
+
+describe('lv-scan-repositories-dialog', () => {
+  beforeEach(() => {
+    invokeCallArgs.length = 0;
+    for (const key of Object.keys(mockResponses)) {
+      delete mockResponses[key];
+    }
+    uiStore.setState({ toasts: [] });
+    repositoryStore.getState().reset();
+    mockResponses['open_repository'] = (args) => mockRepoPayload(args.path as string);
+  });
+
+  it('scans the chosen folder and lists what it found', async () => {
+    mockResponses['scan_for_repositories'] = () => scanResult();
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+
+    await openDialog(el, 'scan');
+    await waitUntil(() => queryAll(el, '.result-item').length > 0, 'the results list');
+
+    const scanCall = invokeCallArgs.find((c) => c.command === 'scan_for_repositories');
+    expect(scanCall?.args.path).to.equal('/code');
+    expect(queryAll(el, '.result-item').length).to.equal(2);
+    expect(text(el, '.results-toolbar')).to.contain('2 repositories');
+    expect(text(el, '.results-toolbar')).to.contain('12 folders');
+  });
+
+  it('opens only the selected repositories and closes', async () => {
+    mockResponses['scan_for_repositories'] = () => scanResult();
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+    let closed = false;
+    el.addEventListener('close', () => {
+      closed = true;
+    });
+
+    await openDialog(el, 'scan');
+    await waitUntil(() => queryAll(el, '.result-item').length > 0, 'the results list');
+
+    // Nothing is selected until the user says so.
+    expect(buttonWithText(el, 'Open selected').disabled).to.equal(true);
+
+    const firstCheckbox = queryAll<HTMLInputElement>(el, '.result-item input')[0];
+    firstCheckbox.click();
+    await el.updateComplete;
+    expect(buttonWithText(el, 'Open selected (1)').disabled).to.equal(false);
+
+    buttonWithText(el, 'Open selected').click();
+    await waitUntil(() => closed, 'the dialog to close after opening');
+
+    const opened = invokeCallArgs
+      .filter((c) => c.command === 'open_repository')
+      .map((c) => c.args.path);
+    expect(opened).to.deep.equal(['/code/alpha']);
+    const state = repositoryStore.getState();
+    expect(state.openRepositories.map((r) => r.repository.path)).to.deep.equal(['/code/alpha']);
+    expect(el.open).to.equal(false);
+    const toasts = uiStore.getState().toasts;
+    expect(toasts[0].type).to.equal('success');
+    expect(toasts[0].message).to.contain('Opened 1 repository');
+  });
+
+  it('selects and clears every result', async () => {
+    mockResponses['scan_for_repositories'] = () => scanResult();
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+
+    await openDialog(el, 'scan');
+    await waitUntil(() => queryAll(el, '.result-item').length > 0, 'the results list');
+
+    buttonWithText(el, 'Select all').click();
+    await el.updateComplete;
+    expect(buttonWithText(el, 'Open selected (2)')).to.exist;
+
+    buttonWithText(el, 'Clear').click();
+    await el.updateComplete;
+    expect(buttonWithText(el, 'Open selected (0)').disabled).to.equal(true);
+  });
+
+  it('marks a repository that is already open', async () => {
+    mockResponses['scan_for_repositories'] = () => scanResult();
+    repositoryStore.getState().addRepository(mockRepoPayload('/code/alpha') as any);
+
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+    await openDialog(el, 'scan');
+    await waitUntil(() => queryAll(el, '.result-item').length > 0, 'the results list');
+
+    const badges = queryAll(el, '.result-item .badge').map((b) => b.textContent?.trim());
+    expect(badges).to.deep.equal(['already open']);
+  });
+
+  it('keeps the dialog open and explains when a repository cannot be opened', async () => {
+    mockResponses['scan_for_repositories'] = () => scanResult();
+    mockResponses['open_repository'] = () => {
+      throw new Error('permission denied');
+    };
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+
+    await openDialog(el, 'scan');
+    await waitUntil(() => queryAll(el, '.result-item').length > 0, 'the results list');
+    buttonWithText(el, 'Select all').click();
+    await el.updateComplete;
+    buttonWithText(el, 'Open selected').click();
+
+    await waitUntil(() => query(el, '.error-message') !== null, 'the failure message');
+    expect(text(el, '.error-message')).to.contain('permission denied');
+    expect(el.open).to.equal(true, 'the dialog stays open so the user can retry');
+    expect(uiStore.getState().toasts[0].type).to.equal('error');
+  });
+
+  it('reports an empty scan and offers to initialize the folder', async () => {
+    mockResponses['scan_for_repositories'] = () =>
+      scanResult({ repositories: [], scannedDirectories: 40 });
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+
+    let initPath: string | undefined;
+    el.addEventListener('initialize-repository', (e) => {
+      initPath = (e as CustomEvent<{ path: string }>).detail.path;
+    });
+
+    await openDialog(el, 'scan');
+    await waitUntil(() => text(el, '.explanation').includes('No Git repositories'), 'the empty state');
+    expect(text(el, '.notice')).to.contain('Searched 40 folders');
+
+    buttonWithText(el, 'Initialize a repository here').click();
+    expect(initPath).to.equal('/code');
+    expect(el.open).to.equal(false);
+  });
+
+  it('shows the truncation and cancellation notices with the partial results', async () => {
+    mockResponses['scan_for_repositories'] = () =>
+      scanResult({ truncated: true, cancelled: true });
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+
+    await openDialog(el, 'scan');
+    await waitUntil(() => queryAll(el, '.result-item').length > 0, 'the partial results');
+
+    const notices = queryAll(el, '.notice').map((n) => n.textContent ?? '');
+    expect(notices.some((n) => n.includes('Scan cancelled'))).to.equal(true);
+    expect(notices.some((n) => n.includes('stopped early'))).to.equal(true);
+  });
+
+  it('surfaces a scan failure instead of an empty list', async () => {
+    mockResponses['scan_for_repositories'] = () => {
+      throw new Error('/code no longer exists');
+    };
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+
+    await openDialog(el, 'scan');
+    await waitUntil(() => query(el, '.error-message') !== null, 'the scan error');
+    expect(text(el, '.error-message')).to.contain('no longer exists');
+  });
+
+  it('cancels a running scan', async () => {
+    let finishScan: (value: unknown) => void = () => {};
+    mockResponses['scan_for_repositories'] = () =>
+      new Promise((resolve) => {
+        finishScan = resolve;
+      });
+    mockResponses['cancel_repository_scan'] = () => null;
+
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+    await openDialog(el, 'scan');
+    await waitUntil(() => query(el, '.spinner') !== null, 'the scanning state');
+    await waitUntil(
+      () => invokeCallArgs.some((c) => c.command === 'scan_for_repositories'),
+      'the scan to reach the backend',
+    );
+
+    buttonWithText(el, 'Cancel scan').click();
+    await waitUntil(
+      () => invokeCallArgs.some((c) => c.command === 'cancel_repository_scan'),
+      'the cancel command',
+    );
+    await el.updateComplete;
+    expect(buttonWithText(el, 'Cancelling…').disabled).to.equal(true);
+
+    finishScan(scanResult({ repositories: [], cancelled: true }));
+    await waitUntil(
+      () => allText(el).includes('before the scan was cancelled'),
+      'the cancelled empty state',
+    );
+  });
+
+  it('never starts a scan the user cancelled before it was sent', async () => {
+    // Hold the progress-listener registration open, which is what runs before
+    // the scan command is sent.
+    let releaseListen: (value: unknown) => void = () => {};
+    mockResponses['plugin:event|listen'] = () =>
+      new Promise((resolve) => {
+        releaseListen = resolve;
+      });
+    mockResponses['scan_for_repositories'] = () => scanResult();
+    mockResponses['cancel_repository_scan'] = () => null;
+
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+    await openDialog(el, 'scan');
+    await waitUntil(() => query(el, '.spinner') !== null, 'the scanning state');
+
+    buttonWithText(el, 'Cancel scan').click();
+    releaseListen(1);
+
+    await waitUntil(
+      () => allText(el).includes('before the scan was cancelled'),
+      'the cancelled empty state',
+    );
+    expect(
+      invokeCallArgs.some((c) => c.command === 'scan_for_repositories'),
+      'no scan is started once the user has cancelled',
+    ).to.equal(false);
+  });
+
+  it('offers a scan or an init for a dropped folder that is not a repository', async () => {
+    mockResponses['scan_for_repositories'] = () => scanResult();
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+
+    await openDialog(el, 'offer', '/projects');
+    expect(text(el, '.explanation')).to.contain('not a Git repository');
+    expect(text(el, '.folder-path')).to.contain('/projects');
+    // Nothing is scanned until the user asks for it.
+    expect(invokeCallArgs.some((c) => c.command === 'scan_for_repositories')).to.equal(false);
+
+    buttonWithText(el, 'Scan it for repositories').click();
+    await waitUntil(() => queryAll(el, '.result-item').length > 0, 'the results list');
+    expect(
+      invokeCallArgs.find((c) => c.command === 'scan_for_repositories')?.args.path,
+    ).to.equal('/projects');
+  });
+
+  it('asks the backend to stop a scan the user closed', async () => {
+    mockResponses['scan_for_repositories'] = () => new Promise(() => {});
+    mockResponses['cancel_repository_scan'] = () => null;
+
+    const el = await fixture<LvScanRepositoriesDialog>(
+      html`<lv-scan-repositories-dialog></lv-scan-repositories-dialog>`,
+    );
+    await openDialog(el, 'scan');
+    await waitUntil(
+      () => invokeCallArgs.some((c) => c.command === 'scan_for_repositories'),
+      'the scan to reach the backend',
+    );
+
+    el.open = false;
+    await el.updateComplete;
+
+    await waitUntil(
+      () => invokeCallArgs.some((c) => c.command === 'cancel_repository_scan'),
+      'the scan to be cancelled on close',
+    );
+  });
+});

--- a/src/components/dialogs/lv-init-dialog.ts
+++ b/src/components/dialogs/lv-init-dialog.ts
@@ -188,12 +188,18 @@ export class LvInitDialog extends LitElement {
 
   @query('lv-modal') private modal!: LvModal;
 
-  public open(): void {
+  /**
+   * @param path Optional folder to pre-fill, so "initialise this folder"
+   *   flows (a folder dropped on the window that is not a repository) do not
+   *   make the user find it again in the picker.
+   */
+  public open(path?: string): void {
     // An init already in flight owns this component; reset() would
     // clear `isInitializing` and re-enable the button for a second concurrent run,
     // and the first run's close() would then yank shut the reopened session.
     if (this.isInitializing) return;
     this.reset();
+    if (path) this.path = path;
     // Seed from the "Default Branch Name" setting on every open so the
     // dialog always reflects the current preference.
     this.initialBranch = settingsStore.getState().defaultBranchName;

--- a/src/components/dialogs/lv-scan-repositories-dialog.ts
+++ b/src/components/dialogs/lv-scan-repositories-dialog.ts
@@ -1,0 +1,671 @@
+/**
+ * Scan for Repositories Dialog
+ *
+ * Two entry points:
+ *  - the welcome screen's "Scan" action, which picks a folder and opens this
+ *    dialog straight into the scan;
+ *  - a folder dropped on the window that is not a repository, which opens this
+ *    dialog on its offer step ("scan it, or initialise it here?").
+ *
+ * Everything found is opened through `openRepositoryPath`, so tabs, the recent
+ * list and persistence behave exactly as they do for the Open button.
+ */
+
+import { LitElement, html, css, type PropertyValues } from 'lit';
+import { customElement, property, state } from 'lit/decorators.js';
+import { sharedStyles } from '../../styles/shared-styles.ts';
+import {
+  scanForRepositories,
+  cancelRepositoryScan,
+  onRepositoryScanProgress,
+  type DiscoveredRepository,
+  type RepositoryScanResult,
+  type RepositoryScanProgress,
+} from '../../services/repo-scan.service.ts';
+import { openRepositoryPath } from '../../services/repository-open.service.ts';
+import { showToast } from '../../services/notification.service.ts';
+import { repositoryStore } from '../../stores/index.ts';
+import type { UnlistenFn } from '@tauri-apps/api/event';
+import './lv-modal.ts';
+
+type ScanPhase = 'offer' | 'scanning' | 'results' | 'error';
+
+@customElement('lv-scan-repositories-dialog')
+export class LvScanRepositoriesDialog extends LitElement {
+  static styles = [
+    sharedStyles,
+    css`
+      .body {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-md);
+        min-width: 420px;
+        max-width: 620px;
+      }
+
+      .folder-path {
+        font-family: var(--font-family-mono);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-secondary);
+        word-break: break-all;
+      }
+
+      .explanation {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+      }
+
+      .offer-actions {
+        display: flex;
+        flex-direction: column;
+        gap: var(--spacing-sm);
+      }
+
+      .progress {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-sm);
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+      }
+
+      .spinner {
+        width: 16px;
+        height: 16px;
+        border: 2px solid var(--color-border);
+        border-top-color: var(--color-primary);
+        border-radius: 50%;
+        animation: spin 0.8s linear infinite;
+        flex-shrink: 0;
+      }
+
+      @keyframes spin {
+        to {
+          transform: rotate(360deg);
+        }
+      }
+
+      @media (prefers-reduced-motion: reduce) {
+        .spinner {
+          animation-duration: 3s;
+        }
+      }
+
+      .results-toolbar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        gap: var(--spacing-sm);
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+      }
+
+      .toolbar-actions {
+        display: flex;
+        gap: var(--spacing-sm);
+      }
+
+      .link-btn {
+        background: none;
+        border: none;
+        color: var(--color-primary);
+        cursor: pointer;
+        font-size: var(--font-size-xs);
+        padding: 0;
+      }
+
+      .link-btn:hover {
+        text-decoration: underline;
+      }
+
+      .results-list {
+        display: flex;
+        flex-direction: column;
+        gap: 2px;
+        max-height: 320px;
+        overflow-y: auto;
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-md);
+        padding: var(--spacing-xs);
+      }
+
+      .result-item {
+        display: flex;
+        align-items: center;
+        gap: var(--spacing-sm);
+        padding: var(--spacing-xs) var(--spacing-sm);
+        border-radius: var(--radius-sm);
+        cursor: pointer;
+      }
+
+      .result-item:hover {
+        background: var(--color-bg-hover);
+      }
+
+      .result-info {
+        min-width: 0;
+        flex: 1;
+      }
+
+      .result-name {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-primary);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .result-path {
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
+
+      .badge {
+        flex-shrink: 0;
+        font-size: var(--font-size-xs);
+        color: var(--color-text-muted);
+        border: 1px solid var(--color-border);
+        border-radius: var(--radius-sm);
+        padding: 0 var(--spacing-xs);
+      }
+
+      .notice {
+        font-size: var(--font-size-xs);
+        padding: var(--spacing-sm);
+        border-radius: var(--radius-md);
+        background: var(--color-bg-secondary);
+        color: var(--color-text-secondary);
+      }
+
+      .notice.warning {
+        color: var(--color-warning);
+      }
+
+      .error-message {
+        font-size: var(--font-size-sm);
+        color: var(--color-error);
+      }
+
+      .btn {
+        padding: var(--spacing-sm) var(--spacing-lg);
+        border-radius: var(--radius-md);
+        font-size: var(--font-size-sm);
+        font-weight: var(--font-weight-medium);
+        cursor: pointer;
+      }
+
+      .btn-primary {
+        background: var(--color-primary);
+        color: var(--color-text-inverse);
+        border: none;
+      }
+
+      .btn-primary:hover:not(:disabled) {
+        background: var(--color-primary-hover);
+      }
+
+      .btn-primary:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+
+      .btn-secondary {
+        background: transparent;
+        color: var(--color-text-secondary);
+        border: 1px solid var(--color-border);
+      }
+
+      .btn-secondary:hover:not(:disabled) {
+        background: var(--color-bg-hover);
+        color: var(--color-text-primary);
+      }
+
+      .btn-secondary:disabled {
+        opacity: 0.5;
+        cursor: not-allowed;
+      }
+    `,
+  ];
+
+  /** Controlled by the shell, like every other top-level dialog. */
+  @property({ type: Boolean, reflect: true }) open = false;
+
+  /** The folder to scan (or the dropped folder being offered). */
+  @property({ type: String }) scanPath = '';
+
+  /**
+   * `scan` starts scanning as soon as the dialog opens (the user already chose
+   * the folder); `offer` first asks what to do with a dropped folder that is
+   * not a repository.
+   */
+  @property({ type: String }) mode: 'scan' | 'offer' = 'scan';
+
+  @state() private phase: ScanPhase = 'offer';
+  @state() private progress: RepositoryScanProgress | null = null;
+  @state() private result: RepositoryScanResult | null = null;
+  @state() private selected: Set<string> = new Set();
+  @state() private error = '';
+  @state() private isOpening = false;
+  @state() private isCancelling = false;
+  /** Paths already open, so the list can mark them instead of implying a new tab. */
+  @state() private openPaths: string[] = [];
+
+  private progressUnlisten?: UnlistenFn;
+  /**
+   * Bumped for every scan (and every close). A scan that resolves after the
+   * dialog was closed — or after a second scan started — must not write its
+   * results over what the user is looking at now.
+   */
+  private scanToken = 0;
+  /**
+   * Set by Cancel. The backend clears its own cancellation flag when a scan
+   * STARTS, so a cancel pressed in the gap between "scanning" appearing and
+   * the scan command actually being sent would be thrown away and the dialog
+   * would sit on "Cancelling…" for the length of a full scan. Cancelling in
+   * that gap stops the scan before it is ever sent.
+   */
+  private cancelRequested = false;
+  /** True once the scan command has actually been sent to the backend. */
+  private scanIssued = false;
+
+  updated(changed: PropertyValues): void {
+    if (!changed.has('open')) return;
+    if (this.open) {
+      this.reset();
+      this.openPaths = repositoryStore
+        .getState()
+        .openRepositories.map((repo) => repo.repository.path);
+      if (this.mode === 'scan' && this.scanPath) {
+        void this.startScan();
+      }
+    } else {
+      // Closing mid-scan must stop the backend walk, not leave it running
+      // against a dialog nobody can see.
+      if (this.phase === 'scanning') {
+        this.cancelRequested = true;
+        if (this.scanIssued) void cancelRepositoryScan();
+      }
+      this.scanToken++;
+      this.detachProgress();
+    }
+  }
+
+  disconnectedCallback(): void {
+    super.disconnectedCallback();
+    this.scanToken++;
+    this.detachProgress();
+  }
+
+  private reset(): void {
+    this.phase = this.mode === 'scan' ? 'scanning' : 'offer';
+    this.progress = null;
+    this.result = null;
+    this.selected = new Set();
+    this.error = '';
+    this.isOpening = false;
+    this.isCancelling = false;
+  }
+
+  private detachProgress(): void {
+    const unlisten = this.progressUnlisten;
+    this.progressUnlisten = undefined;
+    unlisten?.();
+  }
+
+  private async startScan(): Promise<void> {
+    if (!this.scanPath) {
+      this.phase = 'error';
+      this.error = 'No folder was chosen to scan';
+      return;
+    }
+
+    this.phase = 'scanning';
+    this.progress = null;
+    this.error = '';
+    this.isCancelling = false;
+
+    const token = ++this.scanToken;
+    this.cancelRequested = false;
+    this.scanIssued = false;
+    this.detachProgress();
+    this.progressUnlisten = await onRepositoryScanProgress((progress) => {
+      // A late event from a scan the user already cancelled must not reanimate
+      // the progress line under the results.
+      if (token === this.scanToken && this.phase === 'scanning') this.progress = progress;
+    });
+
+    // Closed, reopened, or rescanned while the listener was being attached.
+    if (token !== this.scanToken) {
+      this.detachProgress();
+      return;
+    }
+    if (this.cancelRequested) {
+      // Cancelled before the walk was even asked for: report it as the empty
+      // cancelled scan it is rather than starting one nobody wants.
+      this.detachProgress();
+      this.result = {
+        root: this.scanPath,
+        repositories: [],
+        scannedDirectories: 0,
+        truncated: false,
+        cancelled: true,
+      };
+      this.phase = 'results';
+      return;
+    }
+
+    this.scanIssued = true;
+    const response = await scanForRepositories(this.scanPath);
+    this.detachProgress();
+    // Closed, reopened, or rescanned while this scan was running.
+    if (token !== this.scanToken) return;
+
+    if (!response.success || !response.data) {
+      this.phase = 'error';
+      this.error = response.error?.message ?? 'Failed to scan for repositories';
+      return;
+    }
+
+    this.result = response.data;
+    // Nothing is pre-selected: a scan can return hundreds of repositories and
+    // "Open selected" must never be a one-click way to open all of them.
+    this.selected = new Set();
+    this.phase = 'results';
+  }
+
+  private async handleCancelScan(): Promise<void> {
+    this.isCancelling = true;
+    this.cancelRequested = true;
+    // Nothing is running in the backend yet; startScan will stop on its own.
+    if (!this.scanIssued) return;
+    const result = await cancelRepositoryScan();
+    if (!result.success) {
+      this.isCancelling = false;
+      showToast(result.error?.message ?? 'Failed to cancel the scan', 'error');
+    }
+  }
+
+  private handleScanFromOffer(): void {
+    void this.startScan();
+  }
+
+  private handleInitialize(): void {
+    // The init dialog lives in the shell (or on the welcome screen); it owns
+    // the branch-name settings and the error handling for init.
+    this.dispatchEvent(
+      new CustomEvent<{ path: string }>('initialize-repository', {
+        detail: { path: this.scanPath },
+        bubbles: true,
+        composed: true,
+      }),
+    );
+    this.close();
+  }
+
+  private toggleSelection(path: string): void {
+    const next = new Set(this.selected);
+    if (next.has(path)) {
+      next.delete(path);
+    } else {
+      next.add(path);
+    }
+    this.selected = next;
+  }
+
+  private selectAll(): void {
+    this.selected = new Set((this.result?.repositories ?? []).map((repo) => repo.path));
+  }
+
+  private clearSelection(): void {
+    this.selected = new Set();
+  }
+
+  private async handleOpenSelected(): Promise<void> {
+    const paths = (this.result?.repositories ?? [])
+      .map((repo) => repo.path)
+      .filter((path) => this.selected.has(path));
+    if (paths.length === 0) return;
+
+    this.isOpening = true;
+    let opened = 0;
+    let alreadyOpen = 0;
+    const failures: string[] = [];
+
+    try {
+      for (const path of paths) {
+        const outcome = await openRepositoryPath(path);
+        if (outcome.status === 'opened') opened++;
+        else if (outcome.status === 'already-open') alreadyOpen++;
+        else failures.push(`${outcome.path}: ${outcome.message ?? 'failed to open'}`);
+      }
+    } finally {
+      this.isOpening = false;
+    }
+
+    if (failures.length > 0) {
+      // Keep the dialog open so the user can retry the ones that worked or
+      // deselect the ones that did not.
+      this.error =
+        failures.length === 1
+          ? `Could not open ${failures[0]}`
+          : `Could not open ${failures.length} of ${paths.length} repositories: ${failures.join('; ')}`;
+      showToast(
+        opened > 0
+          ? `Opened ${opened} of ${paths.length} repositories`
+          : 'Could not open the selected repositories',
+        opened > 0 ? 'warning' : 'error',
+      );
+      this.openPaths = repositoryStore
+        .getState()
+        .openRepositories.map((repo) => repo.repository.path);
+      return;
+    }
+
+    if (opened > 0) {
+      showToast(
+        opened === 1 ? 'Opened 1 repository' : `Opened ${opened} repositories`,
+        'success',
+      );
+    } else if (alreadyOpen > 0) {
+      showToast(
+        alreadyOpen === 1
+          ? 'That repository is already open'
+          : 'Those repositories are already open',
+        'info',
+      );
+    }
+    this.close();
+  }
+
+  public close(): void {
+    this.open = false;
+    this.dispatchEvent(new CustomEvent('close', { bubbles: true, composed: true }));
+  }
+
+  private handleModalClose(): void {
+    // Cancel is disabled while repositories are being opened; Escape, the
+    // overlay and the × must honour the same rule.
+    if (this.isOpening) return;
+    this.close();
+  }
+
+  private renderOffer() {
+    return html`
+      <div class="body">
+        <div class="explanation">This folder is not a Git repository.</div>
+        <div class="folder-path">${this.scanPath}</div>
+        <div class="offer-actions">
+          <button class="btn btn-primary" @click=${this.handleScanFromOffer}>
+            Scan it for repositories
+          </button>
+          <button class="btn btn-secondary" @click=${this.handleInitialize}>
+            Initialize a repository here
+          </button>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderScanning() {
+    return html`
+      <div class="body">
+        <div class="folder-path">${this.scanPath}</div>
+        <div class="progress">
+          <span class="spinner" aria-hidden="true"></span>
+          <span role="status">
+            ${this.progress
+              ? `Searched ${this.progress.scannedDirectories} folders — found ${this.progress.found} ${this.progress.found === 1 ? 'repository' : 'repositories'}`
+              : 'Searching for repositories…'}
+          </span>
+        </div>
+      </div>
+    `;
+  }
+
+  private renderResultItem(repo: DiscoveredRepository) {
+    const isOpen = this.openPaths.includes(repo.path);
+    return html`
+      <label class="result-item">
+        <input
+          type="checkbox"
+          .checked=${this.selected.has(repo.path)}
+          aria-label="Select ${repo.name}"
+          @change=${() => this.toggleSelection(repo.path)}
+        />
+        <div class="result-info">
+          <div class="result-name">${repo.name}</div>
+          <div class="result-path">${repo.path}</div>
+        </div>
+        ${repo.isBare ? html`<span class="badge">bare</span>` : ''}
+        ${isOpen ? html`<span class="badge">already open</span>` : ''}
+      </label>
+    `;
+  }
+
+  private renderResults() {
+    const result = this.result;
+    if (!result) return html``;
+    const repositories = result.repositories;
+
+    if (repositories.length === 0) {
+      return html`
+        <div class="body">
+          <div class="explanation">
+            No Git repositories were found in this folder
+            ${result.cancelled ? ' before the scan was cancelled' : ''}.
+          </div>
+          <div class="folder-path">${result.root}</div>
+          <div class="notice">
+            Searched ${result.scannedDirectories}
+            ${result.scannedDirectories === 1 ? 'folder' : 'folders'}. Nested folders more than a
+            few levels deep, hidden folders and dependency folders such as node_modules are
+            skipped.
+          </div>
+          <div class="offer-actions">
+            <button class="btn btn-secondary" @click=${this.handleInitialize}>
+              Initialize a repository here
+            </button>
+          </div>
+        </div>
+      `;
+    }
+
+    return html`
+      <div class="body">
+        <div class="folder-path">${result.root}</div>
+        <div class="results-toolbar">
+          <span>
+            ${repositories.length}
+            ${repositories.length === 1 ? 'repository' : 'repositories'} found in
+            ${result.scannedDirectories}
+            ${result.scannedDirectories === 1 ? 'folder' : 'folders'}
+          </span>
+          <span class="toolbar-actions">
+            <button class="link-btn" @click=${this.selectAll}>Select all</button>
+            <button class="link-btn" @click=${this.clearSelection}>Clear</button>
+          </span>
+        </div>
+        ${result.cancelled
+          ? html`<div class="notice warning">
+              Scan cancelled — showing what was found before you stopped it.
+            </div>`
+          : ''}
+        ${result.truncated
+          ? html`<div class="notice warning">
+              The scan stopped early because this folder is very large. Choose a folder closer to
+              your repositories to see the rest.
+            </div>`
+          : ''}
+        <div class="results-list" role="group" aria-label="Repositories found">
+          ${repositories.map((repo) => this.renderResultItem(repo))}
+        </div>
+        ${this.error ? html`<div class="error-message">${this.error}</div>` : ''}
+      </div>
+    `;
+  }
+
+  private renderError() {
+    return html`
+      <div class="body">
+        <div class="error-message">${this.error}</div>
+        <div class="folder-path">${this.scanPath}</div>
+      </div>
+    `;
+  }
+
+  private renderFooter() {
+    if (this.phase === 'scanning') {
+      return html`
+        <button
+          class="btn btn-secondary"
+          @click=${this.handleCancelScan}
+          ?disabled=${this.isCancelling}
+        >
+          ${this.isCancelling ? 'Cancelling…' : 'Cancel scan'}
+        </button>
+      `;
+    }
+
+    if (this.phase === 'results' && (this.result?.repositories.length ?? 0) > 0) {
+      return html`
+        <button class="btn btn-secondary" @click=${this.close} ?disabled=${this.isOpening}>
+          Close
+        </button>
+        <button
+          class="btn btn-primary"
+          @click=${this.handleOpenSelected}
+          ?disabled=${this.selected.size === 0 || this.isOpening}
+        >
+          ${this.isOpening ? 'Opening…' : `Open selected (${this.selected.size})`}
+        </button>
+      `;
+    }
+
+    return html`<button class="btn btn-secondary" @click=${this.close}>Close</button>`;
+  }
+
+  render() {
+    return html`
+      <lv-modal
+        modalTitle="Scan for Repositories"
+        ?open=${this.open}
+        @close=${this.handleModalClose}
+      >
+        ${this.phase === 'offer' ? this.renderOffer() : ''}
+        ${this.phase === 'scanning' ? this.renderScanning() : ''}
+        ${this.phase === 'results' ? this.renderResults() : ''}
+        ${this.phase === 'error' ? this.renderError() : ''}
+        <div slot="footer">${this.renderFooter()}</div>
+      </lv-modal>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'lv-scan-repositories-dialog': LvScanRepositoriesDialog;
+  }
+}

--- a/src/components/welcome/__tests__/lv-welcome-drop-scan.test.ts
+++ b/src/components/welcome/__tests__/lv-welcome-drop-scan.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Tests for the welcome screen's drop affordance and its "Scan" action: the
+ * two entry points added so a repository can be opened by dropping a folder on
+ * the window, or found on disk instead of typed into a picker.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
+const mockResponses: Record<string, (args: Record<string, unknown>) => unknown> = {};
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCallArgs.push({ command, args: args || {} });
+    const handler = mockResponses[command];
+    try {
+      return Promise.resolve(handler ? handler(args || {}) : null);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import '../lv-welcome.ts';
+import type { LvWelcome } from '../lv-welcome.ts';
+import { repositoryStore, uiStore } from '../../../stores/index.ts';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+async function waitUntil(predicate: () => boolean, what: string): Promise<void> {
+  for (let i = 0; i < 200; i++) {
+    if (predicate()) return;
+    await new Promise((r) => setTimeout(r, 0));
+  }
+  throw new Error(`timed out waiting for ${what}`);
+}
+
+function actionButton(el: LvWelcome, label: string): HTMLButtonElement {
+  const match = Array.from(el.shadowRoot!.querySelectorAll<HTMLButtonElement>('.action-btn')).find(
+    (b) => (b.textContent ?? '').trim() === label,
+  );
+  if (!match) throw new Error(`no action button labelled "${label}"`);
+  return match;
+}
+
+describe('lv-welcome drop affordance and scan action', () => {
+  beforeEach(() => {
+    invokeCallArgs.length = 0;
+    for (const key of Object.keys(mockResponses)) {
+      delete mockResponses[key];
+    }
+    uiStore.setState({ toasts: [] });
+    repositoryStore.getState().reset();
+  });
+
+  it('shows the drop affordance only while a drag is over the window', async () => {
+    const el = await fixture<LvWelcome>(html`<lv-welcome></lv-welcome>`);
+    expect(el.shadowRoot!.querySelector('.drop-overlay')).to.equal(null);
+
+    el.dragActive = true;
+    await el.updateComplete;
+    const overlay = el.shadowRoot!.querySelector('.drop-overlay');
+    expect(overlay).to.not.equal(null);
+    expect(overlay!.textContent).to.contain('Drop a folder');
+
+    el.dragActive = false;
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('.drop-overlay')).to.equal(null);
+  });
+
+  it('asks the shell to scan the folder the user picked', async () => {
+    mockResponses['plugin:dialog|open'] = () => '/code';
+    const el = await fixture<LvWelcome>(html`<lv-welcome></lv-welcome>`);
+
+    const events: Array<{ path: string; mode: string }> = [];
+    el.addEventListener('open-repository-scan', (e) => {
+      events.push((e as CustomEvent<{ path: string; mode: string }>).detail);
+    });
+
+    actionButton(el, 'Scan').click();
+    await waitUntil(() => events.length > 0, 'the scan request');
+
+    expect(events[0]).to.deep.equal({ path: '/code', mode: 'scan' });
+  });
+
+  it('does nothing when the folder picker is cancelled', async () => {
+    mockResponses['plugin:dialog|open'] = () => null;
+    const el = await fixture<LvWelcome>(html`<lv-welcome></lv-welcome>`);
+
+    let requested = false;
+    el.addEventListener('open-repository-scan', () => {
+      requested = true;
+    });
+
+    actionButton(el, 'Scan').click();
+    await waitUntil(
+      () => invokeCallArgs.some((c) => c.command === 'plugin:dialog|open'),
+      'the folder picker',
+    );
+    await el.updateComplete;
+
+    expect(requested).to.equal(false);
+    // Cancelling a picker is not an error and must not toast.
+    expect(uiStore.getState().toasts.length).to.equal(0);
+  });
+
+  it('surfaces a folder picker failure', async () => {
+    mockResponses['plugin:dialog|open'] = () => {
+      throw new Error('no file dialog available');
+    };
+    const el = await fixture<LvWelcome>(html`<lv-welcome></lv-welcome>`);
+
+    actionButton(el, 'Scan').click();
+    await waitUntil(() => uiStore.getState().toasts.length > 0, 'the failure toast');
+
+    const toasts = uiStore.getState().toasts;
+    expect(toasts[0].type).to.equal('error');
+    expect(toasts[0].message).to.contain('no file dialog available');
+  });
+
+  it('opens the init dialog pre-filled with a dropped folder', async () => {
+    const el = await fixture<LvWelcome>(html`<lv-welcome></lv-welcome>`);
+
+    el.openInitDialog('/projects/new-thing');
+    await el.updateComplete;
+
+    const initDialog = el.shadowRoot!.querySelector('lv-init-dialog') as any;
+    await initDialog.updateComplete;
+    expect(initDialog.path).to.equal('/projects/new-thing');
+    const input = initDialog.shadowRoot.querySelector('input') as HTMLInputElement;
+    expect(input.value).to.equal('/projects/new-thing');
+  });
+});

--- a/src/components/welcome/lv-welcome.ts
+++ b/src/components/welcome/lv-welcome.ts
@@ -4,14 +4,14 @@
  */
 
 import { LitElement, html, css } from 'lit';
-import { customElement, state, query } from 'lit/decorators.js';
+import { customElement, property, state, query } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import { repositoryStore, type RecentRepository } from '../../stores/index.ts';
 import { workspaceStore } from '../../stores/workspace.store.ts';
 import { openRepository } from '../../services/git.service.ts';
-import { openRepositoryDialog } from '../../services/dialog.service.ts';
+import { openRepositoryDialog, openDialog } from '../../services/dialog.service.ts';
+import { openRepositoryPath } from '../../services/repository-open.service.ts';
 import { showToast } from '../../services/notification.service.ts';
-import { searchIndexService } from '../../services/search-index.service.ts';
 import * as workspaceService from '../../services/workspace.service.ts';
 import type { Workspace } from '../../types/git.types.ts';
 import { loggers } from '../../utils/logger.ts';
@@ -33,6 +33,8 @@ export class LvWelcome extends LitElement {
         flex-direction: column;
         align-items: center;
         height: 100%;
+        /* Anchors the absolutely positioned drop overlay to the screen. */
+        position: relative;
         padding: var(--spacing-xl);
         background: var(--color-bg-primary);
         overflow: auto;
@@ -316,8 +318,51 @@ export class LvWelcome extends LitElement {
         font-size: var(--font-size-xs);
         color: var(--color-text-muted);
       }
+
+      /* Drop affordance: shown while a folder is dragged over the window so
+         the user can see the drop will be accepted before letting go. */
+      .drop-overlay {
+        position: absolute;
+        inset: var(--spacing-md);
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        gap: var(--spacing-sm);
+        border: 2px dashed var(--color-primary);
+        border-radius: var(--radius-lg);
+        background: var(--color-bg-primary);
+        color: var(--color-text-primary);
+        z-index: 10;
+        /* The OS owns the drag; the overlay must never swallow a pointer. */
+        pointer-events: none;
+      }
+
+      .drop-overlay svg {
+        width: 48px;
+        height: 48px;
+        color: var(--color-primary);
+      }
+
+      .drop-overlay-title {
+        font-size: var(--font-size-lg);
+        font-weight: var(--font-weight-medium);
+      }
+
+      .drop-overlay-hint {
+        font-size: var(--font-size-sm);
+        color: var(--color-text-secondary);
+        max-width: 380px;
+        text-align: center;
+      }
     `,
   ];
+
+  /**
+   * True while an OS drag is over the window. Owned by the shell, which is the
+   * one place listening for the webview's drag events.
+   */
+  @property({ type: Boolean }) dragActive = false;
 
   @state() private recentRepositories: RecentRepository[] = [];
   @state() private workspaces: Workspace[] = [];
@@ -372,28 +417,53 @@ export class LvWelcome extends LitElement {
   }
 
   private async openRepoByPath(path: string): Promise<void> {
-    const store = repositoryStore.getState();
-    store.setLoading(true);
-
-    try {
-      const result = await openRepository({ path });
-      if (result.success && result.data) {
-        store.addRepository(result.data);
-        // Build search index in background (non-blocking)
-        searchIndexService.buildIndex(path);
-      } else {
-        const message = result.error?.message ?? 'Failed to open repository';
-        store.setError(message);
-        // repositoryStore.error has no render sink, so surface it directly.
-        showToast(message, 'error');
-      }
-    } catch (err) {
-      const message = err instanceof Error ? err.message : 'Unknown error';
-      store.setError(message);
-      showToast(message, 'error');
-    } finally {
-      store.setLoading(false);
+    // Shared with the window drop handler and the scan results, so tabs, the
+    // recent list and persistence behave identically however the repository
+    // arrived — and an already-open repository focuses its tab.
+    const outcome = await openRepositoryPath(path);
+    if (outcome.status === 'error') {
+      // repositoryStore.error has no render sink, so surface it directly.
+      showToast(outcome.message ?? 'Failed to open repository', 'error');
     }
+  }
+
+  /**
+   * Pick a folder and hand it to the scan dialog. The shell owns that dialog
+   * so a folder dropped while a repository is open reaches the same surface.
+   */
+  private async handleScan(): Promise<void> {
+    try {
+      const result = await openDialog({
+        title: 'Scan Folder for Repositories',
+        directory: true,
+        multiple: false,
+      });
+      const path = Array.isArray(result) ? result[0] : result;
+      // A cancelled picker is not a failure and needs no feedback.
+      if (!path) return;
+      this.dispatchEvent(
+        new CustomEvent<{ path: string; mode: 'scan' }>('open-repository-scan', {
+          detail: { path, mode: 'scan' },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+    } catch (error) {
+      log.error('Error choosing a folder to scan:', error);
+      showToast(
+        error instanceof Error ? error.message : 'Failed to choose a folder to scan',
+        'error',
+      );
+    }
+  }
+
+  /**
+   * Open the init dialog, optionally pre-filled. Called by the shell when a
+   * dropped folder is not a repository and the user chooses to initialize it —
+   * while no repository is open this component owns the only init dialog.
+   */
+  public openInitDialog(path?: string): void {
+    this.initDialog.open(path);
   }
 
   private handleClone(): void {
@@ -497,6 +567,21 @@ export class LvWelcome extends LitElement {
       <lv-clone-dialog></lv-clone-dialog>
       <lv-init-dialog></lv-init-dialog>
 
+      ${this.dragActive
+        ? html`
+            <div class="drop-overlay" role="status">
+              <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <path d="M22 19a2 2 0 0 1-2 2H4a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h5l2 3h9a2 2 0 0 1 2 2z"></path>
+              </svg>
+              <div class="drop-overlay-title">Drop a folder to open it</div>
+              <div class="drop-overlay-hint">
+                Git repositories open straight away; any other folder can be scanned or
+                initialized.
+              </div>
+            </div>
+          `
+        : ''}
+
       <div class="welcome-content">
         <img class="mascot" src="${mascotImage}" alt="Leviathan - Dragon wrapped around a tower" />
         <div class="logo">Leviathan</div>
@@ -537,6 +622,18 @@ export class LvWelcome extends LitElement {
               <line x1="5" y1="12" x2="19" y2="12"></line>
             </svg>
             <span>Init</span>
+          </button>
+
+          <button
+            class="action-btn"
+            @click=${this.handleScan}
+            ?disabled=${this.isLoading}
+          >
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+              <circle cx="11" cy="11" r="7"></circle>
+              <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
+            </svg>
+            <span>Scan</span>
           </button>
 
           <button

--- a/src/services/__tests__/window-drop.service.test.ts
+++ b/src/services/__tests__/window-drop.service.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Tests for opening repositories dropped onto the window.
+ *
+ * The webview's `tauri://drag-drop` event cannot be produced in this
+ * environment, so the listener wiring is covered by the E2E suite (which can
+ * emit backend events through the Tauri mock) and everything the drop DOES is
+ * covered here, against the same handler the listener calls.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
+const mockResponses: Record<string, (args: Record<string, unknown>) => unknown> = {};
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCallArgs.push({ command, args: args || {} });
+    const handler = mockResponses[command];
+    try {
+      return Promise.resolve(handler ? handler(args || {}) : null);
+    } catch (err) {
+      return Promise.reject(err);
+    }
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect } from '@open-wc/testing';
+import {
+  handleDroppedPaths,
+  offerDirectoryScan,
+  REPOSITORY_SCAN_OFFER_EVENT,
+} from '../window-drop.service.ts';
+import { repositoryStore, uiStore } from '../../stores/index.ts';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+function classification(
+  path: string,
+  overrides: Partial<{
+    exists: boolean;
+    isDirectory: boolean;
+    isRepository: boolean;
+    isBare: boolean;
+  }> = {},
+) {
+  return {
+    path,
+    name: path.split('/').pop(),
+    exists: true,
+    isDirectory: true,
+    isRepository: true,
+    isBare: false,
+    ...overrides,
+  };
+}
+
+function mockRepoPayload(path: string) {
+  return {
+    path,
+    name: path.split('/').pop(),
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+/** Classify every path with the same shape unless `perPath` overrides it. */
+function mockClassifications(perPath: Record<string, ReturnType<typeof classification>>): void {
+  mockResponses['classify_repository_path'] = (args) => {
+    const path = args.path as string;
+    return perPath[path] ?? classification(path);
+  };
+}
+
+function toastMessages(): string[] {
+  return uiStore.getState().toasts.map((t) => t.message);
+}
+
+describe('window drop handler', () => {
+  beforeEach(() => {
+    invokeCallArgs.length = 0;
+    for (const key of Object.keys(mockResponses)) {
+      delete mockResponses[key];
+    }
+    uiStore.setState({ toasts: [] });
+    repositoryStore.getState().reset();
+    mockResponses['open_repository'] = (args) => mockRepoPayload(args.path as string);
+  });
+
+  it('opens a dropped repository and says so', async () => {
+    mockClassifications({});
+
+    const outcome = await handleDroppedPaths(['/repos/alpha']);
+
+    expect(outcome.opened).to.deep.equal(['/repos/alpha']);
+    const state = repositoryStore.getState();
+    expect(state.openRepositories.length).to.equal(1);
+    expect(state.openRepositories[0].repository.path).to.equal('/repos/alpha');
+    const toasts = uiStore.getState().toasts;
+    expect(toasts.length).to.equal(1);
+    expect(toasts[0].type).to.equal('success');
+    expect(toasts[0].message).to.contain('alpha');
+  });
+
+  it('offers a scan for a folder that is not a repository', async () => {
+    mockClassifications({
+      '/projects': classification('/projects', { isRepository: false }),
+    });
+
+    const offers: string[] = [];
+    const listener = (e: Event) => offers.push((e as CustomEvent<{ path: string }>).detail.path);
+    window.addEventListener(REPOSITORY_SCAN_OFFER_EVENT, listener);
+    try {
+      const outcome = await handleDroppedPaths(['/projects']);
+      expect(outcome.notRepositories).to.deep.equal(['/projects']);
+    } finally {
+      window.removeEventListener(REPOSITORY_SCAN_OFFER_EVENT, listener);
+    }
+
+    expect(offers).to.deep.equal(['/projects']);
+    expect(repositoryStore.getState().openRepositories.length).to.equal(0);
+    // The offer dialog IS the feedback; a toast on top of it would be noise.
+    expect(uiStore.getState().toasts.length).to.equal(0);
+  });
+
+  it('focuses the existing tab instead of opening a repository twice', async () => {
+    mockClassifications({});
+    await handleDroppedPaths(['/repos/alpha']);
+    await handleDroppedPaths(['/repos/beta']);
+    uiStore.setState({ toasts: [] });
+    const openCallsBefore = invokeCallArgs.filter((c) => c.command === 'open_repository').length;
+
+    const outcome = await handleDroppedPaths(['/repos/alpha']);
+
+    expect(outcome.alreadyOpen).to.deep.equal(['/repos/alpha']);
+    expect(outcome.opened).to.deep.equal([]);
+    const state = repositoryStore.getState();
+    expect(state.openRepositories.length).to.equal(2, 'no duplicate tab');
+    expect(state.openRepositories[state.activeIndex].repository.path).to.equal('/repos/alpha');
+    expect(
+      invokeCallArgs.filter((c) => c.command === 'open_repository').length,
+      'an already-open repository is not re-opened over IPC',
+    ).to.equal(openCallsBefore);
+    const toasts = uiStore.getState().toasts;
+    expect(toasts.length).to.equal(1);
+    expect(toasts[0].type).to.equal('info');
+    expect(toasts[0].message).to.contain('already open');
+  });
+
+  it('handles a mixed drop: opens the repositories and reports the rest', async () => {
+    mockClassifications({
+      '/repos/beta': classification('/repos/beta', { isRepository: false }),
+      '/repos/notes.txt': classification('/repos/notes.txt', {
+        isDirectory: false,
+        isRepository: false,
+      }),
+      '/repos/gone': classification('/repos/gone', {
+        exists: false,
+        isDirectory: false,
+        isRepository: false,
+      }),
+    });
+
+    const outcome = await handleDroppedPaths([
+      '/repos/alpha',
+      '/repos/gamma',
+      '/repos/beta',
+      '/repos/notes.txt',
+      '/repos/gone',
+    ]);
+
+    expect(outcome.opened).to.deep.equal(['/repos/alpha', '/repos/gamma']);
+    expect(outcome.notRepositories).to.deep.equal(['/repos/beta']);
+    expect(outcome.files).to.deep.equal(['/repos/notes.txt']);
+    expect(outcome.missing).to.deep.equal(['/repos/gone']);
+    expect(repositoryStore.getState().openRepositories.length).to.equal(2);
+
+    const messages = toastMessages();
+    expect(messages.some((m) => m.includes('Opened 2 repositories'))).to.equal(true);
+    expect(messages.some((m) => m.includes('no longer exists'))).to.equal(true);
+    expect(messages.some((m) => m.includes('is a file'))).to.equal(true);
+    expect(messages.some((m) => m.includes('not a Git repository'))).to.equal(true);
+  });
+
+  it('offers a scan from the toast when several folders are not repositories', async () => {
+    mockClassifications({
+      '/a': classification('/a', { isRepository: false }),
+      '/b': classification('/b', { isRepository: false }),
+    });
+
+    await handleDroppedPaths(['/a', '/b']);
+
+    const toasts = uiStore.getState().toasts;
+    expect(toasts.length).to.equal(1);
+    expect(toasts[0].message).to.contain('2 dropped folders');
+    expect(toasts[0].action?.label).to.equal('Scan folder');
+
+    const offers: string[] = [];
+    const listener = (e: Event) => offers.push((e as CustomEvent<{ path: string }>).detail.path);
+    window.addEventListener(REPOSITORY_SCAN_OFFER_EVENT, listener);
+    try {
+      toasts[0].action?.callback();
+    } finally {
+      window.removeEventListener(REPOSITORY_SCAN_OFFER_EVENT, listener);
+    }
+    expect(offers).to.deep.equal(['/a']);
+  });
+
+  it('reports a repository that cannot be opened', async () => {
+    mockClassifications({});
+    mockResponses['open_repository'] = () => {
+      throw new Error('failed to open repository: permission denied');
+    };
+
+    const outcome = await handleDroppedPaths(['/repos/locked']);
+
+    expect(outcome.failures.length).to.equal(1);
+    expect(outcome.failures[0].message).to.contain('permission denied');
+    expect(repositoryStore.getState().openRepositories.length).to.equal(0);
+    const toasts = uiStore.getState().toasts;
+    expect(toasts.length).to.equal(1);
+    expect(toasts[0].type).to.equal('error');
+    expect(toasts[0].message).to.contain('permission denied');
+  });
+
+  it('reports a path that could not even be inspected', async () => {
+    mockResponses['classify_repository_path'] = () => {
+      throw new Error('backend unavailable');
+    };
+
+    const outcome = await handleDroppedPaths(['/repos/alpha']);
+
+    expect(outcome.failures.length).to.equal(1);
+    expect(uiStore.getState().toasts[0].type).to.equal('error');
+    expect(uiStore.getState().toasts[0].message).to.contain('backend unavailable');
+  });
+
+  it('does nothing for an empty drop', async () => {
+    const outcome = await handleDroppedPaths([]);
+
+    expect(outcome.opened).to.deep.equal([]);
+    expect(uiStore.getState().toasts.length).to.equal(0);
+    expect(invokeCallArgs.length).to.equal(0);
+  });
+
+  it('dispatches the scan offer on the window', () => {
+    const offers: string[] = [];
+    const listener = (e: Event) => offers.push((e as CustomEvent<{ path: string }>).detail.path);
+    window.addEventListener(REPOSITORY_SCAN_OFFER_EVENT, listener);
+    try {
+      offerDirectoryScan('/somewhere');
+    } finally {
+      window.removeEventListener(REPOSITORY_SCAN_OFFER_EVENT, listener);
+    }
+    expect(offers).to.deep.equal(['/somewhere']);
+  });
+});

--- a/src/services/repo-scan.service.ts
+++ b/src/services/repo-scan.service.ts
@@ -1,0 +1,91 @@
+/**
+ * Repository Discovery Service
+ *
+ * Thin wrapper over the backend's repository-discovery commands: classifying a
+ * dropped path, and scanning a folder for repositories (with progress and
+ * cancellation, since the folder a user picks can be their whole home
+ * directory).
+ */
+
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { invokeCommand } from './tauri-api.ts';
+import type { CommandResult } from '../types/api.types.ts';
+
+export interface DiscoveredRepository {
+  path: string;
+  name: string;
+  isBare: boolean;
+}
+
+export interface RepositoryScanResult {
+  root: string;
+  repositories: DiscoveredRepository[];
+  scannedDirectories: number;
+  /** The scan hit a limit (results or directories) and stopped early. */
+  truncated: boolean;
+  /** The user cancelled; `repositories` holds what was found so far. */
+  cancelled: boolean;
+}
+
+export interface RepositoryScanProgress {
+  scannedDirectories: number;
+  found: number;
+  currentPath: string;
+}
+
+export interface PathClassification {
+  path: string;
+  name: string;
+  exists: boolean;
+  isDirectory: boolean;
+  isRepository: boolean;
+  isBare: boolean;
+}
+
+/** What a path dropped on the window is, so each case can be reported. */
+export async function classifyRepositoryPath(
+  path: string,
+): Promise<CommandResult<PathClassification>> {
+  return invokeCommand<PathClassification>('classify_repository_path', { path });
+}
+
+/** Walk `path` looking for repositories. Bounded and cancellable in the backend. */
+export async function scanForRepositories(
+  path: string,
+  maxDepth?: number,
+): Promise<CommandResult<RepositoryScanResult>> {
+  return invokeCommand<RepositoryScanResult>('scan_for_repositories', { path, maxDepth });
+}
+
+/** Ask the in-flight scan to stop. It still returns what it found. */
+export async function cancelRepositoryScan(): Promise<CommandResult<null>> {
+  return invokeCommand<null>('cancel_repository_scan');
+}
+
+/**
+ * Subscribe to scan progress. Resolves to a no-op unlisten outside Tauri (unit
+ * tests, the Vite dev server) so callers never have to branch on the
+ * environment.
+ */
+export async function onRepositoryScanProgress(
+  handler: (progress: RepositoryScanProgress) => void,
+): Promise<UnlistenFn> {
+  try {
+    const unlisten = await listen<RepositoryScanProgress>('repository-scan-progress', (event) => {
+      handler(event.payload);
+    });
+    // Teardown must never throw at the caller: `unlisten` reaches into the
+    // event plugin's internals, which are absent outside a real webview.
+    return () => {
+      void (async () => {
+        try {
+          await unlisten();
+        } catch {
+          /* the listener dies with the webview anyway */
+        }
+      })();
+    };
+  } catch {
+    return () => {};
+  }
+}

--- a/src/services/repository-open.service.ts
+++ b/src/services/repository-open.service.ts
@@ -1,0 +1,66 @@
+/**
+ * Repository Open Service
+ *
+ * The single way a repository path becomes an open tab. The welcome screen,
+ * the window drop handler and the scan results list all go through here, so
+ * tabs, persistence and the recent list stay in step no matter which entry
+ * point the user used — and so an already-open repository focuses its tab
+ * instead of being opened twice.
+ */
+
+import { openRepository } from './git.service.ts';
+import { searchIndexService } from './search-index.service.ts';
+import { repositoryStore } from '../stores/index.ts';
+
+export type OpenRepositoryStatus = 'opened' | 'already-open' | 'error';
+
+export interface OpenRepositoryOutcome {
+  path: string;
+  status: OpenRepositoryStatus;
+  /** Repository name, once it is known (opened or already open). */
+  name?: string;
+  /** Set only for `error`. */
+  message?: string;
+}
+
+/**
+ * Open `path` as a repository tab.
+ *
+ * Never throws: every failure comes back as an `error` outcome carrying the
+ * message, so batch callers (a multi-path drop, a scan result selection) can
+ * report a summary instead of one toast per path. The store's `error` field is
+ * still written for parity with the rest of the app, but it has no render sink
+ * — callers MUST surface `message` themselves.
+ */
+export async function openRepositoryPath(path: string): Promise<OpenRepositoryOutcome> {
+  const store = repositoryStore.getState();
+
+  // Focus, never duplicate: addRepository would activate the existing tab
+  // anyway, but going through it would also re-run the index build and reorder
+  // the recent list for a repository that is already right there.
+  const existing = store.openRepositories.find((repo) => repo.repository.path === path);
+  if (existing) {
+    store.setActiveByPath(path);
+    return { path, status: 'already-open', name: existing.repository.name };
+  }
+
+  store.setLoading(true);
+  try {
+    const result = await openRepository({ path });
+    if (result.success && result.data) {
+      store.addRepository(result.data);
+      // Build the search index in the background (non-blocking).
+      searchIndexService.buildIndex(path);
+      return { path, status: 'opened', name: result.data.name };
+    }
+    const message = result.error?.message ?? 'Failed to open repository';
+    store.setError(message);
+    return { path, status: 'error', message };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Unknown error';
+    store.setError(message);
+    return { path, status: 'error', message };
+  } finally {
+    repositoryStore.getState().setLoading(false);
+  }
+}

--- a/src/services/window-drop.service.ts
+++ b/src/services/window-drop.service.ts
@@ -1,0 +1,231 @@
+/**
+ * Window Drop Service
+ *
+ * Opens repositories dropped onto the application window. This is the OS-level
+ * drop (a folder dragged from Finder/Explorer), which Tauri reports on the
+ * webview as `tauri://drag-*` — not the in-app branch/commit/file drags handled
+ * by `drag-drop.service.ts`.
+ *
+ * Every dropped path is classified in the backend first so each case can be
+ * reported for what it is: a repository is opened, a folder that is not a
+ * repository offers a scan or an init, and a file, a missing path or a failed
+ * open says so instead of failing silently.
+ */
+
+import { getCurrentWebview } from '@tauri-apps/api/webview';
+import type { UnlistenFn } from '@tauri-apps/api/event';
+import { classifyRepositoryPath } from './repo-scan.service.ts';
+import { openRepositoryPath } from './repository-open.service.ts';
+import { showToast } from './notification.service.ts';
+import { loggers } from '../utils/logger.ts';
+
+const log = loggers.ui;
+
+/**
+ * Window event asking the UI to offer a scan (or an init) for a dropped folder
+ * that is not a repository. Listened to by `app-shell`.
+ */
+export const REPOSITORY_SCAN_OFFER_EVENT = 'repository-scan-offer';
+
+export interface DroppedPathsOutcome {
+  /** Repositories opened as new tabs. */
+  opened: string[];
+  /** Repositories that already had a tab; their tab was focused. */
+  alreadyOpen: string[];
+  /** Existing folders that are not repositories. */
+  notRepositories: string[];
+  /** Paths that do not exist any more. */
+  missing: string[];
+  /** Paths that exist but are files, not folders. */
+  files: string[];
+  /** Paths whose open (or classification) failed, with the reason. */
+  failures: { path: string; message: string }[];
+}
+
+function emptyOutcome(): DroppedPathsOutcome {
+  return {
+    opened: [],
+    alreadyOpen: [],
+    notRepositories: [],
+    missing: [],
+    files: [],
+    failures: [],
+  };
+}
+
+function baseName(path: string): string {
+  const segments = path.split(/[/\\]/).filter(Boolean);
+  return segments[segments.length - 1] || path;
+}
+
+/** Ask the shell to offer a scan/init for `path`. */
+export function offerDirectoryScan(path: string): void {
+  window.dispatchEvent(
+    new CustomEvent<{ path: string }>(REPOSITORY_SCAN_OFFER_EVENT, { detail: { path } }),
+  );
+}
+
+/**
+ * Open every repository among `paths`, and report everything else.
+ *
+ * Sequential on purpose: opening repositories concurrently would interleave
+ * their store writes and their index builds, and a handful of dropped folders
+ * is never enough work to need the parallelism.
+ */
+export async function handleDroppedPaths(paths: string[]): Promise<DroppedPathsOutcome> {
+  const outcome = emptyOutcome();
+  if (paths.length === 0) return outcome;
+
+  for (const path of paths) {
+    const classification = await classifyRepositoryPath(path);
+    if (!classification.success || !classification.data) {
+      outcome.failures.push({
+        path,
+        message: classification.error?.message ?? 'Could not inspect the dropped path',
+      });
+      continue;
+    }
+
+    const info = classification.data;
+    if (!info.exists) {
+      outcome.missing.push(path);
+      continue;
+    }
+    if (!info.isDirectory) {
+      outcome.files.push(path);
+      continue;
+    }
+    if (!info.isRepository) {
+      outcome.notRepositories.push(path);
+      continue;
+    }
+
+    const result = await openRepositoryPath(path);
+    if (result.status === 'opened') {
+      outcome.opened.push(path);
+    } else if (result.status === 'already-open') {
+      outcome.alreadyOpen.push(path);
+    } else {
+      outcome.failures.push({ path, message: result.message ?? 'Failed to open repository' });
+    }
+  }
+
+  reportOutcome(outcome);
+  return outcome;
+}
+
+/** Turn an outcome into user-visible feedback. Every branch must say something. */
+function reportOutcome(outcome: DroppedPathsOutcome): void {
+  const { opened, alreadyOpen, notRepositories, missing, files, failures } = outcome;
+
+  if (opened.length === 1) {
+    showToast(`Opened ${baseName(opened[0])}`, 'success');
+  } else if (opened.length > 1) {
+    showToast(`Opened ${opened.length} repositories`, 'success');
+  }
+
+  if (alreadyOpen.length === 1) {
+    showToast(`${baseName(alreadyOpen[0])} is already open`, 'info');
+  } else if (alreadyOpen.length > 1) {
+    showToast(`${alreadyOpen.length} of the dropped repositories were already open`, 'info');
+  }
+
+  if (missing.length > 0) {
+    showToast(
+      missing.length === 1
+        ? `${missing[0]} no longer exists`
+        : `${missing.length} dropped paths no longer exist`,
+      'error',
+    );
+  }
+
+  if (files.length > 0) {
+    showToast(
+      files.length === 1
+        ? `${baseName(files[0])} is a file — drop a folder to open it as a repository`
+        : `${files.length} dropped items are files — drop a folder to open it as a repository`,
+      'warning',
+    );
+  }
+
+  for (const failure of failures) {
+    showToast(`${baseName(failure.path)}: ${failure.message}`, 'error');
+  }
+
+  if (notRepositories.length === 0) return;
+
+  // A single folder that is not a repository, with nothing else going on, is
+  // the common case (someone dropped their projects folder): take them
+  // straight to the offer instead of making them read a toast first.
+  const nothingElseHappened =
+    opened.length === 0 &&
+    alreadyOpen.length === 0 &&
+    missing.length === 0 &&
+    files.length === 0 &&
+    failures.length === 0;
+
+  if (notRepositories.length === 1 && nothingElseHappened) {
+    offerDirectoryScan(notRepositories[0]);
+    return;
+  }
+
+  showToast(
+    notRepositories.length === 1
+      ? `${baseName(notRepositories[0])} is not a Git repository`
+      : `${notRepositories.length} dropped folders are not Git repositories`,
+    'warning',
+    8000,
+    {
+      label: 'Scan folder',
+      callback: () => offerDirectoryScan(notRepositories[0]),
+    },
+  );
+}
+
+/** True when the Tauri IPC bridge is present (i.e. not a plain browser). */
+function isTauri(): boolean {
+  return typeof window !== 'undefined' && '__TAURI_INTERNALS__' in window;
+}
+
+/** Guards against a second drop landing while the first is still opening. */
+let dropInFlight = false;
+
+/**
+ * Listen for OS folder drops on this window.
+ *
+ * `onDragActiveChange` drives the drop affordance, so the user can see the
+ * window will accept the folder before letting go.
+ */
+export async function startRepositoryDropListener(
+  onDragActiveChange: (active: boolean) => void,
+): Promise<UnlistenFn> {
+  if (!isTauri()) return () => {};
+
+  try {
+    return await getCurrentWebview().onDragDropEvent(async (event) => {
+      const payload = event.payload;
+      if (payload.type === 'enter' || payload.type === 'over') {
+        onDragActiveChange(true);
+        return;
+      }
+
+      onDragActiveChange(false);
+      if (payload.type !== 'drop') return;
+
+      // Ignore a second drop while the first is still being opened: it would
+      // interleave two batches of store writes and two sets of toasts.
+      if (dropInFlight) return;
+      dropInFlight = true;
+      try {
+        await handleDroppedPaths(payload.paths ?? []);
+      } finally {
+        dropInFlight = false;
+      }
+    });
+  } catch (error) {
+    // A webview that refuses the listener must not take the app down with it;
+    // the picker and the recent list still work.
+    log.error('Failed to listen for window file drops:', error);
+    return () => {};
+  }
+}


### PR DESCRIPTION
## What

Two ways to get a repository open that the app was missing, sharing one open path:

**Drop a folder on the window.** Works anywhere in the app, not just the welcome screen, which shows a drop affordance while a drag is over it. Every dropped path is classified in the backend first (`classify_repository_path`), so each case is reported for what it is:

| dropped | result |
| --- | --- |
| a repository | opens as a tab |
| a repository already open | focuses its tab, no duplicate |
| a folder that is not a repository | offers "scan it" or "initialize here" |
| a file | "drop a folder to open it as a repository" |
| a path that is gone | "… no longer exists" |
| an open that fails | the backend's reason, in a toast |

A mixed drop reports every group at once.

**Scan a folder for repositories.** New `Scan` action on the welcome screen, and the same dialog is the offer for a dropped non-repository folder. The results list marks bare repositories and ones already open, nothing is pre-selected (a scan can return hundreds), and `Open selected` opens them; a failure keeps the dialog open and names what failed.

The walk (`scan_for_repositories`) is bounded on every axis — depth 4 (clamped to 8), 200 results, 20 000 directories — skips hidden, dependency and build directories, never follows symlinks (so a `~/link -> ~` loop cannot hang it), stops at the first repository on a branch, and is cancellable with live progress. Hitting a limit or cancelling shows the partial results with a notice instead of throwing them away.

## Why

The welcome screen could only open one repository at a time through a picker, and dropping a folder on the window did nothing at all — no affordance, no error, nothing. Someone with a folder full of clones had to open them one by one.

## Notes

- All three entry points (Open button, drop, scan results) now go through `src/services/repository-open.service.ts`, so tabs, the recent list, persistence and the search index behave identically however the repository arrived.
- Cancelling in the gap before the scan command is sent stops the scan instead of being swallowed by the backend clearing its own flag when a scan starts.
- Closing the dialog mid-scan cancels the backend walk.

## Tests

- Rust: 16 tests in `commands/repo_scan.rs` — depth/result/directory limits, symlink loops, bare repositories, nested repositories, skipped directories, cancellation, progress, classification.
- Unit: 9 for the drop handler, 12 for the scan dialog, 5 for the welcome screen's affordance and Scan action.
- E2E: 10 in `welcome.spec.ts` — scan → select → open, empty scan, scan failure, cancelled picker, drag affordance, dropped repository, dropped non-repository (scan and init), missing path, failed open.
- Gate green: lint (0 errors), typecheck, `npm test` (5522 passed; the 2 `network gate coverage` timeouts fail identically on a clean tree), `cargo fmt --check`, `cargo clippy --all-targets -D warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_