### PR TITLE
fix: stop clipboard copy hanging when writeText never settles

### DIFF
--- a/src/services/__tests__/clipboard.service.test.ts
+++ b/src/services/__tests__/clipboard.service.test.ts
@@ -24,6 +24,7 @@ Object.defineProperty(navigator, 'clipboard', {
     },
     readText: () => Promise.resolve(clipboardText),
   },
+  configurable: true,
   writable: true,
 });
 
@@ -37,6 +38,50 @@ import {
   copyFilePath,
   type CopyResult,
 } from '../git.service.ts';
+
+/**
+ * Swap navigator.clipboard for the duration of a test. Pass undefined to
+ * simulate a browser/WebView that exposes no async clipboard API at all.
+ */
+function replaceClipboard(value: { writeText: (text: string) => Promise<void> } | undefined) {
+  const original = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+  Object.defineProperty(navigator, 'clipboard', { value, configurable: true, writable: true });
+  return () => {
+    if (original) {
+      Object.defineProperty(navigator, 'clipboard', original);
+    } else {
+      Object.defineProperty(navigator, 'clipboard', {
+        value: undefined,
+        configurable: true,
+        writable: true,
+      });
+    }
+  };
+}
+
+/**
+ * Stub document.execCommand so the legacy fallback path is observable and
+ * deterministic — a real execCommand('copy') depends on browser policy.
+ * Records the value staged in the off-screen textarea at call time.
+ */
+function stubExecCommand(result: boolean) {
+  const original = document.execCommand;
+  const calls: string[] = [];
+  const stagedValues: string[] = [];
+  document.execCommand = ((command: string) => {
+    calls.push(command);
+    const staged = document.activeElement;
+    if (staged instanceof HTMLTextAreaElement) stagedValues.push(staged.value);
+    return result;
+  }) as typeof document.execCommand;
+  return {
+    calls,
+    stagedValues,
+    restore: () => {
+      document.execCommand = original;
+    },
+  };
+}
 
 describe('git.service - Clipboard operations', () => {
   beforeEach(() => {
@@ -55,26 +100,86 @@ describe('git.service - Clipboard operations', () => {
       expect(clipboardText).to.equal('test text');
     });
 
-    it('handles clipboard errors', async () => {
-      // Temporarily break clipboard
-      const originalClipboard = navigator.clipboard;
-      Object.defineProperty(navigator, 'clipboard', {
-        value: {
-          writeText: () => Promise.reject(new Error('Clipboard access denied')),
-        },
-        writable: true,
+    it('falls back to the legacy copy when the async API rejects', async () => {
+      const restoreClipboard = replaceClipboard({
+        writeText: () => Promise.reject(new Error('Clipboard access denied')),
       });
+      const execCommand = stubExecCommand(true);
+
+      const result = await copyToClipboard('fallback text');
+
+      expect(result.success).to.be.true;
+      expect(result.data?.text).to.equal('fallback text');
+      expect(execCommand.calls).to.deep.equal(['copy']);
+      expect(execCommand.stagedValues).to.deep.equal(['fallback text']);
+
+      execCommand.restore();
+      restoreClipboard();
+    });
+
+    it('falls back to the legacy copy when navigator.clipboard is unavailable', async () => {
+      const restoreClipboard = replaceClipboard(undefined);
+      const execCommand = stubExecCommand(true);
+
+      const result = await copyToClipboard('no async api');
+
+      expect(result.success).to.be.true;
+      expect(execCommand.stagedValues).to.deep.equal(['no async api']);
+
+      execCommand.restore();
+      restoreClipboard();
+    });
+
+    it('does not hang when the async API never settles', async () => {
+      // Headless browsers (and WebViews without clipboard-write permission)
+      // leave writeText pending forever rather than rejecting. The call must
+      // still resolve, via the fallback.
+      const restoreClipboard = replaceClipboard({
+        writeText: () => new Promise<void>(() => {}),
+      });
+      const execCommand = stubExecCommand(true);
+
+      const result = await copyToClipboard('never settles');
+
+      expect(result.success).to.be.true;
+      expect(execCommand.stagedValues).to.deep.equal(['never settles']);
+
+      execCommand.restore();
+      restoreClipboard();
+    });
+
+    it('reports a clipboard error when both the async API and the fallback fail', async () => {
+      const restoreClipboard = replaceClipboard({
+        writeText: () => Promise.reject(new Error('Clipboard access denied')),
+      });
+      const execCommand = stubExecCommand(false);
 
       const result = await copyToClipboard('test');
 
       expect(result.success).to.be.false;
       expect(result.error?.code).to.equal('CLIPBOARD_ERROR');
+      expect(result.error?.message).to.equal('Clipboard access denied');
 
-      // Restore clipboard
-      Object.defineProperty(navigator, 'clipboard', {
-        value: originalClipboard,
-        writable: true,
-      });
+      execCommand.restore();
+      restoreClipboard();
+    });
+
+    it('leaves no staging element behind and restores focus', async () => {
+      const focusTarget = document.createElement('button');
+      document.body.appendChild(focusTarget);
+      focusTarget.focus();
+
+      const restoreClipboard = replaceClipboard(undefined);
+      const execCommand = stubExecCommand(true);
+
+      await copyToClipboard('tidy up');
+
+      expect(document.querySelectorAll('textarea[aria-hidden="true"]').length).to.equal(0);
+      expect(document.activeElement).to.equal(focusTarget);
+
+      execCommand.restore();
+      restoreClipboard();
+      focusTarget.remove();
     });
   });
 

--- a/src/services/__tests__/network-gate-coverage.test.ts
+++ b/src/services/__tests__/network-gate-coverage.test.ts
@@ -28,6 +28,24 @@ const invoked: string[] = [];
   transformCallback: () => 0,
 };
 
+/**
+ * The sweep calls `copyToClipboard` like every other export. The real async
+ * clipboard API leaves its promise pending in a headless browser — no
+ * permission, no user gesture — which used to hang both sweeps until the
+ * 10 s mocha timeout, and got written off as load flakiness for months.
+ *
+ * `copyToClipboard` now bounds that wait itself, so the sweep no longer hangs
+ * either way; this stub keeps it instant and deterministic instead of paying
+ * the timeout, exactly as `__TAURI_INTERNALS__` above stubs the IPC layer.
+ * The sweep still calls the function and still checks what it invoked, so
+ * nothing the test guards is weakened.
+ */
+Object.defineProperty(navigator, 'clipboard', {
+  value: { writeText: () => Promise.resolve(), readText: () => Promise.resolve('') },
+  configurable: true,
+  writable: true,
+});
+
 import { expect } from '@open-wc/testing';
 import * as gitService from '../git.service.ts';
 import { settingsStore } from '../../stores/settings.store.ts';

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -7585,30 +7585,117 @@ export type CommitInfoFormat =
 export type FilePathFormat = "relative" | "absolute" | "filename";
 
 /**
+ * How long to wait for `navigator.clipboard.writeText` before giving up on it.
+ *
+ * The async clipboard API does not always reject when it cannot write: without
+ * clipboard-write permission, outside a secure context, or outside a user
+ * gesture it can leave its promise pending forever. An unbounded `await` there
+ * means the caller never returns, so the user clicks "Copy" and gets neither a
+ * clipboard entry nor an error — the operation just disappears. Bound the wait
+ * and fall through to the synchronous fallback below instead.
+ */
+const CLIPBOARD_WRITE_TIMEOUT_MS = 2000;
+
+/**
+ * Last-resort clipboard write using the legacy synchronous API.
+ *
+ * `document.execCommand("copy")` is deprecated but still implemented
+ * everywhere, works without the clipboard-write permission, and — being
+ * synchronous — cannot hang. It only copies the current selection, so the text
+ * is staged in an off-screen textarea first.
+ *
+ * @returns true when the copy was accepted
+ */
+function copyToClipboardFallback(text: string): boolean {
+  if (typeof document === "undefined" || !document.body) {
+    return false;
+  }
+
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  // Keep it out of view and out of the layout, but still focusable/selectable —
+  // `display: none` and `visibility: hidden` elements cannot hold a selection.
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "-9999px";
+  textarea.style.left = "-9999px";
+  textarea.style.opacity = "0";
+  textarea.setAttribute("aria-hidden", "true");
+
+  const previouslyFocused = document.activeElement as HTMLElement | null;
+  document.body.appendChild(textarea);
+
+  try {
+    textarea.select();
+    textarea.setSelectionRange(0, text.length);
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    textarea.remove();
+    // Restore focus so the fallback is invisible to the user.
+    previouslyFocused?.focus?.();
+  }
+}
+
+/**
  * Copy text to the system clipboard
- * Uses the browser's clipboard API for better reliability
+ *
+ * Prefers the async clipboard API and falls back to the legacy synchronous
+ * copy when it is missing, rejects, or never settles. Always resolves — a
+ * clipboard write must never leave a caller (or a test) awaiting forever.
+ *
+ * Note: this deliberately does not route through the `copy_to_clipboard` Tauri
+ * command. That command does not touch the system clipboard; it echoes the
+ * text back, so using it would report success while copying nothing.
+ *
  * @param text Text to copy
  * @returns Result with the copied text
  */
 export async function copyToClipboard(
   text: string,
 ): Promise<CommandResult<CopyResult>> {
-  try {
-    await navigator.clipboard.writeText(text);
+  let asyncError: unknown;
+
+  if (typeof navigator !== "undefined" && navigator.clipboard?.writeText) {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      const wrote = await Promise.race([
+        navigator.clipboard.writeText(text).then(() => true),
+        new Promise<boolean>((resolve) => {
+          timer = setTimeout(() => resolve(false), CLIPBOARD_WRITE_TIMEOUT_MS);
+        }),
+      ]);
+      if (wrote) {
+        return {
+          success: true,
+          data: { success: true, text },
+        };
+      }
+    } catch (error) {
+      asyncError = error;
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
+  }
+
+  if (copyToClipboardFallback(text)) {
     return {
       success: true,
       data: { success: true, text },
     };
-  } catch (error) {
-    return {
-      success: false,
-      error: {
-        code: "CLIPBOARD_ERROR",
-        message:
-          error instanceof Error ? error.message : "Failed to copy to clipboard",
-      },
-    };
   }
+
+  return {
+    success: false,
+    error: {
+      code: "CLIPBOARD_ERROR",
+      message:
+        asyncError instanceof Error
+          ? asyncError.message
+          : "Failed to copy to clipboard",
+    },
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary

- **Copying can no longer silently do nothing.** `copyToClipboard` awaited `navigator.clipboard.writeText` unconditionally. That promise does not always settle — without clipboard-write permission, outside a secure context, or outside a user gesture it can stay pending forever rather than rejecting. The caller then never returns, so a user who clicks Copy gets neither a clipboard entry nor an error toast; the operation just vanishes.
- The async wait is now bounded (2 s), `navigator.clipboard` being absent is guarded, and there is a synchronous `document.execCommand("copy")` fallback staged in an off-screen textarea (focus is restored and the element removed). `copyToClipboard` always resolves — either success or a `CLIPBOARD_ERROR` the UI can show.
- **This is what has been failing the "network gate coverage" sweep.** Two tests in `src/services/__tests__/network-gate-coverage.test.ts` have been red for the entire life of this workstream and were repeatedly written off as "known baseline timeouts under load". They are not flaky and not load-related: they reproduce 2/2 on an idle machine. The sweep calls **every** export of `git.service`, `copyToClipboard` is one of them, and in headless Chromium `writeText` never settles — so both sweeps hung until the 10 s mocha timeout. Every PR since has been reading a dirty baseline, and the one test that proves no exported function bypasses the offline gate has been giving no signal at all.
- The sweep now also stubs `navigator.clipboard`, exactly as it already stubs `__TAURI_INTERNALS__`, so it stays instant and deterministic instead of paying the timeout. **Nothing the test guards was weakened** — it still calls every export, still inspects every invoke, and `copyToClipboard` was not excluded from the sweep. Verified: with the stub removed, the sweep still passes on the production fix alone (6 s), so the fix stands on its own and the stub is only there to keep the file fast.

**Why not route through the Tauri command.** `src-tauri/src/commands/clipboard.rs:65` does expose a `copy_to_clipboard` command, but it does not touch the system clipboard — it echoes the text straight back (`Ok(CopyResult { success: true, text })`), and no clipboard-manager plugin or `arboard` dependency is present. Routing the frontend through it would report success while copying nothing, which is strictly worse than the web API. Left as-is; making that command real would mean adding a Tauri clipboard plugin, which is out of scope here.

## Review finding

`copyToClipboard` at `src/services/git.service.ts:7593` called `await navigator.clipboard.writeText(text)` with no availability guard and no bound on how long it may stay pending, so a clipboard write that the browser neither completes nor refuses hangs the caller forever. The two long-standing failures in `src/services/__tests__/network-gate-coverage.test.ts` — `offline mode stops every exported function from reaching a network command` and `the same sweep does reach those commands when offline mode is off` — are that hang, not load: the sweep reaches `copyToClipboard` and never comes back. Every other export in the sweep returns in well under 100 ms.

## Test plan

- [ ] `PW_CHROMIUM_PATH=/opt/pw-browsers/chromium npm test` — **5502 passed, 0 failed** across 267 files (previously 2 failed). The two sweep tests now pass in 1.9 s instead of timing out at 10 s.
- [ ] Five new unit tests in `src/services/__tests__/clipboard.service.test.ts` cover: async API rejects → fallback used; `navigator.clipboard` undefined → fallback used; **writeText never settles → still resolves** (the regression guard for this bug); both paths fail → `CLIPBOARD_ERROR` with the underlying message; staging textarea removed and focus restored.
- [ ] To confirm the diagnosis, `git stash` the `git.service.ts` change and re-run `network-gate-coverage.test.ts` alone on an idle machine — it fails 2/2 deterministically, not intermittently.
- [ ] `npm run lint` (0 errors, 204 pre-existing warnings — unchanged), `npm run typecheck` clean.
- [ ] `cargo fmt --check` clean, `cargo clippy --all-targets -- -D warnings` clean (no Rust changes in this PR).
- [ ] Clipboard-touching E2E on a private port: `e2e/tests/file-status-context-menu.spec.ts` + `e2e/tests/mcp-settings.spec.ts` — 46 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_