### PR TITLE
feat: predict merge conflicts before the merge runs

### DIFF
--- a/e2e/tests/branches.spec.ts
+++ b/e2e/tests/branches.spec.ts
@@ -7,6 +7,7 @@ import {
   startCommandCapture,
   startCommandCaptureWithMocks,
   findCommand,
+  getCapturedCommands,
   injectCommandError,
   injectCommandMock,
   autoConfirmDialogs,
@@ -1221,5 +1222,138 @@ test.describe('Drag-Drop Merge Error Toast', () => {
     const toastMessage = page.locator('lv-toast-container .toast.error .toast-message');
     await expect(toastMessage).toBeVisible({ timeout: 10000 });
     await expect(toastMessage).toContainText('Merge failed');
+  });
+});
+
+test.describe('Merge Conflict Prediction', () => {
+  let leftPanel: LeftPanelPage;
+
+  const BRANCHES = [
+    {
+      name: 'main',
+      shorthand: 'main',
+      isHead: true,
+      isRemote: false,
+      upstream: null,
+      targetOid: 'abc123',
+      isStale: false,
+    },
+    {
+      name: 'feature-drag',
+      shorthand: 'feature-drag',
+      isHead: false,
+      isRemote: false,
+      upstream: null,
+      targetOid: 'def456',
+      isStale: false,
+    },
+  ];
+
+  test.beforeEach(async ({ page }) => {
+    leftPanel = new LeftPanelPage(page);
+    await setupOpenRepository(page, { branches: BRANCHES });
+  });
+
+  /** The text of the first confirm dialog raised during the run. */
+  async function firstConfirmMessage(page: import('@playwright/test').Page): Promise<string> {
+    const commands = await getCapturedCommands(page);
+    const confirm = commands.find((c) => c.command === 'plugin:dialog|message');
+    return ((confirm?.args as { message?: string } | undefined)?.message) ?? '';
+  }
+
+  test('warns which files would conflict before the merge runs', async ({ page }) => {
+    await startCommandCapture(page);
+    await autoConfirmDialogs(page);
+    await injectCommandMock(page, {
+      preview_merge: {
+        outcome: 'normal',
+        conflictCount: 3,
+        conflictingFiles: ['src/a.ts', 'src/b.ts', 'src/c.ts'],
+        unrelatedHistories: false,
+        operationInProgress: null,
+      },
+      merge: null,
+    });
+
+    await leftPanel.openBranchContextMenu('feature-drag');
+    const mergeMenuItem = page.locator('.context-menu-item', { hasText: 'Merge into current branch' });
+    await mergeMenuItem.waitFor({ state: 'visible' });
+    await mergeMenuItem.click();
+
+    await waitForCommand(page, 'merge');
+
+    // The prediction reached the user in the confirm...
+    const message = await firstConfirmMessage(page);
+    expect(message).toContain('3 files would conflict:');
+    expect(message).toContain('src/a.ts');
+    expect(message).toContain('src/c.ts');
+    expect(message).toContain('You can still merge');
+
+    // ...and it did so BEFORE the merge touched the working tree.
+    const commands = await getCapturedCommands(page);
+    const previewAt = commands.findIndex((c) => c.command === 'preview_merge');
+    const confirmAt = commands.findIndex((c) => c.command === 'plugin:dialog|message');
+    const mergeAt = commands.findIndex((c) => c.command === 'merge');
+    expect(previewAt).toBeGreaterThanOrEqual(0);
+    expect(confirmAt).toBeGreaterThan(previewAt);
+    expect(mergeAt).toBeGreaterThan(confirmAt);
+
+    // Previewed against the branch that was right-clicked.
+    const previews = await findCommand(page, 'preview_merge');
+    expect((previews[0].args as { sourceRef?: string }).sourceRef).toBe('feature-drag');
+
+    // Confirming still merges — the prediction warns, it does not block.
+    const toastMessage = page.locator('lv-toast-container .toast.success .toast-message');
+    await expect(toastMessage).toBeVisible({ timeout: 10000 });
+    await expect(toastMessage).toContainText('Merged feature-drag');
+  });
+
+  test('says a clean merge will create a merge commit', async ({ page }) => {
+    await startCommandCapture(page);
+    await autoConfirmDialogs(page);
+    await injectCommandMock(page, {
+      preview_merge: {
+        outcome: 'normal',
+        conflictCount: 0,
+        conflictingFiles: [],
+        unrelatedHistories: false,
+        operationInProgress: null,
+      },
+      merge: null,
+    });
+
+    await leftPanel.openBranchContextMenu('feature-drag');
+    const mergeMenuItem = page.locator('.context-menu-item', { hasText: 'Merge into current branch' });
+    await mergeMenuItem.waitFor({ state: 'visible' });
+    await mergeMenuItem.click();
+
+    await waitForCommand(page, 'merge');
+
+    const message = await firstConfirmMessage(page);
+    expect(message).toContain('merge commit');
+    expect(message).not.toContain('would conflict');
+  });
+
+  test('confirms without a prediction when the preview fails', async ({ page }) => {
+    await startCommandCapture(page);
+    await autoConfirmDialogs(page);
+    await injectCommandMock(page, { merge: null });
+    await injectCommandError(page, 'preview_merge', 'preview unavailable');
+
+    await leftPanel.openBranchContextMenu('feature-drag');
+    const mergeMenuItem = page.locator('.context-menu-item', { hasText: 'Merge into current branch' });
+    await mergeMenuItem.waitFor({ state: 'visible' });
+    await mergeMenuItem.click();
+
+    await waitForCommand(page, 'merge');
+
+    // A failed prediction must not block the merge or leave a half-written confirm.
+    const message = await firstConfirmMessage(page);
+    expect(message).toContain('Merge "feature-drag" into the current branch?');
+    expect(message).not.toContain('would conflict');
+
+    const toastMessage = page.locator('lv-toast-container .toast.success .toast-message');
+    await expect(toastMessage).toBeVisible({ timeout: 10000 });
+    await expect(toastMessage).toContainText('Merged feature-drag');
   });
 });

--- a/src-tauri/src/commands/merge.rs
+++ b/src-tauri/src/commands/merge.rs
@@ -92,10 +92,9 @@ pub async fn merge(
         }
 
         // Find the commit to merge
-        let reference = repo
-            .find_reference(&format!("refs/heads/{}", source_ref))
-            .or_else(|_| repo.find_reference(&format!("refs/remotes/{}", source_ref)))
-            .or_else(|_| repo.find_reference(&source_ref))?;
+        // Shared with `preview_merge`, so the preview can never resolve a
+        // different commit than the merge it is previewing.
+        let reference = find_merge_ref(&repo, &source_ref)?;
 
         let annotated_commit = repo.reference_to_annotated_commit(&reference)?;
         let (analysis, _preference) = repo.merge_analysis(&[&annotated_commit])?;
@@ -339,6 +338,162 @@ fn default_merge_message(repo: &git2::Repository, source_ref: &str) -> String {
         }
         _ => base,
     }
+}
+
+/// How many conflicting paths a preview lists.
+///
+/// The COUNT is always exact; only the list is capped. A merge that rewrites a
+/// whole tree can conflict in tens of thousands of paths, and shipping all of
+/// them over IPC to render "…and 40,000 more" costs far more than the preview
+/// saves.
+const MERGE_PREVIEW_PATH_CAP: usize = 50;
+
+/// What merging `source_ref` would do, computed without touching the working
+/// tree, the index, or any ref.
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MergePreview {
+    /// `upToDate`, `fastForward`, `normal` or `unborn`.
+    pub outcome: String,
+    /// Exact number of paths that would conflict. Zero unless `outcome` is
+    /// `normal` — a fast-forward and an up-to-date merge cannot conflict.
+    pub conflict_count: usize,
+    /// The conflicting paths, sorted, capped at `MERGE_PREVIEW_PATH_CAP`.
+    pub conflicting_files: Vec<String>,
+    /// The two sides share no common ancestor.
+    pub unrelated_histories: bool,
+    /// Set when the repository is already mid-merge/rebase/cherry-pick, naming
+    /// the state. `merge` refuses outright in that case, so the confirm has to
+    /// be able to say so BEFORE the user commits to the operation.
+    pub operation_in_progress: Option<String>,
+}
+
+/// Resolve a merge source the way `merge` itself does.
+///
+/// refs/heads FIRST, then refs/remotes, then the name verbatim — see the
+/// comment at the sidebar call sites about `origin/feature` vs `feature`. The
+/// preview and the merge MUST resolve identically, or the preview describes a
+/// merge of a different commit than the one that actually runs.
+fn find_merge_ref<'repo>(
+    repo: &'repo git2::Repository,
+    name: &str,
+) -> Result<git2::Reference<'repo>> {
+    repo.find_reference(&format!("refs/heads/{}", name))
+        .or_else(|_| repo.find_reference(&format!("refs/remotes/{}", name)))
+        .or_else(|_| repo.find_reference(name))
+        .map_err(Into::into)
+}
+
+/// Predict a merge without performing it.
+///
+/// The rebase equivalent (`preview_rebase`) has to shell out to `git rebase` in
+/// a throwaway worktree, because replaying a series of commits has no in-memory
+/// form. A merge does: libgit2 merges the two trees into an index that never
+/// leaves memory, so this needs no worktree, writes no `index.lock`, moves no
+/// ref and leaves nothing to clean up — which also means it cannot deadlock
+/// against, or corrupt, a real operation running on the same repository. Every
+/// caller runs it inside the working-tree claim it already holds for the merge
+/// it is about to confirm (see `utils/ref-lock.ts`), so a preview never runs
+/// concurrently with another ref operation either.
+///
+/// `into_ref` names the branch the merge will land on; omit it for HEAD. The
+/// drag-to-merge path checks the target branch out FIRST and merges into that,
+/// so previewing against HEAD there would describe a merge into the branch the
+/// user is leaving.
+#[command]
+pub async fn preview_merge(
+    path: String,
+    source_ref: String,
+    into_ref: Option<String>,
+) -> Result<MergePreview> {
+    let repo = git2::Repository::open(Path::new(&path))?;
+
+    // Read-only: reported, not refused. The preview is still worth computing —
+    // the user wants to know what the merge would do once the current operation
+    // is concluded — and `merge` produces the actionable refusal itself.
+    let operation_in_progress = match repo.state() {
+        git2::RepositoryState::Clean => None,
+        state => Some(format!("{:?}", state)),
+    };
+
+    let source = find_merge_ref(&repo, &source_ref)?;
+    let annotated_commit = repo.reference_to_annotated_commit(&source)?;
+
+    let our_ref = match into_ref.as_deref().filter(|r| !r.is_empty()) {
+        Some(name) => Some(find_merge_ref(&repo, name)?),
+        None => None,
+    };
+
+    let (analysis, _preference) = match our_ref.as_ref() {
+        Some(our) => repo.merge_analysis_for_ref(our, &[&annotated_commit])?,
+        None => repo.merge_analysis(&[&annotated_commit])?,
+    };
+
+    let mut preview = MergePreview {
+        outcome: "normal".to_string(),
+        conflict_count: 0,
+        conflicting_files: Vec::new(),
+        unrelated_histories: false,
+        operation_in_progress,
+    };
+
+    // UP_TO_DATE before UNBORN before FAST_FORWARD: libgit2 sets FASTFORWARD
+    // alongside UNBORN, and "this will fast-forward" is the wrong thing to tell
+    // someone whose branch has no commits at all.
+    if analysis.is_up_to_date() {
+        preview.outcome = "upToDate".to_string();
+        return Ok(preview);
+    }
+    if analysis.is_unborn() {
+        preview.outcome = "unborn".to_string();
+        return Ok(preview);
+    }
+    if analysis.is_fast_forward() {
+        preview.outcome = "fastForward".to_string();
+        return Ok(preview);
+    }
+
+    // A real merge commit. Up-to-date, unborn and fast-forward are all handled
+    // above, so both sides are known to exist and peel.
+    let our_commit = match our_ref.as_ref() {
+        Some(our) => our.peel_to_commit()?,
+        None => repo.head()?.peel_to_commit()?,
+    };
+    let their_commit = repo.find_commit(annotated_commit.id())?;
+
+    // No merge base at all. libgit2 merges unrelated histories against an empty
+    // ancestor rather than refusing the way the git CLI does without
+    // --allow-unrelated-histories, so `merge` WILL go through with it — the
+    // preview says so instead of leaving the user to discover it.
+    preview.unrelated_histories = match repo.merge_base(our_commit.id(), their_commit.id()) {
+        Ok(_) => false,
+        Err(e) if e.code() == git2::ErrorCode::NotFound => true,
+        Err(e) => return Err(e.into()),
+    };
+
+    // `None` options: exactly what `merge` passes to `repo.merge()`, so the
+    // prediction is made with the same rename detection and conflict rules the
+    // real merge will use.
+    let merged = repo.merge_commits(&our_commit, &their_commit, None)?;
+
+    if merged.has_conflicts() {
+        // One path occupies up to three conflict stages; "N files would
+        // conflict" is a count of distinct paths, not of index entries.
+        let mut paths = std::collections::BTreeSet::new();
+        for conflict in merged.conflicts()? {
+            let conflict = conflict?;
+            // Any stage names the path. A delete/modify conflict has no `our`
+            // or no `their` entry, so all three have to be tried or those
+            // conflicts go unnamed.
+            if let Some(entry) = conflict.our.or(conflict.their).or(conflict.ancestor) {
+                paths.insert(String::from_utf8_lossy(&entry.path).into_owned());
+            }
+        }
+        preview.conflict_count = paths.len();
+        preview.conflicting_files = paths.into_iter().take(MERGE_PREVIEW_PATH_CAP).collect();
+    }
+
+    Ok(preview)
 }
 
 /// Abort an in-progress merge.
@@ -4221,6 +4376,312 @@ mod tests {
         repo.create_commit("Feature change", &[("shared.txt", "feature content")]);
         repo.checkout_branch(&initial_branch);
         repo.create_commit("Main change", &[("shared.txt", "main content")]);
+    }
+
+    // ── Merge preview ────────────────────────────────────────────────────────
+
+    /// The whole point: name the files that would conflict, before the working
+    /// tree is in a conflicted state.
+    #[tokio::test]
+    async fn test_preview_merge_reports_the_conflicting_paths() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit(
+            "Add shared",
+            &[("shared.txt", "base"), ("other.txt", "base")],
+        );
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit(
+            "Feature change",
+            &[("shared.txt", "feature"), ("other.txt", "feature")],
+        );
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit(
+            "Main change",
+            &[("shared.txt", "main"), ("other.txt", "main")],
+        );
+
+        let preview = preview_merge(repo.path_str(), "feature".to_string(), None)
+            .await
+            .expect("preview should succeed even though the merge conflicts");
+
+        assert_eq!(preview.outcome, "normal");
+        assert_eq!(preview.conflict_count, 2);
+        assert_eq!(
+            preview.conflicting_files,
+            vec!["other.txt".to_string(), "shared.txt".to_string()],
+            "the exact conflicting paths must be named, sorted"
+        );
+        assert!(!preview.unrelated_histories);
+        assert!(preview.operation_in_progress.is_none());
+    }
+
+    /// A preview that mutated anything would be worse than no preview at all:
+    /// the user asked what WOULD happen, not for it to happen.
+    #[tokio::test]
+    async fn test_preview_merge_leaves_the_working_tree_and_index_untouched() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main")]);
+
+        // An uncommitted edit as well, so a preview that checked anything out
+        // would be caught destroying work rather than just moving the index.
+        repo.create_file("dirty.txt", "uncommitted");
+
+        let head_before = repo.head_oid();
+        let index_before = repo.repo().index().unwrap().write_tree().unwrap();
+        let workdir_before =
+            std::fs::read_to_string(repo.path.join("shared.txt")).expect("shared.txt");
+        let reflog_before = repo.repo().reflog("HEAD").map(|l| l.len()).unwrap_or(0);
+
+        let preview = preview_merge(repo.path_str(), "feature".to_string(), None)
+            .await
+            .expect("preview should succeed");
+        assert_eq!(preview.conflict_count, 1, "sanity: this merge conflicts");
+
+        let after = repo.repo();
+        assert_eq!(after.head().unwrap().target().unwrap(), head_before);
+        assert_eq!(
+            after.index().unwrap().write_tree().unwrap(),
+            index_before,
+            "the on-disk index must be byte-identical after a preview"
+        );
+        assert!(
+            !after.index().unwrap().has_conflicts(),
+            "the preview must not stage conflicts"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("shared.txt")).unwrap(),
+            workdir_before,
+            "the working copy must not gain conflict markers"
+        );
+        assert_eq!(
+            std::fs::read_to_string(repo.path.join("dirty.txt")).unwrap(),
+            "uncommitted",
+            "uncommitted work must survive a preview"
+        );
+        assert_eq!(after.state(), git2::RepositoryState::Clean);
+        assert!(!after.path().join("MERGE_HEAD").exists());
+        assert_eq!(after.worktrees().unwrap().len(), 0, "no ghost worktree");
+        assert_eq!(
+            after.reflog("HEAD").map(|l| l.len()).unwrap_or(0),
+            reflog_before,
+            "no ref moved"
+        );
+    }
+
+    /// A branch ahead of HEAD with no divergence fast-forwards.
+    #[tokio::test]
+    async fn test_preview_merge_reports_a_fast_forward() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature file", &[("feature.txt", "feature")]);
+        repo.checkout_branch(&initial_branch);
+
+        let preview = preview_merge(repo.path_str(), "feature".to_string(), None)
+            .await
+            .expect("preview should succeed");
+
+        assert_eq!(preview.outcome, "fastForward");
+        assert_eq!(preview.conflict_count, 0);
+        assert!(preview.conflicting_files.is_empty());
+    }
+
+    /// Divergent branches touching different files need a merge commit and
+    /// conflict in nothing.
+    #[tokio::test]
+    async fn test_preview_merge_reports_a_clean_merge_commit() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature file", &[("feature.txt", "feature")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main file", &[("main.txt", "main")]);
+
+        let preview = preview_merge(repo.path_str(), "feature".to_string(), None)
+            .await
+            .expect("preview should succeed");
+
+        assert_eq!(preview.outcome, "normal");
+        assert_eq!(preview.conflict_count, 0);
+        assert!(preview.conflicting_files.is_empty());
+        assert!(!preview.unrelated_histories);
+    }
+
+    /// Merging an ancestor changes nothing, and the confirm must say so rather
+    /// than promising a merge commit that will never be recorded.
+    #[tokio::test]
+    async fn test_preview_merge_reports_up_to_date() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_branch("feature");
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main file", &[("main.txt", "main")]);
+
+        let preview = preview_merge(repo.path_str(), "feature".to_string(), None)
+            .await
+            .expect("preview should succeed");
+
+        assert_eq!(preview.outcome, "upToDate");
+        assert_eq!(preview.conflict_count, 0);
+    }
+
+    /// libgit2 merges unrelated histories rather than refusing the way the CLI
+    /// does, so the preview is the only place a user can be warned.
+    #[tokio::test]
+    async fn test_preview_merge_reports_unrelated_histories() {
+        let repo = TestRepo::with_initial_commit();
+        let repository = repo.repo();
+        let signature = repository.signature().unwrap();
+
+        // An orphan commit: a tree of its own with no parents at all.
+        let orphan_tree = {
+            let mut builder = repository.treebuilder(None).unwrap();
+            let blob = repository.blob(b"orphan").unwrap();
+            builder.insert("orphan.txt", blob, 0o100644).unwrap();
+            let oid = builder.write().unwrap();
+            repository.find_tree(oid).unwrap()
+        };
+        let orphan = repository
+            .commit(
+                Some("refs/heads/orphan"),
+                &signature,
+                &signature,
+                "Orphan root",
+                &orphan_tree,
+                &[],
+            )
+            .unwrap();
+        assert!(repository.find_commit(orphan).is_ok());
+
+        let preview = preview_merge(repo.path_str(), "orphan".to_string(), None)
+            .await
+            .expect("preview should succeed for unrelated histories");
+
+        assert_eq!(preview.outcome, "normal");
+        assert!(
+            preview.unrelated_histories,
+            "the two sides share no merge base"
+        );
+    }
+
+    /// A branch with no commits yet: `merge` cannot fast-forward a HEAD that
+    /// does not point at anything, so "this will fast-forward" would be a lie.
+    #[tokio::test]
+    async fn test_preview_merge_reports_an_unborn_head() {
+        let repo = TestRepo::new();
+        let repository = repo.repo();
+        let signature = repository.signature().unwrap();
+        let tree = {
+            let mut builder = repository.treebuilder(None).unwrap();
+            let blob = repository.blob(b"seed").unwrap();
+            builder.insert("seed.txt", blob, 0o100644).unwrap();
+            let oid = builder.write().unwrap();
+            repository.find_tree(oid).unwrap()
+        };
+        repository
+            .commit(
+                Some("refs/heads/seed"),
+                &signature,
+                &signature,
+                "Seed",
+                &tree,
+                &[],
+            )
+            .unwrap();
+
+        let preview = preview_merge(repo.path_str(), "seed".to_string(), None)
+            .await
+            .expect("preview should succeed on an unborn HEAD");
+
+        assert_eq!(preview.outcome, "unborn");
+        assert_eq!(preview.conflict_count, 0);
+    }
+
+    /// A repository already mid-merge: the preview still answers, and names the
+    /// state that will make the real merge refuse.
+    #[tokio::test]
+    async fn test_preview_merge_reports_an_operation_in_progress() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("feature");
+        repo.checkout_branch("feature");
+        repo.create_commit("Feature change", &[("shared.txt", "feature")]);
+        repo.checkout_branch(&initial_branch);
+        repo.create_commit("Main change", &[("shared.txt", "main")]);
+
+        // Leave the repository in the state a conflicted merge leaves it in.
+        merge(repo.path_str(), "feature".to_string(), None, None, None)
+            .await
+            .expect_err("this merge conflicts");
+        assert_eq!(repo.repo().state(), git2::RepositoryState::Merge);
+
+        let preview = preview_merge(repo.path_str(), "feature".to_string(), None)
+            .await
+            .expect("the preview is read-only and must still answer");
+
+        assert_eq!(preview.operation_in_progress.as_deref(), Some("Merge"));
+    }
+
+    /// The drop-onto-another-branch path checks the target out and merges into
+    /// THAT, so a preview against HEAD would describe the wrong merge.
+    #[tokio::test]
+    async fn test_preview_merge_predicts_a_merge_into_another_branch() {
+        let repo = TestRepo::with_initial_commit();
+        let initial_branch = repo.current_branch();
+        repo.create_commit("Add shared", &[("shared.txt", "base")]);
+        repo.create_branch("target");
+        repo.create_branch("source");
+
+        repo.checkout_branch("source");
+        repo.create_commit("Source change", &[("shared.txt", "source")]);
+
+        repo.checkout_branch("target");
+        repo.create_commit("Target change", &[("shared.txt", "target")]);
+
+        // HEAD is somewhere else entirely, and merging source into it is clean.
+        repo.checkout_branch(&initial_branch);
+
+        let into_head = preview_merge(repo.path_str(), "source".to_string(), None)
+            .await
+            .expect("preview should succeed");
+        assert_eq!(into_head.conflict_count, 0, "sanity: clean against HEAD");
+
+        let into_target = preview_merge(
+            repo.path_str(),
+            "source".to_string(),
+            Some("target".to_string()),
+        )
+        .await
+        .expect("preview should succeed");
+
+        assert_eq!(into_target.outcome, "normal");
+        assert_eq!(
+            into_target.conflicting_files,
+            vec!["shared.txt".to_string()]
+        );
+    }
+
+    /// An unknown ref must fail loudly rather than come back as a clean merge.
+    #[tokio::test]
+    async fn test_preview_merge_errors_on_an_unknown_source() {
+        let repo = TestRepo::with_initial_commit();
+
+        let result = preview_merge(repo.path_str(), "no-such-branch".to_string(), None).await;
+        assert!(
+            result.is_err(),
+            "an unknown source must not be reported as a clean merge"
+        );
     }
 
     // ── Ghost-rebase preview ─────────────────────────────────────────────────

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -369,6 +369,7 @@ pub fn run() {
             commands::remote::deepen_repository,
             commands::remote::unshallow_repository,
             commands::merge::merge,
+            commands::merge::preview_merge,
             commands::merge::abort_merge,
             commands::merge::commit_merge,
             commands::merge::rebase,

--- a/src/__tests__/app-shell-ref-context-menu.integration.test.ts
+++ b/src/__tests__/app-shell-ref-context-menu.integration.test.ts
@@ -274,6 +274,62 @@ describe('app-shell ref context menu handlers (integration)', () => {
       });
     });
 
+    it('predicts the conflict in the confirm BEFORE the merge runs', async () => {
+      const previous = mockInvoke;
+      mockInvoke = (command: string, args?: unknown) => {
+        if (command === 'preview_merge') {
+          return Promise.resolve({
+            outcome: 'normal',
+            conflictCount: 2,
+            conflictingFiles: ['src/a.ts', 'src/b.ts'],
+            unrelatedHistories: false,
+            operationInProgress: null,
+          });
+        }
+        return previous(command, args);
+      };
+
+      const el = createAppShell();
+      setRefContextMenu(el, 'feature-branch');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRefMerge();
+
+      const confirms = findCommands('plugin:dialog|message');
+      expect(confirms.length).to.be.greaterThan(0);
+      const message = (confirms[0].args as { message?: string }).message ?? '';
+      expect(message).to.contain('2 files would conflict:');
+      expect(message).to.contain('src/a.ts');
+
+      // Useless unless it lands before the merge does.
+      expect(commandIndex('preview_merge')).to.be.greaterThan(-1);
+      expect(commandIndex('plugin:dialog|message')).to.be.greaterThan(
+        commandIndex('preview_merge'),
+      );
+      expect(commandIndex('merge')).to.be.greaterThan(commandIndex('plugin:dialog|message'));
+    });
+
+    it('still confirms and merges when the preview fails', async () => {
+      const previous = mockInvoke;
+      mockInvoke = (command: string, args?: unknown) => {
+        if (command === 'preview_merge') return Promise.reject(new Error('no preview'));
+        return previous(command, args);
+      };
+
+      const el = createAppShell();
+      setRefContextMenu(el, 'feature-branch');
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      await (el as any).handleRefMerge();
+
+      const confirms = findCommands('plugin:dialog|message');
+      expect(confirms.length, 'the confirm is still shown').to.be.greaterThan(0);
+      const message = (confirms[0].args as { message?: string }).message ?? '';
+      expect(message).to.contain('Merge "feature-branch" into the current branch?');
+      expect(message).to.not.contain('would conflict');
+      expect(findCommands('merge').length, 'the merge still runs').to.equal(1);
+    });
+
     it('calls open_repository after successful merge', async () => {
       const el = createAppShell();
       setRefContextMenu(el, 'feature-branch');

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -139,6 +139,7 @@ import {
   openRepositoryInEditor,
 } from './services/open-location.service.ts';
 import { showConfirm, showPrompt } from './services/dialog.service.ts';
+import { mergePreviewSummary } from './utils/merge-preview.ts';
 import {
   confirmGarbageCollection,
   confirmPrune,
@@ -2386,9 +2387,13 @@ export class AppShell extends LitElement {
     // is an IPC round trip, so a claim taken after it does not serialize two
     // dispatches that both got past the check.
     if (!this.claimRefOperation(repoPath)) return;
+    // Predicted before the confirm and inside the claim — see the sidebar's
+    // handleMergeBranch. Falls back to an unpredicted confirm when the preview
+    // cannot be computed; it must never be the reason a merge is unavailable.
+    const prediction = await mergePreviewSummary(repoPath, refName);
     if (!await showConfirm(
       'Merge Branch',
-      `Merge "${refName}" into the current branch?`,
+      `Merge "${refName}" into the current branch?${prediction}`,
       'info',
     )) {
       this.releaseRefOperation(repoPath);

--- a/src/components/sidebar/__tests__/lv-branch-list-merge-preview.test.ts
+++ b/src/components/sidebar/__tests__/lv-branch-list-merge-preview.test.ts
@@ -1,0 +1,288 @@
+/**
+ * Tests for the merge-conflict prediction shown in lv-branch-list's confirms.
+ *
+ * Every surface that starts a merge has to predict it BEFORE the user commits
+ * to it — the context menu and both drag-to-merge arms. The prediction must
+ * also never gate the merge: if preview_merge fails, the confirm still appears
+ * and the merge still runs.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeCalls: Array<{ command: string; args?: unknown }> = [];
+/** Button label the mocked confirm resolves with. 'Ok' means accepted. */
+let confirmAnswer = 'Ok';
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeCalls.push({ command, args });
+    if (command === 'plugin:dialog|message') return Promise.resolve(confirmAnswer);
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { LvBranchList } from '../lv-branch-list.ts';
+import '../lv-branch-list.ts';
+import { resetRefOpLocks } from '../../../utils/ref-lock.ts';
+import { uiStore } from '../../../stores/ui.store.ts';
+
+const REPO_PATH = '/test/repo';
+
+interface PreviewShape {
+  outcome: string;
+  conflictCount: number;
+  conflictingFiles: string[];
+  unrelatedHistories: boolean;
+  operationInProgress: string | null;
+}
+
+function preview(overrides: Partial<PreviewShape> = {}): PreviewShape {
+  return {
+    outcome: 'normal',
+    conflictCount: 0,
+    conflictingFiles: [],
+    unrelatedHistories: false,
+    operationInProgress: null,
+    ...overrides,
+  };
+}
+
+function makeBranch(name: string, isHead = false) {
+  return {
+    name,
+    shorthand: name,
+    isHead,
+    isRemote: false,
+    upstream: null,
+    targetOid: 'abc123',
+    isStale: false,
+  };
+}
+
+function baseMock(command: string, _args?: unknown): Promise<unknown> {
+  if (command === 'get_branches') return Promise.resolve([]);
+  if (command === 'get_remotes') return Promise.resolve([]);
+  if (command === 'get_hidden_branches') return Promise.resolve([]);
+  if (command === 'get_branch_sort_mode') return Promise.resolve('name');
+  return Promise.resolve(null);
+}
+
+async function createComponent(): Promise<LvBranchList> {
+  mockInvoke = baseMock;
+  const el = await fixture<LvBranchList>(
+    html`<lv-branch-list .repositoryPath=${REPO_PATH}></lv-branch-list>`
+  );
+  await el.updateComplete;
+  invokeCalls.length = 0;
+  return el;
+}
+
+/** The message text of the confirm dialog, or null when none was shown. */
+function confirmMessage(): string | null {
+  const call = invokeCalls.find((c) => c.command === 'plugin:dialog|message');
+  return call ? ((call.args as { message?: string }).message ?? null) : null;
+}
+
+function indexOfCommand(command: string): number {
+  return invokeCalls.findIndex((c) => c.command === command);
+}
+
+function fakeDragEvent(altKey = false): DragEvent {
+  return { preventDefault() {}, altKey } as unknown as DragEvent;
+}
+
+type MergeMenuHost = { contextMenu: { branch: unknown; visible: boolean }; handleMergeBranch(): Promise<void> };
+type DropHost = { draggingBranch: unknown; handleDrop(e: DragEvent, b: unknown): Promise<void> };
+
+async function mergeFromContextMenu(el: LvBranchList, branchName: string): Promise<void> {
+  const host = el as unknown as MergeMenuHost;
+  host.contextMenu = { branch: makeBranch(branchName), visible: true };
+  await host.handleMergeBranch();
+}
+
+describe('lv-branch-list merge preview', () => {
+  beforeEach(() => {
+    resetRefOpLocks();
+    invokeCalls.length = 0;
+    confirmAnswer = 'Ok';
+    uiStore.setState({ toasts: [] });
+  });
+
+  afterEach(() => {
+    resetRefOpLocks();
+  });
+
+  it('names the conflicting files in the confirm BEFORE the merge runs', async () => {
+    const el = await createComponent();
+    mockInvoke = (command, args) => {
+      if (command === 'preview_merge') {
+        return Promise.resolve(
+          preview({ conflictCount: 2, conflictingFiles: ['src/a.ts', 'src/b.ts'] })
+        );
+      }
+      return baseMock(command, args);
+    };
+
+    await mergeFromContextMenu(el, 'feature');
+
+    const message = confirmMessage();
+    expect(message, 'the merge confirm was shown').to.not.be.null;
+    expect(message!).to.contain('2 files would conflict:');
+    expect(message!).to.contain('src/a.ts');
+    expect(message!).to.contain('src/b.ts');
+
+    // The prediction is worthless if it arrives after the merge started.
+    const previewAt = indexOfCommand('preview_merge');
+    const confirmAt = indexOfCommand('plugin:dialog|message');
+    const mergeAt = indexOfCommand('merge');
+    expect(previewAt).to.be.greaterThan(-1);
+    expect(confirmAt).to.be.greaterThan(previewAt);
+    expect(mergeAt).to.be.greaterThan(confirmAt);
+  });
+
+  it('previews against HEAD, using the full ref name of the row', async () => {
+    const el = await createComponent();
+    mockInvoke = (command, args) => {
+      if (command === 'preview_merge') return Promise.resolve(preview());
+      return baseMock(command, args);
+    };
+
+    await mergeFromContextMenu(el, 'origin/feature');
+
+    const call = invokeCalls.find((c) => c.command === 'preview_merge');
+    expect(call!.args).to.deep.equal({
+      path: REPO_PATH,
+      sourceRef: 'origin/feature',
+      intoRef: undefined,
+    });
+  });
+
+  it('says a fast-forward will fast-forward', async () => {
+    const el = await createComponent();
+    mockInvoke = (command, args) => {
+      if (command === 'preview_merge') {
+        return Promise.resolve(preview({ outcome: 'fastForward' }));
+      }
+      return baseMock(command, args);
+    };
+
+    await mergeFromContextMenu(el, 'feature');
+    expect(confirmMessage()!).to.contain('fast-forward');
+  });
+
+  it('says a divergent clean merge will create a merge commit', async () => {
+    const el = await createComponent();
+    mockInvoke = (command, args) => {
+      if (command === 'preview_merge') return Promise.resolve(preview());
+      return baseMock(command, args);
+    };
+
+    await mergeFromContextMenu(el, 'feature');
+    expect(confirmMessage()!).to.contain('merge commit');
+  });
+
+  it('still confirms and merges when the preview fails', async () => {
+    const el = await createComponent();
+    mockInvoke = (command, args) => {
+      if (command === 'preview_merge') return Promise.reject(new Error('no preview'));
+      return baseMock(command, args);
+    };
+
+    await mergeFromContextMenu(el, 'feature');
+
+    const message = confirmMessage();
+    expect(message, 'the confirm is shown without a prediction').to.not.be.null;
+    expect(message!).to.contain('Merge "feature" into the current branch?');
+    expect(message!).to.not.contain('would conflict');
+    expect(invokeCalls.some((c) => c.command === 'merge'), 'merge still ran').to.be.true;
+  });
+
+  it('does not merge when the user declines the predicted conflict', async () => {
+    const el = await createComponent();
+    confirmAnswer = 'Cancel';
+    mockInvoke = (command, args) => {
+      if (command === 'preview_merge') {
+        return Promise.resolve(preview({ conflictCount: 1, conflictingFiles: ['src/a.ts'] }));
+      }
+      return baseMock(command, args);
+    };
+
+    await mergeFromContextMenu(el, 'feature');
+
+    expect(confirmMessage()!).to.contain('1 file would conflict:');
+    expect(invokeCalls.some((c) => c.command === 'merge'), 'merge NOT called').to.be.false;
+  });
+
+  it('predicts a drag-merge onto the current branch', async () => {
+    const el = await createComponent();
+    mockInvoke = (command, args) => {
+      if (command === 'preview_merge') {
+        return Promise.resolve(preview({ conflictCount: 1, conflictingFiles: ['shared.txt'] }));
+      }
+      return baseMock(command, args);
+    };
+
+    (el as unknown as DropHost).draggingBranch = makeBranch('feature');
+    await (el as unknown as DropHost).handleDrop(fakeDragEvent(false), makeBranch('main', true));
+
+    const call = invokeCalls.find((c) => c.command === 'preview_merge');
+    expect(call, 'the drop path previews too').to.not.be.undefined;
+    expect((call!.args as { intoRef?: string }).intoRef).to.be.undefined;
+    expect(confirmMessage()!).to.contain('shared.txt');
+  });
+
+  it('predicts a drag-merge onto another branch against THAT branch', async () => {
+    const el = await createComponent();
+    mockInvoke = (command, args) => {
+      if (command === 'preview_merge') {
+        return Promise.resolve(preview({ conflictCount: 1, conflictingFiles: ['shared.txt'] }));
+      }
+      if (command === 'checkout_with_autostash') {
+        return Promise.resolve({ success: true, stashed: false, message: '' });
+      }
+      return baseMock(command, args);
+    };
+
+    (el as unknown as DropHost).draggingBranch = makeBranch('feature');
+    await (el as unknown as DropHost).handleDrop(fakeDragEvent(false), makeBranch('develop'));
+
+    const call = invokeCalls.find((c) => c.command === 'preview_merge');
+    expect(call, 'the checkout-then-merge arm previews too').to.not.be.undefined;
+    expect(call!.args).to.deep.equal({
+      path: REPO_PATH,
+      sourceRef: 'feature',
+      intoRef: 'develop',
+    });
+
+    // Predicted BEFORE the checkout, which is the point of no return here.
+    const previewAt = indexOfCommand('preview_merge');
+    const checkoutAt = indexOfCommand('checkout_with_autostash');
+    expect(previewAt).to.be.greaterThan(-1);
+    expect(checkoutAt).to.be.greaterThan(previewAt);
+    expect(confirmMessage()!).to.contain('shared.txt');
+  });
+
+  it('does not preview an alt-drag rebase', async () => {
+    const el = await createComponent();
+    mockInvoke = (command, args) => {
+      if (command === 'checkout_with_autostash') {
+        return Promise.resolve({ success: true, stashed: false, message: '' });
+      }
+      return baseMock(command, args);
+    };
+
+    (el as unknown as DropHost).draggingBranch = makeBranch('feature');
+    await (el as unknown as DropHost).handleDrop(fakeDragEvent(true), makeBranch('develop'));
+
+    expect(
+      invokeCalls.some((c) => c.command === 'preview_merge'),
+      'a rebase is not a merge'
+    ).to.be.false;
+  });
+});

--- a/src/components/sidebar/lv-branch-list.ts
+++ b/src/components/sidebar/lv-branch-list.ts
@@ -3,6 +3,7 @@ import { customElement, property, state, query } from 'lit/decorators.js';
 import { sharedStyles } from '../../styles/shared-styles.ts';
 import * as gitService from '../../services/git.service.ts';
 import { showConfirm, showPrompt } from '../../services/dialog.service.ts';
+import { mergePreviewSummary } from '../../utils/merge-preview.ts';
 import { showToast } from '../../services/notification.service.ts';
 import { sweepRepoScopedDialogs } from '../../utils/repo-scoped-dialogs.ts';
 import { showErrorWithSuggestion } from '../../services/error-suggestion.service.ts';
@@ -1390,9 +1391,14 @@ export class LvBranchList extends LitElement {
     // Captured BEFORE the confirm await: the merge must run on the repo it was
     // invoked on, even if the user switches tabs while the confirm is up.
     const repoPath = this.repositoryPath;
+    // Predicted BEFORE the confirm, inside the claim taken above: the user has
+    // to be able to see "N files would conflict" while deciding, not discover
+    // it from a working tree that is already conflicted. Read-only and
+    // in-memory in the backend, so it cannot race the merge it precedes.
+    const prediction = await mergePreviewSummary(repoPath, branch.name);
     const confirmed = await showConfirm(
       'Merge Branch',
-      `Merge "${branch.name}" into the current branch?`,
+      `Merge "${branch.name}" into the current branch?${prediction}`,
       'info'
     );
 
@@ -1875,10 +1881,13 @@ export class LvBranchList extends LitElement {
     // If target is HEAD, merge source into current
     if (targetBranch.isHead) {
       if (action === 'merge') {
-        // Merge source branch into current (HEAD)
+        // Merge source branch into current (HEAD). Same conflict prediction the
+        // context menu shows — a drag is the least deliberate of the merge
+        // gestures, so it is the one that most needs the warning.
+        const prediction = await mergePreviewSummary(repoPath, sourceBranch.name);
         const confirmed = await showConfirm(
           'Merge Branch',
-          `Merge "${sourceBranch.name}" into the current branch?`,
+          `Merge "${sourceBranch.name}" into the current branch?${prediction}`,
           'info'
         );
         if (!confirmed) return;
@@ -1943,10 +1952,18 @@ export class LvBranchList extends LitElement {
     } else {
       // Dropping on a non-HEAD branch: need to checkout first, then merge/rebase
       const actionText = action === 'merge' ? 'merge' : 'rebase onto';
+      // Previewed against the TARGET branch, not HEAD: this arm checks the
+      // target out first and merges into that, so a prediction against the
+      // branch the user is leaving would describe a different merge.
+      const prediction =
+        action === 'merge'
+          ? await mergePreviewSummary(repoPath, sourceBranch.name, targetBranch.name)
+          : '';
       const confirmed = await showConfirm(
         action === 'merge' ? 'Merge Branch' : 'Rebase Branch',
         `This will checkout "${targetBranch.name}" and ${actionText} "${sourceBranch.name}". Continue?` +
-          (action === 'rebase' ? `\n\nThis will rewrite commit history.` : ''),
+          (action === 'rebase' ? `\n\nThis will rewrite commit history.` : '') +
+          prediction,
         action === 'merge' ? 'info' : 'warning'
       );
       if (!confirmed) return;

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -1842,6 +1842,42 @@ export async function merge(args: MergeCommand): Promise<CommandResult<void>> {
   return invokeCommand<void>("merge", args);
 }
 
+export interface MergePreview {
+  /**
+   * What the merge would do. `unborn` means the branch being merged INTO has
+   * no commits yet, which `merge` cannot fast-forward.
+   */
+  outcome: "upToDate" | "fastForward" | "normal" | "unborn";
+  /** Exact number of paths that would conflict. */
+  conflictCount: number;
+  /** The conflicting paths, sorted — capped, so it can be shorter than the count. */
+  conflictingFiles: string[];
+  /** The two sides share no common ancestor. */
+  unrelatedHistories: boolean;
+  /** Repository state blocking the merge (e.g. "Merge"), or null when clean. */
+  operationInProgress: string | null;
+}
+
+/**
+ * Predict a merge without performing it.
+ *
+ * Purely in-memory in the backend (libgit2 merges the two trees into an index
+ * that is never checked out), so it touches neither the working tree nor the
+ * index and leaves nothing to clean up. `intoRef` names the branch the merge
+ * will land on; omit it for HEAD.
+ */
+export async function previewMerge(
+  path: string,
+  sourceRef: string,
+  intoRef?: string,
+): Promise<CommandResult<MergePreview>> {
+  return invokeCommand<MergePreview>("preview_merge", {
+    path,
+    sourceRef,
+    intoRef,
+  });
+}
+
 export async function abortMerge(
   args: AbortMergeCommand,
 ): Promise<CommandResult<void>> {

--- a/src/utils/__tests__/merge-preview.test.ts
+++ b/src/utils/__tests__/merge-preview.test.ts
@@ -1,0 +1,183 @@
+/**
+ * Tests for the shared merge-confirm prediction.
+ *
+ * A merge used to be confirmed with no warning that it would conflict — the
+ * user found out only when the working tree was already conflicted. The
+ * prediction has to be exact in every outcome the backend can report, and it
+ * must never be the reason a merge cannot be started: when the preview fails,
+ * the confirm is shown WITHOUT a prediction rather than blocked.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+const invokeHistory: Array<{ command: string; args?: unknown }> = [];
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => {
+    invokeHistory.push({ command, args });
+    return mockInvoke(command, args);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect } from '@open-wc/testing';
+import type { MergePreview } from '../../services/git.service.ts';
+import { formatMergePreview, mergePreviewSummary } from '../merge-preview.ts';
+
+const REPO_PATH = '/test/repo';
+
+function preview(overrides: Partial<MergePreview> = {}): MergePreview {
+  return {
+    outcome: 'normal',
+    conflictCount: 0,
+    conflictingFiles: [],
+    unrelatedHistories: false,
+    operationInProgress: null,
+    ...overrides,
+  };
+}
+
+describe('formatMergePreview', () => {
+  it('says a fast-forward will fast-forward', () => {
+    const text = formatMergePreview(preview({ outcome: 'fastForward' }), 'feature');
+    expect(text).to.contain('fast-forward');
+    expect(text).to.not.contain('will create a merge commit');
+  });
+
+  it('says a divergent, clean merge will create a merge commit', () => {
+    const text = formatMergePreview(preview({ outcome: 'normal' }), 'feature');
+    expect(text).to.contain('merge commit');
+    expect(text).to.contain('No conflicts predicted');
+  });
+
+  it('says an already-merged branch would do nothing', () => {
+    const text = formatMergePreview(preview({ outcome: 'upToDate' }), 'feature');
+    expect(text).to.contain('Already up to date');
+  });
+
+  it('names the conflicting files and keeps the merge available', () => {
+    const text = formatMergePreview(
+      preview({
+        outcome: 'normal',
+        conflictCount: 2,
+        conflictingFiles: ['src/a.ts', 'src/b.ts'],
+      }),
+      'feature',
+    );
+
+    expect(text).to.contain('2 files would conflict:');
+    expect(text).to.contain('src/a.ts');
+    expect(text).to.contain('src/b.ts');
+    // Not a block — the user may be merging into the conflict deliberately.
+    expect(text).to.contain('You can still merge');
+  });
+
+  it('uses the singular for exactly one conflicting file', () => {
+    const text = formatMergePreview(
+      preview({ outcome: 'normal', conflictCount: 1, conflictingFiles: ['src/a.ts'] }),
+      'feature',
+    );
+    expect(text).to.contain('1 file would conflict:');
+    expect(text).to.not.contain('1 files');
+  });
+
+  it('caps the listed paths and counts the rest', () => {
+    const files = Array.from({ length: 12 }, (_, i) => `src/file${i}.ts`);
+    const text = formatMergePreview(
+      preview({ outcome: 'normal', conflictCount: 12, conflictingFiles: files }),
+      'feature',
+    );
+
+    expect(text).to.contain('12 files would conflict:');
+    expect(text).to.contain('src/file7.ts');
+    expect(text).to.not.contain('src/file8.ts');
+    expect(text).to.contain('…and 4 more');
+  });
+
+  it('counts the remainder from the exact count, not the truncated list', () => {
+    // The backend caps `conflictingFiles` itself, so the list can be shorter
+    // than the count; the remainder must still add up.
+    const files = Array.from({ length: 50 }, (_, i) => `src/file${i}.ts`);
+    const text = formatMergePreview(
+      preview({ outcome: 'normal', conflictCount: 4000, conflictingFiles: files }),
+      'feature',
+    );
+    expect(text).to.contain('…and 3992 more');
+  });
+
+  it('says an unborn branch will simply be set to the source', () => {
+    const text = formatMergePreview(preview({ outcome: 'unborn' }), 'feature');
+    expect(text).to.contain('no commits yet');
+    expect(text).to.contain('"feature"');
+    expect(text).to.not.contain('fast-forward');
+  });
+
+  it('warns about unrelated histories', () => {
+    const text = formatMergePreview(preview({ unrelatedHistories: true }), 'feature');
+    expect(text).to.contain('no common history');
+  });
+
+  it('warns that an operation already in progress will refuse the merge', () => {
+    const text = formatMergePreview(preview({ operationInProgress: 'Merge' }), 'feature');
+    expect(text).to.contain('merge is already in progress');
+    expect(text).to.contain('refused');
+  });
+
+  it('starts with a blank line so it appends cleanly to a confirm', () => {
+    expect(formatMergePreview(preview({ outcome: 'fastForward' }), 'feature')).to.match(/^\n\n/);
+  });
+
+  it('says nothing about an outcome it does not recognise', () => {
+    const unknown = { ...preview(), outcome: 'somethingNew' } as unknown as MergePreview;
+    expect(formatMergePreview(unknown, 'feature')).to.equal('');
+  });
+});
+
+describe('mergePreviewSummary', () => {
+  beforeEach(() => {
+    invokeHistory.length = 0;
+    mockInvoke = async () => null;
+  });
+
+  it('passes the source ref and no target when merging into HEAD', async () => {
+    mockInvoke = async () => preview({ outcome: 'fastForward' });
+
+    const text = await mergePreviewSummary(REPO_PATH, 'origin/feature');
+
+    const calls = invokeHistory.filter((c) => c.command === 'preview_merge');
+    expect(calls).to.have.lengthOf(1);
+    expect(calls[0].args).to.deep.equal({
+      path: REPO_PATH,
+      sourceRef: 'origin/feature',
+      intoRef: undefined,
+    });
+    expect(text).to.contain('fast-forward');
+  });
+
+  it('passes the target branch when the merge lands somewhere other than HEAD', async () => {
+    mockInvoke = async () => preview();
+
+    await mergePreviewSummary(REPO_PATH, 'feature', 'develop');
+
+    const calls = invokeHistory.filter((c) => c.command === 'preview_merge');
+    expect((calls[0].args as { intoRef?: string }).intoRef).to.equal('develop');
+  });
+
+  it('falls back to no prediction when the preview command fails', async () => {
+    mockInvoke = async () => {
+      throw new Error('preview_merge exploded');
+    };
+
+    expect(await mergePreviewSummary(REPO_PATH, 'feature')).to.equal('');
+  });
+
+  it('falls back to no prediction when the backend returns nothing', async () => {
+    mockInvoke = async () => undefined;
+
+    expect(await mergePreviewSummary(REPO_PATH, 'feature')).to.equal('');
+  });
+});

--- a/src/utils/merge-preview.ts
+++ b/src/utils/merge-preview.ts
@@ -1,0 +1,114 @@
+/**
+ * The merge confirm's prediction, shared by every surface that starts a merge.
+ *
+ * A merge used to be confirmed with nothing but "Merge X into the current
+ * branch?" — the user learned it would conflict only once the working tree was
+ * already conflicted and the conflict-resolution flow had taken over. The
+ * backend can answer the question first: `preview_merge` merges the two trees
+ * in memory (no checkout, no index, no worktree, nothing to clean up) and
+ * reports whether the merge fast-forwards, records a merge commit, or
+ * conflicts — and in which files.
+ *
+ * Worded once, here, rather than per surface, for the same reason
+ * `maintenance-confirms.ts` and `restore-file.ts` share theirs: the branch
+ * context menu, the drag-to-merge drop and the graph's ref menu all confirm the
+ * same operation and must not drift apart.
+ *
+ * The prediction NEVER blocks the merge. A user may deliberately merge into a
+ * conflict to resolve it; the point is that they choose to.
+ */
+
+import * as gitService from '../services/git.service.ts';
+import type { MergePreview } from '../services/git.service.ts';
+import { loggers } from './logger.ts';
+
+/** How many conflicting paths the confirm lists before it summarises the rest. */
+export const MERGE_PREVIEW_LISTED_PATHS = 8;
+
+/**
+ * The prediction as a block appended to a merge confirm, starting with a blank
+ * line. Empty string when there is nothing to say.
+ */
+export function formatMergePreview(preview: MergePreview, sourceLabel: string): string {
+  const lines: string[] = [];
+
+  switch (preview.outcome) {
+    case 'upToDate':
+      lines.push('Already up to date — this merge would do nothing.');
+      break;
+    case 'fastForward':
+      lines.push('This will fast-forward — no merge commit, no conflicts.');
+      break;
+    case 'unborn':
+      lines.push(
+        `The branch being merged into has no commits yet — it will be set to "${sourceLabel}".`,
+      );
+      break;
+    case 'normal':
+      if (preview.conflictCount === 0) {
+        lines.push('This will create a merge commit. No conflicts predicted.');
+      } else {
+        const shown = preview.conflictingFiles.slice(0, MERGE_PREVIEW_LISTED_PATHS);
+        lines.push(
+          preview.conflictCount === 1
+            ? '1 file would conflict:'
+            : `${preview.conflictCount} files would conflict:`,
+        );
+        for (const file of shown) lines.push(`  • ${file}`);
+        // `conflictingFiles` is itself capped by the backend, so the remainder
+        // is counted from conflictCount — the only exact number available.
+        const remaining = preview.conflictCount - shown.length;
+        if (remaining > 0) lines.push(`  …and ${remaining} more`);
+        lines.push('You can still merge and resolve the conflicts.');
+      }
+      break;
+    default:
+      // An outcome this build does not know about. Saying nothing beats
+      // guessing — the confirm still works, just without a prediction.
+      break;
+  }
+
+  if (preview.unrelatedHistories) {
+    lines.push('These branches share no common history.');
+  }
+  if (preview.operationInProgress) {
+    lines.push(
+      `A ${preview.operationInProgress.toLowerCase()} is already in progress — ` +
+        'finish or abort it first, or this merge will be refused.',
+    );
+  }
+
+  return lines.length > 0 ? `\n\n${lines.join('\n')}` : '';
+}
+
+/**
+ * Predict the merge and return the block to append to its confirm.
+ *
+ * Resolves to '' when the preview could not be computed, so the confirm is
+ * shown WITHOUT a prediction rather than the merge being blocked on a
+ * best-effort extra. Callers must already hold the repository's working-tree
+ * claim (see `ref-lock.ts`); the preview itself takes no lock and writes
+ * nothing, so it cannot deadlock against the merge it is previewing.
+ *
+ * @param intoRef Branch the merge will land on; omit for HEAD.
+ */
+export async function mergePreviewSummary(
+  repoPath: string,
+  sourceRef: string,
+  intoRef?: string,
+): Promise<string> {
+  try {
+    const result = await gitService.previewMerge(repoPath, sourceRef, intoRef);
+    if (!result.success || !result.data) {
+      // Deliberately not a toast: the confirm that follows is the user-visible
+      // feedback, and a warning about a prediction they never asked for would
+      // be noise in front of the question they did ask.
+      loggers.git.warn('Merge preview unavailable:', result.error);
+      return '';
+    }
+    return formatMergePreview(result.data, sourceRef);
+  } catch (error) {
+    loggers.git.warn('Merge preview failed:', error);
+    return '';
+  }
+}


### PR DESCRIPTION
## Summary

- New `preview_merge` backend command reports what a merge would do — fast-forward, merge commit, up-to-date, or unborn target — plus the exact number of conflicting paths and their names, whether the histories are unrelated, and any operation already in progress that will make the real merge refuse.
- Every merge confirm now carries that prediction *before* the user commits to it: the branch context menu (`lv-branch-list.ts` `handleMergeBranch`), both drag-to-merge arms (`runDrop`), and the graph ref menu (`app-shell.ts` `handleRefMerge`). The wording lives in one shared helper (`src/utils/merge-preview.ts`) so the surfaces cannot drift apart, the same way `maintenance-confirms.ts` and `restore-file.ts` share theirs.
- The drop-onto-another-branch arm checks the target out first and merges into *that*, so it previews against the target branch rather than the branch the user is leaving.
- The prediction never blocks the merge — a user may be merging into a conflict deliberately — and a preview that fails falls back to the plain confirm rather than standing between the user and the operation.
- There is no merge entry in the command palette (its `merge` case is only an icon), so the four call sites above are the complete set.

## Review finding

A user could start a merge with no warning that it would conflict; the only feedback was the conflicted working tree afterwards. `lv-branch-list.ts:1394` (context menu), `lv-branch-list.ts:1880` and `:1955` (drag-to-merge, onto HEAD and onto another branch) and `app-shell.ts:2390` (graph ref menu) all confirmed with nothing but `Merge "X" into the current branch?` before invoking `merge`, which returns `MERGE_CONFLICT` only once `repo.merge()` has already filled the index and working tree.

## Why in-memory rather than the ghost-rebase worktree

The brief asked for the choice to be justified. `preview_rebase` (`src-tauri/src/commands/merge.rs:822`) shells out to `git rebase` in a temporary detached worktree because replaying a series of commits has no in-memory form; it then has to abort the rebase, remove the worktree, and defer its error report until after the removal so a failed preview does not strand a worktree registration. A merge needs none of that: `Repository::merge_analysis` gives the fast-forward/normal/up-to-date determination and `Repository::merge_commits` produces an `Index` that never leaves memory, whose conflict iterator gives the paths. Nothing is checked out, no `index.lock` is taken, no ref moves, and there is no debris to clean up — so it is both faster and strictly safer than reusing the worktree helper. A test asserts the working tree, the index, `HEAD`, the reflog, the repository state and the worktree list are all unchanged after a preview.

**Locking.** As `src/utils/ref-lock.ts` documents, there is no per-repo lock in the backend; serialization is the frontend working-tree claim. Every call site already claims that lock *before* its confirm, and the preview is issued inside that claim, so it can never run concurrently with another ref operation — and because it writes nothing and takes no lock of its own, it cannot deadlock against the merge it precedes. `merge()` and `preview_merge()` now share one `find_merge_ref` helper so the preview can never resolve a different commit than the merge it is previewing.

**Every state is handled.** Preview fails → confirm shown without a prediction, merge still available. Mid-merge/rebase → reported as `operationInProgress` and named in the confirm ("a merge is already in progress — finish or abort it first, or this merge will be refused"). Unborn HEAD → its own outcome, since libgit2 sets `FASTFORWARD` alongside `UNBORN` and "this will fast-forward" would be wrong. Unrelated histories → flagged, because libgit2 merges them rather than refusing the way the CLI does.

## Test plan

- [ ] Rust: 10 new tests in `src-tauri/src/commands/merge.rs` — conflicting merge (asserts the exact sorted paths), fast-forward, clean merge commit, up-to-date, unrelated histories, unborn HEAD, operation-in-progress, merge into a non-HEAD branch, unknown source errors, and the working-tree/index/HEAD/reflog-untouched assertion. `cargo test --lib merge` → 194 passed, 0 failed.
- [ ] Frontend: `src/utils/__tests__/merge-preview.test.ts` (16 tests — every outcome, singular/plural, the path cap and remainder arithmetic, unrelated histories, operation in progress, unknown outcome, and both preview-failure fallbacks) and `src/components/sidebar/__tests__/lv-branch-list-merge-preview.test.ts` (9 tests — confirm content, preview-before-merge ordering, both drag arms, decline path, rebase not previewed). Two cases added to `app-shell-ref-context-menu.integration.test.ts` for the graph ref menu.
- [ ] E2E: new `Merge Conflict Prediction` block in `e2e/tests/branches.spec.ts` asserting the conflict prediction reaches the confirm and that `preview_merge` → confirm → `merge` happen in that order, that a clean merge says "merge commit", and that a failed preview still confirms and merges. `branches.spec.ts` → 46 passed.
- [ ] Gate: `npm run lint` (0 errors, 203 warnings — baseline), `npm run typecheck`, `npm test` (5523 passed; the two "network gate coverage" sweep timeouts are the known baseline failures — verified they fail identically with `git.service.ts` reverted to `origin/main`), `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` all clean. The CLAUDE.md snake_case check returns nothing new.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_