### PR TITLE
feat: add a native application menu bar

### DIFF
--- a/e2e/fixtures/tauri-mock.ts
+++ b/e2e/fixtures/tauri-mock.ts
@@ -1314,6 +1314,13 @@ export async function setupTauriMocks(
             );
             return null;
           }
+          // === Application menu bar ===
+          // The frontend pushes enabled state and accelerators on startup and
+          // whenever a repository opens or closes; there is no native menu in
+          // the browser, so the call just succeeds.
+          case 'sync_app_menu':
+            return null;
+
           // === Git Flow ===
           case 'get_gitflow_config':
             return state.gitflowConfig;

--- a/e2e/tests/app-menu.spec.ts
+++ b/e2e/tests/app-menu.spec.ts
@@ -1,0 +1,161 @@
+import { test, expect, type Page } from '@playwright/test';
+import { setupOpenRepository, setupTauriMocks, initializeRepositoryStore } from '../fixtures/tauri-mock';
+import {
+  emitBackendEvent,
+  findCommand,
+  injectCommandMock,
+  startCommandCapture,
+  waitForCommand,
+} from '../fixtures/test-helpers';
+
+/**
+ * E2E tests for the native application menu bar.
+ *
+ * Playwright cannot click a native OS menu, so what is covered here is
+ * everything on this side of the boundary: choosing a menu item emits
+ * `app-menu-action` with the item's id, and the app must react exactly as it
+ * does when the same action is run from the command palette — including the
+ * "open a repository first" guard, and the enabled/disabled state pushed back
+ * to the native menu as repositories open and close.
+ *
+ * The native menu itself (labels, ordering, the accelerators the OS draws,
+ * greyed-out items) needs manual verification per platform.
+ */
+
+/** Choose a menu item, exactly as the Rust side reports it. */
+async function chooseMenuItem(page: Page, id: string): Promise<void> {
+  await emitBackendEvent(page, 'app-menu-action', id);
+}
+
+type MenuSyncItems = Array<{ id: string; enabled: boolean; accelerator: string | null }>;
+
+async function lastMenuSync(page: Page): Promise<MenuSyncItems> {
+  const calls = await findCommand(page, 'sync_app_menu');
+  expect(calls.length, 'sync_app_menu should have been invoked').toBeGreaterThan(0);
+  return (calls[calls.length - 1].args as { items: MenuSyncItems }).items;
+}
+
+test.describe('Application menu — with a repository open', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupOpenRepository(page);
+  });
+
+  test('Repository ▸ Clean opens the same dialog as the palette command', async ({ page }) => {
+    await injectCommandMock(page, {
+      get_cleanable_files: [
+        { path: 'untracked-file.txt', isDirectory: false, isIgnored: false, size: 1024 },
+      ],
+    });
+
+    await chooseMenuItem(page, 'clean');
+
+    await expect(page.locator('lv-clean-dialog[open] .dialog')).toBeVisible();
+    await expect(page.locator('lv-clean-dialog .title')).toContainText('Clean Working Directory');
+  });
+
+  test('View ▸ Command Palette opens the palette', async ({ page }) => {
+    await chooseMenuItem(page, 'command-palette');
+
+    await expect(page.locator('lv-command-palette[open]')).toBeVisible();
+  });
+
+  test('Help ▸ Keyboard Shortcuts opens the shortcuts dialog', async ({ page }) => {
+    await chooseMenuItem(page, 'keyboard-shortcuts');
+
+    await expect(page.locator('lv-keyboard-shortcuts-dialog[open]')).toBeVisible();
+  });
+
+  test('File ▸ Close Repository Tab closes the active tab', async ({ page }) => {
+    await expect(page.locator('lv-toolbar .tab')).toHaveCount(1);
+
+    await chooseMenuItem(page, 'close-repository-tab');
+
+    await expect(page.locator('lv-toolbar .tab')).toHaveCount(0);
+    await expect(page.locator('lv-welcome')).toBeVisible();
+  });
+
+  test('an unroutable menu id is reported rather than ignored', async ({ page }) => {
+    await chooseMenuItem(page, 'not-a-real-menu-item');
+
+    await expect(page.locator('lv-toast-container .toast.error')).toContainText('not available');
+  });
+});
+
+test.describe('Application menu — with no repository open', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupTauriMocks(page);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('lv-welcome')).toBeVisible();
+  });
+
+  test('a repository action explains why nothing happened', async ({ page }) => {
+    await chooseMenuItem(page, 'clean');
+
+    await expect(page.locator('lv-toast-container .toast.warning')).toContainText(
+      'open a repository'
+    );
+    await expect(page.locator('lv-clean-dialog[open] .dialog')).toHaveCount(0);
+  });
+
+  test('actions that need no repository still work', async ({ page }) => {
+    await chooseMenuItem(page, 'command-palette');
+
+    await expect(page.locator('lv-command-palette[open]')).toBeVisible();
+    await expect(page.locator('lv-toast-container .toast.warning')).toHaveCount(0);
+  });
+
+  test('File ▸ Clone Repository opens the clone dialog', async ({ page }) => {
+    await chooseMenuItem(page, 'clone-repository');
+
+    await expect(page.locator('lv-clone-dialog lv-modal[open]')).toBeVisible();
+  });
+});
+
+test.describe('Application menu — enabled state follows the open repository', () => {
+  test('every repository item is enabled once a repository opens', async ({ page }) => {
+    await setupTauriMocks(page);
+    await page.goto('/');
+    await page.waitForLoadState('domcontentloaded');
+    await expect(page.locator('lv-welcome')).toBeVisible();
+
+    await startCommandCapture(page);
+    await initializeRepositoryStore(page);
+    await waitForCommand(page, 'sync_app_menu');
+
+    const items = await lastMenuSync(page);
+    expect(items.find((i) => i.id === 'fetch')?.enabled).toBe(true);
+    expect(items.find((i) => i.id === 'repository-health')?.enabled).toBe(true);
+    expect(items.find((i) => i.id === 'close-repository-tab')?.enabled).toBe(true);
+  });
+
+  test('repository items are disabled again when the last tab closes', async ({ page }) => {
+    await setupOpenRepository(page);
+    await startCommandCapture(page);
+
+    await chooseMenuItem(page, 'close-repository-tab');
+    await expect(page.locator('lv-welcome')).toBeVisible();
+    await waitForCommand(page, 'sync_app_menu');
+
+    const items = await lastMenuSync(page);
+    expect(items.find((i) => i.id === 'fetch')?.enabled).toBe(false);
+    expect(items.find((i) => i.id === 'repository-health')?.enabled).toBe(false);
+    // Items that work without a repository stay clickable.
+    expect(items.find((i) => i.id === 'command-palette')?.enabled).toBe(true);
+    expect(items.find((i) => i.id === 'open-repository')?.enabled).toBe(true);
+  });
+
+  test('menu items carry the keyboard shortcut they are bound to', async ({ page }) => {
+    await setupOpenRepository(page);
+    await startCommandCapture(page);
+
+    await chooseMenuItem(page, 'close-repository-tab');
+    await waitForCommand(page, 'sync_app_menu');
+
+    const items = await lastMenuSync(page);
+    expect(items.find((i) => i.id === 'fetch')?.accelerator).toBe('CmdOrCtrl+Shift+F');
+    expect(items.find((i) => i.id === 'toggle-left-panel')?.accelerator).toBe('CmdOrCtrl+B');
+    // Nothing invented for an action with no binding.
+    expect(items.find((i) => i.id === 'bisect')?.accelerator).toBe(null);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "tauri:dev": "tauri dev",
     "tauri:build": "tauri build",
     "test": "npm run test:contract && web-test-runner",
-    "test:contract": "node --test scripts/ipc-contract.test.mjs",
+    "test:contract": "node --test scripts/ipc-contract.test.mjs scripts/menu-contract.test.mjs",
     "test:watch": "web-test-runner --watch",
     "test:e2e": "playwright test --config=e2e/playwright.config.ts",
     "test:e2e:ui": "playwright test --config=e2e/playwright.config.ts --ui",

--- a/scripts/menu-contract.test.mjs
+++ b/scripts/menu-contract.test.mjs
@@ -1,0 +1,114 @@
+/**
+ * Application menu contract test.
+ *
+ * The native menu bar is built in Rust (`src-tauri/src/menu.rs`) and every item
+ * it emits is routed to an action by a table in TypeScript
+ * (`src/services/app-menu.service.ts`). Neither side can see the other, so a
+ * menu item added, renamed or dropped on one side only compiles, type-checks
+ * and ships — and shows up as a menu entry that does nothing, or an action no
+ * menu can reach.
+ *
+ * This test compares the two tables directly:
+ *   - the same ids, in the same order
+ *   - the same repository-scoped flags, so an item that needs a repository is
+ *     greyed out by both halves
+ */
+
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { test } from 'node:test';
+
+const RUST_MENU = 'src-tauri/src/menu.rs';
+const TS_MENU = 'src/services/app-menu.service.ts';
+
+/** Items declared by the Rust menu table, in display order. */
+function parseRustMenu(source) {
+  const table = source.slice(
+    source.indexOf('pub const APP_MENU'),
+    source.indexOf('/// Every clickable item')
+  );
+  assert.ok(table.length > 0, `${RUST_MENU}: APP_MENU table not found`);
+
+  const items = [];
+  const pattern = /\b(repo_item|item)\("([^"]+)",\s*"/g;
+  let match;
+  while ((match = pattern.exec(table)) !== null) {
+    items.push({ id: match[2], repositoryScoped: match[1] === 'repo_item' });
+  }
+  return items;
+}
+
+/** Items declared by the frontend action table, in display order. */
+function parseTsMenu(source) {
+  const start = source.indexOf('export const APP_MENU_ACTIONS');
+  assert.notEqual(start, -1, `${TS_MENU}: APP_MENU_ACTIONS table not found`);
+  const table = source.slice(start, source.indexOf('\n];', start));
+
+  const items = [];
+  for (const entry of table.match(/\{[^{}]*\}/g) ?? []) {
+    const id = entry.match(/id:\s*'([^']+)'/);
+    const scoped = entry.match(/repositoryScoped:\s*(true|false)/);
+    assert.ok(id, `${TS_MENU}: menu entry without an id: ${entry}`);
+    assert.ok(scoped, `${TS_MENU}: menu entry "${id[1]}" without repositoryScoped`);
+    items.push({ id: id[1], repositoryScoped: scoped[1] === 'true' });
+  }
+  return items;
+}
+
+const rustItems = parseRustMenu(readFileSync(RUST_MENU, 'utf8'));
+const tsItems = parseTsMenu(readFileSync(TS_MENU, 'utf8'));
+
+test('both tables declare at least the documented menu items', () => {
+  assert.ok(rustItems.length >= 20, `only ${rustItems.length} items parsed from ${RUST_MENU}`);
+  assert.ok(tsItems.length >= 20, `only ${tsItems.length} items parsed from ${TS_MENU}`);
+});
+
+test('neither table repeats an id', () => {
+  for (const [file, items] of [
+    [RUST_MENU, rustItems],
+    [TS_MENU, tsItems],
+  ]) {
+    const ids = items.map((i) => i.id);
+    assert.equal(new Set(ids).size, ids.length, `${file} has duplicate menu ids`);
+  }
+});
+
+test('every native menu item has a frontend action, and vice versa', () => {
+  const rustIds = rustItems.map((i) => i.id);
+  const tsIds = tsItems.map((i) => i.id);
+
+  const missingInTs = rustIds.filter((id) => !tsIds.includes(id));
+  const missingInRust = tsIds.filter((id) => !rustIds.includes(id));
+
+  assert.deepEqual(
+    missingInTs,
+    [],
+    `menu items with no frontend action in ${TS_MENU}: ${missingInTs.join(', ')}`
+  );
+  assert.deepEqual(
+    missingInRust,
+    [],
+    `frontend actions no menu item emits in ${RUST_MENU}: ${missingInRust.join(', ')}`
+  );
+});
+
+test('the two tables stay in the same order', () => {
+  assert.deepEqual(
+    tsItems.map((i) => i.id),
+    rustItems.map((i) => i.id),
+    'reorder the two menu tables together so they stay readable side by side'
+  );
+});
+
+test('repository-scoped flags agree on both sides', () => {
+  const rustScoped = new Map(rustItems.map((i) => [i.id, i.repositoryScoped]));
+
+  for (const item of tsItems) {
+    assert.equal(
+      item.repositoryScoped,
+      rustScoped.get(item.id),
+      `"${item.id}" is repository-scoped in one table but not the other; ` +
+        'the native item would be clickable with no repository open, or greyed out with one'
+    );
+  }
+});

--- a/src-tauri/src/commands/menu.rs
+++ b/src-tauri/src/commands/menu.rs
@@ -1,0 +1,41 @@
+//! Application menu command handlers
+//!
+//! The menu's structure is static (see `crate::menu`); its enabled state and
+//! the accelerator shown on each item are not. Both depend on state only the
+//! frontend has — whether a repository is open, and what the user has rebound
+//! their keyboard shortcuts to — so the frontend pushes them here.
+
+use tauri::{AppHandle, Manager};
+
+use crate::error::{LeviathanError, Result};
+use crate::menu::{AppMenuState, MenuItemUpdate};
+
+/// Update the enabled state and accelerator of application menu items.
+#[tauri::command]
+pub fn sync_app_menu(app: AppHandle, items: Vec<MenuItemUpdate>) -> Result<()> {
+    // `try_state` rather than `state`: the menu is not installed when the menu
+    // build failed at startup (or on a platform without one), and a missing
+    // state must be a plain error the frontend can log, not a panic that takes
+    // the whole command bridge down.
+    let state = app.try_state::<AppMenuState>().ok_or_else(|| {
+        LeviathanError::OperationFailed("application menu is not available".into())
+    })?;
+
+    state.apply(&items)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::menu::{AppMenuState, MenuItemUpdate};
+
+    #[test]
+    fn applying_an_update_for_a_missing_item_is_reported() {
+        let state = AppMenuState::default();
+        let result = state.apply(&[MenuItemUpdate {
+            id: "no-such-item".into(),
+            enabled: false,
+            accelerator: None,
+        }]);
+        assert!(result.is_err());
+    }
+}

--- a/src-tauri/src/commands/mod.rs
+++ b/src-tauri/src/commands/mod.rs
@@ -40,6 +40,7 @@ pub mod lfs;
 pub mod local_ai;
 pub mod maintenance;
 pub mod mcp;
+pub mod menu;
 pub mod merge;
 pub mod merge_tool;
 pub mod notes;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod commands;
 pub mod error;
+pub mod menu;
 pub mod models;
 pub mod services;
 pub mod utils;
@@ -199,6 +200,14 @@ pub fn run() {
                 } else {
                     tracing::warn!("Main window not found, skipping devtools");
                 }
+            }
+
+            // Install the native application menu bar. A failure here must not
+            // stop the app from starting — the command palette and the toolbar
+            // still reach every action — so it is logged and startup continues
+            // with no menu (the frontend's sync then reports it and moves on).
+            if let Err(e) = menu::init_app_menu(app.handle()) {
+                tracing::error!("Failed to build the application menu: {}", e);
             }
 
             // Set up system tray
@@ -480,6 +489,8 @@ pub fn run() {
             commands::maintenance::run_prune,
             commands::maintenance::get_repository_stats,
             commands::maintenance::get_pack_info,
+            // Application menu bar
+            commands::menu::sync_app_menu,
             commands::gpg::get_gpg_config,
             commands::gpg::get_gpg_keys,
             commands::gpg::set_signing_key,

--- a/src-tauri/src/menu.rs
+++ b/src-tauri/src/menu.rs
@@ -1,0 +1,504 @@
+//! Native application menu bar.
+//!
+//! Most of Leviathan's feature set (clean, bisect, worktrees, submodules, LFS,
+//! hooks, git configuration, repository health, .gitignore/.gitattributes) was
+//! reachable only by typing into the command palette. A desktop app is expected
+//! to show those commands — and the keys that trigger them — in a menu bar.
+//!
+//! This module owns the *structure* of that menu only. It deliberately performs
+//! no git work: choosing an item emits [`MENU_ACTION_EVENT`] with the item id
+//! and the frontend runs the very same handler its command-palette twin runs
+//! (see `src/services/app-menu.service.ts`), so the two can never drift.
+//!
+//! Labels are static; the enabled state and the accelerator shown on each item
+//! are pushed from the frontend through the `sync_app_menu` command, because
+//! both depend on state only the frontend has: whether a repository is open and
+//! what the user has rebound their shortcuts to.
+
+use std::collections::HashMap;
+use std::sync::Mutex;
+
+use serde::Deserialize;
+use tauri::menu::{MenuBuilder, MenuItem, SubmenuBuilder};
+use tauri::{AppHandle, Emitter, Manager, Wry};
+
+use crate::error::{LeviathanError, Result};
+
+/// Event emitted to the frontend with the id of the chosen menu item.
+pub const MENU_ACTION_EVENT: &str = "app-menu-action";
+
+/// Ids owned by the tray menu built in `lib.rs`.
+///
+/// Tauri routes EVERY menu event — tray and application menu alike — to every
+/// global menu listener, so the tray's handler sees our items and ours sees the
+/// tray's. Both filter by id, which only works while the two id spaces stay
+/// disjoint; `app_menu_ids_do_not_collide_with_tray` keeps them that way.
+pub const TRAY_MENU_IDS: &[&str] = &["show_hide", "quit"];
+
+/// A single clickable application-menu item.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct MenuItemDef {
+    /// Stable id, forwarded verbatim to the frontend.
+    pub id: &'static str,
+    pub label: &'static str,
+    /// Acts on the active repository, so it starts disabled and is enabled by
+    /// the frontend only while a repository is open.
+    pub repository_scoped: bool,
+}
+
+/// One entry inside a menu section.
+#[derive(Debug, Clone, Copy)]
+pub enum MenuEntry {
+    Item(MenuItemDef),
+    Separator,
+}
+
+/// A top-level menu (File, Repository, …).
+#[derive(Debug, Clone, Copy)]
+pub struct MenuSection {
+    pub id: &'static str,
+    pub label: &'static str,
+    pub entries: &'static [MenuEntry],
+}
+
+const fn item(id: &'static str, label: &'static str) -> MenuEntry {
+    MenuEntry::Item(MenuItemDef {
+        id,
+        label,
+        repository_scoped: false,
+    })
+}
+
+/// An item that needs an open repository; disabled until the frontend says one
+/// is open, so it can never fire into nothing.
+const fn repo_item(id: &'static str, label: &'static str) -> MenuEntry {
+    MenuEntry::Item(MenuItemDef {
+        id,
+        label,
+        repository_scoped: true,
+    })
+}
+
+/// The application menu, in display order.
+///
+/// Every id here must have a matching entry in `APP_MENU_ACTIONS` in
+/// `src/services/app-menu.service.ts` — `scripts/menu-contract.test.mjs` fails
+/// the build when the two lists disagree.
+pub const APP_MENU: &[MenuSection] = &[
+    MenuSection {
+        id: "file",
+        label: "File",
+        entries: &[
+            item("open-repository", "Open Repository…"),
+            item("clone-repository", "Clone Repository…"),
+            item("init-repository", "New Repository…"),
+            MenuEntry::Separator,
+            repo_item("close-repository-tab", "Close Repository Tab"),
+        ],
+    },
+    MenuSection {
+        id: "repository",
+        label: "Repository",
+        entries: &[
+            repo_item("fetch", "Fetch"),
+            repo_item("pull", "Pull"),
+            repo_item("push", "Push"),
+            MenuEntry::Separator,
+            repo_item("clean", "Clean Working Directory…"),
+            repo_item("bisect", "Bisect…"),
+            MenuEntry::Separator,
+            repo_item("worktrees", "Worktrees…"),
+            repo_item("submodules", "Submodules…"),
+            repo_item("lfs", "Git LFS…"),
+            repo_item("hooks", "Hooks…"),
+            MenuEntry::Separator,
+            repo_item("config", "Git Configuration…"),
+            repo_item("gitignore", ".gitignore & .gitattributes…"),
+            repo_item("repository-health", "Repository Health & Maintenance…"),
+        ],
+    },
+    MenuSection {
+        id: "branch",
+        label: "Branch",
+        entries: &[
+            repo_item("create-branch", "New Branch…"),
+            repo_item("switch-branch", "Switch Branch…"),
+            MenuEntry::Separator,
+            repo_item("compare-branches", "Compare Branches…"),
+            repo_item("branch-cleanup", "Clean Up Branches…"),
+        ],
+    },
+    MenuSection {
+        id: "view",
+        label: "View",
+        entries: &[
+            item("toggle-left-panel", "Toggle Left Panel"),
+            item("toggle-right-panel", "Toggle Right Panel"),
+            item("toggle-output-panel", "Toggle Output Panel"),
+            MenuEntry::Separator,
+            item("command-palette", "Command Palette…"),
+        ],
+    },
+    MenuSection {
+        id: "help",
+        label: "Help",
+        entries: &[
+            item("keyboard-shortcuts", "Keyboard Shortcuts"),
+            item("about", "About Leviathan"),
+        ],
+    },
+];
+
+/// Every clickable item in the application menu, in display order.
+pub fn menu_item_defs() -> Vec<MenuItemDef> {
+    APP_MENU
+        .iter()
+        .flat_map(|section| section.entries.iter())
+        .filter_map(|entry| match entry {
+            MenuEntry::Item(def) => Some(*def),
+            MenuEntry::Separator => None,
+        })
+        .collect()
+}
+
+/// Whether `id` belongs to the application menu (as opposed to the tray menu,
+/// whose events reach the same global listener).
+pub fn is_app_menu_id(id: &str) -> bool {
+    menu_item_defs().iter().any(|def| def.id == id)
+}
+
+/// A frontend-pushed update for one menu item.
+#[derive(Debug, Clone, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MenuItemUpdate {
+    pub id: String,
+    pub enabled: bool,
+    /// Tauri accelerator string (e.g. `CmdOrCtrl+Shift+F`), or `None` when the
+    /// action has no keyboard binding.
+    pub accelerator: Option<String>,
+}
+
+/// Handles to the built menu items, so their enabled state and accelerators can
+/// be updated after the menu has been attached.
+#[derive(Default)]
+pub struct AppMenuState {
+    items: Mutex<HashMap<String, MenuItem<Wry>>>,
+}
+
+impl AppMenuState {
+    fn new(items: HashMap<String, MenuItem<Wry>>) -> Self {
+        Self {
+            items: Mutex::new(items),
+        }
+    }
+
+    /// Apply frontend-pushed enabled/accelerator updates.
+    ///
+    /// Unknown ids and unparseable accelerators are logged and skipped rather
+    /// than aborting the sync: a single bad entry must not leave the rest of the
+    /// menu stale (which would show items as clickable with no repository open).
+    pub fn apply(&self, updates: &[MenuItemUpdate]) -> Result<()> {
+        let items = self
+            .items
+            .lock()
+            .map_err(|_| LeviathanError::OperationFailed("app menu state is poisoned".into()))?;
+
+        let mut failures: Vec<String> = Vec::new();
+
+        for update in updates {
+            let Some(menu_item) = items.get(&update.id) else {
+                failures.push(format!("unknown menu item '{}'", update.id));
+                continue;
+            };
+
+            if let Err(e) = menu_item.set_enabled(update.enabled) {
+                failures.push(format!("{}: {}", update.id, e));
+            }
+
+            let result = match update.accelerator.as_deref() {
+                Some(accelerator) => menu_item.set_accelerator(Some(accelerator)),
+                None => menu_item.set_accelerator(None::<&str>),
+            };
+            if let Err(e) = result {
+                failures.push(format!("{} accelerator: {}", update.id, e));
+            }
+        }
+
+        if failures.is_empty() {
+            Ok(())
+        } else {
+            Err(LeviathanError::OperationFailed(format!(
+                "failed to update {} menu item(s): {}",
+                failures.len(),
+                failures.join("; ")
+            )))
+        }
+    }
+}
+
+/// Build the application menu, attach it, and forward chosen items to the
+/// frontend.
+///
+/// Repository-scoped items start disabled — with no repository open they must
+/// not fire — and the frontend enables them as soon as one is opened.
+pub fn init_app_menu(app: &AppHandle) -> tauri::Result<()> {
+    let mut items: HashMap<String, MenuItem<Wry>> = HashMap::new();
+    let mut menu = MenuBuilder::new(app);
+
+    // macOS keeps the application menu (Services/Hide/Quit) and the Edit menu's
+    // clipboard items in the menu bar itself. Attaching a custom menu REPLACES
+    // Tauri's default one, so without these two submenus macOS users lose
+    // ⌘X/⌘C/⌘V/⌘A and ⌘Q entirely.
+    #[cfg(target_os = "macos")]
+    {
+        let about_metadata = tauri::menu::AboutMetadata {
+            name: Some("Leviathan".into()),
+            version: Some(env!("CARGO_PKG_VERSION").into()),
+            ..Default::default()
+        };
+        let app_menu = SubmenuBuilder::new(app, "Leviathan")
+            .about(Some(about_metadata))
+            .separator()
+            .services()
+            .separator()
+            .hide()
+            .hide_others()
+            .show_all()
+            .separator()
+            .quit()
+            .build()?;
+        menu = menu.item(&app_menu);
+    }
+
+    for section in APP_MENU {
+        let mut submenu = SubmenuBuilder::new(app, section.label);
+
+        for entry in section.entries {
+            match entry {
+                MenuEntry::Separator => submenu = submenu.separator(),
+                MenuEntry::Item(def) => {
+                    let menu_item = MenuItem::with_id(
+                        app,
+                        def.id,
+                        def.label,
+                        !def.repository_scoped,
+                        None::<&str>,
+                    )?;
+                    submenu = submenu.item(&menu_item);
+                    items.insert(def.id.to_string(), menu_item);
+                }
+            }
+        }
+
+        // Quit belongs to the application menu on macOS and to File everywhere
+        // else.
+        #[cfg(not(target_os = "macos"))]
+        if section.id == "file" {
+            submenu = submenu.separator().quit();
+        }
+
+        menu = menu.item(&submenu.build()?);
+
+        #[cfg(target_os = "macos")]
+        if section.id == "file" {
+            let edit_menu = SubmenuBuilder::new(app, "Edit")
+                .undo()
+                .redo()
+                .separator()
+                .cut()
+                .copy()
+                .paste()
+                .select_all()
+                .build()?;
+            menu = menu.item(&edit_menu);
+        }
+    }
+
+    app.set_menu(menu.build()?)?;
+    app.manage(AppMenuState::new(items));
+
+    app.on_menu_event(move |app, event| {
+        let id = event.id().as_ref();
+        // The tray menu's events arrive here too (Tauri fans every menu event
+        // out to every global listener), so ignore anything that is not ours.
+        if !is_app_menu_id(id) {
+            return;
+        }
+        if let Err(e) = app.emit(MENU_ACTION_EVENT, id) {
+            tracing::error!("Failed to forward menu action '{}': {}", id, e);
+        }
+    });
+
+    tracing::info!("Application menu installed");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    #[test]
+    fn every_menu_id_is_unique() {
+        let mut seen = HashSet::new();
+        for def in menu_item_defs() {
+            assert!(seen.insert(def.id), "duplicate menu item id: {}", def.id);
+        }
+    }
+
+    #[test]
+    fn app_menu_ids_do_not_collide_with_tray() {
+        // A collision would make "Fetch" hide the window or quit the app,
+        // because both menus share one global event listener.
+        for def in menu_item_defs() {
+            assert!(
+                !TRAY_MENU_IDS.contains(&def.id),
+                "menu item '{}' collides with a tray menu id",
+                def.id
+            );
+        }
+    }
+
+    #[test]
+    fn every_menu_id_is_kebab_case() {
+        // The frontend table keys off these ids verbatim; keeping them to one
+        // shape stops "repositoryHealth" vs "repository-health" drift.
+        for def in menu_item_defs() {
+            assert!(
+                def.id
+                    .chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "menu item id '{}' is not kebab-case",
+                def.id
+            );
+            assert!(!def.id.is_empty());
+            assert!(!def.label.is_empty(), "menu item '{}' has no label", def.id);
+        }
+    }
+
+    #[test]
+    fn every_section_has_a_label_and_items() {
+        for section in APP_MENU {
+            assert!(!section.label.is_empty());
+            assert!(!section.id.is_empty());
+            assert!(
+                section
+                    .entries
+                    .iter()
+                    .any(|e| matches!(e, MenuEntry::Item(_))),
+                "section '{}' has no clickable items",
+                section.id
+            );
+        }
+    }
+
+    #[test]
+    fn sections_are_the_conventional_desktop_set() {
+        let ids: Vec<&str> = APP_MENU.iter().map(|s| s.id).collect();
+        assert_eq!(ids, vec!["file", "repository", "branch", "view", "help"]);
+    }
+
+    #[test]
+    fn repository_actions_are_repository_scoped() {
+        let scoped: HashSet<&str> = menu_item_defs()
+            .iter()
+            .filter(|d| d.repository_scoped)
+            .map(|d| d.id)
+            .collect();
+
+        for id in [
+            "fetch",
+            "pull",
+            "push",
+            "clean",
+            "bisect",
+            "worktrees",
+            "submodules",
+            "lfs",
+            "hooks",
+            "config",
+            "gitignore",
+            "repository-health",
+            "create-branch",
+            "switch-branch",
+            "compare-branches",
+            "branch-cleanup",
+            "close-repository-tab",
+        ] {
+            assert!(scoped.contains(id), "'{}' must be repository-scoped", id);
+        }
+
+        // These work with no repository open and must stay clickable.
+        for id in [
+            "open-repository",
+            "clone-repository",
+            "init-repository",
+            "toggle-left-panel",
+            "toggle-right-panel",
+            "toggle-output-panel",
+            "command-palette",
+            "keyboard-shortcuts",
+            "about",
+        ] {
+            assert!(
+                !scoped.contains(id),
+                "'{}' must not be repository-scoped",
+                id
+            );
+        }
+    }
+
+    #[test]
+    fn is_app_menu_id_only_matches_our_items() {
+        assert!(is_app_menu_id("fetch"));
+        assert!(is_app_menu_id("about"));
+        assert!(!is_app_menu_id("show_hide"));
+        assert!(!is_app_menu_id("quit"));
+        assert!(!is_app_menu_id(""));
+        assert!(!is_app_menu_id("not-a-menu-item"));
+    }
+
+    #[test]
+    fn menu_item_update_deserializes_from_the_frontend_payload() {
+        let update: MenuItemUpdate = serde_json::from_str(
+            r#"{"id":"fetch","enabled":true,"accelerator":"CmdOrCtrl+Shift+F"}"#,
+        )
+        .expect("payload should deserialize");
+        assert_eq!(update.id, "fetch");
+        assert!(update.enabled);
+        assert_eq!(update.accelerator.as_deref(), Some("CmdOrCtrl+Shift+F"));
+
+        let without: MenuItemUpdate =
+            serde_json::from_str(r#"{"id":"about","enabled":false,"accelerator":null}"#)
+                .expect("payload without an accelerator should deserialize");
+        assert!(!without.enabled);
+        assert_eq!(without.accelerator, None);
+    }
+
+    #[test]
+    fn apply_reports_unknown_ids() {
+        // No menu is built in a unit test, so every id is unknown — which is
+        // exactly the "menu item disappeared" case the caller must hear about.
+        let state = AppMenuState::default();
+        let err = state
+            .apply(&[MenuItemUpdate {
+                id: "fetch".into(),
+                enabled: true,
+                accelerator: None,
+            }])
+            .expect_err("unknown ids must be reported");
+        assert!(err.to_string().contains("fetch"));
+    }
+
+    #[test]
+    fn apply_accepts_an_empty_update_list() {
+        let state = AppMenuState::default();
+        assert!(state.apply(&[]).is_ok());
+    }
+
+    #[test]
+    fn menu_action_event_name_is_stable() {
+        // The frontend listens for this exact string.
+        assert_eq!(MENU_ACTION_EVENT, "app-menu-action");
+    }
+}

--- a/src/__tests__/app-shell-app-menu.test.ts
+++ b/src/__tests__/app-shell-app-menu.test.ts
@@ -1,0 +1,239 @@
+/**
+ * Native menu bar routing in app-shell.
+ *
+ * A native menu cannot be driven from a test, so what is pinned here is the
+ * half that can go wrong: an `app-menu-action` id must run the SAME handler its
+ * command-palette twin runs, repository-scoped ids must stay guarded when no
+ * repository is open, and the enabled state pushed to the native menu must
+ * follow the repository-open state.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+const invokeCalls: Array<{ command: string; args: Record<string, unknown> }> = [];
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCalls.push({ command, args: args ?? {} });
+    return Promise.resolve(null);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect } from '@open-wc/testing';
+import type { AppShell } from '../app-shell.ts';
+import '../app-shell.ts';
+import { repositoryStore, uiStore } from '../stores/index.ts';
+import {
+  APP_MENU_ACTIONS,
+  noteAcceleratorKeydown,
+  resetAcceleratorGuard,
+} from '../services/app-menu.service.ts';
+import { keyboardService, registerDefaultShortcuts } from '../services/keyboard.service.ts';
+import type { Repository } from '../types/git.types.ts';
+
+function mockRepo(path: string, name: string): Repository {
+  return {
+    path,
+    name,
+    isValid: true,
+    isBare: false,
+    headRef: 'main',
+    detachedHeadOid: null,
+    state: 'clean',
+    isShallow: false,
+    isPartialClone: false,
+    cloneFilter: null,
+  };
+}
+
+function noop(): void {
+  /* stub action */
+}
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+interface PaletteCommandLike {
+  id: string;
+  label: string;
+  action: () => void;
+}
+
+describe('app-shell application menu routing', () => {
+  beforeEach(() => {
+    invokeCalls.length = 0;
+    uiStore.setState({ toasts: [] });
+    repositoryStore.getState().reset();
+    resetAcceleratorGuard();
+  });
+
+  afterEach(() => {
+    repositoryStore.getState().reset();
+    keyboardService.resetAllBindings();
+    resetAcceleratorGuard();
+  });
+
+  function shell(path: string | null = '/repo/active'): AppShell {
+    const el = document.createElement('lv-app-shell') as AppShell;
+    if (path) {
+      (el as any).activeRepository = { repository: mockRepo(path, 'active') };
+    }
+    return el;
+  }
+
+  function toasts(type: string): Array<{ message: string }> {
+    return uiStore.getState().toasts.filter((t) => t.type === type) as Array<{
+      message: string;
+    }>;
+  }
+
+  function paletteCommands(el: AppShell): PaletteCommandLike[] {
+    return (el as any).getPaletteCommands() as PaletteCommandLike[];
+  }
+
+  function runMenuAction(el: AppShell, id: string): void {
+    (el as any).handleAppMenuAction(id);
+  }
+
+  it('every palette-backed menu item names a palette command that exists', () => {
+    // The anti-drift guard: renaming or dropping a palette command must fail
+    // here rather than leaving a menu item that quietly does nothing.
+    const ids = new Set(paletteCommands(shell()).map((c) => c.id));
+
+    for (const action of APP_MENU_ACTIONS) {
+      if (!action.paletteId) continue;
+      expect(ids.has(action.paletteId), `palette command "${action.paletteId}"`).to.be.true;
+    }
+  });
+
+  it('runs the same handler as the palette twin for repository dialogs', () => {
+    const cases: Array<[string, string]> = [
+      ['clean', 'showClean'],
+      ['bisect', 'showBisect'],
+      ['worktrees', 'showWorktrees'],
+      ['submodules', 'showSubmodules'],
+      ['lfs', 'showLfs'],
+      ['hooks', 'showHooksDialog'],
+      ['config', 'showConfig'],
+      ['gitignore', 'showGitignoreDialog'],
+      ['repository-health', 'showRepositoryHealth'],
+    ];
+
+    for (const [id, flag] of cases) {
+      // What the palette does…
+      const viaPalette = shell();
+      paletteCommands(viaPalette).find((c) => c.id === id)!.action();
+      expect((viaPalette as any)[flag], `palette "${id}" sets ${flag}`).to.be.true;
+
+      // …the menu must do too.
+      const viaMenu = shell();
+      runMenuAction(viaMenu, id);
+      expect((viaMenu as any)[flag], `menu "${id}" sets ${flag}`).to.be.true;
+    }
+  });
+
+  it('keeps the repository guard when no repository is open', () => {
+    const el = shell(null);
+
+    runMenuAction(el, 'clean');
+
+    expect((el as any).showClean, 'no dialog without a repository').to.not.be.true;
+    const warnings = toasts('warning');
+    expect(warnings, 'the user must be told why nothing happened').to.have.lengthOf(1);
+    expect(warnings[0].message).to.contain('open a repository');
+  });
+
+  it('opens the keyboard shortcuts dialog from Help', () => {
+    const el = shell(null);
+    runMenuAction(el, 'keyboard-shortcuts');
+    expect((el as any).showShortcuts).to.be.true;
+  });
+
+  it('closes the active repository tab from File', () => {
+    const el = shell('/repo/active');
+    repositoryStore.getState().addRepository(mockRepo('/repo/active', 'active'));
+    repositoryStore.getState().addRepository(mockRepo('/repo/other', 'other'));
+
+    runMenuAction(el, 'close-repository-tab');
+
+    const paths = repositoryStore.getState().openRepositories.map((r) => r.repository.path);
+    expect(paths).to.deep.equal(['/repo/other']);
+  });
+
+  it('reports a menu id it cannot route instead of doing nothing', () => {
+    const el = shell();
+
+    runMenuAction(el, 'not-a-real-menu-item');
+
+    expect(toasts('error'), 'an unroutable menu item must not be silent').to.have.lengthOf(1);
+  });
+
+  it('reports when the toolbar that owns Open/Clone/Init is unavailable', () => {
+    // Never rendered, so there is no toolbar in the shadow root.
+    const el = shell(null);
+
+    runMenuAction(el, 'open-repository');
+
+    const errors = toasts('error');
+    expect(errors).to.have.lengthOf(1);
+    expect(errors[0].message).to.contain('Open Repository');
+  });
+
+  it('pushes the disabled state to the native menu and skips no-op syncs', async () => {
+    const el = shell(null);
+
+    (el as any).syncAppMenuState(false);
+    await new Promise((r) => setTimeout(r, 0));
+
+    const first = invokeCalls.filter((c) => c.command === 'sync_app_menu');
+    expect(first, 'the first sync must reach the backend').to.have.lengthOf(1);
+    const items = first[0].args.items as Array<{ id: string; enabled: boolean }>;
+    expect(items.find((i) => i.id === 'fetch')!.enabled).to.be.false;
+    expect(items.find((i) => i.id === 'command-palette')!.enabled).to.be.true;
+
+    // Same state again: no IPC.
+    (el as any).syncAppMenuState(false);
+    await new Promise((r) => setTimeout(r, 0));
+    expect(invokeCalls.filter((c) => c.command === 'sync_app_menu')).to.have.lengthOf(1);
+
+    // A repository opens: everything becomes clickable.
+    (el as any).syncAppMenuState(true);
+    await new Promise((r) => setTimeout(r, 0));
+    const second = invokeCalls.filter((c) => c.command === 'sync_app_menu');
+    expect(second).to.have.lengthOf(2);
+    const enabled = second[1].args.items as Array<{ id: string; enabled: boolean }>;
+    expect(enabled.every((i) => i.enabled)).to.be.true;
+  });
+
+  it('does not run an action twice when the webview also saw the accelerator', () => {
+    registerDefaultShortcuts({
+      navigateUp: noop,
+      navigateDown: noop,
+      selectCommit: noop,
+      stageAll: noop,
+      unstageAll: noop,
+      commit: noop,
+      refresh: noop,
+      search: noop,
+      openSettings: noop,
+      openShortcuts: noop,
+      toggleLeftPanel: noop,
+      toggleRightPanel: noop,
+    });
+
+    const el = shell();
+    const visible = () => uiStore.getState().panels.right.isVisible;
+    const before = visible();
+
+    // The keyboard route has just toggled the right panel for this key press.
+    noteAcceleratorKeydown(new KeyboardEvent('keydown', { key: 'J', ctrlKey: true }));
+
+    runMenuAction(el, 'toggle-right-panel');
+    expect(visible(), 'the menu event for that same press is dropped').to.equal(before);
+
+    // The next visit to the menu works normally.
+    runMenuAction(el, 'toggle-right-panel');
+    expect(visible()).to.equal(!before);
+  });
+});

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -3,6 +3,14 @@ import { customElement, state, query } from 'lit/decorators.js';
 import { sharedStyles } from './styles/shared-styles.ts';
 import { repositoryStore, uiStore, type OpenRepository } from './stores/index.ts';
 import { registerDefaultShortcuts, keyboardService } from './services/keyboard.service.ts';
+import {
+  MENU_ACTION_EVENT,
+  resolveMenuAction,
+  shouldSuppressMenuAction,
+  startAcceleratorWatch,
+  syncAppMenu,
+  type MenuShellHandlers,
+} from './services/app-menu.service.ts';
 import { loggers } from './utils/logger.ts';
 import { sweepRepoScopedDialogs } from './utils/repo-scoped-dialogs.ts';
 import { rebasedOntoMessage } from './utils/rebase-messages.ts';
@@ -138,7 +146,7 @@ import {
   openRepositoryInFileManager,
   openRepositoryInEditor,
 } from './services/open-location.service.ts';
-import { showConfirm, showPrompt } from './services/dialog.service.ts';
+import { showConfirm, showMessage, showPrompt } from './services/dialog.service.ts';
 import {
   confirmGarbageCollection,
   confirmPrune,
@@ -990,6 +998,12 @@ export class AppShell extends LitElement {
   private lastRemoteAllowlistKey = '';
   private refsChangedDebounceTimer?: ReturnType<typeof setTimeout>;
   private updateUnlisteners: UnlistenFn[] = [];
+  /** Teardown for the native menu's key-press watcher. */
+  private appMenuWatchDispose?: () => void;
+  /** Last repository-open state pushed to the native menu, to skip no-op IPC. */
+  private appMenuHasRepository?: boolean;
+  /** Teardown for the keyboard-settings subscription that refreshes the menu. */
+  private appMenuShortcutUnsubscribe?: () => void;
   private shownIntegrationSuggestions: Set<string> = new Set();
   private isRestoringRepositories = false;
   private autoFetchUnsubscribe?: () => void;
@@ -1520,6 +1534,10 @@ export class AppShell extends LitElement {
       const repoChanged = this.activeRepository?.repository.path !== newActiveRepo?.repository.path;
       this.activeRepository = newActiveRepo;
 
+      // Repository-scoped menu items must be greyed out the moment the last
+      // tab closes, and live again the moment one opens.
+      this.syncAppMenuState(state.openRepositories.length > 0);
+
       // Every repo-scoped dialog flag must die with the last repository.
       //
       // These dialogs render inside the `${this.activeRepository ? ...}` block,
@@ -1936,6 +1954,10 @@ export class AppShell extends LitElement {
       selectTab: (index) => repositoryStore.getState().setActiveIndex(index),
     });
 
+    // Wire the native application menu. AFTER registerDefaultShortcuts, so the
+    // accelerators pushed to the menu are the bindings that actually exist.
+    void this.setupAppMenu();
+
     // Subscribe to progress updates
     this.progressUnsubscribe = progressService.subscribe((operations) => {
       this.progressOperations = operations;
@@ -1999,6 +2021,13 @@ export class AppShell extends LitElement {
     this.updateUnlisteners = [];
     // Unsubscribe from progress service
     this.progressUnsubscribe?.();
+    // Tear down the native menu wiring (its Tauri listener rides in
+    // updateUnlisteners, torn down just above)
+    this.appMenuWatchDispose?.();
+    this.appMenuWatchDispose = undefined;
+    this.appMenuShortcutUnsubscribe?.();
+    this.appMenuShortcutUnsubscribe = undefined;
+    this.appMenuHasRepository = undefined;
   }
 
   private async checkUnifiedProfilesMigration(): Promise<void> {
@@ -4293,6 +4322,130 @@ export class AppShell extends LitElement {
       }
       action();
     };
+  }
+
+  /**
+   * Wire the native application menu bar (built in `src-tauri/src/menu.rs`).
+   *
+   * The menu never implements an action of its own: an item's id arrives here
+   * and is resolved - through `app-menu.service` - to the very function its
+   * command-palette twin runs.
+   */
+  private async setupAppMenu(): Promise<void> {
+    // Watch key presses so a menu action triggered by its own accelerator is
+    // not run twice on platforms where the webview sees the key press too.
+    this.appMenuWatchDispose = startAcceleratorWatch();
+
+    // Rebinding a shortcut in Settings must re-print it on the menu.
+    this.appMenuShortcutUnsubscribe = keyboardService.addSettingsChangeListener(() => {
+      this.syncAppMenuState(this.hasOpenRepository(), true);
+    });
+
+    try {
+      const unlisten = await listenToEvent<string>(MENU_ACTION_EVENT, (id) => {
+        this.handleAppMenuAction(id);
+      });
+      this.updateUnlisteners.push(unlisten);
+    } catch (error) {
+      // No Tauri host (unit tests, a browser preview): there is no native menu
+      // to drive, and every action stays reachable from the palette.
+      log.warn('Application menu events are unavailable:', error);
+      return;
+    }
+
+    this.syncAppMenuState(this.hasOpenRepository(), true);
+  }
+
+  private hasOpenRepository(): boolean {
+    return repositoryStore.getState().openRepositories.length > 0;
+  }
+
+  /**
+   * Push the enabled state and current accelerators to the native menu.
+   *
+   * Repository-scoped items are disabled with no repository open, so they can
+   * never fire into nothing - the palette's "open a repository first" guard
+   * still backs them up for the keyboard route.
+   */
+  private syncAppMenuState(hasRepository: boolean, force = false): void {
+    if (!force && this.appMenuHasRepository === hasRepository) return;
+    this.appMenuHasRepository = hasRepository;
+    void syncAppMenu(hasRepository).then((result) => {
+      if (!result.success) {
+        // A stale menu is not worth interrupting the user for, but it must not
+        // disappear silently either.
+        log.warn('Failed to update the application menu:', result.error?.message);
+      }
+    });
+  }
+
+  /** Run the action a native menu item stands for. */
+  private handleAppMenuAction(id: string): void {
+    if (shouldSuppressMenuAction(id)) return;
+
+    const action = resolveMenuAction(id, this.getPaletteCommands(), this.appMenuShellHandlers());
+    if (!action) {
+      log.warn(`No handler for application menu item "${id}"`);
+      showToast('That menu action is not available', 'error');
+      return;
+    }
+    action();
+  }
+
+  /**
+   * The handful of menu actions with no command-palette entry. Each one calls
+   * the code that already owns the action - the toolbar's own handlers for
+   * open/clone/init, the repository store for closing a tab.
+   */
+  private appMenuShellHandlers(): MenuShellHandlers {
+    return {
+      openRepository: () => this.dispatchToToolbar('open-repository', 'Open Repository'),
+      cloneRepository: () => this.dispatchToToolbar('clone-repository', 'Clone Repository'),
+      initRepository: () => this.dispatchToToolbar('init-repository', 'New Repository'),
+      closeRepositoryTab: this.requiresRepository(() => {
+        repositoryStore.getState().removeRepository(this.activeRepository!.repository.path);
+      }),
+      // The palette lists every branch with its checkout action; opening it is
+      // the branch switcher, rather than a second one built for the menu.
+      switchBranch: this.requiresRepository(() => {
+        void this.openCommandPalette();
+      }),
+      commandPalette: () => {
+        void this.openCommandPalette();
+      },
+      keyboardShortcuts: () => {
+        this.showShortcuts = true;
+      },
+      about: () => {
+        void this.showAboutDialog();
+      },
+    };
+  }
+
+  /**
+   * Hand a menu action to the toolbar, which owns the Open/Clone/Init flows and
+   * their dialogs - the same route handleToggleSearch already uses.
+   */
+  private dispatchToToolbar(eventName: string, label: string): void {
+    const toolbar = this.shadowRoot?.querySelector('lv-toolbar');
+    if (!toolbar) {
+      showToast(`${label} is not available right now`, 'error');
+      return;
+    }
+    toolbar.dispatchEvent(new CustomEvent(eventName));
+  }
+
+  private async showAboutDialog(): Promise<void> {
+    try {
+      const version = await updateService.getAppVersion();
+      await showMessage(
+        'About Leviathan',
+        `Leviathan ${version}\n\nA fully-featured, open-source, cross-platform Git GUI client.`
+      );
+    } catch (error) {
+      log.warn('Failed to show the About dialog:', error);
+      showToast('Could not show application information', 'error');
+    }
   }
 
   private getPaletteCommands(): PaletteCommand[] {

--- a/src/components/toolbar/__tests__/lv-toolbar.test.ts
+++ b/src/components/toolbar/__tests__/lv-toolbar.test.ts
@@ -517,3 +517,66 @@ describe('lv-toolbar repository tabs', () => {
     });
   });
 });
+
+describe('lv-toolbar menu bar routed actions', () => {
+  // The native menu bar's File items are forwarded here by app-shell instead of
+  // being reimplemented, so each one must land on the toolbar's own handler.
+  beforeEach(() => {
+    repositoryStore.getState().reset();
+    mockInvoke = () => Promise.resolve(null);
+  });
+
+  it('opens the clone dialog for the Clone Repository menu item', async () => {
+    const el = await createToolbar();
+    const dialog = el.shadowRoot!.querySelector('lv-clone-dialog')!;
+    let opened = 0;
+    (dialog as unknown as { open: () => void }).open = () => {
+      opened++;
+    };
+
+    el.dispatchEvent(new CustomEvent('clone-repository'));
+
+    expect(opened).to.equal(1);
+  });
+
+  it('opens the init dialog for the New Repository menu item', async () => {
+    const el = await createToolbar();
+    const dialog = el.shadowRoot!.querySelector('lv-init-dialog')!;
+    let opened = 0;
+    (dialog as unknown as { open: () => void }).open = () => {
+      opened++;
+    };
+
+    el.dispatchEvent(new CustomEvent('init-repository'));
+
+    expect(opened).to.equal(1);
+  });
+
+  it('runs the same folder picker for the Open Repository menu item', async () => {
+    const calls: string[] = [];
+    mockInvoke = (command: string) => {
+      calls.push(command);
+      return Promise.resolve(null);
+    };
+    const el = await createToolbar();
+
+    el.dispatchEvent(new CustomEvent('open-repository'));
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(calls.some((c) => c.startsWith('plugin:dialog|open'))).to.be.true;
+  });
+
+  it('stops listening once the toolbar is disconnected', async () => {
+    const el = await createToolbar();
+    const dialog = el.shadowRoot!.querySelector('lv-clone-dialog')!;
+    let opened = 0;
+    (dialog as unknown as { open: () => void }).open = () => {
+      opened++;
+    };
+
+    el.remove();
+    el.dispatchEvent(new CustomEvent('clone-repository'));
+
+    expect(opened).to.equal(0);
+  });
+});

--- a/src/components/toolbar/lv-toolbar.ts
+++ b/src/components/toolbar/lv-toolbar.ts
@@ -410,12 +410,34 @@ export class LvToolbar extends LitElement {
         this.searchBar?.focus();
       });
     });
+
+    // The native menu bar's File items are routed here by app-shell rather
+    // than reimplemented: these are the same handlers the toolbar buttons run,
+    // dialogs and error toasts included.
+    this.addEventListener('open-repository', this.handleMenuOpenRepo);
+    this.addEventListener('clone-repository', this.handleMenuCloneRepo);
+    this.addEventListener('init-repository', this.handleMenuInitRepo);
   }
+
+  private handleMenuOpenRepo = (): void => {
+    void this.handleOpenRepo();
+  };
+
+  private handleMenuCloneRepo = (): void => {
+    this.handleCloneRepo();
+  };
+
+  private handleMenuInitRepo = (): void => {
+    this.handleInitRepo();
+  };
 
   disconnectedCallback(): void {
     super.disconnectedCallback();
     this.unsubscribe?.();
     this._resizeObserver?.disconnect();
+    this.removeEventListener('open-repository', this.handleMenuOpenRepo);
+    this.removeEventListener('clone-repository', this.handleMenuCloneRepo);
+    this.removeEventListener('init-repository', this.handleMenuInitRepo);
     if (this.menuEscapeListenerAttached) {
       document.removeEventListener('keydown', this.handleMenuEscape, { capture: true });
       this.menuEscapeListenerAttached = false;

--- a/src/services/__tests__/app-menu.service.test.ts
+++ b/src/services/__tests__/app-menu.service.test.ts
@@ -1,0 +1,312 @@
+/**
+ * Application menu service: the table that maps native menu ids onto actions
+ * the app already has, the accelerators printed next to those items, the
+ * enabled state pushed to the native menu, and the guard that stops one key
+ * press running an action twice.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+const invokeCalls: Array<{ command: string; args: Record<string, unknown> }> = [];
+let invokeFails = false;
+
+let cbId = 0;
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: Record<string, unknown>) => {
+    invokeCalls.push({ command, args: args ?? {} });
+    if (invokeFails) return Promise.reject(new Error('no menu'));
+    return Promise.resolve(null);
+  },
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect } from '@open-wc/testing';
+import {
+  APP_MENU_ACTIONS,
+  MENU_ACTION_EVENT,
+  acceleratorForMenuItem,
+  acceleratorFromEvent,
+  buildMenuUpdates,
+  noteAcceleratorKeydown,
+  resetAcceleratorGuard,
+  resolveMenuAction,
+  shouldSuppressMenuAction,
+  startAcceleratorWatch,
+  syncAppMenu,
+  toAccelerator,
+  type MenuShellHandlers,
+} from '../app-menu.service.ts';
+import { keyboardService, registerDefaultShortcuts } from '../keyboard.service.ts';
+import type { PaletteCommand } from '../../components/dialogs/lv-command-palette.ts';
+
+function noop(): void {
+  /* stub action */
+}
+
+function registerShortcuts(): void {
+  registerDefaultShortcuts({
+    navigateUp: noop,
+    navigateDown: noop,
+    selectCommit: noop,
+    stageAll: noop,
+    unstageAll: noop,
+    commit: noop,
+    refresh: noop,
+    search: noop,
+    openSettings: noop,
+    openShortcuts: noop,
+    toggleLeftPanel: noop,
+    toggleRightPanel: noop,
+    openCommandPalette: noop,
+    fetch: noop,
+    pull: noop,
+    push: noop,
+    createBranch: noop,
+    createStash: noop,
+  });
+}
+
+function paletteCommand(id: string, action: () => void): PaletteCommand {
+  return { id, label: id, category: 'action', action };
+}
+
+function shellHandlers(record: string[]): MenuShellHandlers {
+  return {
+    openRepository: () => record.push('openRepository'),
+    cloneRepository: () => record.push('cloneRepository'),
+    initRepository: () => record.push('initRepository'),
+    closeRepositoryTab: () => record.push('closeRepositoryTab'),
+    switchBranch: () => record.push('switchBranch'),
+    commandPalette: () => record.push('commandPalette'),
+    keyboardShortcuts: () => record.push('keyboardShortcuts'),
+    about: () => record.push('about'),
+  };
+}
+
+describe('app-menu service', () => {
+  beforeEach(() => {
+    invokeCalls.length = 0;
+    invokeFails = false;
+    resetAcceleratorGuard();
+    registerShortcuts();
+  });
+
+  afterEach(() => {
+    keyboardService.resetAllBindings();
+    resetAcceleratorGuard();
+  });
+
+  describe('the action table', () => {
+    it('gives every menu item exactly one action source', () => {
+      for (const action of APP_MENU_ACTIONS) {
+        const sources = [action.paletteId, action.shell].filter(Boolean);
+        expect(sources, `menu item "${action.id}"`).to.have.lengthOf(1);
+      }
+    });
+
+    it('has no duplicate ids', () => {
+      const ids = APP_MENU_ACTIONS.map((a) => a.id);
+      expect(new Set(ids).size).to.equal(ids.length);
+    });
+
+    it('marks every repository action as repository-scoped', () => {
+      const scoped = new Set(
+        APP_MENU_ACTIONS.filter((a) => a.repositoryScoped).map((a) => a.id)
+      );
+      for (const id of [
+        'fetch',
+        'pull',
+        'push',
+        'clean',
+        'bisect',
+        'worktrees',
+        'submodules',
+        'lfs',
+        'hooks',
+        'config',
+        'gitignore',
+        'repository-health',
+        'create-branch',
+        'switch-branch',
+        'compare-branches',
+        'branch-cleanup',
+        'close-repository-tab',
+      ]) {
+        expect(scoped.has(id), `"${id}" must be repository-scoped`).to.be.true;
+      }
+      for (const id of [
+        'open-repository',
+        'clone-repository',
+        'init-repository',
+        'toggle-left-panel',
+        'toggle-right-panel',
+        'toggle-output-panel',
+        'command-palette',
+        'keyboard-shortcuts',
+        'about',
+      ]) {
+        expect(scoped.has(id), `"${id}" must work with no repository open`).to.be.false;
+      }
+    });
+
+    it('listens on the event name the backend emits', () => {
+      expect(MENU_ACTION_EVENT).to.equal('app-menu-action');
+    });
+  });
+
+  describe('accelerators', () => {
+    it('formats a modified letter binding', () => {
+      expect(toAccelerator({ key: 'f', ctrl: true, shift: true })).to.equal(
+        'CmdOrCtrl+Shift+F'
+      );
+      expect(toAccelerator({ key: 'b', ctrl: true })).to.equal('CmdOrCtrl+B');
+      expect(toAccelerator({ key: 'p', meta: true })).to.equal('CmdOrCtrl+P');
+      expect(toAccelerator({ key: 'ArrowUp', alt: true })).to.equal('Alt+ArrowUp');
+    });
+
+    it('names punctuation and special keys the way the native layer expects', () => {
+      expect(toAccelerator({ key: ',', ctrl: true })).to.equal('CmdOrCtrl+Comma');
+      expect(toAccelerator({ key: 'Escape', ctrl: true })).to.equal('CmdOrCtrl+Escape');
+      expect(toAccelerator({ key: '1', ctrl: true })).to.equal('CmdOrCtrl+1');
+    });
+
+    it('refuses combos a native menu would misappropriate or cannot express', () => {
+      // A bare letter accelerator would swallow that letter app-wide.
+      expect(toAccelerator({ key: 's' })).to.equal(null);
+      expect(toAccelerator({ key: '?', shift: true })).to.equal(null);
+      expect(toAccelerator({ key: 'F13', ctrl: true })).to.equal(null);
+      expect(toAccelerator(undefined)).to.equal(null);
+    });
+
+    it('shows the binding a user has customised, not the default', () => {
+      expect(acceleratorForMenuItem('fetch')).to.equal('CmdOrCtrl+Shift+F');
+
+      expect(keyboardService.rebind('fetch', { key: 'g', ctrl: true, shift: true })).to.be
+        .true;
+      expect(acceleratorForMenuItem('fetch')).to.equal('CmdOrCtrl+Shift+G');
+    });
+
+    it('has no accelerator for items with no keyboard binding', () => {
+      expect(acceleratorForMenuItem('bisect')).to.equal(null);
+      expect(acceleratorForMenuItem('not-a-menu-item')).to.equal(null);
+    });
+
+    it('derives the same notation from a key press', () => {
+      const event = new KeyboardEvent('keydown', { key: 'F', ctrlKey: true, shiftKey: true });
+      expect(acceleratorFromEvent(event)).to.equal('CmdOrCtrl+Shift+F');
+    });
+  });
+
+  describe('enabled state', () => {
+    it('disables every repository-scoped item with no repository open', () => {
+      const updates = buildMenuUpdates(false);
+      expect(updates).to.have.lengthOf(APP_MENU_ACTIONS.length);
+
+      for (const action of APP_MENU_ACTIONS) {
+        const update = updates.find((u) => u.id === action.id)!;
+        expect(update.enabled, `"${action.id}" enabled`).to.equal(!action.repositoryScoped);
+      }
+    });
+
+    it('enables everything once a repository is open', () => {
+      for (const update of buildMenuUpdates(true)) {
+        expect(update.enabled, `"${update.id}" enabled`).to.be.true;
+      }
+    });
+
+    it('carries the current accelerators', () => {
+      const updates = buildMenuUpdates(true);
+      expect(updates.find((u) => u.id === 'push')!.accelerator).to.equal('CmdOrCtrl+Shift+U');
+      expect(updates.find((u) => u.id === 'bisect')!.accelerator).to.equal(null);
+    });
+
+    it('sends the payload to the backend command', async () => {
+      const result = await syncAppMenu(false);
+
+      expect(result.success).to.be.true;
+      const call = invokeCalls.find((c) => c.command === 'sync_app_menu');
+      expect(call, 'sync_app_menu should be invoked').to.exist;
+      const items = call!.args.items as Array<{ id: string; enabled: boolean }>;
+      expect(items.find((i) => i.id === 'fetch')!.enabled).to.be.false;
+      expect(items.find((i) => i.id === 'about')!.enabled).to.be.true;
+    });
+
+    it('reports a failed sync instead of throwing', async () => {
+      invokeFails = true;
+      const result = await syncAppMenu(true);
+      expect(result.success).to.be.false;
+      expect(result.error?.message).to.contain('no menu');
+    });
+  });
+
+  describe('resolving an action', () => {
+    it('returns the palette command’s own action, not a copy', () => {
+      const action = () => undefined;
+      const commands = [paletteCommand('clean', action)];
+
+      expect(resolveMenuAction('clean', commands, shellHandlers([]))).to.equal(action);
+    });
+
+    it('runs the shell handler for items with no palette twin', () => {
+      const record: string[] = [];
+      resolveMenuAction('about', [], shellHandlers(record))!();
+      resolveMenuAction('close-repository-tab', [], shellHandlers(record))!();
+
+      expect(record).to.deep.equal(['about', 'closeRepositoryTab']);
+    });
+
+    it('returns null for an unknown id or a missing palette command', () => {
+      expect(resolveMenuAction('nope', [], shellHandlers([]))).to.equal(null);
+      expect(resolveMenuAction('clean', [], shellHandlers([]))).to.equal(null);
+    });
+  });
+
+  describe('duplicate suppression', () => {
+    it('drops a menu action whose own accelerator was just pressed', () => {
+      noteAcceleratorKeydown(
+        new KeyboardEvent('keydown', { key: 'F', ctrlKey: true, shiftKey: true })
+      );
+      expect(shouldSuppressMenuAction('fetch')).to.be.true;
+    });
+
+    it('suppresses at most one menu event per key press', () => {
+      noteAcceleratorKeydown(
+        new KeyboardEvent('keydown', { key: 'F', ctrlKey: true, shiftKey: true })
+      );
+      expect(shouldSuppressMenuAction('fetch')).to.be.true;
+      // Choosing Fetch from the menu straight afterwards must still work.
+      expect(shouldSuppressMenuAction('fetch')).to.be.false;
+    });
+
+    it('does not drop a different action, or the same one later', () => {
+      const now = 1_000_000;
+      noteAcceleratorKeydown(
+        new KeyboardEvent('keydown', { key: 'F', ctrlKey: true, shiftKey: true }),
+        now
+      );
+      expect(shouldSuppressMenuAction('pull', now)).to.be.false;
+      expect(shouldSuppressMenuAction('fetch', now + 5000)).to.be.false;
+    });
+
+    it('never drops an item that has no accelerator at all', () => {
+      noteAcceleratorKeydown(
+        new KeyboardEvent('keydown', { key: 'F', ctrlKey: true, shiftKey: true })
+      );
+      expect(shouldSuppressMenuAction('bisect')).to.be.false;
+    });
+
+    it('watches key presses until it is disposed', () => {
+      const dispose = startAcceleratorWatch();
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'B', ctrlKey: true, bubbles: true })
+      );
+      expect(shouldSuppressMenuAction('toggle-left-panel')).to.be.true;
+
+      dispose();
+      document.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'B', ctrlKey: true, bubbles: true })
+      );
+      expect(shouldSuppressMenuAction('toggle-left-panel')).to.be.false;
+    });
+  });
+});

--- a/src/services/app-menu.service.ts
+++ b/src/services/app-menu.service.ts
@@ -1,0 +1,298 @@
+/**
+ * Application menu bar service.
+ *
+ * The native menu is built in `src-tauri/src/menu.rs`; choosing an item emits
+ * `app-menu-action` with the item's id. This module is the single place that
+ * maps such an id onto an action the app already has, so a menu item can never
+ * do something subtly different from its command-palette twin — it literally
+ * runs the palette command's own `action`.
+ *
+ * It also computes what the native menu cannot know on its own:
+ * - which items must be greyed out (everything repository-scoped, with no
+ *   repository open), and
+ * - the accelerator to print next to each item, taken from keyboard.service so
+ *   the menu teaches the shortcut the user actually has, custom rebinds
+ *   included.
+ */
+
+import type { PaletteCommand } from '../components/dialogs/lv-command-palette.ts';
+import { keyboardService, type ShortcutBinding } from './keyboard.service.ts';
+import { invokeCommand } from './tauri-api.ts';
+import type { CommandResult } from '../types/api.types.ts';
+
+/** Tauri event carrying the id of the chosen menu item. */
+export const MENU_ACTION_EVENT = 'app-menu-action';
+
+/**
+ * Actions with no command-palette twin. Each one is implemented once, in
+ * app-shell, and handed to `resolveMenuAction`.
+ */
+export type MenuShellActionId =
+  | 'openRepository'
+  | 'cloneRepository'
+  | 'initRepository'
+  | 'closeRepositoryTab'
+  | 'switchBranch'
+  | 'commandPalette'
+  | 'keyboardShortcuts'
+  | 'about';
+
+export interface AppMenuAction {
+  /** Menu item id, identical to the one in `src-tauri/src/menu.rs`. */
+  id: string;
+  /** Id of the command-palette entry whose action this item runs. */
+  paletteId?: string;
+  /** Shell action, for the few items the palette has no entry for. */
+  shell?: MenuShellActionId;
+  /** keyboard.service shortcut id whose current binding is shown on the item. */
+  shortcutId?: string;
+  /** Must be greyed out while no repository is open. */
+  repositoryScoped: boolean;
+}
+
+/**
+ * Menu id -> action, mirroring `APP_MENU` in `src-tauri/src/menu.rs`.
+ * `scripts/menu-contract.test.mjs` fails when the two lists disagree, so a
+ * menu item can never be added on one side only.
+ */
+export const APP_MENU_ACTIONS: readonly AppMenuAction[] = [
+  // File
+  { id: 'open-repository', shell: 'openRepository', repositoryScoped: false },
+  { id: 'clone-repository', shell: 'cloneRepository', repositoryScoped: false },
+  { id: 'init-repository', shell: 'initRepository', repositoryScoped: false },
+  { id: 'close-repository-tab', shell: 'closeRepositoryTab', repositoryScoped: true },
+  // Repository
+  { id: 'fetch', paletteId: 'fetch', shortcutId: 'fetch', repositoryScoped: true },
+  { id: 'pull', paletteId: 'pull', shortcutId: 'pull', repositoryScoped: true },
+  { id: 'push', paletteId: 'push', shortcutId: 'push', repositoryScoped: true },
+  { id: 'clean', paletteId: 'clean', repositoryScoped: true },
+  { id: 'bisect', paletteId: 'bisect', repositoryScoped: true },
+  { id: 'worktrees', paletteId: 'worktrees', repositoryScoped: true },
+  { id: 'submodules', paletteId: 'submodules', repositoryScoped: true },
+  { id: 'lfs', paletteId: 'lfs', repositoryScoped: true },
+  { id: 'hooks', paletteId: 'hooks', repositoryScoped: true },
+  { id: 'config', paletteId: 'config', repositoryScoped: true },
+  { id: 'gitignore', paletteId: 'gitignore', repositoryScoped: true },
+  { id: 'repository-health', paletteId: 'repository-health', repositoryScoped: true },
+  // Branch
+  {
+    id: 'create-branch',
+    paletteId: 'create-branch',
+    shortcutId: 'new-branch',
+    repositoryScoped: true,
+  },
+  { id: 'switch-branch', shell: 'switchBranch', repositoryScoped: true },
+  { id: 'compare-branches', paletteId: 'compare-branches', repositoryScoped: true },
+  { id: 'branch-cleanup', paletteId: 'branch-cleanup', repositoryScoped: true },
+  // View
+  {
+    id: 'toggle-left-panel',
+    paletteId: 'toggle-left-panel',
+    shortcutId: 'toggle-left',
+    repositoryScoped: false,
+  },
+  {
+    id: 'toggle-right-panel',
+    paletteId: 'toggle-right-panel',
+    shortcutId: 'toggle-right',
+    repositoryScoped: false,
+  },
+  { id: 'toggle-output-panel', paletteId: 'toggle-output-panel', repositoryScoped: false },
+  {
+    id: 'command-palette',
+    shell: 'commandPalette',
+    shortcutId: 'command-palette',
+    repositoryScoped: false,
+  },
+  // Help
+  {
+    id: 'keyboard-shortcuts',
+    shell: 'keyboardShortcuts',
+    shortcutId: 'shortcuts',
+    repositoryScoped: false,
+  },
+  { id: 'about', shell: 'about', repositoryScoped: false },
+];
+
+/** One item's state, as the `sync_app_menu` command expects it. */
+export interface MenuItemUpdate {
+  id: string;
+  enabled: boolean;
+  accelerator: string | null;
+}
+
+export type MenuShellHandlers = Record<MenuShellActionId, () => void>;
+
+/**
+ * Key names muda (Tauri's menu layer) understands, keyed by the lowercase
+ * `KeyboardEvent.key` keyboard.service stores.
+ *
+ * Anything absent yields no accelerator at all rather than a guess: a menu item
+ * that advertises the wrong key teaches the user something false, and a wrong
+ * accelerator string is rejected by the native layer anyway.
+ */
+const ACCELERATOR_KEYS: Readonly<Record<string, string>> = {
+  '`': 'Backquote',
+  '\\': 'Backslash',
+  '[': 'BracketLeft',
+  ']': 'BracketRight',
+  ',': 'Comma',
+  '=': 'Equal',
+  '-': 'Minus',
+  '.': 'Period',
+  "'": 'Quote',
+  ';': 'Semicolon',
+  '/': 'Slash',
+  ' ': 'Space',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  end: 'End',
+  enter: 'Enter',
+  escape: 'Escape',
+  home: 'Home',
+  insert: 'Insert',
+  pagedown: 'PageDown',
+  pageup: 'PageUp',
+  tab: 'Tab',
+  arrowdown: 'ArrowDown',
+  arrowleft: 'ArrowLeft',
+  arrowright: 'ArrowRight',
+  arrowup: 'ArrowUp',
+};
+
+function acceleratorKey(key: string): string | null {
+  const lower = key.toLowerCase();
+  if (/^[a-z]$/.test(lower)) return lower.toUpperCase();
+  if (/^[0-9]$/.test(lower)) return lower;
+  return ACCELERATOR_KEYS[lower] ?? null;
+}
+
+/**
+ * Convert a keyboard.service binding into a Tauri accelerator string.
+ *
+ * Returns null when the combo cannot be expressed, and — deliberately — for any
+ * binding without Ctrl/Cmd/Alt: a bare "S" accelerator on a native menu item
+ * swallows the letter S everywhere in the app, including inside text fields.
+ */
+export function toAccelerator(binding: ShortcutBinding | undefined): string | null {
+  if (!binding) return null;
+  const key = acceleratorKey(binding.key);
+  if (!key) return null;
+
+  const modifier = binding.ctrl || binding.meta;
+  if (!modifier && !binding.alt) return null;
+
+  const parts: string[] = [];
+  if (modifier) parts.push('CmdOrCtrl');
+  if (binding.alt) parts.push('Alt');
+  if (binding.shift) parts.push('Shift');
+  parts.push(key);
+  return parts.join('+');
+}
+
+/** The accelerator a key press corresponds to, in the same notation. */
+export function acceleratorFromEvent(e: KeyboardEvent): string | null {
+  return toAccelerator({
+    key: e.key,
+    ctrl: e.ctrlKey,
+    shift: e.shiftKey,
+    alt: e.altKey,
+    meta: e.metaKey,
+  });
+}
+
+/** The accelerator currently bound to a menu item, custom rebinds included. */
+export function acceleratorForMenuItem(id: string): string | null {
+  const action = APP_MENU_ACTIONS.find((a) => a.id === id);
+  if (!action?.shortcutId) return null;
+  return toAccelerator(keyboardService.getBinding(action.shortcutId));
+}
+
+/** The payload `sync_app_menu` expects for the current repository state. */
+export function buildMenuUpdates(hasRepository: boolean): MenuItemUpdate[] {
+  return APP_MENU_ACTIONS.map((action) => ({
+    id: action.id,
+    enabled: action.repositoryScoped ? hasRepository : true,
+    accelerator: acceleratorForMenuItem(action.id),
+  }));
+}
+
+/**
+ * Push the current enabled state and accelerators to the native menu.
+ * Returns the raw command result so callers can log a failure; a stale menu is
+ * not worth a toast, but it must not vanish silently either.
+ */
+export async function syncAppMenu(hasRepository: boolean): Promise<CommandResult<void>> {
+  return invokeCommand<void>('sync_app_menu', { items: buildMenuUpdates(hasRepository) });
+}
+
+/**
+ * Find the function a menu id must run.
+ *
+ * Palette-backed ids return the palette command's own action — not a copy of it
+ * — so the menu and the palette can never diverge in behaviour, including the
+ * "Please open a repository first" guard the palette entries already carry.
+ */
+export function resolveMenuAction(
+  id: string,
+  paletteCommands: readonly PaletteCommand[],
+  shell: MenuShellHandlers
+): (() => void) | null {
+  const action = APP_MENU_ACTIONS.find((a) => a.id === id);
+  if (!action) return null;
+  if (action.shell) return shell[action.shell];
+  if (action.paletteId) {
+    return paletteCommands.find((c) => c.id === action.paletteId)?.action ?? null;
+  }
+  return null;
+}
+
+/**
+ * Guard against an action running twice for one key press.
+ *
+ * A menu accelerator is consumed by the menu on macOS, but on Linux (and, in
+ * some window states, Windows) the webview can see the same key press as well —
+ * so keyboard.service runs the action AND the native menu emits its event.
+ * "Push" twice from one Ctrl+Shift+U is not acceptable, so a menu action is
+ * dropped when its own accelerator was pressed a moment earlier.
+ */
+const DUPLICATE_WINDOW_MS = 500;
+let lastAcceleratorPress: { accelerator: string; at: number } | null = null;
+
+/** Record a key press for the duplicate guard. Exported for the watcher below. */
+export function noteAcceleratorKeydown(e: KeyboardEvent, now: number = Date.now()): void {
+  const accelerator = acceleratorFromEvent(e);
+  if (!accelerator) return;
+  lastAcceleratorPress = { accelerator, at: now };
+}
+
+/** Whether this menu action has just been run by its own keyboard shortcut. */
+export function shouldSuppressMenuAction(id: string, now: number = Date.now()): boolean {
+  const accelerator = acceleratorForMenuItem(id);
+  if (!accelerator || !lastAcceleratorPress) return false;
+  const isDuplicate =
+    lastAcceleratorPress.accelerator === accelerator &&
+    now - lastAcceleratorPress.at < DUPLICATE_WINDOW_MS;
+  // Consume it either way: one key press may only ever suppress one menu event,
+  // otherwise a deliberate second visit to the menu inside the window is eaten.
+  if (isDuplicate) lastAcceleratorPress = null;
+  return isDuplicate;
+}
+
+/** Reset the duplicate guard. Used by tests and on teardown. */
+export function resetAcceleratorGuard(): void {
+  lastAcceleratorPress = null;
+}
+
+/**
+ * Watch key presses for the duplicate guard. Capture phase, so a press is
+ * recorded even when a dialog stops the event on its way down.
+ */
+export function startAcceleratorWatch(target: Document = document): () => void {
+  const listener = (e: Event) => noteAcceleratorKeydown(e as KeyboardEvent);
+  target.addEventListener('keydown', listener, { capture: true });
+  return () => {
+    target.removeEventListener('keydown', listener, { capture: true });
+    resetAcceleratorGuard();
+  };
+}


### PR DESCRIPTION
## Summary

- Adds the menu bar every desktop Git client ships — **File / Repository / Branch / View / Help** — so Clean, Bisect, Worktrees, Submodules, Git LFS, Hooks, Git Configuration, Repository Health and .gitignore/.gitattributes are discoverable by browsing instead of only by typing the right words into the command palette.
- **No action is reimplemented.** Choosing an item emits its id to the frontend and app-shell runs the *very same function* its command-palette twin runs (`resolveMenuAction` returns the palette command's own `action`), so the two can never behave differently. A contract test (`scripts/menu-contract.test.mjs`, wired into `npm test`) compares the Rust menu table with the frontend action table and fails when either side gains, loses or renames an item.
- **Each item teaches its shortcut.** Accelerators come from `keyboard.service`, so a user who rebinds Fetch sees the new key on the menu. A guard drops a menu event whose own accelerator was pressed a moment earlier, so on platforms where the webview also sees the key press an action cannot run twice (a double push, say).
- **Nothing fires into nothing.** Repository-scoped items are built disabled and enabled/disabled by the frontend as tabs open and close; the palette's "Please open a repository first" guard still backs up the keyboard route.
- **macOS specifics.** Attaching a custom menu replaces Tauri's default one, so the macOS application menu (About / Services / Hide / Hide Others / Show All / Quit) and an Edit menu with Undo/Redo/Cut/Copy/Paste/Select All are included — without them macOS users would lose ⌘X/⌘C/⌘V/⌘A and ⌘Q entirely. Quit sits in the File menu on Windows/Linux instead. The tray menu is untouched: menu ids are kept disjoint from the tray's (`show_hide`, `quit`) and both handlers filter by id, since Tauri fans every menu event out to every global listener — there is a Rust test pinning that.

## Review finding

`tauri::menu` was used in `src-tauri/src/lib.rs` (~lines 203-222) only to build the tray menu; `set_menu` was never called, so the app had no menu bar at all. Meanwhile a large part of the feature set was reachable only through the command palette (`src/app-shell.ts`, `getPaletteCommands`) — Clean, Bisect, Submodules, Worktrees, Git LFS, Git Configuration, Repository Health, Hooks, .gitignore/.gitattributes — while the left panel offers only Branches/Stashes/Tags/Git Flow and the toolbar's buttons reach none of them. A menu bar is where desktop discoverability and shortcut hints live.

## Not included, and why

- **Branch ▸ Merge / Rebase.** Both exist today only on the branch-list context menu, acting on a branch the user has already picked. A top-level menu item would need a new branch-picker dialog, i.e. reimplementing the action, which this change deliberately avoids. Branch offers New Branch, Switch Branch… (opens the palette, which lists every branch with its checkout action), Compare Branches… and Clean Up Branches….
- **View ▸ toggle bottom panel.** `uiStore` has a `bottom` panel id but nothing renders it; the bottom pane users actually have is the Output panel, which is in the menu. A bottom-panel toggle would have been a menu item that does nothing.

## Test plan

- [ ] `npm run lint` — 0 errors (204 pre-existing warnings, unchanged)
- [ ] `npm run typecheck` — clean (src and e2e)
- [ ] `npm test` — 5532 passed; the only 2 failures are the pre-existing "network gate coverage" timeouts, verified failing identically on a clean tree at this base
- [ ] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` — clean
- [ ] `cargo test menu` — 12 tests (id uniqueness, kebab-case ids, no collision with the tray ids, repository-scoped set, section order, payload deserialization, update error reporting)
- [ ] `npx playwright test e2e/tests/app-menu.spec.ts` — 11 passed (menu event routing with and without a repository, the guard toast, tab close, palette/shortcuts/clone dialogs, enabled state in both directions, accelerators in the sync payload)
- [ ] Frontend unit tests: `src/services/__tests__/app-menu.service.test.ts` (23) and `src/__tests__/app-shell-app-menu.test.ts` (9), including the drift guard that every palette-backed menu id names a palette command that exists

### Manual verification needed (a native menu cannot be driven by a test)

Playwright and web-test-runner cover everything from the emitted event inwards; the OS-drawn menu itself has to be looked at. On **each** of macOS, Windows and Linux, in a `tauri dev`/packaged build:

1. The menu bar appears with File, Repository, Branch, View, Help (macOS: plus the Leviathan and Edit menus).
2. With no repository open, every Repository and Branch item and File ▸ Close Repository Tab is greyed out; open a repository and they become live; close the last tab and they grey out again.
3. Shortcuts are printed on Fetch (Ctrl/⌘⇧F), Pull, Push, New Branch, Toggle Left/Right Panel, Command Palette — rebind one in Settings ▸ Keyboard and confirm the menu updates.
4. Choosing an item does the same thing as the palette command of the same name, and pressing its shortcut performs the action exactly **once**.
5. macOS: ⌘X/⌘C/⌘V/⌘A still work in text fields, ⌘Q quits, and the menu bar is present when the window is not focused.
6. The tray menu still works: Show/Hide and Quit, and minimize-to-tray still closes to the tray rather than exiting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_