### PR TITLE
feat(output-panel): show real git commands instead of IPC names

### DIFF
--- a/e2e/tests/output-panel.spec.ts
+++ b/e2e/tests/output-panel.spec.ts
@@ -334,21 +334,33 @@ test.describe('Output Panel - Error Entry Display', () => {
     await expect(page.locator('lv-output-panel .entry-command.failure')).toHaveCount(2);
   });
 
-  test('failed entry with empty output should expand but show nothing', async ({ page }) => {
+  test('failed entry with empty output should explain the empty row', async ({ page }) => {
     await addFailedEntry(page, 'git checkout nonexistent', '');
     await expect(page.locator('lv-output-panel .entry')).toHaveCount(1);
 
-    // Expand the entry - with empty output, no .entry-output div should render
     await page.locator('lv-output-panel .entry-header').click();
 
-    // The component renders entry-output only when entry.output is truthy
-    // An empty string is falsy, so no output div appears
-    await expect(page.locator('lv-output-panel .entry-output')).toHaveCount(0);
+    // An expanded row is never an unexplained empty box: with nothing captured
+    // the panel says so rather than rendering blank.
+    await expect(page.locator('lv-output-panel .entry-output.empty-output')).toContainText(
+      'Failed with no output'
+    );
 
-    // But the expand icon should still toggle
+    // And the expand icon still toggles
     await expect(
       page.locator('lv-output-panel .entry').first().locator('.expand-icon.expanded')
     ).toBeVisible();
+  });
+
+  test('failed output is styled distinctly from a successful one', async ({ page }) => {
+    await addFailedEntry(page, 'git push origin main', 'error: failed to push some refs');
+    await expect(page.locator('lv-output-panel .entry')).toHaveCount(1);
+
+    await page.locator('lv-output-panel .entry-header').click();
+
+    await expect(page.locator('lv-output-panel .entry-output.failure')).toContainText(
+      'error: failed to push some refs'
+    );
   });
 });
 
@@ -380,12 +392,109 @@ test.describe('Output Panel - In-app integration', () => {
     await expect(promptInput).toBeVisible();
     await promptInput.fill('panel probe');
     await page.locator('lv-prompt-dialog .btn-primary').click();
+
+    // The panel shows a READABLE GIT COMMAND, not the IPC name.
     await expect(
-      appPanel.locator('.entry-command', { hasText: 'create_stash' }).first()
-    ).toBeVisible();
+      appPanel.locator('.entry-command', { hasText: 'git stash push' }).first()
+    ).toContainText('git stash push --include-untracked -m "panel probe"');
+    // The IPC name is still there, as secondary detail.
+    await expect(appPanel.locator('.entry-ipc').first()).toHaveText('create_stash');
 
     // Close button hides the panel again
     await appPanel.locator('.close-btn').click();
     await expect(appPanel).toHaveCount(0);
+  });
+
+  test('a libgit2-backed operation is marked as an equivalent, with a legend', async ({
+    page,
+  }) => {
+    const { AppPage } = await import('../pages/app.page');
+    const app = new AppPage(page);
+
+    await app.executeCommand('Toggle Output Panel');
+    const appPanel = page.locator('lv-app-shell lv-output-panel');
+    await expect(appPanel).toBeVisible();
+
+    await app.executeCommand('Create stash');
+    const promptInput = page.locator('lv-prompt-dialog .prompt-input');
+    await expect(promptInput).toBeVisible();
+    await promptInput.fill('equivalence probe');
+    await page.locator('lv-prompt-dialog .btn-primary').click();
+
+    // git2 did the work — the panel must not imply the CLI ran.
+    await expect(appPanel.locator('.synth-mark').first()).toBeVisible();
+    await expect(appPanel.locator('.entry-command.synthesized').first()).toBeVisible();
+    await expect(appPanel.locator('.legend')).toContainText('libgit2');
+
+    // Timing is shown so a slow operation is visible as one.
+    await expect(appPanel.locator('.entry-duration').first()).toHaveText(/\d/);
+  });
+
+  test('a failing operation shows its git line and its error output', async ({ page }) => {
+    const { injectCommandError } = await import('../fixtures/test-helpers');
+    const { AppPage } = await import('../pages/app.page');
+    const app = new AppPage(page);
+
+    await injectCommandError(
+      page,
+      'create_stash',
+      'error: cannot stash: your index contains uncommitted changes',
+      'STASH_FAILED'
+    );
+
+    await app.executeCommand('Toggle Output Panel');
+    const appPanel = page.locator('lv-app-shell lv-output-panel');
+    await expect(appPanel).toBeVisible();
+
+    await app.executeCommand('Create stash');
+    const promptInput = page.locator('lv-prompt-dialog .prompt-input');
+    await expect(promptInput).toBeVisible();
+    await promptInput.fill('doomed');
+    await page.locator('lv-prompt-dialog .btn-primary').click();
+
+    // The failure is marked, and the git line is still readable
+    const failedEntry = appPanel.locator('.entry').filter({ has: page.locator('.status-dot.failure') }).first();
+    await expect(failedEntry.locator('.entry-command.failure')).toContainText(
+      'git stash push --include-untracked -m doomed'
+    );
+
+    // Expanding it shows the backend's error output, styled as an error
+    await failedEntry.locator('.entry-header').click();
+    await expect(failedEntry.locator('.entry-output.failure')).toContainText(
+      'your index contains uncommitted changes'
+    );
+  });
+
+  test('a credentialed URL in an error is redacted before it reaches the panel', async ({
+    page,
+  }) => {
+    const { injectCommandError } = await import('../fixtures/test-helpers');
+    const { AppPage } = await import('../pages/app.page');
+    const app = new AppPage(page);
+
+    await injectCommandError(
+      page,
+      'create_stash',
+      'failed talking to https://someone:ghp_0123456789abcdefghij@github.com/o/r.git',
+      'AUTH'
+    );
+
+    await app.executeCommand('Toggle Output Panel');
+    const appPanel = page.locator('lv-app-shell lv-output-panel');
+    await expect(appPanel).toBeVisible();
+
+    await app.executeCommand('Create stash');
+    const promptInput = page.locator('lv-prompt-dialog .prompt-input');
+    await expect(promptInput).toBeVisible();
+    await promptInput.fill('leak probe');
+    await page.locator('lv-prompt-dialog .btn-primary').click();
+
+    const failedEntry = appPanel.locator('.entry').filter({ has: page.locator('.status-dot.failure') }).first();
+    await failedEntry.locator('.entry-header').click();
+
+    const output = failedEntry.locator('.entry-output');
+    // The token is gone; the host survives so the entry still says where.
+    await expect(output).toContainText('***@github.com/o/r.git');
+    await expect(output).not.toContainText('ghp_');
   });
 });

--- a/src-tauri/src/commands/bisect.rs
+++ b/src-tauri/src/commands/bisect.rs
@@ -71,7 +71,7 @@ pub struct CulpritCommit {
 /// never advanced to its result step, and the finished search was reachable
 /// only through the danger-styled "Abort Bisect" that discards it. The sibling
 /// CLI shell-outs in merge.rs and worktree.rs already pin this.
-fn git_command(repo_path: &Path) -> std::process::Command {
+fn git_command(repo_path: &Path) -> crate::utils::GitCommand {
     let mut cmd = create_command("git");
     cmd.current_dir(repo_path).env("LC_ALL", "C");
     cmd

--- a/src-tauri/src/commands/lfs.rs
+++ b/src-tauri/src/commands/lfs.rs
@@ -85,7 +85,7 @@ fn build_lfs_command(
     repo_path: &Path,
     args: &[&str],
     token: Option<&str>,
-) -> std::process::Command {
+) -> crate::utils::GitCommand {
     let mut cmd = create_command("git");
     cmd.current_dir(repo_path).arg("lfs").args(args);
 

--- a/src-tauri/src/commands/maintenance.rs
+++ b/src-tauri/src/commands/maintenance.rs
@@ -286,7 +286,7 @@ fn prune_command(
     remote_url: Option<&str>,
     token: Option<&str>,
     dry_run: bool,
-) -> std::process::Command {
+) -> crate::utils::GitCommand {
     let mut cmd = create_command("git");
     cmd.current_dir(path);
     if dry_run {

--- a/src-tauri/src/commands/remote.rs
+++ b/src-tauri/src/commands/remote.rs
@@ -1548,12 +1548,17 @@ fn push_remote_url(path: &str, remote_name: &str) -> Option<String> {
 /// to stderr, and leaving a piped stream unread deadlocks the child once the
 /// pipe buffer fills — the same trap `clone_repository` documents.
 fn run_push_command(
-    mut cmd: std::process::Command,
+    mut cmd: crate::utils::GitCommand,
     monitor: &TransferMonitor,
 ) -> Result<std::process::Output> {
     if monitor.is_cancelled() {
         return Err(LeviathanError::OperationCancelled);
     }
+
+    // The child is driven by hand below so a cancellation can kill it, which
+    // means `GitCommand::output()` never runs and never reports the push to the
+    // Output panel. Time it here and report the result explicitly instead.
+    let started = std::time::Instant::now();
 
     cmd.stdout(std::process::Stdio::piped());
     cmd.stderr(std::process::Stdio::piped());
@@ -1611,11 +1616,13 @@ fn run_push_command(
         }
     };
 
-    Ok(std::process::Output {
+    let output = std::process::Output {
         status,
         stdout: stdout_reader.join().unwrap_or_default(),
         stderr: stderr_reader.join().unwrap_or_default(),
-    })
+    };
+    cmd.report_run(started, &output);
+    Ok(output)
 }
 
 /// Push via git CLI (used for --force-with-lease and --tags which git2 doesn't support)

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -159,7 +159,7 @@ fn build_clone_command(
     filter: Option<&str>,
     single_branch: bool,
     token: Option<&str>,
-) -> std::process::Command {
+) -> crate::utils::GitCommand {
     // `create_command` is what pins `LC_ALL=C`. That is not cosmetic here:
     // `parse_cli_clone_progress` matches git's English stage names
     // ("Receiving objects", "Resolving deltas"). Under a localized git those

--- a/src-tauri/src/commands/submodule.rs
+++ b/src-tauri/src/commands/submodule.rs
@@ -2,12 +2,11 @@
 //! Manage git submodules
 
 use std::path::Path;
-use std::process::Command;
 use tauri::command;
 
 use crate::error::{LeviathanError, Result};
 use crate::utils::cli_safety::reject_flag_like;
-use crate::utils::{apply_token_credential_helper, create_command};
+use crate::utils::{apply_token_credential_helper, create_command, GitCommand};
 
 /// Information about a submodule
 #[derive(Debug, Clone, serde::Serialize)]
@@ -75,7 +74,7 @@ fn submodule_command(
     args: &[&str],
     token: Option<&str>,
     token_remote: Option<&str>,
-) -> Command {
+) -> GitCommand {
     let mut cmd = create_command("git");
     cmd.current_dir(repo_path).args(args);
     if let (Some(token_value), Some(remote_name)) = (token, token_remote) {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -144,6 +144,18 @@ pub fn run() {
         .manage(RemoteOpRegistry::default())
         .manage(SharedCommitIndex::default())
         .setup(|app| {
+            // Report every `git` subprocess the app runs to the Output panel.
+            // Installed before anything else in setup so a command run during
+            // startup is not silently dropped. The payload is built (and
+            // redacted) in utils::command; this only carries it to the
+            // frontend, which `src/services/git-output.service.ts` listens for.
+            {
+                let emitter = app.handle().clone();
+                crate::utils::set_git_command_log_sink(move |entry| {
+                    let _ = emitter.emit("git-command-executed", entry);
+                });
+            }
+
             // Initialize AI state with config directory
             let config_dir = app.path().app_config_dir().unwrap_or_default();
             app.manage(create_ai_state(config_dir.clone()));

--- a/src-tauri/src/utils/command.rs
+++ b/src-tauri/src/utils/command.rs
@@ -2,14 +2,466 @@
 //!
 //! This module provides helpers to create commands that don't show
 //! console windows on Windows.
+//!
+//! Every `git` subprocess in the app goes through [`create_command`], which
+//! hands back a [`GitCommand`] rather than a bare [`Command`]. That wrapper is
+//! what lets the Output panel show the real `git` invocation together with its
+//! stdout/stderr: it times the run and reports it to the sink `lib.rs`
+//! installs. Because the wrapper owns `output()`/`status()`, a NEW shell-out is
+//! reported automatically — nothing has to be added to a hand-kept list.
 
-use std::process::Command;
+use std::ffi::OsStr;
+use std::io;
+use std::ops::{Deref, DerefMut};
+use std::path::Path;
+use std::process::{Child, Command, ExitStatus, Output, Stdio};
+use std::sync::OnceLock;
+use std::time::Instant;
+
+/// One executed `git` invocation, as the Output panel shows it.
+///
+/// `command` is the effective command line with secrets redacted — see
+/// [`redact_secrets`]. Environment variables are deliberately NOT included:
+/// the token credential helper reaches git through the ENVIRONMENT (see
+/// [`apply_token_credential_helper`]), so leaving env out of this payload is
+/// what keeps tokens out of the panel by construction rather than by filtering.
+#[derive(Clone, Debug, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GitCommandLog {
+    /// The effective, redacted command line (e.g. `git push --force origin main`)
+    pub command: String,
+    /// Combined stderr/stdout of the run, redacted and truncated
+    pub output: String,
+    pub success: bool,
+    pub duration_ms: u64,
+    /// Repository the command ran in, when it can be determined
+    pub repo_path: Option<String>,
+}
+
+type LogSink = Box<dyn Fn(GitCommandLog) + Send + Sync + 'static>;
+
+static LOG_SINK: OnceLock<LogSink> = OnceLock::new();
+
+/// Install the sink executed `git` invocations are reported to.
+///
+/// Called once from `lib.rs` setup with a closure that emits the
+/// `git-command-executed` Tauri event. Installing is idempotent: a second call
+/// is ignored, so nothing can displace the real sink once the app is running.
+pub fn set_git_command_log_sink(sink: impl Fn(GitCommandLog) + Send + Sync + 'static) {
+    let _ = LOG_SINK.set(Box::new(sink));
+}
+
+/// How much of a command's output is kept. A `git fetch` on a large repo can
+/// print megabytes; the panel only needs enough to be readable, and the event
+/// crosses the IPC boundary on every command.
+const MAX_OUTPUT_CHARS: usize = 8_000;
+
+/// git subcommands whose runs are worth showing in the Output panel.
+///
+/// An ALLOWLIST rather than a denylist of reads on purpose: the app shells out
+/// to `git rev-parse`, `git for-each-ref` and friends constantly, and a
+/// denylist that misses one floods the 100-entry panel with noise the user
+/// never asked for. `config` and `credential` are deliberately absent — they
+/// are plumbing reads, and they are the two subcommands whose arguments are
+/// most likely to name a secret.
+const LOGGED_SUBCOMMANDS: &[&str] = &[
+    "add",
+    "am",
+    "apply",
+    "archive",
+    "bisect",
+    "branch",
+    "bundle",
+    "checkout",
+    "cherry-pick",
+    "clean",
+    "clone",
+    "commit",
+    "difftool",
+    "fetch",
+    "filter-branch",
+    "gc",
+    "init",
+    "lfs",
+    "maintenance",
+    "merge",
+    "mergetool",
+    "mv",
+    "notes",
+    "prune",
+    "pull",
+    "push",
+    "rebase",
+    "reflog",
+    "remote",
+    "repack",
+    "replace",
+    "reset",
+    "restore",
+    "revert",
+    "rm",
+    "sparse-checkout",
+    "stash",
+    "submodule",
+    "switch",
+    "tag",
+    "update-index",
+    "update-ref",
+    "worktree",
+];
+
+/// git's own options that take a SEPARATE value argument, so the subcommand
+/// scan skips two slots rather than mistaking the value for the subcommand.
+const GLOBAL_OPTS_WITH_VALUE: &[&str] = &[
+    "-C",
+    "-c",
+    "--git-dir",
+    "--work-tree",
+    "--namespace",
+    "--exec-path",
+    "--config-env",
+];
+
+/// The subcommand of a `git` invocation — the first argument that is neither a
+/// global option nor a global option's value.
+fn git_subcommand(args: &[String]) -> Option<&str> {
+    let mut i = 0;
+    while i < args.len() {
+        let arg = args[i].as_str();
+        if GLOBAL_OPTS_WITH_VALUE.contains(&arg) {
+            i += 2;
+        } else if arg.starts_with('-') {
+            i += 1;
+        } else {
+            return Some(arg);
+        }
+    }
+    None
+}
+
+/// The repository a `git` invocation targets: its working directory, or the
+/// value of a `-C <path>` global option when no working directory is set.
+fn git_repo_path(cwd: Option<&Path>, args: &[String]) -> Option<String> {
+    if let Some(dir) = cwd {
+        return Some(dir.to_string_lossy().to_string());
+    }
+    args.iter()
+        .position(|a| a == "-C")
+        .and_then(|i| args.get(i + 1))
+        .cloned()
+}
+
+/// Quote an argument so the rendered line reads as the tokens git received.
+fn quote_arg(arg: &str) -> String {
+    if arg.is_empty() {
+        return "\"\"".to_string();
+    }
+    if arg
+        .chars()
+        .any(|c| c.is_whitespace() || c == '"' || c == '\'' || c == '\\')
+    {
+        format!("\"{}\"", arg.replace('\\', "\\\\").replace('"', "\\\""))
+    } else {
+        arg.to_string()
+    }
+}
+
+/// Render a `git` invocation the way a user would type it, with every argument
+/// passed through [`redact_secrets`].
+fn format_command_line(program: &str, args: &[String]) -> String {
+    let mut parts = Vec::with_capacity(args.len() + 1);
+    parts.push(program.to_string());
+    for arg in args {
+        parts.push(quote_arg(&redact_secrets(arg)));
+    }
+    parts.join(" ")
+}
+
+/// Patterns for the secrets that can reach a command line or a command's
+/// output, compiled once.
+///
+/// Redaction is a SAFETY NET, not the primary defence: the app's own tokens
+/// reach git through the environment and never as arguments, and env is never
+/// logged. But a user's own remote URL can carry `user:token@host`, and git
+/// echoes remote URLs in its progress and error messages, so everything on its
+/// way to the panel is scrubbed.
+fn secret_patterns() -> &'static [(regex::Regex, &'static str)] {
+    static PATTERNS: OnceLock<Vec<(regex::Regex, &'static str)>> = OnceLock::new();
+    PATTERNS
+        .get_or_init(|| {
+            vec![
+                // Credentials embedded in a URL: https://user:token@host,
+                // ssh://user@host. The userinfo goes; the host stays so the
+                // line still says which remote it was.
+                (
+                    regex::Regex::new(r"(?i)\b([a-z][a-z0-9+.\-]*://)[^/\s@]+@").unwrap(),
+                    "${1}***@",
+                ),
+                // Provider tokens, by their documented prefixes.
+                (
+                    regex::Regex::new(r"\bgh[pousr]_[A-Za-z0-9]{16,}").unwrap(),
+                    "***",
+                ),
+                (
+                    regex::Regex::new(r"\bgithub_pat_[A-Za-z0-9_]{20,}").unwrap(),
+                    "***",
+                ),
+                (
+                    regex::Regex::new(r"\bglpat-[A-Za-z0-9_\-]{16,}").unwrap(),
+                    "***",
+                ),
+                (
+                    regex::Regex::new(r"\bxox[abprs]-[A-Za-z0-9\-]{10,}").unwrap(),
+                    "***",
+                ),
+                (regex::Regex::new(r"\bsk-[A-Za-z0-9_\-]{16,}").unwrap(), "***"),
+                (regex::Regex::new(r"\bAKIA[0-9A-Z]{16}\b").unwrap(), "***"),
+                // JSON Web Tokens (three base64url segments).
+                (
+                    regex::Regex::new(
+                        r"\bey[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}\.[A-Za-z0-9_\-]{8,}",
+                    )
+                    .unwrap(),
+                    "***",
+                ),
+                // `Bearer <token>` — matched BEFORE the named-secret rule
+                // below, which would otherwise consume the word `Bearer` as
+                // `Authorization`'s value and leave the token itself standing.
+                (
+                    regex::Regex::new(r"(?i)\bbearer\s+[A-Za-z0-9._\-+/=]{6,}").unwrap(),
+                    "Bearer ***",
+                ),
+                // Anything explicitly NAMED as a secret, whatever its shape.
+                (
+                    regex::Regex::new(
+                        r"(?i)\b(password|passwd|token|access[_\-]?token|api[_\-]?key|secret|authorization)([=:]\s*|\s+)\S+",
+                    )
+                    .unwrap(),
+                    "${1}=***",
+                ),
+            ]
+        })
+        .as_slice()
+}
+
+/// Replace anything that looks like a credential with `***`.
+///
+/// Applied to every command line and every captured output before it leaves
+/// the backend, so a credentialed remote URL or a token echoed by git can
+/// never reach the Output panel.
+pub fn redact_secrets(text: &str) -> String {
+    let mut out = text.to_string();
+    for (pattern, replacement) in secret_patterns() {
+        out = pattern.replace_all(&out, *replacement).into_owned();
+    }
+    out
+}
+
+/// Trim captured output to something the panel can hold, keeping the head.
+fn truncate_output(text: &str) -> String {
+    if text.chars().count() <= MAX_OUTPUT_CHARS {
+        return text.to_string();
+    }
+    let kept: String = text.chars().take(MAX_OUTPUT_CHARS).collect();
+    format!("{}\n… (output truncated)", kept)
+}
+
+/// A `Command` that reports its `git` runs to the Output panel.
+///
+/// Deliberately NOT a bare `Command`: the builder methods return `&mut Self`,
+/// so a chained `create_command("git").arg(..).output()` stays on this type and
+/// gets reported. `Deref`/`DerefMut` still expose everything else on `Command`
+/// (`get_args`, `get_envs`, platform extension traits) and let a
+/// `&mut GitCommand` be passed wherever a `&mut Command` is expected.
+pub struct GitCommand {
+    inner: Command,
+    /// Only `git` invocations are reported; `ssh`, `gpg`, `where`/`which` and
+    /// friends are not git commands and have no place in a panel of them.
+    is_git: bool,
+}
+
+impl GitCommand {
+    pub fn arg<S: AsRef<OsStr>>(&mut self, arg: S) -> &mut Self {
+        self.inner.arg(arg);
+        self
+    }
+
+    pub fn args<I, S>(&mut self, args: I) -> &mut Self
+    where
+        I: IntoIterator<Item = S>,
+        S: AsRef<OsStr>,
+    {
+        self.inner.args(args);
+        self
+    }
+
+    pub fn env<K, V>(&mut self, key: K, val: V) -> &mut Self
+    where
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.inner.env(key, val);
+        self
+    }
+
+    pub fn envs<I, K, V>(&mut self, vars: I) -> &mut Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: AsRef<OsStr>,
+        V: AsRef<OsStr>,
+    {
+        self.inner.envs(vars);
+        self
+    }
+
+    pub fn env_remove<K: AsRef<OsStr>>(&mut self, key: K) -> &mut Self {
+        self.inner.env_remove(key);
+        self
+    }
+
+    pub fn env_clear(&mut self) -> &mut Self {
+        self.inner.env_clear();
+        self
+    }
+
+    pub fn current_dir<P: AsRef<Path>>(&mut self, dir: P) -> &mut Self {
+        self.inner.current_dir(dir);
+        self
+    }
+
+    pub fn stdin<S: Into<Stdio>>(&mut self, cfg: S) -> &mut Self {
+        self.inner.stdin(cfg);
+        self
+    }
+
+    pub fn stdout<S: Into<Stdio>>(&mut self, cfg: S) -> &mut Self {
+        self.inner.stdout(cfg);
+        self
+    }
+
+    pub fn stderr<S: Into<Stdio>>(&mut self, cfg: S) -> &mut Self {
+        self.inner.stderr(cfg);
+        self
+    }
+
+    /// The redacted command line for this invocation and the repository it
+    /// runs in, or `None` when it is not a git subcommand worth showing.
+    fn loggable_command_line(&self) -> Option<(String, Option<String>)> {
+        if !self.is_git {
+            return None;
+        }
+        let args: Vec<String> = self
+            .inner
+            .get_args()
+            .map(|a| a.to_string_lossy().to_string())
+            .collect();
+        let subcommand = git_subcommand(&args)?;
+        if !LOGGED_SUBCOMMANDS.contains(&subcommand) {
+            return None;
+        }
+        let program = self.inner.get_program().to_string_lossy().to_string();
+        Some((
+            format_command_line(&program, &args),
+            git_repo_path(self.inner.get_current_dir(), &args),
+        ))
+    }
+
+    fn report(&self, started: Instant, output: String, success: bool) {
+        let Some(sink) = LOG_SINK.get() else {
+            return;
+        };
+        let Some((command, repo_path)) = self.loggable_command_line() else {
+            return;
+        };
+        sink(GitCommandLog {
+            command,
+            output: truncate_output(&redact_secrets(output.trim())),
+            success,
+            duration_ms: started.elapsed().as_millis() as u64,
+            repo_path,
+        });
+    }
+
+    /// Run to completion capturing output, reporting the run to the panel.
+    pub fn output(&mut self) -> io::Result<Output> {
+        let started = Instant::now();
+        let result = self.inner.output();
+        match &result {
+            Ok(out) => {
+                // stderr first: git puts progress and the failure reason there,
+                // which is what a user opening the panel is looking for.
+                let stderr = String::from_utf8_lossy(&out.stderr);
+                let stdout = String::from_utf8_lossy(&out.stdout);
+                let combined = match (stderr.trim().is_empty(), stdout.trim().is_empty()) {
+                    (true, true) => String::new(),
+                    (true, false) => stdout.to_string(),
+                    (false, true) => stderr.to_string(),
+                    (false, false) => format!("{}\n{}", stderr.trim_end(), stdout),
+                };
+                self.report(started, combined, out.status.success());
+            }
+            Err(e) => self.report(started, e.to_string(), false),
+        }
+        result
+    }
+
+    /// Run to completion with inherited stdio. Nothing is captured, so the
+    /// panel entry carries the command and its exit status only.
+    pub fn status(&mut self) -> io::Result<ExitStatus> {
+        let started = Instant::now();
+        let result = self.inner.status();
+        match &result {
+            Ok(status) => self.report(started, String::new(), status.success()),
+            Err(e) => self.report(started, e.to_string(), false),
+        }
+        result
+    }
+
+    /// Start the process without waiting for it. The outcome is unknown here,
+    /// so nothing is reported — a caller that drives the child itself should
+    /// call [`GitCommand::report_run`] once it has the result.
+    pub fn spawn(&mut self) -> io::Result<Child> {
+        self.inner.spawn()
+    }
+
+    /// Report a run this command performed OUTSIDE `output()`/`status()`.
+    ///
+    /// `remote::run_push_command` spawns the child itself so a cancellation can
+    /// kill it mid-transfer; without this hook the operation users most want to
+    /// read in the panel — a force push and the remote's rejection of it —
+    /// would be the one that never appears.
+    pub fn report_run(&self, started: Instant, output: &Output) {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let combined = match (stderr.trim().is_empty(), stdout.trim().is_empty()) {
+            (true, true) => String::new(),
+            (true, false) => stdout.to_string(),
+            (false, true) => stderr.to_string(),
+            (false, false) => format!("{}\n{}", stderr.trim_end(), stdout),
+        };
+        self.report(started, combined, output.status.success());
+    }
+}
+
+impl Deref for GitCommand {
+    type Target = Command;
+
+    fn deref(&self) -> &Command {
+        &self.inner
+    }
+}
+
+impl DerefMut for GitCommand {
+    fn deref_mut(&mut self) -> &mut Command {
+        &mut self.inner
+    }
+}
 
 /// Creates a Command with platform-specific settings to hide console windows.
 ///
 /// On Windows, this sets the CREATE_NO_WINDOW flag to prevent CMD popups.
 /// On other platforms, it returns a standard Command.
-pub fn create_command(program: &str) -> Command {
+pub fn create_command(program: &str) -> GitCommand {
     let mut cmd = Command::new(program);
 
     #[cfg(target_os = "windows")]
@@ -53,7 +505,10 @@ pub fn create_command(program: &str) -> Command {
         }
     }
 
-    cmd
+    GitCommand {
+        inner: cmd,
+        is_git: program == "git",
+    }
 }
 
 /// The host of an SSH remote, in either the `ssh://[user@]host[:port]/path`
@@ -194,6 +649,216 @@ pub fn apply_token_credential_helper(cmd: &mut Command, token: &str, remote_url:
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ---- Output panel: which invocations are reported -------------------
+
+    fn args(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    /// The subcommand has to be found past git's own global options, or a
+    /// `git -C <path> push` would be filed under the path.
+    #[test]
+    fn test_git_subcommand_skips_global_options_and_their_values() {
+        assert_eq!(git_subcommand(&args(&["push", "origin"])).unwrap(), "push");
+        assert_eq!(
+            git_subcommand(&args(&["-C", "/repo", "commit", "-m", "x"])).unwrap(),
+            "commit"
+        );
+        assert_eq!(
+            git_subcommand(&args(&["-c", "core.pager=cat", "--no-pager", "rebase"])).unwrap(),
+            "rebase"
+        );
+        assert!(git_subcommand(&args(&["--version"])).is_none());
+        assert!(git_subcommand(&[]).is_none());
+    }
+
+    /// Reads must not reach the panel: they run constantly and would push every
+    /// real operation out of the 100-entry buffer.
+    #[test]
+    fn test_only_mutating_subcommands_are_reported() {
+        for mutating in ["push", "commit", "rebase", "difftool", "lfs", "stash"] {
+            assert!(
+                LOGGED_SUBCOMMANDS.contains(&mutating),
+                "{mutating} should be reported"
+            );
+        }
+        for read in [
+            "rev-parse",
+            "log",
+            "status",
+            "for-each-ref",
+            "config",
+            "ls-remote",
+        ] {
+            assert!(
+                !LOGGED_SUBCOMMANDS.contains(&read),
+                "{read} should not be reported"
+            );
+        }
+    }
+
+    #[test]
+    fn test_git_repo_path_prefers_the_working_directory_then_dash_c() {
+        assert_eq!(
+            git_repo_path(Some(Path::new("/work/repo")), &args(&["status"])).as_deref(),
+            Some("/work/repo")
+        );
+        assert_eq!(
+            git_repo_path(None, &args(&["-C", "/other/repo", "push"])).as_deref(),
+            Some("/other/repo")
+        );
+        assert!(git_repo_path(None, &args(&["push"])).is_none());
+    }
+
+    /// A commit message with spaces has to survive as ONE token, or the panel
+    /// line reads as a completely different command.
+    #[test]
+    fn test_format_command_line_quotes_multiword_arguments() {
+        assert_eq!(
+            format_command_line("git", &args(&["commit", "-m", "fix the thing"])),
+            "git commit -m \"fix the thing\""
+        );
+        assert_eq!(
+            format_command_line("git", &args(&["push", "--force", "origin", "main"])),
+            "git push --force origin main"
+        );
+    }
+
+    /// A real invocation, end to end: the wrapper must render exactly what it
+    /// is about to run.
+    #[test]
+    fn test_loggable_command_line_renders_the_effective_invocation() {
+        let mut cmd = create_command("git");
+        cmd.current_dir("/work/repo")
+            .arg("push")
+            .args(["--force-with-lease", "origin", "main"]);
+
+        let (line, repo) = cmd.loggable_command_line().expect("push is reported");
+        assert_eq!(line, "git push --force-with-lease origin main");
+        assert_eq!(repo.as_deref(), Some("/work/repo"));
+    }
+
+    /// Non-git programs (ssh, gpg, which) are not git invocations and must
+    /// never appear in a panel of them.
+    #[test]
+    fn test_non_git_programs_are_never_reported() {
+        let mut cmd = create_command("ssh");
+        cmd.arg("push");
+        assert!(cmd.loggable_command_line().is_none());
+    }
+
+    #[test]
+    fn test_read_only_git_invocations_are_not_reported() {
+        let mut cmd = create_command("git");
+        cmd.args(["rev-parse", "HEAD"]);
+        assert!(cmd.loggable_command_line().is_none());
+    }
+
+    // ---- Output panel: redaction ---------------------------------------
+
+    /// The single most likely leak: a user's own remote URL with the token
+    /// baked into it, which git echoes back in its progress and error output.
+    #[test]
+    fn test_redact_secrets_strips_credentials_from_remote_urls() {
+        assert_eq!(
+            redact_secrets("git push https://someone:ghp_abcdefghijklmnopqrst@github.com/o/r.git"),
+            "git push https://***@github.com/o/r.git"
+        );
+        assert_eq!(
+            redact_secrets("remote: https://x-access-token:v1.9f8e7d@github.com/o/r"),
+            "remote: https://***@github.com/o/r"
+        );
+        // The host must SURVIVE — the entry is useless if it cannot say which
+        // remote was involved.
+        assert!(
+            redact_secrets("https://u:p@gitlab.example.com/g/r.git").contains("gitlab.example.com")
+        );
+    }
+
+    /// A URL with no userinfo is not a secret and must be left readable.
+    #[test]
+    fn test_redact_secrets_leaves_plain_urls_alone() {
+        assert_eq!(
+            redact_secrets("git fetch https://github.com/owner/repo.git"),
+            "git fetch https://github.com/owner/repo.git"
+        );
+        assert_eq!(
+            redact_secrets("git commit -m \"fix login for user@example.com\""),
+            "git commit -m \"fix login for user@example.com\""
+        );
+    }
+
+    /// Bare provider tokens, wherever they turn up.
+    #[test]
+    fn test_redact_secrets_strips_bare_provider_tokens() {
+        for secret in [
+            "ghp_0123456789abcdefghij",
+            "gho_0123456789abcdefghij",
+            "github_pat_11ABCDEFG0abcdefghijklmnop",
+            "glpat-abcdefghij0123456789",
+            "xoxb-1234567890-abcdefghij",
+            "sk-abcdefghijklmnopqrstuvwx",
+            "AKIAIOSFODNN7EXAMPLE",
+        ] {
+            let redacted = redact_secrets(&format!("failed with {secret} here"));
+            assert!(
+                !redacted.contains(secret),
+                "{secret} survived redaction: {redacted}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_redact_secrets_strips_jwts_and_named_secrets() {
+        let jwt = "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r";
+        assert!(!redact_secrets(jwt).contains(jwt));
+
+        assert!(!redact_secrets("--password=hunter2").contains("hunter2"));
+        assert!(!redact_secrets("Authorization: Bearer abc123def").contains("abc123def"));
+        assert!(!redact_secrets("api_key=abcd1234").contains("abcd1234"));
+        assert!(!redact_secrets("token: s3cr3tvalue").contains("s3cr3tvalue"));
+    }
+
+    /// Redaction happens while the line is BUILT, so a credentialed URL cannot
+    /// reach the panel even for a command that legitimately takes one.
+    #[test]
+    fn test_command_line_redacts_a_credentialed_url_argument() {
+        let mut cmd = create_command("git");
+        cmd.args([
+            "remote",
+            "add",
+            "origin",
+            "https://user:ghp_abcdefghijklmnopqrst@github.com/o/r.git",
+        ]);
+
+        let (line, _) = cmd.loggable_command_line().expect("remote is reported");
+        assert!(!line.contains("ghp_"), "token survived: {line}");
+        assert!(!line.contains("user:"), "userinfo survived: {line}");
+        assert!(line.contains("github.com/o/r.git"));
+    }
+
+    /// Output is capped so one noisy fetch cannot ship megabytes over IPC.
+    #[test]
+    fn test_truncate_output_caps_long_output() {
+        let long = "x".repeat(MAX_OUTPUT_CHARS + 500);
+        let truncated = truncate_output(&long);
+        assert!(truncated.len() < long.len());
+        assert!(truncated.ends_with("(output truncated)"));
+        assert_eq!(truncate_output("short"), "short");
+    }
+
+    /// The wrapper must still behave like a Command: run the process and hand
+    /// back its real output.
+    #[test]
+    fn test_git_command_still_runs_and_captures_output() {
+        let out = create_command("git")
+            .args(["--version"])
+            .output()
+            .expect("git must be installed for the test suite");
+        assert!(out.status.success());
+        assert!(String::from_utf8_lossy(&out.stdout).starts_with("git version"));
+    }
 
     #[test]
     fn test_credential_url_key_scopes_to_the_host() {

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -5,7 +5,10 @@ mod command;
 mod editor_command;
 
 pub use cli_safety::reject_flag_like;
-pub use command::{apply_token_credential_helper, create_command};
+pub use command::{
+    apply_token_credential_helper, create_command, redact_secrets, set_git_command_log_sink,
+    GitCommand, GitCommandLog,
+};
 pub use editor_command::{copy_file_editor_command, todo_action_editor_command, TODO_FORMAT_ARGS};
 
 /// True once `deadline` has passed. `None` means no deadline.

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -131,6 +131,10 @@ import { settingsStore } from './stores/settings.store.ts';
 import { workspaceStore } from './stores/workspace.store.ts';
 import * as workspaceService from './services/workspace.service.ts';
 import { listenToEvent } from './services/tauri-api.ts';
+import {
+  startGitCommandLogging,
+  stopGitCommandLogging,
+} from './services/git-output.service.ts';
 import { showToast, notifyWarning } from './services/notification.service.ts';
 import { showErrorWithSuggestion } from './services/error-suggestion.service.ts';
 import {
@@ -1837,6 +1841,10 @@ export class AppShell extends LitElement {
     // Set up remote operation event listeners (for auto-fetch notifications)
     gitService.setupRemoteOperationListeners();
 
+    // Record the backend's real `git` invocations (interactive rebase, force
+    // push, difftool, LFS, …) into the Output panel's log.
+    void startGitCommandLogging();
+
     // Load profiles
     gitService.loadProfiles();
 
@@ -1946,6 +1954,7 @@ export class AppShell extends LitElement {
   // Verified: every addEventListener has a corresponding removeEventListener below.
   disconnectedCallback(): void {
     super.disconnectedCallback();
+    stopGitCommandLogging();
     this.unsubscribeRefOps?.();
     this.unsubscribeRefOps = undefined;
     this.unsubscribe?.();

--- a/src/components/panels/__tests__/lv-output-panel.test.ts
+++ b/src/components/panels/__tests__/lv-output-panel.test.ts
@@ -159,4 +159,108 @@ describe('lv-output-panel', () => {
     btn.click();
     expect(closed).to.be.true;
   });
+
+  describe('git command lines', () => {
+    it('shows the git command line rather than the IPC name', async () => {
+      const el = await fixture<LvOutputPanel>(html`<lv-output-panel></lv-output-panel>`);
+      logGitCommand('create_commit', '', true, {
+        gitCommand: 'git commit -m "fix the bug"',
+        synthesized: true,
+        durationMs: 42,
+      });
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.querySelector('.entry-command')!.textContent!.trim()).to.equal(
+        'git commit -m "fix the bug"',
+      );
+      // The IPC name stays visible so the entry is still traceable.
+      expect(el.shadowRoot!.querySelector('.entry-ipc')!.textContent!.trim()).to.equal(
+        'create_commit',
+      );
+    });
+
+    it('marks a synthesised line and explains it in a legend', async () => {
+      const el = await fixture<LvOutputPanel>(html`<lv-output-panel></lv-output-panel>`);
+      logGitCommand('checkout', '', true, {
+        gitCommand: 'git checkout main',
+        synthesized: true,
+      });
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.querySelector('.synth-mark')).to.exist;
+      expect(el.shadowRoot!.querySelector('.entry-command.synthesized')).to.exist;
+      const legend = el.shadowRoot!.querySelector('.legend');
+      expect(legend, 'legend explains the marker').to.exist;
+      expect(legend!.textContent).to.contain('libgit2');
+    });
+
+    it('does not mark — or explain away — a command that really ran', async () => {
+      const el = await fixture<LvOutputPanel>(html`<lv-output-panel></lv-output-panel>`);
+      logGitCommand('git rebase --continue', 'Successfully rebased.', true, {
+        gitCommand: 'git rebase --continue',
+        synthesized: false,
+        durationMs: 180,
+      });
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.querySelector('.synth-mark')).to.not.exist;
+      expect(el.shadowRoot!.querySelector('.entry-ipc')).to.not.exist;
+      expect(el.shadowRoot!.querySelector('.legend'), 'no libgit2 legend').to.not.exist;
+    });
+
+    it('falls back to the IPC name when there is no git line', async () => {
+      const el = await fixture<LvOutputPanel>(html`<lv-output-panel></lv-output-panel>`);
+      logGitCommand('start_auto_fetch', '', true);
+      await el.updateComplete;
+
+      expect(el.shadowRoot!.querySelector('.entry-command')!.textContent!.trim()).to.equal(
+        'start_auto_fetch',
+      );
+      expect(el.shadowRoot!.querySelector('.synth-mark')).to.not.exist;
+    });
+
+    it('shows timing when it was measured, and nothing when it was not', async () => {
+      const el = await fixture<LvOutputPanel>(html`<lv-output-panel></lv-output-panel>`);
+      logGitCommand('a', '', true, { durationMs: 84 });
+      logGitCommand('b', '', true, { durationMs: 1500 });
+      logGitCommand('c', '', true, { durationMs: 65_000 });
+      logGitCommand('d', '', true);
+      await el.updateComplete;
+
+      const durations = Array.from(
+        el.shadowRoot!.querySelectorAll('.entry-duration'),
+      ).map((n) => n.textContent!.trim());
+      // Newest first: c, b, a — `d` has no duration and renders none.
+      expect(durations).to.deep.equal(['1m 05s', '1.5s', '84ms']);
+    });
+
+    it('styles a failed command output distinctly from a successful one', async () => {
+      const el = await fixture<LvOutputPanel>(html`<lv-output-panel></lv-output-panel>`);
+      logGitCommand('push', 'error: failed to push some refs', false, {
+        gitCommand: 'git push origin main',
+        synthesized: false,
+      });
+      await el.updateComplete;
+
+      (el.shadowRoot!.querySelector('.entry-header') as HTMLElement).click();
+      await el.updateComplete;
+
+      const output = el.shadowRoot!.querySelector('.entry-output');
+      expect(output!.classList.contains('failure')).to.be.true;
+      expect(output!.textContent).to.contain('error: failed to push some refs');
+    });
+
+    it('explains an expanded entry that captured no output', async () => {
+      const el = await fixture<LvOutputPanel>(html`<lv-output-panel></lv-output-panel>`);
+      logGitCommand('checkout', '', true, { gitCommand: 'git checkout main' });
+      await el.updateComplete;
+
+      (el.shadowRoot!.querySelector('.entry-header') as HTMLElement).click();
+      await el.updateComplete;
+
+      const output = el.shadowRoot!.querySelector('.entry-output.empty-output');
+      expect(output, 'an expanded row is never an unexplained empty box').to.exist;
+      expect(output!.textContent).to.contain('no output');
+    });
+  });
 });

--- a/src/components/panels/lv-output-panel.ts
+++ b/src/components/panels/lv-output-panel.ts
@@ -26,6 +26,26 @@ function formatTimestamp(ts: number): string {
   return `${hh}:${mm}:${ss}`;
 }
 
+/** Compact duration: `84ms`, `1.2s`, `1m 05s`. */
+export function formatDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60_000) return `${(ms / 1000).toFixed(1)}s`;
+  const minutes = Math.floor(ms / 60_000);
+  const seconds = Math.round((ms % 60_000) / 1000);
+  return `${minutes}m ${String(seconds).padStart(2, '0')}s`;
+}
+
+/**
+ * Marker on a line Leviathan DERIVED rather than executed.
+ *
+ * Most operations run through libgit2, so no `git` process exists to quote.
+ * The panel shows the equivalent command line so the user can see what git was
+ * asked to do — but it must never read as though the CLI ran, hence the `≈`
+ * and the legend at the foot of the panel.
+ */
+const SYNTHESIZED_MARK = '≈';
+
 @customElement('lv-output-panel')
 export class LvOutputPanel extends LitElement {
   static styles = [
@@ -155,6 +175,33 @@ export class LvOutputPanel extends LitElement {
         color: var(--color-error);
       }
 
+      .entry-duration {
+        flex-shrink: 0;
+        color: var(--color-text-muted);
+        font-variant-numeric: tabular-nums;
+      }
+
+      /* The ≈ marker on a line derived from a libgit2 operation rather than one
+         that really ran. Subdued so an executed command reads as the stronger
+         statement it is. */
+      .synth-mark {
+        flex-shrink: 0;
+        color: var(--color-text-muted);
+        cursor: help;
+      }
+
+      .entry-command.synthesized {
+        color: var(--color-text-secondary);
+      }
+
+      /* The IPC command behind a synthesised line, so the entry is still
+         traceable to the operation the app actually invoked. */
+      .entry-ipc {
+        flex-shrink: 0;
+        color: var(--color-text-muted);
+        opacity: 0.8;
+      }
+
       .entry-output {
         padding: var(--spacing-xs) var(--spacing-md) var(--spacing-sm);
         padding-left: calc(var(--spacing-md) + 12px + var(--spacing-sm) + 8px + var(--spacing-sm));
@@ -165,6 +212,29 @@ export class LvOutputPanel extends LitElement {
         border-top: 1px solid var(--color-border);
         max-height: 200px;
         overflow-y: auto;
+      }
+
+      /* A failing command's output is the reason the user opened the panel —
+         give it the error colour and a rule so it is findable at a glance. */
+      .entry-output.failure {
+        color: var(--color-error);
+        border-left: 2px solid var(--color-error);
+      }
+
+      /* Shown when an entry carries nothing but its exit status, so an
+         expanded row is never an empty box the user cannot explain. */
+      .entry-output.empty-output {
+        color: var(--color-text-muted);
+        font-style: italic;
+      }
+
+      .legend {
+        flex-shrink: 0;
+        padding: var(--spacing-xs) var(--spacing-md);
+        border-top: 1px solid var(--color-border);
+        background: var(--color-bg-tertiary);
+        color: var(--color-text-muted);
+        font-size: var(--font-size-xs);
       }
 
       .empty {
@@ -251,23 +321,53 @@ export class LvOutputPanel extends LitElement {
     // Keyed by stable entry id — array positions shift when entries prepend
     const expanded = this.expandedEntries.has(entry.id);
     const statusClass = entry.success ? 'success' : 'failure';
+    // The git line when there is one, otherwise the IPC name — a command with
+    // no synthesis is still worth showing, it just says less.
+    const line = entry.gitCommand ?? entry.command;
+    const synthesized = entry.synthesized === true;
+    const duration =
+      entry.durationMs === undefined ? '' : formatDuration(entry.durationMs);
+    const tooltip = synthesized
+      ? `${line}\n\nEquivalent command — Leviathan performed this with libgit2 (IPC: ${entry.command})`
+      : line;
 
     return html`
       <div class="entry">
         <div
           class="entry-header"
           @click=${() => this.toggleEntry(entry.id)}
-          title="${entry.command}"
+          title="${tooltip}"
         >
           <svg class="expand-icon ${expanded ? 'expanded' : ''}" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
             <polyline points="9 18 15 12 9 6"></polyline>
           </svg>
           <span class="status-dot ${statusClass}"></span>
           <span class="entry-timestamp">${formatTimestamp(entry.timestamp)}</span>
-          <span class="entry-command ${statusClass}">${entry.command}</span>
+          ${synthesized
+            ? html`<span
+                class="synth-mark"
+                aria-label="Equivalent command — performed with libgit2"
+                >${SYNTHESIZED_MARK}</span
+              >`
+            : nothing}
+          <span class="entry-command ${statusClass} ${synthesized ? 'synthesized' : ''}"
+            >${line}</span
+          >
+          ${synthesized && entry.gitCommand
+            ? html`<span class="entry-ipc">${entry.command}</span>`
+            : nothing}
+          ${duration ? html`<span class="entry-duration">${duration}</span>` : nothing}
         </div>
-        ${expanded && entry.output
-          ? html`<div class="entry-output">${entry.output}</div>`
+        ${expanded
+          ? entry.output
+            ? html`<div class="entry-output ${statusClass}">${entry.output}</div>`
+            : // An entry with no captured output still owes the user an
+              // explanation of why the row is empty.
+              html`<div class="entry-output empty-output">
+                ${entry.success
+                  ? 'Completed with no output.'
+                  : 'Failed with no output.'}
+              </div>`
           : nothing}
       </div>
     `;
@@ -275,6 +375,7 @@ export class LvOutputPanel extends LitElement {
 
   render() {
     const visible = this.visibleEntries;
+    const hasSynthesized = visible.some((e) => e.synthesized === true);
     return html`
       <div class="header">
         <span class="header-title">
@@ -313,6 +414,13 @@ export class LvOutputPanel extends LitElement {
           ? html`<div class="empty">No output yet</div>`
           : visible.map((entry) => this.renderEntry(entry))}
       </div>
+      ${hasSynthesized
+        ? html`<div class="legend">
+            ${SYNTHESIZED_MARK} Leviathan runs these operations with libgit2 —
+            the line shown is the equivalent <code>git</code> command, not one
+            that was executed.
+          </div>`
+        : nothing}
     `;
   }
 }

--- a/src/services/__tests__/git-command-format.test.ts
+++ b/src/services/__tests__/git-command-format.test.ts
@@ -1,0 +1,401 @@
+import { expect } from '@open-wc/testing';
+
+import {
+  redactSecrets,
+  synthesizeGitCommand,
+  SYNTHESIZED_COMMANDS,
+} from '../git-command-format.ts';
+
+describe('git-command-format', () => {
+  describe('synthesizeGitCommand — the main operations', () => {
+    const cases: Array<[string, string, Record<string, unknown>, string]> = [
+      // commit
+      [
+        'commit',
+        'create_commit',
+        { path: '/r', message: 'fix the login bug' },
+        'git commit -m "fix the login bug"',
+      ],
+      [
+        'commit with amend and signing',
+        'create_commit',
+        { path: '/r', message: 'redo', amend: true, signCommit: true },
+        'git commit --amend -S -m redo',
+      ],
+      [
+        'empty commit',
+        'create_commit',
+        { path: '/r', message: 'wip', allowEmpty: true },
+        'git commit --allow-empty -m wip',
+      ],
+      [
+        'amend without a new message',
+        'amend_commit',
+        { path: '/r' },
+        'git commit --amend --no-edit',
+      ],
+      [
+        'amend resetting the author',
+        'amend_commit',
+        { path: '/r', message: 'better', resetAuthor: true },
+        'git commit --amend --reset-author -m better',
+      ],
+      ['merge commit', 'commit_merge', { path: '/r' }, 'git commit --no-edit'],
+
+      // staging
+      [
+        'stage',
+        'stage_files',
+        { path: '/r', paths: ['src/a.ts', 'src/b.ts'] },
+        'git add -- src/a.ts src/b.ts',
+      ],
+      ['stage everything', 'stage_files', { path: '/r', paths: [] }, 'git add -A'],
+      [
+        'unstage',
+        'unstage_files',
+        { path: '/r', paths: ['src/a.ts'] },
+        'git restore --staged -- src/a.ts',
+      ],
+      [
+        'discard',
+        'discard_changes',
+        { path: '/r', paths: ['src/a.ts'] },
+        'git restore -- src/a.ts',
+      ],
+
+      // checkout / branches
+      ['checkout', 'checkout', { path: '/r', refName: 'feature/x' }, 'git checkout feature/x'],
+      [
+        'forced checkout',
+        'checkout',
+        { path: '/r', refName: 'main', force: true },
+        'git checkout --force main',
+      ],
+      [
+        'checkout with autostash',
+        'checkout_with_autostash',
+        { path: '/r', refName: 'main', autoStash: true },
+        'git stash push && git checkout main && git stash pop',
+      ],
+      [
+        'checkout without autostash',
+        'checkout_with_autostash',
+        { path: '/r', refName: 'main', autoStash: false },
+        'git checkout main',
+      ],
+      [
+        'branch create',
+        'create_branch',
+        { path: '/r', name: 'feature/y' },
+        'git branch feature/y',
+      ],
+      [
+        'branch create and switch from a start point',
+        'create_branch',
+        { path: '/r', name: 'feature/y', startPoint: 'origin/main', checkout: true },
+        'git checkout -b feature/y origin/main',
+      ],
+      ['branch delete', 'delete_branch', { path: '/r', name: 'old' }, 'git branch -d old'],
+      [
+        'forced branch delete',
+        'delete_branch',
+        { path: '/r', name: 'old', force: true },
+        'git branch -D old',
+      ],
+      [
+        'branch rename',
+        'rename_branch',
+        { path: '/r', oldName: 'a', newName: 'b' },
+        'git branch -m a b',
+      ],
+
+      // merge
+      ['merge', 'merge', { path: '/r', sourceRef: 'feature' }, 'git merge feature'],
+      [
+        'merge --no-ff',
+        'merge',
+        { path: '/r', sourceRef: 'feature', noFf: true },
+        'git merge --no-ff feature',
+      ],
+      [
+        'squash merge with a message',
+        'merge',
+        { path: '/r', sourceRef: 'feature', squash: true, message: 'merge it' },
+        'git merge --squash -m "merge it" feature',
+      ],
+      ['merge abort', 'abort_merge', { path: '/r' }, 'git merge --abort'],
+
+      // rebase
+      ['rebase', 'rebase', { path: '/r', onto: 'main' }, 'git rebase main'],
+      ['rebase continue', 'continue_rebase', { path: '/r' }, 'git rebase --continue'],
+      ['rebase abort', 'abort_rebase', { path: '/r' }, 'git rebase --abort'],
+      ['rebase skip', 'skip_rebase_commit', { path: '/r' }, 'git rebase --skip'],
+
+      // remote transfer
+      ['fetch', 'fetch', { path: '/r', remote: 'origin' }, 'git fetch origin'],
+      [
+        'fetch with prune',
+        'fetch',
+        { path: '/r', remote: 'origin', prune: true },
+        'git fetch --prune origin',
+      ],
+      ['fetch all', 'fetch_all_remotes', { path: '/r' }, 'git fetch --all'],
+      [
+        'pull with rebase',
+        'pull',
+        { path: '/r', remote: 'origin', branch: 'main', rebase: true },
+        'git pull --rebase origin main',
+      ],
+      ['push', 'push', { path: '/r', remote: 'origin', branch: 'main' }, 'git push origin main'],
+      [
+        'push --force-with-lease wins over --force',
+        'push',
+        { path: '/r', remote: 'origin', branch: 'main', force: true, forceWithLease: true },
+        'git push --force-with-lease origin main',
+      ],
+      [
+        'push with upstream and tags',
+        'push',
+        { path: '/r', remote: 'origin', branch: 'main', pushTags: true, setUpstream: true },
+        'git push --tags --set-upstream origin main',
+      ],
+
+      // stash
+      [
+        'stash with a message',
+        'create_stash',
+        { path: '/r', message: 'wip work', includeUntracked: true },
+        'git stash push --include-untracked -m "wip work"',
+      ],
+      ['stash apply', 'apply_stash', { path: '/r', index: 2 }, 'git stash apply stash@{2}'],
+      [
+        'stash apply with drop is a pop',
+        'apply_stash',
+        { path: '/r', index: 0, dropAfter: true },
+        'git stash pop stash@{0}',
+      ],
+      ['stash pop', 'pop_stash', { path: '/r', index: 1 }, 'git stash pop stash@{1}'],
+      ['stash drop', 'drop_stash', { path: '/r', index: 3 }, 'git stash drop stash@{3}'],
+
+      // reset
+      [
+        'hard reset',
+        'reset',
+        { path: '/r', targetRef: 'HEAD~1', mode: 'hard' },
+        'git reset --hard HEAD~1',
+      ],
+      [
+        'soft reset',
+        'reset',
+        { path: '/r', targetRef: 'abc1234', mode: 'soft' },
+        'git reset --soft abc1234',
+      ],
+
+      // cherry-pick / revert
+      [
+        'cherry-pick',
+        'cherry_pick',
+        { path: '/r', commitOid: 'abc1234' },
+        'git cherry-pick abc1234',
+      ],
+      [
+        'cherry-pick a merge without committing',
+        'cherry_pick',
+        { path: '/r', commitOid: 'abc1234', noCommit: true, mainline: 1 },
+        'git cherry-pick --no-commit -m 1 abc1234',
+      ],
+      ['revert', 'revert', { path: '/r', commitOid: 'abc1234' }, 'git revert abc1234'],
+      [
+        'revert a merge',
+        'revert',
+        { path: '/r', commitOid: 'abc1234', mainline: 2 },
+        'git revert -m 2 abc1234',
+      ],
+      ['revert abort', 'abort_revert', { path: '/r' }, 'git revert --abort'],
+
+      // tags
+      ['lightweight tag', 'create_tag', { path: '/r', name: 'v1.0.0' }, 'git tag v1.0.0'],
+      [
+        'annotated tag on a target',
+        'create_tag',
+        { path: '/r', name: 'v1.0.0', message: 'release one', target: 'abc1234' },
+        'git tag -a -m "release one" v1.0.0 abc1234',
+      ],
+      ['tag delete', 'delete_tag', { path: '/r', name: 'v1.0.0' }, 'git tag -d v1.0.0'],
+      [
+        'tag push',
+        'push_tag',
+        { path: '/r', name: 'v1.0.0', remote: 'upstream' },
+        'git push upstream refs/tags/v1.0.0',
+      ],
+      [
+        'remote tag delete',
+        'delete_remote_tag',
+        { path: '/r', name: 'v1.0.0' },
+        'git push origin --delete refs/tags/v1.0.0',
+      ],
+    ];
+
+    for (const [label, command, args, expected] of cases) {
+      it(`renders ${label}`, () => {
+        expect(synthesizeGitCommand(command, args)).to.equal(expected);
+      });
+    }
+
+    it('covers every operation the review called out', () => {
+      for (const command of [
+        'create_commit',
+        'stage_files',
+        'unstage_files',
+        'checkout',
+        'create_branch',
+        'delete_branch',
+        'merge',
+        'rebase',
+        'fetch',
+        'pull',
+        'push',
+        'create_stash',
+        'reset',
+        'cherry_pick',
+        'revert',
+        'create_tag',
+      ]) {
+        expect(SYNTHESIZED_COMMANDS, command).to.include(command);
+      }
+    });
+  });
+
+  describe('synthesizeGitCommand — refusals', () => {
+    it('returns undefined for an operation with no synthesis', () => {
+      // Better the honest IPC name than a half-guessed command line.
+      expect(synthesizeGitCommand('start_auto_fetch', { path: '/r' })).to.equal(undefined);
+      expect(synthesizeGitCommand('store_github_token', { token: 'x' })).to.equal(undefined);
+    });
+
+    it('returns undefined when a required argument is missing', () => {
+      expect(synthesizeGitCommand('checkout', { path: '/r' })).to.equal(undefined);
+      expect(synthesizeGitCommand('merge', { path: '/r' })).to.equal(undefined);
+      expect(synthesizeGitCommand('reset', { path: '/r', targetRef: 'HEAD' })).to.equal(
+        undefined,
+      );
+      expect(synthesizeGitCommand('cherry_pick', {})).to.equal(undefined);
+    });
+
+    it('tolerates missing or malformed args without throwing', () => {
+      expect(synthesizeGitCommand('create_commit', undefined)).to.equal('git commit');
+      expect(synthesizeGitCommand('create_commit', 'not an object')).to.equal('git commit');
+      expect(synthesizeGitCommand('stage_files', { paths: 'nope' })).to.equal('git add -A');
+      expect(synthesizeGitCommand('stage_files', { paths: ['a.ts', 7, null] })).to.equal(
+        'git add -- a.ts',
+      );
+    });
+  });
+
+  describe('synthesizeGitCommand — secrets', () => {
+    // The IPC layer deliberately logs no arguments, because arguments can carry
+    // credentials. Synthesis only reads fields it explicitly names, so a token
+    // is never even read — these tests pin that.
+    it('never renders a token argument', () => {
+      const line = synthesizeGitCommand('push', {
+        path: '/r',
+        remote: 'origin',
+        branch: 'main',
+        token: 'ghp_0123456789abcdefghij',
+      });
+      expect(line).to.equal('git push origin main');
+      expect(line).to.not.contain('ghp_');
+    });
+
+    it('never renders a token on fetch or pull', () => {
+      expect(
+        synthesizeGitCommand('fetch', { path: '/r', remote: 'origin', token: 'secret-token' }),
+      ).to.equal('git fetch origin');
+      expect(
+        synthesizeGitCommand('pull', { path: '/r', remote: 'origin', token: 'secret-token' }),
+      ).to.equal('git pull origin');
+    });
+
+    it('redacts a credentialed remote URL that reaches a rendered field', () => {
+      // A remote can be named by URL rather than by name.
+      const line = synthesizeGitCommand('push', {
+        path: '/r',
+        remote: 'https://someone:ghp_0123456789abcdefghij@github.com/o/r.git',
+        branch: 'main',
+      });
+      expect(line).to.not.contain('ghp_');
+      expect(line).to.not.contain('someone:');
+      expect(line).to.contain('github.com/o/r.git');
+    });
+
+    it('redacts a token pasted into a commit message', () => {
+      const line = synthesizeGitCommand('create_commit', {
+        path: '/r',
+        message: 'rotate key glpat-abcdefghij0123456789',
+      });
+      expect(line).to.not.contain('glpat-');
+      expect(line).to.contain('***');
+    });
+  });
+
+  describe('redactSecrets', () => {
+    it('strips credentials from remote URLs but keeps the host', () => {
+      expect(redactSecrets('https://user:ghp_0123456789abcdefghij@github.com/o/r.git')).to.equal(
+        'https://***@github.com/o/r.git',
+      );
+      expect(redactSecrets('ssh://git@github.com/o/r.git')).to.equal(
+        'ssh://***@github.com/o/r.git',
+      );
+      expect(
+        redactSecrets('remote: rejected https://x-access-token:v1.abc@gitlab.example.com/g/r'),
+      ).to.contain('gitlab.example.com');
+    });
+
+    it('leaves a URL with no credentials readable', () => {
+      expect(redactSecrets('git fetch https://github.com/owner/repo.git')).to.equal(
+        'git fetch https://github.com/owner/repo.git',
+      );
+    });
+
+    it('leaves an email address in a commit message alone', () => {
+      expect(redactSecrets('git commit -m "fix login for user@example.com"')).to.equal(
+        'git commit -m "fix login for user@example.com"',
+      );
+    });
+
+    it('strips bare provider tokens wherever they appear', () => {
+      for (const secret of [
+        'ghp_0123456789abcdefghij',
+        'gho_0123456789abcdefghij',
+        'github_pat_11ABCDEFG0abcdefghijklmnop',
+        'glpat-abcdefghij0123456789',
+        'xoxb-1234567890-abcdefghij',
+        'sk-abcdefghijklmnopqrstuvwx',
+        'AKIAIOSFODNN7EXAMPLE',
+      ]) {
+        const redacted = redactSecrets(`failed with ${secret} here`);
+        expect(redacted, secret).to.not.contain(secret);
+        expect(redacted, secret).to.contain('***');
+      }
+    });
+
+    it('strips JWTs', () => {
+      const jwt =
+        'eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NTY3ODkwIn0.dBjftJeZ4CVPmB92K27uhbUJU1p1r';
+      expect(redactSecrets(`bearer ${jwt}`)).to.not.contain(jwt);
+    });
+
+    it('strips anything explicitly named as a secret', () => {
+      expect(redactSecrets('--password=hunter2')).to.not.contain('hunter2');
+      expect(redactSecrets('Authorization: Bearer abc123def')).to.not.contain('abc123def');
+      expect(redactSecrets('api_key=abcd1234')).to.not.contain('abcd1234');
+      expect(redactSecrets('token: s3cr3tvalue')).to.not.contain('s3cr3tvalue');
+      expect(redactSecrets('access-token abcd1234efgh')).to.not.contain('abcd1234efgh');
+    });
+
+    it('is a no-op on ordinary git output', () => {
+      const output = 'To github.com:o/r.git\n   abc1234..def5678  main -> main';
+      expect(redactSecrets(output)).to.equal(output);
+    });
+  });
+});

--- a/src/services/__tests__/git-output.service.test.ts
+++ b/src/services/__tests__/git-output.service.test.ts
@@ -1,0 +1,87 @@
+import { expect } from '@open-wc/testing';
+
+// Mock the Tauri IPC bridge before importing anything that reaches for it.
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+(globalThis as unknown as { __TAURI_INTERNALS__: { invoke: MockInvoke } }).__TAURI_INTERNALS__ = {
+  invoke: () => Promise.resolve(null),
+};
+
+import { clearLogEntries, getLogEntries } from '../output-log.service.ts';
+import {
+  recordGitCommandEvent,
+  startGitCommandLogging,
+  stopGitCommandLogging,
+} from '../git-output.service.ts';
+
+describe('git-output.service', () => {
+  beforeEach(() => {
+    clearLogEntries();
+  });
+
+  afterEach(() => {
+    stopGitCommandLogging();
+  });
+
+  it('records a real backend invocation with its command line and output', () => {
+    recordGitCommandEvent({
+      command: 'git push --force-with-lease origin main',
+      output: 'To github.com:o/r.git\n + abc1234...def5678 main -> main (forced update)',
+      success: true,
+      durationMs: 1820,
+      repoPath: '/repo/a',
+    });
+
+    const entry = getLogEntries()[0];
+    expect(entry.command).to.equal('git push --force-with-lease origin main');
+    expect(entry.gitCommand).to.equal('git push --force-with-lease origin main');
+    // It really ran — it must never be marked as a libgit2 equivalent.
+    expect(entry.synthesized).to.be.false;
+    expect(entry.success).to.be.true;
+    expect(entry.durationMs).to.equal(1820);
+    expect(entry.repoPath).to.equal('/repo/a');
+    expect(entry.output).to.contain('forced update');
+  });
+
+  it('records a failing invocation with its error output', () => {
+    recordGitCommandEvent({
+      command: 'git rebase --continue',
+      output: 'error: could not apply abc1234',
+      success: false,
+      durationMs: 12,
+      repoPath: '/repo/a',
+    });
+
+    const entry = getLogEntries()[0];
+    expect(entry.success).to.be.false;
+    expect(entry.output).to.equal('error: could not apply abc1234');
+  });
+
+  it('tolerates an event with no repo path or output', () => {
+    recordGitCommandEvent({
+      command: 'git gc',
+      output: '',
+      success: true,
+      durationMs: 5,
+      repoPath: null,
+    });
+
+    const entry = getLogEntries()[0];
+    expect(entry.repoPath).to.equal(undefined);
+    expect(entry.output).to.equal('');
+  });
+
+  it('starting twice attaches only one listener, so nothing is logged twice', async () => {
+    // Both calls resolve without a working event bridge; the point is that the
+    // second is a no-op rather than a second subscription.
+    await Promise.all([startGitCommandLogging(), startGitCommandLogging()]);
+    await startGitCommandLogging();
+
+    recordGitCommandEvent({
+      command: 'git fetch origin',
+      output: '',
+      success: true,
+      durationMs: 1,
+    });
+    expect(getLogEntries().length).to.equal(1);
+  });
+});

--- a/src/services/__tests__/output-log.service.test.ts
+++ b/src/services/__tests__/output-log.service.test.ts
@@ -88,6 +88,27 @@ describe('output-log.service', () => {
       unsubscribe();
     });
 
+    it('accepts a details object as well as a bare repo path', () => {
+      logGitCommand('push', 'ok', true, {
+        repoPath: '/repoA',
+        gitCommand: 'git push origin main',
+        synthesized: false,
+        durationMs: 1234,
+      });
+      logGitCommand('merge', '', true, '/repoB');
+
+      // Newest first.
+      const [mergeEntry, pushEntry] = getLogEntries();
+      expect(pushEntry.repoPath).to.equal('/repoA');
+      expect(pushEntry.gitCommand).to.equal('git push origin main');
+      expect(pushEntry.synthesized).to.be.false;
+      expect(pushEntry.durationMs).to.equal(1234);
+
+      // The original 4th-parameter shape still works.
+      expect(mergeEntry.repoPath).to.equal('/repoB');
+      expect(mergeEntry.gitCommand).to.equal(undefined);
+    });
+
     it('zero-arg clear still empties everything (e2e/injected usage)', () => {
       logGitCommand('checkout', '', true, '/repoA');
       logGitCommand('merge', '', true, '/repoB');
@@ -125,10 +146,59 @@ describe('output-log.service', () => {
       expect(entries.length).to.equal(1);
       expect(entries[0].command).to.equal('checkout');
       expect(entries[0].success).to.be.true;
-      // Args may carry credentials and must never appear in the log
+      // Args are still never dumped wholesale into the output field
       expect(entries[0].output).to.equal('');
       // The repository path IS recorded so multi-repo sessions can scope entries
       expect(entries[0].repoPath).to.equal('/repo');
+    });
+
+    it('records the equivalent git command line, marked as synthesised', async () => {
+      await invokeCommand('checkout', { path: '/repo', refName: 'feature/x' });
+
+      const entry = getLogEntries()[0];
+      expect(entry.gitCommand).to.equal('git checkout feature/x');
+      // git2 did the work — the panel must not imply the CLI ran
+      expect(entry.synthesized).to.be.true;
+      expect(entry.durationMs).to.be.a('number');
+      expect(entry.durationMs).to.be.at.least(0);
+    });
+
+    it('records no git line for a command with no honest synthesis', async () => {
+      await invokeCommand('start_auto_fetch', { path: '/repo' });
+
+      const entry = getLogEntries()[0];
+      expect(entry.command).to.equal('start_auto_fetch');
+      expect(entry.gitCommand).to.equal(undefined);
+      expect(entry.synthesized).to.be.false;
+    });
+
+    it('never puts a token into the synthesised line', async () => {
+      await invokeCommand('push', {
+        path: '/repo',
+        remote: 'origin',
+        branch: 'main',
+        token: 'ghp_0123456789abcdefghij',
+      });
+
+      const entry = getLogEntries()[0];
+      expect(entry.gitCommand).to.equal('git push origin main');
+      expect(JSON.stringify(entry)).to.not.contain('ghp_');
+    });
+
+    it('redacts a credentialed URL echoed back in a backend error', async () => {
+      mockInvoke = () =>
+        Promise.reject({
+          code: 'AUTH',
+          message:
+            'failed to push to https://user:ghp_0123456789abcdefghij@github.com/o/r.git',
+        });
+
+      await invokeCommand('push', { path: '/repo', remote: 'origin', branch: 'main' });
+
+      const entry = getLogEntries()[0];
+      expect(entry.success).to.be.false;
+      expect(entry.output).to.not.contain('ghp_');
+      expect(entry.output).to.contain('***@github.com/o/r.git');
     });
 
     it('scopes commands that pass the repo path as repoPath (e.g. stage_hunk)', async () => {

--- a/src/services/git-command-format.ts
+++ b/src/services/git-command-format.ts
@@ -1,0 +1,363 @@
+/**
+ * Git command formatting for the Output panel.
+ *
+ * Leviathan runs most operations through libgit2 (git2), so there is no `git`
+ * process to quote. The panel would otherwise show the IPC command name
+ * (`create_commit`, `stage_files`), which tells a user nothing about what git
+ * was asked to do. `synthesizeGitCommand` renders the EQUIVALENT command line
+ * for the main operations instead.
+ *
+ * Two properties this module exists to guarantee:
+ *
+ * 1. **Honesty.** A synthesised line is not a command that ran. Callers mark
+ *    these entries (`synthesized: true`) and the panel renders them with a `≈`
+ *    and a legend, so the panel never implies a CLI invocation happened.
+ * 2. **No secrets.** The IPC layer deliberately logs no arguments at all,
+ *    because arguments can carry credentials. Synthesis reads an EXPLICIT,
+ *    per-command allowlist of fields — never the whole args object — so a
+ *    field like `token` is not merely filtered, it is never read. Everything
+ *    that does get rendered is then passed through `redactSecrets` as a safety
+ *    net, because a user's own remote URL can carry `user:token@host`.
+ */
+
+/**
+ * Patterns for anything that looks like a credential.
+ *
+ * Mirrors `redact_secrets` in `src-tauri/src/utils/command.rs` — the backend
+ * scrubs what it captures from real `git` processes, this scrubs what the
+ * frontend synthesises. Kept as two implementations on purpose: they run in
+ * different runtimes and each must hold on its own.
+ */
+const SECRET_PATTERNS: ReadonlyArray<readonly [RegExp, string]> = [
+  // Credentials embedded in a URL: https://user:token@host, ssh://user@host.
+  // The userinfo goes; the host stays so the line still says which remote.
+  [/\b([a-z][a-z0-9+.-]*:\/\/)[^/\s@]+@/gi, '$1***@'],
+  // Provider tokens, by their documented prefixes.
+  [/\bgh[pousr]_[A-Za-z0-9]{16,}/g, '***'],
+  [/\bgithub_pat_[A-Za-z0-9_]{20,}/g, '***'],
+  [/\bglpat-[A-Za-z0-9_-]{16,}/g, '***'],
+  [/\bxox[abprs]-[A-Za-z0-9-]{10,}/g, '***'],
+  [/\bsk-[A-Za-z0-9_-]{16,}/g, '***'],
+  [/\bAKIA[0-9A-Z]{16}\b/g, '***'],
+  // JSON Web Tokens (three base64url segments).
+  [/\bey[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g, '***'],
+  // `Bearer <token>` — matched BEFORE the named-secret rule below, which would
+  // otherwise consume the word `Bearer` as `Authorization`'s value and leave
+  // the token itself standing.
+  [/\bbearer\s+[A-Za-z0-9._\-+/=]{6,}/gi, 'Bearer ***'],
+  // Anything explicitly NAMED as a secret, whatever its shape.
+  [
+    /\b(password|passwd|token|access[_-]?token|api[_-]?key|secret|authorization)([=:]\s*|\s+)\S+/gi,
+    '$1=***',
+  ],
+];
+
+/**
+ * Replace anything that looks like a credential with `***`.
+ *
+ * Applied to every synthesised command line and to every error message before
+ * it reaches the Output panel.
+ */
+export function redactSecrets(text: string): string {
+  let out = text;
+  for (const [pattern, replacement] of SECRET_PATTERNS) {
+    out = out.replace(pattern, replacement);
+  }
+  return out;
+}
+
+/** Quote an argument so a multi-word value reads as one token. */
+function quoteArg(value: string): string {
+  if (value === '') return '""';
+  if (/[\s"'\\]/.test(value)) {
+    return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+  }
+  return value;
+}
+
+/** A string field, or undefined when absent/blank/of the wrong type. */
+function str(args: Record<string, unknown>, key: string): string | undefined {
+  const value = args[key];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function bool(args: Record<string, unknown>, key: string): boolean {
+  return args[key] === true;
+}
+
+function num(args: Record<string, unknown>, key: string): number | undefined {
+  const value = args[key];
+  return typeof value === 'number' && Number.isFinite(value) ? value : undefined;
+}
+
+/** A `paths: string[]` field, keeping only the entries that really are strings. */
+function paths(args: Record<string, unknown>): string[] {
+  const value = args['paths'];
+  return Array.isArray(value)
+    ? value.filter((p): p is string => typeof p === 'string')
+    : [];
+}
+
+/** `stash@{n}` for an index, falling back to the plain form when absent. */
+function stashRef(args: Record<string, unknown>): string {
+  const index = num(args, 'index');
+  return index === undefined ? 'stash@{0}' : `stash@{${index}}`;
+}
+
+/**
+ * Builders for the main operations, keyed by IPC command name.
+ *
+ * Deliberately not exhaustive: the app exposes hundreds of commands, and a
+ * half-guessed line is worse than the honest IPC name. Anything absent here
+ * falls through to the command name, exactly as before.
+ *
+ * Each builder returns the argv AFTER `git`, or `undefined` when the arguments
+ * it needs are missing (a line built from absent values would be a lie).
+ */
+const BUILDERS: Record<
+  string,
+  (args: Record<string, unknown>) => string[] | undefined
+> = {
+  // --- commit ---
+  create_commit: (a) => {
+    const argv = ['commit'];
+    if (bool(a, 'amend')) argv.push('--amend');
+    if (bool(a, 'signCommit')) argv.push('-S');
+    if (bool(a, 'allowEmpty')) argv.push('--allow-empty');
+    const message = str(a, 'message');
+    if (message) argv.push('-m', message);
+    return argv;
+  },
+  amend_commit: (a) => {
+    const argv = ['commit', '--amend'];
+    if (bool(a, 'resetAuthor')) argv.push('--reset-author');
+    if (bool(a, 'signAmend')) argv.push('-S');
+    const message = str(a, 'message');
+    if (message) argv.push('-m', message);
+    else argv.push('--no-edit');
+    return argv;
+  },
+  commit_merge: (a) => {
+    const argv = ['commit'];
+    const message = str(a, 'message');
+    if (message) argv.push('-m', message);
+    else argv.push('--no-edit');
+    return argv;
+  },
+
+  // --- staging ---
+  stage_files: (a) => {
+    const files = paths(a);
+    return files.length > 0 ? ['add', '--', ...files] : ['add', '-A'];
+  },
+  unstage_files: (a) => {
+    const files = paths(a);
+    return files.length > 0
+      ? ['restore', '--staged', '--', ...files]
+      : ['restore', '--staged', '.'];
+  },
+  discard_changes: (a) => {
+    const files = paths(a);
+    return files.length > 0 ? ['restore', '--', ...files] : undefined;
+  },
+
+  // --- branches / checkout ---
+  checkout: (a) => {
+    const ref = str(a, 'refName');
+    if (!ref) return undefined;
+    return bool(a, 'force') ? ['checkout', '--force', ref] : ['checkout', ref];
+  },
+  checkout_with_autostash: (a) => {
+    const ref = str(a, 'refName');
+    if (!ref) return undefined;
+    // The autostash variant is a checkout wrapped in a stash push/pop; showing
+    // the checkout alone would misrepresent what the operation does to the
+    // working tree, so spell out all three steps. (`&&` has nothing that needs
+    // quoting, so it survives `quoteArg` as the operator it is.)
+    return bool(a, 'autoStash')
+      ? ['stash', 'push', '&&', 'git', 'checkout', ref, '&&', 'git', 'stash', 'pop']
+      : ['checkout', ref];
+  },
+  create_branch: (a) => {
+    const name = str(a, 'name');
+    if (!name) return undefined;
+    const startPoint = str(a, 'startPoint');
+    const argv = bool(a, 'checkout') ? ['checkout', '-b', name] : ['branch', name];
+    if (startPoint) argv.push(startPoint);
+    return argv;
+  },
+  delete_branch: (a) => {
+    const name = str(a, 'name');
+    if (!name) return undefined;
+    return ['branch', bool(a, 'force') ? '-D' : '-d', name];
+  },
+  rename_branch: (a) => {
+    const oldName = str(a, 'oldName');
+    const newName = str(a, 'newName');
+    if (!oldName || !newName) return undefined;
+    return ['branch', '-m', oldName, newName];
+  },
+
+  // --- merge ---
+  merge: (a) => {
+    const source = str(a, 'sourceRef');
+    if (!source) return undefined;
+    const argv = ['merge'];
+    if (bool(a, 'noFf')) argv.push('--no-ff');
+    if (bool(a, 'squash')) argv.push('--squash');
+    const message = str(a, 'message');
+    if (message) argv.push('-m', message);
+    argv.push(source);
+    return argv;
+  },
+  abort_merge: () => ['merge', '--abort'],
+
+  // --- rebase ---
+  rebase: (a) => {
+    const onto = str(a, 'onto');
+    return onto ? ['rebase', onto] : undefined;
+  },
+  continue_rebase: () => ['rebase', '--continue'],
+  abort_rebase: () => ['rebase', '--abort'],
+  skip_rebase_commit: () => ['rebase', '--skip'],
+
+  // --- remote transfer ---
+  fetch: (a) => {
+    const argv = ['fetch'];
+    if (bool(a, 'prune')) argv.push('--prune');
+    const remote = str(a, 'remote');
+    if (remote) argv.push(remote);
+    return argv;
+  },
+  fetch_all_remotes: (a) => (bool(a, 'prune') ? ['fetch', '--all', '--prune'] : ['fetch', '--all']),
+  pull: (a) => {
+    const argv = ['pull'];
+    if (bool(a, 'rebase')) argv.push('--rebase');
+    const remote = str(a, 'remote');
+    const branch = str(a, 'branch');
+    if (remote) argv.push(remote);
+    if (remote && branch) argv.push(branch);
+    return argv;
+  },
+  push: (a) => {
+    const argv = ['push'];
+    if (bool(a, 'forceWithLease')) argv.push('--force-with-lease');
+    else if (bool(a, 'force')) argv.push('--force');
+    if (bool(a, 'pushTags')) argv.push('--tags');
+    if (bool(a, 'setUpstream')) argv.push('--set-upstream');
+    const remote = str(a, 'remote');
+    const branch = str(a, 'branch');
+    if (remote) argv.push(remote);
+    if (remote && branch) argv.push(branch);
+    return argv;
+  },
+
+  // --- stash ---
+  create_stash: (a) => {
+    const argv = ['stash', 'push'];
+    if (bool(a, 'includeUntracked')) argv.push('--include-untracked');
+    const message = str(a, 'message');
+    if (message) argv.push('-m', message);
+    return argv;
+  },
+  apply_stash: (a) => [
+    'stash',
+    bool(a, 'dropAfter') ? 'pop' : 'apply',
+    stashRef(a),
+  ],
+  pop_stash: (a) => ['stash', 'pop', stashRef(a)],
+  drop_stash: (a) => ['stash', 'drop', stashRef(a)],
+
+  // --- reset ---
+  reset: (a) => {
+    const target = str(a, 'targetRef');
+    const mode = str(a, 'mode');
+    if (!target || !mode) return undefined;
+    return ['reset', `--${mode}`, target];
+  },
+
+  // --- cherry-pick / revert ---
+  cherry_pick: (a) => {
+    const oid = str(a, 'commitOid');
+    if (!oid) return undefined;
+    const argv = ['cherry-pick'];
+    if (bool(a, 'noCommit')) argv.push('--no-commit');
+    const mainline = num(a, 'mainline');
+    if (mainline !== undefined) argv.push('-m', String(mainline));
+    argv.push(oid);
+    return argv;
+  },
+  continue_cherry_pick: () => ['cherry-pick', '--continue'],
+  abort_cherry_pick: () => ['cherry-pick', '--abort'],
+  skip_cherry_pick: () => ['cherry-pick', '--skip'],
+  revert: (a) => {
+    const oid = str(a, 'commitOid');
+    if (!oid) return undefined;
+    const argv = ['revert'];
+    const mainline = num(a, 'mainline');
+    if (mainline !== undefined) argv.push('-m', String(mainline));
+    argv.push(oid);
+    return argv;
+  },
+  continue_revert: () => ['revert', '--continue'],
+  abort_revert: () => ['revert', '--abort'],
+  skip_revert: () => ['revert', '--skip'],
+
+  // --- tags ---
+  create_tag: (a) => {
+    const name = str(a, 'name');
+    if (!name) return undefined;
+    const argv = ['tag'];
+    const message = str(a, 'message');
+    if (message) argv.push('-a', '-m', message);
+    argv.push(name);
+    const target = str(a, 'target');
+    if (target) argv.push(target);
+    return argv;
+  },
+  delete_tag: (a) => {
+    const name = str(a, 'name');
+    return name ? ['tag', '-d', name] : undefined;
+  },
+  push_tag: (a) => {
+    const name = str(a, 'name');
+    if (!name) return undefined;
+    const argv = ['push'];
+    if (bool(a, 'force')) argv.push('--force');
+    argv.push(str(a, 'remote') ?? 'origin', `refs/tags/${name}`);
+    return argv;
+  },
+  delete_remote_tag: (a) => {
+    const name = str(a, 'name');
+    if (!name) return undefined;
+    return ['push', str(a, 'remote') ?? 'origin', '--delete', `refs/tags/${name}`];
+  },
+};
+
+/**
+ * The `git` command line equivalent to an IPC command, or `undefined` when the
+ * operation has no synthesis (the caller then shows the IPC command name).
+ *
+ * The returned line describes what git2 was asked to do — it is NOT a command
+ * that ran. Callers must mark it as synthesised.
+ */
+export function synthesizeGitCommand(
+  command: string,
+  args?: unknown,
+): string | undefined {
+  const build = BUILDERS[command];
+  if (!build) return undefined;
+
+  const record =
+    typeof args === 'object' && args !== null
+      ? (args as Record<string, unknown>)
+      : {};
+
+  const argv = build(record);
+  if (!argv) return undefined;
+
+  return redactSecrets(['git', ...argv.map(quoteArg)].join(' '));
+}
+
+/** The operations `synthesizeGitCommand` covers — exported for tests. */
+export const SYNTHESIZED_COMMANDS: ReadonlyArray<string> = Object.keys(BUILDERS);

--- a/src/services/git-output.service.ts
+++ b/src/services/git-output.service.ts
@@ -1,0 +1,84 @@
+/**
+ * Real `git` invocations from the backend.
+ *
+ * A large share of the app's operations shell out to the git CLI — interactive
+ * rebase, force push, difftool/mergetool, GPG signing, LFS, maintenance. Those
+ * runs have a REAL command line and real stdout/stderr, and
+ * `src-tauri/src/utils/command.rs` reports each of them on the
+ * `git-command-executed` event. This service carries them into the Output
+ * panel's log, where they appear as executed commands (never marked
+ * synthesised) alongside the git2 equivalents.
+ *
+ * Redaction happens in the backend, on the command line and on the captured
+ * output, before the event is emitted — see `redact_secrets` there.
+ */
+
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { logGitCommand } from './output-log.service.ts';
+
+/** Payload of the backend's `git-command-executed` event. */
+export interface GitCommandExecutedEvent {
+  /** The effective, already-redacted command line (e.g. `git push --force origin main`) */
+  command: string;
+  /** Combined stderr/stdout of the run, already redacted and truncated */
+  output: string;
+  success: boolean;
+  durationMs: number;
+  repoPath?: string | null;
+}
+
+/**
+ * Record one backend git invocation in the output log.
+ *
+ * Split out from the listener so the mapping is testable without a Tauri event
+ * bridge — the listener below is a one-line adapter onto this.
+ */
+export function recordGitCommandEvent(payload: GitCommandExecutedEvent): void {
+  const { command, output, success, durationMs, repoPath } = payload;
+  logGitCommand(command, output ?? '', success, {
+    repoPath: repoPath ?? undefined,
+    gitCommand: command,
+    // This command really ran. Never marked synthesised — that flag is what
+    // tells the user the difference between "git did this" and "this is the
+    // equivalent of what libgit2 did".
+    synthesized: false,
+    durationMs,
+  });
+}
+
+let unlisten: UnlistenFn | undefined;
+let starting: Promise<void> | undefined;
+
+/**
+ * Start recording backend git invocations into the output log.
+ *
+ * Idempotent: a second call while a listener is attached (or being attached)
+ * is a no-op, so the panel can never show one command twice.
+ */
+export async function startGitCommandLogging(): Promise<void> {
+  if (unlisten || starting) {
+    return starting;
+  }
+
+  starting = listen<GitCommandExecutedEvent>('git-command-executed', (event) => {
+    recordGitCommandEvent(event.payload);
+  })
+    .then((fn) => {
+      unlisten = fn;
+    })
+    .catch(() => {
+      // No Tauri event bridge (unit tests, plain browser). The panel still
+      // shows the git2 equivalents recorded by the IPC layer.
+    })
+    .finally(() => {
+      starting = undefined;
+    });
+
+  return starting;
+}
+
+/** Stop recording backend git invocations. */
+export function stopGitCommandLogging(): void {
+  unlisten?.();
+  unlisten = undefined;
+}

--- a/src/services/output-log.service.ts
+++ b/src/services/output-log.service.ts
@@ -17,6 +17,29 @@ export interface OutputLogEntry {
   success: boolean;
   /** Repository the command ran against (absent for repo-independent commands) */
   repoPath?: string;
+  /**
+   * The git command line for this entry: the REAL invocation for operations
+   * that shell out to git, or the equivalent line for the git2-backed ones.
+   * Absent when there is no honest line to show, in which case the panel falls
+   * back to `command` (the IPC name).
+   */
+  gitCommand?: string;
+  /**
+   * True when `gitCommand` was SYNTHESISED from a git2 operation's arguments
+   * rather than being a command line that actually executed. The panel must
+   * mark these so it never implies the CLI ran — see `git-command-format.ts`.
+   */
+  synthesized?: boolean;
+  /** Wall-clock duration of the operation in milliseconds, when measured. */
+  durationMs?: number;
+}
+
+/** Optional detail a caller can attach to a log entry. */
+export interface OutputLogDetails {
+  repoPath?: string;
+  gitCommand?: string;
+  synthesized?: boolean;
+  durationMs?: number;
 }
 
 // Singleton log entries array and listeners
@@ -42,20 +65,32 @@ export function subscribeOutputLog(listener: () => void): () => void {
 
 /**
  * Log a git command execution result.
+ *
+ * The fourth parameter accepts either a bare repository path (its original
+ * shape, still used by tests and injected setups) or a details object carrying
+ * the git command line, timing and repo path.
  */
 export function logGitCommand(
   command: string,
   output: string,
   success: boolean,
-  repoPath?: string,
+  repoPathOrDetails?: string | OutputLogDetails,
 ): void {
+  const details: OutputLogDetails =
+    typeof repoPathOrDetails === 'string'
+      ? { repoPath: repoPathOrDetails }
+      : (repoPathOrDetails ?? {});
+
   logEntries.unshift({
     id: nextEntryId++,
     timestamp: Date.now(),
     command,
     output,
     success,
-    repoPath,
+    repoPath: details.repoPath,
+    gitCommand: details.gitCommand,
+    synthesized: details.synthesized,
+    durationMs: details.durationMs,
   });
 
   // Trim to max entries

--- a/src/services/tauri-api.ts
+++ b/src/services/tauri-api.ts
@@ -7,6 +7,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import type { CommandResult } from '../types/api.types.ts';
 import { logGitCommand, shouldLogToOutput } from './output-log.service.ts';
+import { redactSecrets, synthesizeGitCommand } from './git-command-format.ts';
 
 /**
  * Invoke a Tauri command with type safety
@@ -27,11 +28,26 @@ export async function invokeCommand<T, A = unknown>(
         ? (argsRecord.repoPath as string)
         : undefined;
 
+  // The equivalent `git` command line for the operations that run through
+  // libgit2, so the Output panel shows a git invocation rather than an IPC
+  // name. Args are STILL never logged wholesale — they can carry credentials.
+  // `synthesizeGitCommand` reads an explicit per-command allowlist of fields
+  // (never `token`) and redacts what it renders; anything it does not cover
+  // falls back to the command name, exactly as before.
+  const gitCommand = shouldLogToOutput(command)
+    ? synthesizeGitCommand(command, args)
+    : undefined;
+  const startedAt = Date.now();
+
   try {
     const data = await invoke<T>(command, args as Record<string, unknown>);
-    // Args are intentionally never logged — they can carry credentials
     if (shouldLogToOutput(command)) {
-      logGitCommand(command, '', true, repoPath);
+      logGitCommand(command, '', true, {
+        repoPath,
+        gitCommand,
+        synthesized: gitCommand !== undefined,
+        durationMs: Date.now() - startedAt,
+      });
     }
     return { success: true, data };
   } catch (error) {
@@ -51,7 +67,14 @@ export async function invokeCommand<T, A = unknown>(
     }
 
     if (shouldLogToOutput(command)) {
-      logGitCommand(command, message, false, repoPath);
+      // Backend error messages routinely quote a remote URL, which can carry
+      // `user:token@host` — scrub before it reaches the panel.
+      logGitCommand(command, redactSecrets(message), false, {
+        repoPath,
+        gitCommand,
+        synthesized: gitCommand !== undefined,
+        durationMs: Date.now() - startedAt,
+      });
     }
 
     return {


### PR DESCRIPTION
## Problem

The Output panel logged the Tauri **IPC command name** — `create_commit`, `stage_files`, `checkout` — with an always-empty output body. A user opening the panel to see "what git did" got an opaque list of internal function names and no output at all.

## What changed

The app has two kinds of git operation, and each needed a different answer.

### 1. Real `git` subprocesses now report themselves

A large share of operations shell out to the CLI: interactive rebase, force push / `--force-with-lease`, difftool & mergetool, GPG signing, LFS, clone, maintenance, bisect, submodules.

`create_command("git")` now returns a `GitCommand` wrapper (`src-tauri/src/utils/command.rs`) instead of a bare `std::process::Command`. It derefs to `Command`, so call sites are unchanged, but it **owns** `output()` / `status()` / `spawn()` — which means it times the run, captures stdout/stderr, and reports it. A *new* shell-out added later is covered automatically rather than having to be remembered and added to a hand-kept list.

`lib.rs` installs a sink during `setup` that emits `git-command-executed`; `src/services/git-output.service.ts` records it into the panel's log.

`run_push_command` drives its child by hand so cancellation can kill it, so `output()` never runs there — it calls `report_run` explicitly instead.

### 2. libgit2 operations show the equivalent command

Most operations go through git2 and have no process to quote. `src/services/git-command-format.ts` synthesises the **equivalent** command line from the IPC arguments for the main operations:

commit / amend · stage / unstage / discard · checkout (incl. autostash) · branch create, delete, rename · merge · rebase (+continue/abort/skip) · fetch / pull / push · stash push, apply, pop, drop · reset · cherry-pick / revert (+continue/abort/skip) · tag create, delete, push

```
git commit --amend -S -m "fix the login bug"
git stash push --include-untracked -m "panel probe"
git push --force-with-lease origin main
```

An operation with no synthesis still shows its IPC name — better an honest name than a half-guessed command line.

### Honesty

A synthesised line is **not** a command that ran. Those entries render with a `≈` marker, a subdued style, the IPC name beside them, and a legend at the foot of the panel:

> ≈ Leviathan runs these operations with libgit2 — the line shown is the equivalent `git` command, not one that was executed.

Lines from real subprocesses are never marked, and do not trigger the legend.

### Also fixed in the panel

- **Timing** on every entry (`84ms`, `1.5s`, `1m 05s`).
- **Failed output is styled as an error** — the reason the user opened the panel is now findable at a glance.
- **An expanded row is never an unexplained empty box** — with nothing captured it says "Completed/Failed with no output."

## Secrets

Arguments can carry credentials, which is why the IPC layer logged none of them. That guard is kept:

- Synthesis reads an **explicit per-command allowlist** of fields. A field like `token` is not filtered out — it is never read.
- Everything rendered, plus every backend error message reaching the panel, passes through a redactor: URL userinfo (`user:token@host` → `***@host`, host preserved), provider token prefixes (`ghp_`, `github_pat_`, `glpat-`, `xox*-`, `sk-`, `AKIA`), JWTs, `Bearer <token>`, and anything named `password`/`token`/`api_key`/`secret`/`authorization`. Implemented in **both** Rust and TypeScript — they run in different runtimes and each must hold on its own.
- Subprocess **environment is deliberately excluded** from the event payload. The token credential helper reaches git through the environment, so leaving env out keeps tokens out of the panel by construction rather than by filtering.
- Backend logging is an **allowlist of interesting subcommands**, not a denylist of reads. The app runs `rev-parse` and `for-each-ref` constantly, and a denylist that misses one floods the 100-entry panel with noise. `config` and `credential` are excluded on purpose — they are plumbing reads whose arguments are the most likely to name a secret.
- Output is truncated to 8k chars, since a `git fetch` on a large repo can print megabytes across the IPC boundary.

## Tests

- **Rust** (`utils/command.rs`, 26 tests): subcommand detection past global options, allowlist filtering, argument quoting, truncation, sink reporting, and redaction of each secret shape.
- **TypeScript** (`git-command-format.test.ts`, 66 tests): every synthesised operation, refusals when a required argument is missing, malformed-args tolerance, and that a `token` never reaches a rendered line.
- `git-output.service.test.ts`: event → log-entry mapping, and that starting twice cannot double-log.
- `lv-output-panel.test.ts` / `output-log.service.test.ts`: marker, legend, IPC fallback, duration formatting, failure styling, empty-output explanation, backward-compatible `logGitCommand` signature.
- **E2E** (`e2e/tests/output-panel.spec.ts`, 31 passing): a real stash shows `git stash push --include-untracked -m "panel probe"`; the `≈` marker and legend appear; a failing operation shows its git line and error output; a credentialed URL in a backend error reaches the panel redacted.

## Gate

`npm run lint` (0 errors) · `npm run typecheck` · `npm test` · `cargo fmt --check` · `cargo clippy --all-targets -- -D warnings` — all green.

Two failures in `network-gate-coverage.test.ts` are **pre-existing** — they fail identically on the clean tree with this branch stashed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_