### PR TITLE
perf: run hot git commands on the blocking pool

### DIFF
--- a/src-tauri/src/commands/branch.rs
+++ b/src-tauri/src/commands/branch.rs
@@ -12,108 +12,111 @@ const STALE_THRESHOLD_DAYS: i64 = 90;
 /// Get all branches in the repository
 #[command]
 pub async fn get_branches(path: String) -> Result<Vec<Branch>> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let mut branches = Vec::new();
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let mut branches = Vec::new();
 
-    let head = repo.head().ok();
-    let _head_oid = head.as_ref().and_then(|h| h.target());
+        let head = repo.head().ok();
+        let _head_oid = head.as_ref().and_then(|h| h.target());
 
-    // Calculate stale threshold (90 days ago in seconds since epoch)
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    let stale_threshold = now - (STALE_THRESHOLD_DAYS * 24 * 60 * 60);
+        // Calculate stale threshold (90 days ago in seconds since epoch)
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let stale_threshold = now - (STALE_THRESHOLD_DAYS * 24 * 60 * 60);
 
-    for branch_result in repo.branches(None)? {
-        let (branch, branch_type) = branch_result?;
-        let name = branch.name()?.unwrap_or("").to_string();
-        let reference = branch.get();
+        for branch_result in repo.branches(None)? {
+            let (branch, branch_type) = branch_result?;
+            let name = branch.name()?.unwrap_or("").to_string();
+            let reference = branch.get();
 
-        let is_remote = branch_type == git2::BranchType::Remote;
+            let is_remote = branch_type == git2::BranchType::Remote;
 
-        // Skip the remote's symbolic HEAD pointer (refs/remotes/origin/HEAD),
-        // which every clone has.
-        //
-        // It is a pointer at the remote's default branch, not a branch of its
-        // own: `git branch -r` renders it as "origin/HEAD -> origin/main" and
-        // never offers it for checkout. Listing it produced a row named
-        // "origin/HEAD" with an empty target oid and no timestamp — a symbolic
-        // ref has no direct target — and checking that row out derived the
-        // local branch name "HEAD", which libgit2 rejects as invalid.
-        if is_remote && reference.kind() == Some(git2::ReferenceType::Symbolic) {
-            continue;
-        }
+            // Skip the remote's symbolic HEAD pointer (refs/remotes/origin/HEAD),
+            // which every clone has.
+            //
+            // It is a pointer at the remote's default branch, not a branch of its
+            // own: `git branch -r` renders it as "origin/HEAD -> origin/main" and
+            // never offers it for checkout. Listing it produced a row named
+            // "origin/HEAD" with an empty target oid and no timestamp — a symbolic
+            // ref has no direct target — and checking that row out derived the
+            // local branch name "HEAD", which libgit2 rejects as invalid.
+            if is_remote && reference.kind() == Some(git2::ReferenceType::Symbolic) {
+                continue;
+            }
 
-        let is_head = head
-            .as_ref()
-            .map(|h| h.name() == reference.name())
-            .unwrap_or(false);
-
-        let target_oid = reference
-            .target()
-            .map(|oid| oid.to_string())
-            .unwrap_or_default();
-
-        // Get the last commit timestamp for this branch
-        let last_commit_timestamp = reference.target().and_then(|oid| {
-            repo.find_commit(oid)
-                .ok()
-                .map(|commit| commit.time().seconds())
-        });
-
-        // Branch is stale if it's not HEAD and hasn't been updated in threshold days
-        let is_stale = !is_head
-            && last_commit_timestamp
-                .map(|ts| ts < stale_threshold)
+            let is_head = head
+                .as_ref()
+                .map(|h| h.name() == reference.name())
                 .unwrap_or(false);
 
-        let upstream = branch
-            .upstream()
-            .ok()
-            .and_then(|u| u.name().ok().flatten().map(|n| n.to_string()));
+            let target_oid = reference
+                .target()
+                .map(|oid| oid.to_string())
+                .unwrap_or_default();
 
-        let ahead_behind = if !is_remote {
-            if let (Some(local_oid), Some(upstream_branch)) =
-                (reference.target(), branch.upstream().ok())
-            {
-                if let Some(upstream_oid) = upstream_branch.get().target() {
-                    repo.graph_ahead_behind(local_oid, upstream_oid)
-                        .ok()
-                        .map(|(ahead, behind)| AheadBehind { ahead, behind })
+            // Get the last commit timestamp for this branch
+            let last_commit_timestamp = reference.target().and_then(|oid| {
+                repo.find_commit(oid)
+                    .ok()
+                    .map(|commit| commit.time().seconds())
+            });
+
+            // Branch is stale if it's not HEAD and hasn't been updated in threshold days
+            let is_stale = !is_head
+                && last_commit_timestamp
+                    .map(|ts| ts < stale_threshold)
+                    .unwrap_or(false);
+
+            let upstream = branch
+                .upstream()
+                .ok()
+                .and_then(|u| u.name().ok().flatten().map(|n| n.to_string()));
+
+            let ahead_behind = if !is_remote {
+                if let (Some(local_oid), Some(upstream_branch)) =
+                    (reference.target(), branch.upstream().ok())
+                {
+                    if let Some(upstream_oid) = upstream_branch.get().target() {
+                        repo.graph_ahead_behind(local_oid, upstream_oid)
+                            .ok()
+                            .map(|(ahead, behind)| AheadBehind { ahead, behind })
+                    } else {
+                        None
+                    }
                 } else {
                     None
                 }
             } else {
                 None
-            }
-        } else {
-            None
-        };
+            };
 
-        branches.push(Branch {
-            name: name.clone(),
-            shorthand: if is_remote {
-                // For remote branches, strip the remote name prefix (e.g., "origin/main" -> "main")
-                name.split_once('/')
-                    .map(|x| x.1)
-                    .unwrap_or(&name)
-                    .to_string()
-            } else {
-                // For local branches, use the full name (e.g., "feature/my-fix")
-                name.clone()
-            },
-            is_head,
-            is_remote,
-            upstream,
-            target_oid,
-            ahead_behind,
-            last_commit_timestamp,
-            is_stale,
-        });
-    }
+            branches.push(Branch {
+                name: name.clone(),
+                shorthand: if is_remote {
+                    // For remote branches, strip the remote name prefix (e.g., "origin/main" -> "main")
+                    name.split_once('/')
+                        .map(|x| x.1)
+                        .unwrap_or(&name)
+                        .to_string()
+                } else {
+                    // For local branches, use the full name (e.g., "feature/my-fix")
+                    name.clone()
+                },
+                is_head,
+                is_remote,
+                upstream,
+                target_oid,
+                ahead_behind,
+                last_commit_timestamp,
+                is_stale,
+            });
+        }
 
-    Ok(branches)
+        Ok(branches)
+    })
+    .await
 }
 
 /// Create a new branch
@@ -124,132 +127,138 @@ pub async fn create_branch(
     start_point: Option<String>,
     checkout: Option<bool>,
 ) -> Result<Branch> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    // "Checkout new branch after creation" is the dialog's default, so this
-    // switches branches without being called checkout — which is how it was
-    // missed when ensure_checkoutable was added to the two commands that are.
-    // Checked BEFORE the ref is created so a refusal leaves nothing behind.
-    if checkout.unwrap_or(false) {
-        ensure_checkoutable(&repo)?;
-    }
-
-    let commit = if let Some(ref start) = start_point {
-        let obj = repo.revparse_single(start)?;
-        obj.peel_to_commit()?
-    } else {
-        repo.head()?.peel_to_commit()?
-    };
-
-    let branch = repo.branch(&name, &commit, false)?;
-    let reference = branch.get();
-
-    if checkout.unwrap_or(false) {
-        let old_head = crate::commands::hooks::head_oid_string(&repo);
-        let obj = reference.peel(git2::ObjectType::Commit)?;
-        // The checkout is fallible (a dirty file that differs between HEAD and
-        // the start point conflicts), and the ref already exists by now. Roll
-        // it back so "create failed" stays literally true — otherwise the
-        // dialog showed an error while the refs watcher made the branch appear
-        // in the sidebar, and a retry dead-ended on "already exists".
-        let switch = (|| -> Result<()> {
-            repo.checkout_tree(&obj, None)?;
-            repo.set_head(reference.name().map_err(|_| {
-                LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
-            })?)?;
-            Ok(())
-        })();
-        if let Err(e) = switch {
-            if let Ok(mut created) = repo.find_branch(&name, git2::BranchType::Local) {
-                let _ = created.delete();
-            }
-            return Err(e);
+        // "Checkout new branch after creation" is the dialog's default, so this
+        // switches branches without being called checkout — which is how it was
+        // missed when ensure_checkoutable was added to the two commands that are.
+        // Checked BEFORE the ref is created so a refusal leaves nothing behind.
+        if checkout.unwrap_or(false) {
+            ensure_checkoutable(&repo)?;
         }
-        let new_head = crate::commands::hooks::head_oid_string(&repo);
-        crate::commands::hooks::run_post_checkout(&repo, &old_head, &new_head, true);
-    }
 
-    Ok(Branch {
-        name: name.clone(),
-        shorthand: name.clone(),
-        is_head: checkout.unwrap_or(false),
-        is_remote: false,
-        upstream: None,
-        target_oid: commit.id().to_string(),
-        ahead_behind: None,
-        last_commit_timestamp: Some(commit.time().seconds()),
-        is_stale: false, // Newly created branches are never stale
+        let commit = if let Some(ref start) = start_point {
+            let obj = repo.revparse_single(start)?;
+            obj.peel_to_commit()?
+        } else {
+            repo.head()?.peel_to_commit()?
+        };
+
+        let branch = repo.branch(&name, &commit, false)?;
+        let reference = branch.get();
+
+        if checkout.unwrap_or(false) {
+            let old_head = crate::commands::hooks::head_oid_string(&repo);
+            let obj = reference.peel(git2::ObjectType::Commit)?;
+            // The checkout is fallible (a dirty file that differs between HEAD and
+            // the start point conflicts), and the ref already exists by now. Roll
+            // it back so "create failed" stays literally true — otherwise the
+            // dialog showed an error while the refs watcher made the branch appear
+            // in the sidebar, and a retry dead-ended on "already exists".
+            let switch = (|| -> Result<()> {
+                repo.checkout_tree(&obj, None)?;
+                repo.set_head(reference.name().map_err(|_| {
+                    LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
+                })?)?;
+                Ok(())
+            })();
+            if let Err(e) = switch {
+                if let Ok(mut created) = repo.find_branch(&name, git2::BranchType::Local) {
+                    let _ = created.delete();
+                }
+                return Err(e);
+            }
+            let new_head = crate::commands::hooks::head_oid_string(&repo);
+            crate::commands::hooks::run_post_checkout(&repo, &old_head, &new_head, true);
+        }
+
+        Ok(Branch {
+            name: name.clone(),
+            shorthand: name.clone(),
+            is_head: checkout.unwrap_or(false),
+            is_remote: false,
+            upstream: None,
+            target_oid: commit.id().to_string(),
+            ahead_behind: None,
+            last_commit_timestamp: Some(commit.time().seconds()),
+            is_stale: false, // Newly created branches are never stale
+        })
     })
+    .await
 }
 
 /// Delete a branch
 #[command]
 pub async fn delete_branch(path: String, name: String, force: Option<bool>) -> Result<()> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let mut branch = repo
-        .find_branch(&name, git2::BranchType::Local)
-        .map_err(|_| LeviathanError::BranchNotFound(name.clone()))?;
+        let mut branch = repo
+            .find_branch(&name, git2::BranchType::Local)
+            .map_err(|_| LeviathanError::BranchNotFound(name.clone()))?;
 
-    // Enforce preventDeletion branch rules HERE rather than only in the cleanup
-    // dialog's candidate listing: the sidebar and the graph ref menu call this
-    // command directly, so a rule the UI displays as active was inert on both
-    // of those surfaces. Checked before the force branch so force cannot bypass
-    // an explicit protection rule.
-    // Propagated, NOT unwrap_or_default: load_rules errors both when the file
-    // is unreadable and when it fails to parse (save_rules is a non-atomic
-    // write, so a crash mid-save can truncate it). Defaulting to "no rules"
-    // would make an unreadable rule set indistinguishable from an empty one and
-    // silently disable every protection in the repo — a protection that fails
-    // open is worse than none, because the UI still shows the branch as
-    // protected.
-    let rules = super::branch_rules::load_rules(Path::new(&path))?;
-    if super::branch_rules::is_deletion_prevented(&rules, &name) {
-        return Err(LeviathanError::OperationFailed(format!(
-            "Branch \"{}\" is protected by a branch rule and cannot be deleted. Remove the rule first.",
-            name
-        )));
-    }
-
-    if force.unwrap_or(false) {
-        branch.delete()?;
-    } else {
-        // Check if branch is merged before deleting.
-        //
-        // An UNBORN HEAD is not an error here. On an orphan branch with no
-        // commits (`git checkout --orphan gh-pages`, the standard way to start
-        // a docs branch) repo.head() fails, and propagating that reported
-        // "reference 'refs/heads/gh-pages' not found" — naming a branch the
-        // user had not selected. Worse, the frontend gates its Force Delete
-        // escalation on /not fully merged/i, so that message hid the one
-        // recovery the app offers, even though force delete works fine here.
-        // Canonical git says "not fully merged" in this state.
-        let head = match repo.head() {
-            Ok(h) => h,
-            Err(_) => {
-                return Err(LeviathanError::OperationFailed(
-                    "Branch is not fully merged. Use force to delete anyway.".to_string(),
-                ))
-            }
-        };
-        if let (Some(head_oid), Some(branch_oid)) = (head.target(), branch.get().target()) {
-            // A branch is fully merged into HEAD when HEAD is at or descends
-            // from the branch tip. The equality case matters: `git branch -d`
-            // deletes a branch that points at the same commit as HEAD, but
-            // graph_descendant_of returns false for equal oids.
-            if head_oid == branch_oid || repo.graph_descendant_of(head_oid, branch_oid)? {
-                branch.delete()?;
-            } else {
-                return Err(LeviathanError::OperationFailed(
-                    "Branch is not fully merged. Use force to delete anyway.".to_string(),
-                ));
-            }
-        } else {
-            branch.delete()?;
+        // Enforce preventDeletion branch rules HERE rather than only in the cleanup
+        // dialog's candidate listing: the sidebar and the graph ref menu call this
+        // command directly, so a rule the UI displays as active was inert on both
+        // of those surfaces. Checked before the force branch so force cannot bypass
+        // an explicit protection rule.
+        // Propagated, NOT unwrap_or_default: load_rules errors both when the file
+        // is unreadable and when it fails to parse (save_rules is a non-atomic
+        // write, so a crash mid-save can truncate it). Defaulting to "no rules"
+        // would make an unreadable rule set indistinguishable from an empty one and
+        // silently disable every protection in the repo — a protection that fails
+        // open is worse than none, because the UI still shows the branch as
+        // protected.
+        let rules = super::branch_rules::load_rules(Path::new(&path))?;
+        if super::branch_rules::is_deletion_prevented(&rules, &name) {
+            return Err(LeviathanError::OperationFailed(format!(
+                "Branch \"{}\" is protected by a branch rule and cannot be deleted. Remove the rule first.",
+                name
+            )));
         }
-    }
 
-    Ok(())
+        if force.unwrap_or(false) {
+            branch.delete()?;
+        } else {
+            // Check if branch is merged before deleting.
+            //
+            // An UNBORN HEAD is not an error here. On an orphan branch with no
+            // commits (`git checkout --orphan gh-pages`, the standard way to start
+            // a docs branch) repo.head() fails, and propagating that reported
+            // "reference 'refs/heads/gh-pages' not found" — naming a branch the
+            // user had not selected. Worse, the frontend gates its Force Delete
+            // escalation on /not fully merged/i, so that message hid the one
+            // recovery the app offers, even though force delete works fine here.
+            // Canonical git says "not fully merged" in this state.
+            let head = match repo.head() {
+                Ok(h) => h,
+                Err(_) => {
+                    return Err(LeviathanError::OperationFailed(
+                        "Branch is not fully merged. Use force to delete anyway.".to_string(),
+                    ))
+                }
+            };
+            if let (Some(head_oid), Some(branch_oid)) = (head.target(), branch.get().target()) {
+                // A branch is fully merged into HEAD when HEAD is at or descends
+                // from the branch tip. The equality case matters: `git branch -d`
+                // deletes a branch that points at the same commit as HEAD, but
+                // graph_descendant_of returns false for equal oids.
+                if head_oid == branch_oid || repo.graph_descendant_of(head_oid, branch_oid)? {
+                    branch.delete()?;
+                } else {
+                    return Err(LeviathanError::OperationFailed(
+                        "Branch is not fully merged. Use force to delete anyway.".to_string(),
+                    ));
+                }
+            } else {
+                branch.delete()?;
+            }
+        }
+
+        Ok(())
+    })
+    .await
 }
 
 /// Rename a branch
@@ -264,80 +273,83 @@ pub async fn rename_branch(
     new_name: String,
     update_tracking: Option<bool>,
 ) -> Result<Branch> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let mut branch = repo
-        .find_branch(&old_name, git2::BranchType::Local)
-        .map_err(|_| LeviathanError::BranchNotFound(old_name.clone()))?;
+        let mut branch = repo
+            .find_branch(&old_name, git2::BranchType::Local)
+            .map_err(|_| LeviathanError::BranchNotFound(old_name.clone()))?;
 
-    // Capture existing upstream info before rename
-    let upstream_name = branch
-        .upstream()
-        .ok()
-        .and_then(|u| u.name().ok().flatten().map(|n| n.to_string()));
-
-    branch.rename(&new_name, false)?;
-
-    // Get the renamed branch to return updated info
-    let mut renamed_branch = repo.find_branch(&new_name, git2::BranchType::Local)?;
-
-    // Re-apply upstream tracking if requested (default: true)
-    let should_update = update_tracking.unwrap_or(true);
-    if should_update {
-        if let Some(ref up_name) = upstream_name {
-            // Re-set the upstream on the renamed branch
-            let _ = renamed_branch.set_upstream(Some(up_name));
-            // Re-fetch the branch after setting upstream
-            renamed_branch = repo.find_branch(&new_name, git2::BranchType::Local)?;
-        }
-    }
-
-    let reference = renamed_branch.get();
-    let target_oid = reference
-        .target()
-        .map(|o| o.to_string())
-        .unwrap_or_default();
-
-    let is_head = repo
-        .head()
-        .ok()
-        .map(|h| h.name() == reference.name())
-        .unwrap_or(false);
-
-    let upstream = renamed_branch
-        .upstream()
-        .ok()
-        .and_then(|u| u.name().ok().flatten().map(|n| n.to_string()));
-
-    // Get the last commit timestamp
-    let last_commit_timestamp = reference.target().and_then(|oid| {
-        repo.find_commit(oid)
+        // Capture existing upstream info before rename
+        let upstream_name = branch
+            .upstream()
             .ok()
-            .map(|commit| commit.time().seconds())
-    });
+            .and_then(|u| u.name().ok().flatten().map(|n| n.to_string()));
 
-    // Calculate if stale (if not HEAD)
-    let now = std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs() as i64)
-        .unwrap_or(0);
-    let stale_threshold = now - (STALE_THRESHOLD_DAYS * 24 * 60 * 60);
-    let is_stale = !is_head
-        && last_commit_timestamp
-            .map(|ts| ts < stale_threshold)
+        branch.rename(&new_name, false)?;
+
+        // Get the renamed branch to return updated info
+        let mut renamed_branch = repo.find_branch(&new_name, git2::BranchType::Local)?;
+
+        // Re-apply upstream tracking if requested (default: true)
+        let should_update = update_tracking.unwrap_or(true);
+        if should_update {
+            if let Some(ref up_name) = upstream_name {
+                // Re-set the upstream on the renamed branch
+                let _ = renamed_branch.set_upstream(Some(up_name));
+                // Re-fetch the branch after setting upstream
+                renamed_branch = repo.find_branch(&new_name, git2::BranchType::Local)?;
+            }
+        }
+
+        let reference = renamed_branch.get();
+        let target_oid = reference
+            .target()
+            .map(|o| o.to_string())
+            .unwrap_or_default();
+
+        let is_head = repo
+            .head()
+            .ok()
+            .map(|h| h.name() == reference.name())
             .unwrap_or(false);
 
-    Ok(Branch {
-        name: new_name.clone(),
-        shorthand: new_name,
-        is_head,
-        is_remote: false,
-        upstream,
-        target_oid,
-        ahead_behind: None,
-        last_commit_timestamp,
-        is_stale,
+        let upstream = renamed_branch
+            .upstream()
+            .ok()
+            .and_then(|u| u.name().ok().flatten().map(|n| n.to_string()));
+
+        // Get the last commit timestamp
+        let last_commit_timestamp = reference.target().and_then(|oid| {
+            repo.find_commit(oid)
+                .ok()
+                .map(|commit| commit.time().seconds())
+        });
+
+        // Calculate if stale (if not HEAD)
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs() as i64)
+            .unwrap_or(0);
+        let stale_threshold = now - (STALE_THRESHOLD_DAYS * 24 * 60 * 60);
+        let is_stale = !is_head
+            && last_commit_timestamp
+                .map(|ts| ts < stale_threshold)
+                .unwrap_or(false);
+
+        Ok(Branch {
+            name: new_name.clone(),
+            shorthand: new_name,
+            is_head,
+            is_remote: false,
+            upstream,
+            target_oid,
+            ahead_behind: None,
+            last_commit_timestamp,
+            is_stale,
+        })
     })
+    .await
 }
 
 /// Checkout a branch or commit
@@ -538,148 +550,154 @@ pub(crate) fn ensure_checkoutable(repo: &git2::Repository) -> Result<()> {
 
 #[command]
 pub async fn checkout(path: String, ref_name: String, force: Option<bool>) -> Result<()> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    ensure_checkoutable(&repo)?;
-    // BEFORE checkout_tree — see branch_checked_out_elsewhere.
-    ensure_not_checked_out_elsewhere(&repo, &ref_name)?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        ensure_checkoutable(&repo)?;
+        // BEFORE checkout_tree — see branch_checked_out_elsewhere.
+        ensure_not_checked_out_elsewhere(&repo, &ref_name)?;
 
-    // Capture HEAD before the switch so the post-checkout hook receives the
-    // correct <old-ref> argument (githooks(5)).
-    let old_head = crate::commands::hooks::head_oid_string(&repo);
+        // Capture HEAD before the switch so the post-checkout hook receives the
+        // correct <old-ref> argument (githooks(5)).
+        let old_head = crate::commands::hooks::head_oid_string(&repo);
 
-    let mut checkout_opts = git2::build::CheckoutBuilder::new();
-    if force.unwrap_or(false) {
-        checkout_opts.force();
-    } else {
-        checkout_opts.safe();
-    }
+        let mut checkout_opts = git2::build::CheckoutBuilder::new();
+        if force.unwrap_or(false) {
+            checkout_opts.force();
+        } else {
+            checkout_opts.safe();
+        }
 
-    // The working tree must always be checked out from the same commit HEAD
-    // ends up pointing at, so resolve the effective target ref FIRST. In
-    // particular, checking out a remote branch when a same-named local branch
-    // already exists must check out the LOCAL branch (like `git checkout`),
-    // not the remote tip — otherwise tree and HEAD diverge.
-    if let Ok(branch) = repo.find_branch(&ref_name, git2::BranchType::Local) {
-        let obj = branch.get().peel(git2::ObjectType::Commit)?;
-        repo.checkout_tree(&obj, Some(&mut checkout_opts))?;
-        repo.set_head(branch.get().name().map_err(|_| {
-            LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
-        })?)?;
-    } else if let Ok(remote_branch) = repo.find_branch(&ref_name, git2::BranchType::Remote) {
-        // Checking out a remote branch - use or create a local tracking branch.
-        // Extract the branch name without the remote prefix (e.g., "origin/feature" -> "feature")
-        let remote_name = remote_branch
-            .get()
-            .shorthand()
-            .unwrap_or(&ref_name)
-            .to_string();
+        // The working tree must always be checked out from the same commit HEAD
+        // ends up pointing at, so resolve the effective target ref FIRST. In
+        // particular, checking out a remote branch when a same-named local branch
+        // already exists must check out the LOCAL branch (like `git checkout`),
+        // not the remote tip — otherwise tree and HEAD diverge.
+        if let Ok(branch) = repo.find_branch(&ref_name, git2::BranchType::Local) {
+            let obj = branch.get().peel(git2::ObjectType::Commit)?;
+            repo.checkout_tree(&obj, Some(&mut checkout_opts))?;
+            repo.set_head(branch.get().name().map_err(|_| {
+                LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
+            })?)?;
+        } else if let Ok(remote_branch) = repo.find_branch(&ref_name, git2::BranchType::Remote) {
+            // Checking out a remote branch - use or create a local tracking branch.
+            // Extract the branch name without the remote prefix (e.g., "origin/feature" -> "feature")
+            let remote_name = remote_branch
+                .get()
+                .shorthand()
+                .unwrap_or(&ref_name)
+                .to_string();
 
-        if let Some(slash_pos) = remote_name.find('/') {
-            let local_name = &remote_name[slash_pos + 1..];
+            if let Some(slash_pos) = remote_name.find('/') {
+                let local_name = &remote_name[slash_pos + 1..];
 
-            if let Ok(local_branch) = repo.find_branch(local_name, git2::BranchType::Local) {
-                // Local branch exists: check out ITS tree, not the remote tip
-                let obj = local_branch.get().peel(git2::ObjectType::Commit)?;
-                repo.checkout_tree(&obj, Some(&mut checkout_opts))?;
-                repo.set_head(local_branch.get().name().map_err(|_| {
-                    LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
-                })?)?;
-            } else {
-                // Create new local branch from the remote branch.
-                //
-                // The ref must exist BEFORE the working tree is rewritten. A
-                // failure here (invalid derived name such as "HEAD" from
-                // refs/remotes/origin/HEAD, or a D/F conflict against an
-                // existing refs/heads/<name>/*) would otherwise return with the
-                // tree already holding the remote tip while HEAD still names the
-                // old branch — the whole inter-branch diff appears staged and
-                // committing writes the other branch's tree onto this one.
-                let commit = remote_branch.get().peel_to_commit()?;
-                let mut new_branch = repo.branch(local_name, &commit, false)?;
-
-                // Upstream tracking is best-effort: the branch already exists, so
-                // a tracking-config failure must not abort the checkout (matches
-                // checkout_with_autostash).
-                let _ = new_branch.set_upstream(Some(&remote_name));
-
-                let branch_ref = new_branch
-                    .get()
-                    .name()
-                    .map_err(|_| {
+                if let Ok(local_branch) = repo.find_branch(local_name, git2::BranchType::Local) {
+                    // Local branch exists: check out ITS tree, not the remote tip
+                    let obj = local_branch.get().peel(git2::ObjectType::Commit)?;
+                    repo.checkout_tree(&obj, Some(&mut checkout_opts))?;
+                    repo.set_head(local_branch.get().name().map_err(|_| {
                         LeviathanError::OperationFailed(
                             "Invalid reference name encoding".to_string(),
                         )
-                    })?
-                    .to_string();
+                    })?)?;
+                } else {
+                    // Create new local branch from the remote branch.
+                    //
+                    // The ref must exist BEFORE the working tree is rewritten. A
+                    // failure here (invalid derived name such as "HEAD" from
+                    // refs/remotes/origin/HEAD, or a D/F conflict against an
+                    // existing refs/heads/<name>/*) would otherwise return with the
+                    // tree already holding the remote tip while HEAD still names the
+                    // old branch — the whole inter-branch diff appears staged and
+                    // committing writes the other branch's tree onto this one.
+                    let commit = remote_branch.get().peel_to_commit()?;
+                    let mut new_branch = repo.branch(local_name, &commit, false)?;
 
-                // Roll the new ref back if the tree cannot be written, so a
-                // failed checkout leaves no half-created branch behind.
-                if let Err(e) = repo.checkout_tree(commit.as_object(), Some(&mut checkout_opts)) {
-                    let _ = new_branch.delete();
-                    return Err(e.into());
-                }
+                    // Upstream tracking is best-effort: the branch already exists, so
+                    // a tracking-config failure must not abort the checkout (matches
+                    // checkout_with_autostash).
+                    let _ = new_branch.set_upstream(Some(&remote_name));
 
-                // Moving HEAD is the LAST thing that can fail, and by then the
-                // working tree already holds the remote tip. Returning there
-                // left HEAD naming the old branch over the other branch's
-                // content: the whole inter-branch diff reads as uncommitted
-                // work, and committing it writes the other branch's tree onto
-                // this one — the exact corruption creating the ref early is
-                // meant to prevent, just one step later. Reachable through a
-                // HEAD.lock left by a crashed process or a concurrent git.
-                //
-                // So put the tree back, then drop the ref, and report the
-                // original failure.
-                //
-                // The restore is `force()`, and has to be: the files to undo
-                // now differ from HEAD, so a `safe()` checkout reads them as
-                // local modifications and refuses to touch the very files it
-                // needs to revert. That is safe here only because the checkout
-                // above ran `safe()` and SUCCEEDED — which means no tracked
-                // file carried a conflicting local edit, so everything this
-                // reverts is content we just wrote ourselves. Untracked files
-                // are not touched either way.
-                if let Err(e) = repo.set_head(&branch_ref) {
-                    let restored = repo
-                        .head()
-                        .and_then(|h| h.peel_to_commit())
-                        .and_then(|prev| {
-                            let mut restore = git2::build::CheckoutBuilder::new();
-                            restore.force();
-                            repo.checkout_tree(prev.as_object(), Some(&mut restore))
-                        })
-                        .is_ok();
-                    let _ = new_branch.delete();
+                    let branch_ref = new_branch
+                        .get()
+                        .name()
+                        .map_err(|_| {
+                            LeviathanError::OperationFailed(
+                                "Invalid reference name encoding".to_string(),
+                            )
+                        })?
+                        .to_string();
 
-                    if !restored {
-                        return Err(LeviathanError::OperationFailed(format!(
-                            "Could not switch to {}: {}. The working tree still holds \
-                             {}'s content — check it out again to recover.",
-                            local_name, e, remote_name
-                        )));
+                    // Roll the new ref back if the tree cannot be written, so a
+                    // failed checkout leaves no half-created branch behind.
+                    if let Err(e) = repo.checkout_tree(commit.as_object(), Some(&mut checkout_opts))
+                    {
+                        let _ = new_branch.delete();
+                        return Err(e.into());
                     }
-                    return Err(e.into());
+
+                    // Moving HEAD is the LAST thing that can fail, and by then the
+                    // working tree already holds the remote tip. Returning there
+                    // left HEAD naming the old branch over the other branch's
+                    // content: the whole inter-branch diff reads as uncommitted
+                    // work, and committing it writes the other branch's tree onto
+                    // this one — the exact corruption creating the ref early is
+                    // meant to prevent, just one step later. Reachable through a
+                    // HEAD.lock left by a crashed process or a concurrent git.
+                    //
+                    // So put the tree back, then drop the ref, and report the
+                    // original failure.
+                    //
+                    // The restore is `force()`, and has to be: the files to undo
+                    // now differ from HEAD, so a `safe()` checkout reads them as
+                    // local modifications and refuses to touch the very files it
+                    // needs to revert. That is safe here only because the checkout
+                    // above ran `safe()` and SUCCEEDED — which means no tracked
+                    // file carried a conflicting local edit, so everything this
+                    // reverts is content we just wrote ourselves. Untracked files
+                    // are not touched either way.
+                    if let Err(e) = repo.set_head(&branch_ref) {
+                        let restored = repo
+                            .head()
+                            .and_then(|h| h.peel_to_commit())
+                            .and_then(|prev| {
+                                let mut restore = git2::build::CheckoutBuilder::new();
+                                restore.force();
+                                repo.checkout_tree(prev.as_object(), Some(&mut restore))
+                            })
+                            .is_ok();
+                        let _ = new_branch.delete();
+
+                        if !restored {
+                            return Err(LeviathanError::OperationFailed(format!(
+                                "Could not switch to {}: {}. The working tree still holds \
+                                 {}'s content — check it out again to recover.",
+                                local_name, e, remote_name
+                            )));
+                        }
+                        return Err(e.into());
+                    }
                 }
+            } else {
+                // Couldn't parse remote name, detach HEAD
+                let commit = remote_branch.get().peel_to_commit()?;
+                repo.checkout_tree(commit.as_object(), Some(&mut checkout_opts))?;
+                repo.set_head_detached(commit.id())?;
             }
         } else {
-            // Couldn't parse remote name, detach HEAD
-            let commit = remote_branch.get().peel_to_commit()?;
-            repo.checkout_tree(commit.as_object(), Some(&mut checkout_opts))?;
+            // Not a branch (could be a commit SHA or tag), detach HEAD
+            let obj = repo.revparse_single(&ref_name)?;
+            let commit = obj.peel_to_commit()?;
+            repo.checkout_tree(&obj, Some(&mut checkout_opts))?;
             repo.set_head_detached(commit.id())?;
         }
-    } else {
-        // Not a branch (could be a commit SHA or tag), detach HEAD
-        let obj = repo.revparse_single(&ref_name)?;
-        let commit = obj.peel_to_commit()?;
-        repo.checkout_tree(&obj, Some(&mut checkout_opts))?;
-        repo.set_head_detached(commit.id())?;
-    }
 
-    // Branch/commit switch complete — run post-checkout (flag=1), non-blocking.
-    let new_head = crate::commands::hooks::head_oid_string(&repo);
-    crate::commands::hooks::run_post_checkout(&repo, &old_head, &new_head, true);
+        // Branch/commit switch complete — run post-checkout (flag=1), non-blocking.
+        let new_head = crate::commands::hooks::head_oid_string(&repo);
+        crate::commands::hooks::run_post_checkout(&repo, &old_head, &new_head, true);
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 /// Set the upstream branch for a local branch
@@ -692,8 +710,9 @@ pub async fn set_upstream_branch(
     let path_clone = path.clone();
     let branch_clone = branch.clone();
 
-    // Wrap git2 operations in a block so they're dropped before the await
-    {
+    // git2 operations run on the blocking pool and are dropped before the
+    // await: git2 handles are not `Send`, so none may cross it.
+    crate::utils::blocking_git(move || {
         let repo = git2::Repository::open(Path::new(&path))?;
 
         let mut local_branch = repo
@@ -723,7 +742,9 @@ pub async fn set_upstream_branch(
 
         // Set the upstream using the shorthand form
         local_branch.set_upstream(Some(&upstream_short))?;
-    }
+        Ok(())
+    })
+    .await?;
 
     // Return the updated tracking info
     get_branch_tracking_info(path_clone, branch_clone).await
@@ -732,111 +753,117 @@ pub async fn set_upstream_branch(
 /// Remove the upstream tracking for a local branch
 #[command]
 pub async fn unset_upstream_branch(path: String, branch: String) -> Result<()> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let mut local_branch = repo
-        .find_branch(&branch, git2::BranchType::Local)
-        .map_err(|_| LeviathanError::BranchNotFound(branch.clone()))?;
+        let mut local_branch = repo
+            .find_branch(&branch, git2::BranchType::Local)
+            .map_err(|_| LeviathanError::BranchNotFound(branch.clone()))?;
 
-    // Remove the upstream (ignore error if no upstream was set)
-    let _ = local_branch.set_upstream(None);
+        // Remove the upstream (ignore error if no upstream was set)
+        let _ = local_branch.set_upstream(None);
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 /// Get detailed tracking information for a branch
 #[command]
 pub async fn get_branch_tracking_info(path: String, branch: String) -> Result<BranchTrackingInfo> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let local_branch = repo
-        .find_branch(&branch, git2::BranchType::Local)
-        .map_err(|_| LeviathanError::BranchNotFound(branch.clone()))?;
+        let local_branch = repo
+            .find_branch(&branch, git2::BranchType::Local)
+            .map_err(|_| LeviathanError::BranchNotFound(branch.clone()))?;
 
-    let local_oid = local_branch
-        .get()
-        .target()
-        .ok_or_else(|| LeviathanError::OperationFailed("Branch has no target".to_string()))?;
+        let local_oid = local_branch
+            .get()
+            .target()
+            .ok_or_else(|| LeviathanError::OperationFailed("Branch has no target".to_string()))?;
 
-    // Try to get upstream info
-    let upstream_result = local_branch.upstream();
+        // Try to get upstream info
+        let upstream_result = local_branch.upstream();
 
-    match upstream_result {
-        Ok(upstream_branch) => {
-            let upstream_name = upstream_branch
-                .name()?
-                .map(|s| s.to_string())
-                .unwrap_or_default();
+        match upstream_result {
+            Ok(upstream_branch) => {
+                let upstream_name = upstream_branch
+                    .name()?
+                    .map(|s| s.to_string())
+                    .unwrap_or_default();
 
-            // Parse remote and remote branch from upstream name (e.g., "origin/main")
-            let (remote, remote_branch) = if let Some((r, b)) = upstream_name.split_once('/') {
-                (Some(r.to_string()), Some(b.to_string()))
-            } else {
-                (None, Some(upstream_name.clone()))
-            };
+                // Parse remote and remote branch from upstream name (e.g., "origin/main")
+                let (remote, remote_branch) = if let Some((r, b)) = upstream_name.split_once('/') {
+                    (Some(r.to_string()), Some(b.to_string()))
+                } else {
+                    (None, Some(upstream_name.clone()))
+                };
 
-            // Calculate ahead/behind
-            let upstream_oid = upstream_branch.get().target();
-            let (ahead, behind) = if let Some(up_oid) = upstream_oid {
-                repo.graph_ahead_behind(local_oid, up_oid)
-                    .map(|(a, b)| (a as u32, b as u32))
-                    .unwrap_or((0, 0))
-            } else {
-                (0, 0)
-            };
-
-            Ok(BranchTrackingInfo {
-                local_branch: branch,
-                upstream: Some(format!("refs/remotes/{}", upstream_name)),
-                ahead,
-                behind,
-                remote,
-                remote_branch,
-                is_gone: false,
-            })
-        }
-        Err(e) => {
-            // Check if upstream is configured but the remote branch is gone
-            let config = repo.config()?;
-            let merge_key = format!("branch.{}.merge", branch);
-            let remote_key = format!("branch.{}.remote", branch);
-
-            let has_merge = config.get_string(&merge_key).is_ok();
-            let remote_name = config.get_string(&remote_key).ok();
-
-            if has_merge && remote_name.is_some() {
-                // Upstream is configured but branch is gone
-                let remote = remote_name;
-                let remote_branch = config
-                    .get_string(&merge_key)
-                    .ok()
-                    .map(|m| m.strip_prefix("refs/heads/").unwrap_or(&m).to_string());
+                // Calculate ahead/behind
+                let upstream_oid = upstream_branch.get().target();
+                let (ahead, behind) = if let Some(up_oid) = upstream_oid {
+                    repo.graph_ahead_behind(local_oid, up_oid)
+                        .map(|(a, b)| (a as u32, b as u32))
+                        .unwrap_or((0, 0))
+                } else {
+                    (0, 0)
+                };
 
                 Ok(BranchTrackingInfo {
                     local_branch: branch,
-                    upstream: None,
-                    ahead: 0,
-                    behind: 0,
+                    upstream: Some(format!("refs/remotes/{}", upstream_name)),
+                    ahead,
+                    behind,
                     remote,
                     remote_branch,
-                    is_gone: true,
-                })
-            } else if e.code() == git2::ErrorCode::NotFound {
-                // No upstream configured
-                Ok(BranchTrackingInfo {
-                    local_branch: branch,
-                    upstream: None,
-                    ahead: 0,
-                    behind: 0,
-                    remote: None,
-                    remote_branch: None,
                     is_gone: false,
                 })
-            } else {
-                Err(e.into())
+            }
+            Err(e) => {
+                // Check if upstream is configured but the remote branch is gone
+                let config = repo.config()?;
+                let merge_key = format!("branch.{}.merge", branch);
+                let remote_key = format!("branch.{}.remote", branch);
+
+                let has_merge = config.get_string(&merge_key).is_ok();
+                let remote_name = config.get_string(&remote_key).ok();
+
+                if has_merge && remote_name.is_some() {
+                    // Upstream is configured but branch is gone
+                    let remote = remote_name;
+                    let remote_branch = config
+                        .get_string(&merge_key)
+                        .ok()
+                        .map(|m| m.strip_prefix("refs/heads/").unwrap_or(&m).to_string());
+
+                    Ok(BranchTrackingInfo {
+                        local_branch: branch,
+                        upstream: None,
+                        ahead: 0,
+                        behind: 0,
+                        remote,
+                        remote_branch,
+                        is_gone: true,
+                    })
+                } else if e.code() == git2::ErrorCode::NotFound {
+                    // No upstream configured
+                    Ok(BranchTrackingInfo {
+                        local_branch: branch,
+                        upstream: None,
+                        ahead: 0,
+                        behind: 0,
+                        remote: None,
+                        remote_branch: None,
+                        is_gone: false,
+                    })
+                } else {
+                    Err(e.into())
+                }
             }
         }
-    }
+    })
+    .await
 }
 
 /// Create an orphan branch (a branch with no parent commits)
@@ -849,50 +876,53 @@ pub async fn get_branch_tracking_info(path: String, branch: String) -> Result<Br
 /// refused rather than half-performed. See the body for why.
 #[command]
 pub async fn create_orphan_branch(path: String, name: String, checkout: bool) -> Result<()> {
-    // `git checkout --orphan` is the only way to start an orphan branch, and it
-    // ALWAYS switches to it. That is not a limitation of this command: an
-    // unborn branch has no ref until its first commit, so there is nothing to
-    // create and leave behind.
-    //
-    // checkout=false used to run `git checkout -` afterwards to switch back,
-    // and that never worked — `--orphan` writes no HEAD reflog entry, so
-    // `@{-1}` does not resolve and git fails with "pathspec '-' did not match
-    // any file(s) known to git". The command returned an error AND left HEAD on
-    // the unborn orphan, where repo.head() fails for the whole app: the graph,
-    // the branch list and the status panel all go blank — after the user
-    // explicitly asked NOT to switch.
-    //
-    // Refused up front, so the repository is never touched.
-    if !checkout {
-        return Err(LeviathanError::OperationFailed(
-            "An orphan branch has no commits, so it is not a branch until its first commit is \
-             made — git cannot create one without switching to it. Check it out, make the first \
-             commit, then switch back."
-                .to_string(),
-        ));
-    }
+    crate::utils::blocking_git(move || {
+        // `git checkout --orphan` is the only way to start an orphan branch, and it
+        // ALWAYS switches to it. That is not a limitation of this command: an
+        // unborn branch has no ref until its first commit, so there is nothing to
+        // create and leave behind.
+        //
+        // checkout=false used to run `git checkout -` afterwards to switch back,
+        // and that never worked — `--orphan` writes no HEAD reflog entry, so
+        // `@{-1}` does not resolve and git fails with "pathspec '-' did not match
+        // any file(s) known to git". The command returned an error AND left HEAD on
+        // the unborn orphan, where repo.head() fails for the whole app: the graph,
+        // the branch list and the status panel all go blank — after the user
+        // explicitly asked NOT to switch.
+        //
+        // Refused up front, so the repository is never touched.
+        if !checkout {
+            return Err(LeviathanError::OperationFailed(
+                "An orphan branch has no commits, so it is not a branch until its first commit is \
+                 made — git cannot create one without switching to it. Check it out, make the first \
+                 commit, then switch back."
+                    .to_string(),
+            ));
+        }
 
-    let mut args = vec!["checkout", "--orphan"];
-    let name_ref = name.as_str();
-    args.push(name_ref);
+        let mut args = vec!["checkout", "--orphan"];
+        let name_ref = name.as_str();
+        args.push(name_ref);
 
-    let output = crate::utils::create_command("git")
-        .current_dir(&path)
-        .args(&args)
-        .output()
-        .map_err(|e| {
-            LeviathanError::OperationFailed(format!("Failed to run git checkout --orphan: {}", e))
-        })?;
+        let output = crate::utils::create_command("git")
+            .current_dir(&path)
+            .args(&args)
+            .output()
+            .map_err(|e| {
+                LeviathanError::OperationFailed(format!("Failed to run git checkout --orphan: {}", e))
+            })?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(LeviathanError::OperationFailed(format!(
-            "Git checkout --orphan failed: {}",
-            stderr
-        )));
-    }
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(LeviathanError::OperationFailed(format!(
+                "Git checkout --orphan failed: {}",
+                stderr
+            )));
+        }
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 /// Result of checkout with auto-stash
@@ -948,475 +978,478 @@ pub async fn checkout_with_autostash(
     ref_name: String,
     auto_stash: Option<bool>,
 ) -> Result<CheckoutWithStashResult> {
-    let mut repo = git2::Repository::open(Path::new(&path))?;
-    ensure_checkoutable(&repo)?;
-    // BEFORE the stash and BEFORE checkout_tree. Refusing later meant the tree
-    // was already rewritten and the auto-stash could not be popped back over
-    // the staged entries checkout_tree had left.
-    ensure_not_checked_out_elsewhere(&repo, &ref_name)?;
+    crate::utils::blocking_git(move || {
+        let mut repo = git2::Repository::open(Path::new(&path))?;
+        ensure_checkoutable(&repo)?;
+        // BEFORE the stash and BEFORE checkout_tree. Refusing later meant the tree
+        // was already rewritten and the auto-stash could not be popped back over
+        // the staged entries checkout_tree had left.
+        ensure_not_checked_out_elsewhere(&repo, &ref_name)?;
 
-    // Capture HEAD before the switch for the post-checkout hook's <old-ref>.
-    let old_head = crate::commands::hooks::head_oid_string(&repo);
+        // Capture HEAD before the switch for the post-checkout hook's <old-ref>.
+        let old_head = crate::commands::hooks::head_oid_string(&repo);
 
-    // Check if there are uncommitted changes
-    let has_changes = auto_stash.unwrap_or(true) && {
-        let statuses = repo.statuses(None)?;
-        statuses.iter().any(|s| {
-            let flags = s.status();
-            flags.intersects(
-                git2::Status::WT_MODIFIED
-                    | git2::Status::WT_NEW
-                    | git2::Status::WT_DELETED
-                    | git2::Status::WT_RENAMED
-                    | git2::Status::WT_TYPECHANGE
-                    | git2::Status::INDEX_MODIFIED
-                    | git2::Status::INDEX_NEW
-                    | git2::Status::INDEX_DELETED
-                    | git2::Status::INDEX_RENAMED
-                    | git2::Status::INDEX_TYPECHANGE,
-            )
-        })
-    }; // statuses is dropped here
+        // Check if there are uncommitted changes
+        let has_changes = auto_stash.unwrap_or(true) && {
+            let statuses = repo.statuses(None)?;
+            statuses.iter().any(|s| {
+                let flags = s.status();
+                flags.intersects(
+                    git2::Status::WT_MODIFIED
+                        | git2::Status::WT_NEW
+                        | git2::Status::WT_DELETED
+                        | git2::Status::WT_RENAMED
+                        | git2::Status::WT_TYPECHANGE
+                        | git2::Status::INDEX_MODIFIED
+                        | git2::Status::INDEX_NEW
+                        | git2::Status::INDEX_DELETED
+                        | git2::Status::INDEX_RENAMED
+                        | git2::Status::INDEX_TYPECHANGE,
+                )
+            })
+        }; // statuses is dropped here
 
-    let mut stashed = false;
-    let mut stash_oid: Option<git2::Oid> = None;
+        let mut stashed = false;
+        let mut stash_oid: Option<git2::Oid> = None;
 
-    // If there are changes, stash them
-    if has_changes {
-        let sig = repo.signature()?;
-        let stash_message = format!("Auto-stash before checkout to {}", ref_name);
+        // If there are changes, stash them
+        if has_changes {
+            let sig = repo.signature()?;
+            let stash_message = format!("Auto-stash before checkout to {}", ref_name);
 
-        match repo.stash_save(
-            &sig,
-            &stash_message,
-            Some(git2::StashFlags::INCLUDE_UNTRACKED),
-        ) {
-            Ok(oid) => {
-                stashed = true;
-                stash_oid = Some(oid);
-            }
-            Err(e) => {
-                return Ok(CheckoutWithStashResult {
-                    success: false,
-                    stashed: false,
-                    stash_applied: false,
-                    stash_conflict: false,
-                    stash_oid: stash_oid.map(|o| o.to_string()),
-                    message: format!("Failed to stash changes: {}", e.message()),
-                });
-            }
-        }
-    }
-
-    // Get target commit OID for checkout. Errors are produced as closure
-    // values (NOT early function returns) so the map_err below actually runs
-    // and restores the auto-stash on failure.
-    let resolve_result: std::result::Result<(git2::Oid, bool, bool), String> = (|| {
-        let is_local = repo.find_branch(&ref_name, git2::BranchType::Local).is_ok();
-        let is_remote = !is_local
-            && (repo
-                .find_branch(&ref_name, git2::BranchType::Remote)
-                .is_ok()
-                || repo
-                    .find_reference(&format!("refs/remotes/{}", ref_name))
-                    .is_ok());
-
-        // The working tree must be checked out from the commit HEAD ends up
-        // pointing at. A remote branch whose same-named local branch already
-        // exists checks out the LOCAL branch tip (mirrors `git checkout`),
-        // not the remote tip — otherwise tree and HEAD diverge.
-        if is_remote {
-            let local_name = ref_name
-                .find('/')
-                .map(|pos| &ref_name[pos + 1..])
-                .unwrap_or(ref_name.as_str());
-            if let Ok(local) = repo.find_branch(local_name, git2::BranchType::Local) {
-                let commit = local
-                    .get()
-                    .peel_to_commit()
-                    .map_err(|e| format!("Could not resolve commit: {}", e.message()))?;
-                return Ok((commit.id(), is_local, is_remote));
-            }
-        }
-
-        let obj = repo
-            .revparse_single(&ref_name)
-            .map_err(|e| format!("Could not find ref '{}': {}", ref_name, e.message()))?;
-        let commit = obj
-            .peel_to_commit()
-            .map_err(|e| format!("Could not resolve commit: {}", e.message()))?;
-        Ok((commit.id(), is_local, is_remote))
-    })();
-
-    let (target_oid, is_local_branch, is_remote_branch) = match resolve_result {
-        Ok(v) => v,
-        Err(msg) => {
-            // Restore the stash if the checkout target failed to resolve.
-            // Resolved by oid, not popped positionally: a stash created by
-            // another surface or a terminal in the meantime sits at index 0 and
-            // would be applied and destroyed in place of the auto-stash. The
-            // checkout-failure path below has always verified the oid; this one
-            // did not. Best effort — a failure to restore must not mask the
-            // resolution error the user actually needs to see.
-            //
-            // A failure to restore must not MASK the resolution error the user
-            // needs to see — but not masking and not mentioning are different
-            // things. The sibling arm below concatenates both; this one
-            // discarded the restore's outcome, so the user was told only
-            // "could not find ref" while looking at an empty working tree with
-            // no hint that their changes were sitting in the stash list.
-            let restore_note = if stashed {
-                match auto_stash_index(&mut repo, stash_oid) {
-                    Some(idx) => match repo.stash_pop(idx, None) {
-                        Ok(()) => "",
-                        Err(_) => {
-                            " Your changes could not be restored — they are still in \
-                             the stash list, apply them manually."
-                        }
-                    },
-                    None => {
-                        " Your changes could not be found to restore — they are still \
-                         in the stash list, apply them manually."
-                    }
+            match repo.stash_save(
+                &sig,
+                &stash_message,
+                Some(git2::StashFlags::INCLUDE_UNTRACKED),
+            ) {
+                Ok(oid) => {
+                    stashed = true;
+                    stash_oid = Some(oid);
                 }
-            } else {
-                ""
-            };
-            return Err(LeviathanError::OperationFailed(format!(
-                "{}{}",
-                msg, restore_note
-            )));
+                Err(e) => {
+                    return Ok(CheckoutWithStashResult {
+                        success: false,
+                        stashed: false,
+                        stash_applied: false,
+                        stash_conflict: false,
+                        stash_oid: stash_oid.map(|o| o.to_string()),
+                        message: format!("Failed to stash changes: {}", e.message()),
+                    });
+                }
+            }
         }
-    };
 
-    // Routed through autostash_failure like every other exit past the stash.
-    //
-    // This was the ONE that abandoned the user's work silently: a bare
-    // "Could not find object" with the whole working tree gone and nothing
-    // saying it was in the stash list. The comment here claimed a borrow
-    // prevented the restore; `repo` is already &mut and autostash_failure
-    // takes &mut, so it does not. Resolved before the borrow below begins.
-    let find_error: Option<String> = match repo.find_object(target_oid, None) {
-        Ok(_) => None,
-        Err(e) => Some(format!("Could not find object: {}", e.message())),
-    };
-    if let Some(msg) = find_error {
-        return Err(autostash_failure(&mut repo, stashed, stash_oid, &msg));
-    }
+        // Get target commit OID for checkout. Errors are produced as closure
+        // values (NOT early function returns) so the map_err below actually runs
+        // and restores the auto-stash on failure.
+        let resolve_result: std::result::Result<(git2::Oid, bool, bool), String> = (|| {
+            let is_local = repo.find_branch(&ref_name, git2::BranchType::Local).is_ok();
+            let is_remote = !is_local
+                && (repo
+                    .find_branch(&ref_name, git2::BranchType::Remote)
+                    .is_ok()
+                    || repo
+                        .find_reference(&format!("refs/remotes/{}", ref_name))
+                        .is_ok());
 
-    // Create the local tracking branch BEFORE the working tree is rewritten.
-    //
-    // Creating it inside the set_head closure below put it AFTER checkout_tree,
-    // so a failure (invalid derived name such as "HEAD", or a D/F conflict
-    // against an existing refs/heads/<name>/*) reached autostash_failure with
-    // the tree already at the target commit — popping the auto-stash over the
-    // wrong tree while HEAD still named the old branch. Failing here leaves the
-    // working tree untouched, so the restore lands on the tree it came from.
-    // Records a branch created by THIS call, so a later failure can roll it back
-    // the way checkout() does. Without it a failing checkout_tree left the new
-    // tracking branch behind, making a failed checkout non-transactional.
-    let mut created_branch: Option<String> = None;
+            // The working tree must be checked out from the commit HEAD ends up
+            // pointing at. A remote branch whose same-named local branch already
+            // exists checks out the LOCAL branch tip (mirrors `git checkout`),
+            // not the remote tip — otherwise tree and HEAD diverge.
+            if is_remote {
+                let local_name = ref_name
+                    .find('/')
+                    .map(|pos| &ref_name[pos + 1..])
+                    .unwrap_or(ref_name.as_str());
+                if let Ok(local) = repo.find_branch(local_name, git2::BranchType::Local) {
+                    let commit = local
+                        .get()
+                        .peel_to_commit()
+                        .map_err(|e| format!("Could not resolve commit: {}", e.message()))?;
+                    return Ok((commit.id(), is_local, is_remote));
+                }
+            }
 
-    if is_remote_branch {
-        let local_name = if let Some(pos) = ref_name.find('/') {
-            &ref_name[pos + 1..]
-        } else {
-            ref_name.as_str()
+            let obj = repo
+                .revparse_single(&ref_name)
+                .map_err(|e| format!("Could not find ref '{}': {}", ref_name, e.message()))?;
+            let commit = obj
+                .peel_to_commit()
+                .map_err(|e| format!("Could not resolve commit: {}", e.message()))?;
+            Ok((commit.id(), is_local, is_remote))
+        })();
+
+        let (target_oid, is_local_branch, is_remote_branch) = match resolve_result {
+            Ok(v) => v,
+            Err(msg) => {
+                // Restore the stash if the checkout target failed to resolve.
+                // Resolved by oid, not popped positionally: a stash created by
+                // another surface or a terminal in the meantime sits at index 0 and
+                // would be applied and destroyed in place of the auto-stash. The
+                // checkout-failure path below has always verified the oid; this one
+                // did not. Best effort — a failure to restore must not mask the
+                // resolution error the user actually needs to see.
+                //
+                // A failure to restore must not MASK the resolution error the user
+                // needs to see — but not masking and not mentioning are different
+                // things. The sibling arm below concatenates both; this one
+                // discarded the restore's outcome, so the user was told only
+                // "could not find ref" while looking at an empty working tree with
+                // no hint that their changes were sitting in the stash list.
+                let restore_note = if stashed {
+                    match auto_stash_index(&mut repo, stash_oid) {
+                        Some(idx) => match repo.stash_pop(idx, None) {
+                            Ok(()) => "",
+                            Err(_) => {
+                                " Your changes could not be restored — they are still in \
+                                 the stash list, apply them manually."
+                            }
+                        },
+                        None => {
+                            " Your changes could not be found to restore — they are still \
+                             in the stash list, apply them manually."
+                        }
+                    }
+                } else {
+                    ""
+                };
+                return Err(LeviathanError::OperationFailed(format!(
+                    "{}{}",
+                    msg, restore_note
+                )));
+            }
         };
 
-        if repo
-            .find_branch(local_name, git2::BranchType::Local)
-            .is_err()
-        {
-            let create_error: Option<String> = match repo.find_commit(target_oid) {
-                Ok(commit) => match repo.branch(local_name, &commit, false) {
-                    Ok(mut new_branch) => {
-                        // Best effort: tracking config must not abort the checkout.
-                        let _ = new_branch.set_upstream(Some(&ref_name));
-                        created_branch = Some(local_name.to_string());
-                        None
-                    }
-                    Err(e) => Some(format!(
-                        "Could not create local branch '{}': {}",
-                        local_name,
-                        e.message()
-                    )),
-                },
-                Err(e) => Some(format!("Could not find object: {}", e.message())),
-            };
-
-            if let Some(msg) = create_error {
-                return Err(autostash_failure(&mut repo, stashed, stash_oid, &msg));
-            }
-        }
-    }
-
-    // Perform checkout using the OID
-    let checkout_error: Option<String> = {
-        let obj = repo.find_object(target_oid, None)?;
-        let mut checkout_opts = git2::build::CheckoutBuilder::new();
-        checkout_opts.safe();
-
-        match repo.checkout_tree(&obj, Some(&mut checkout_opts)) {
-            Ok(()) => None,
-            Err(e) => Some(e.message().to_string()),
-        }
-    }; // obj dropped here
-
-    if let Some(msg) = checkout_error {
-        // Roll back a branch this call created. The checkout failed, so the ref
-        // must not outlive it — otherwise a retry sees a branch that already
-        // exists and silently takes the "local branch exists" path instead.
-        rollback_created_branch(&repo, created_branch.as_deref());
-
-        // Restore the auto-stash now the checkout has failed.
+        // Routed through autostash_failure like every other exit past the stash.
         //
-        // Resolved by oid rather than verified at index 0: `git stash push`
-        // prepends, so a stash created during the (multi-second) checkout
-        // pushes ours down a slot. The old check only compared against index 0,
-        // so it declined to restore and returned a bare "Checkout failed" —
-        // leaving the user with an empty working tree, their changes in the
-        // stash list, and nothing on screen saying so.
-        return Err(autostash_failure(&mut repo, stashed, stash_oid, &msg));
-    }
+        // This was the ONE that abandoned the user's work silently: a bare
+        // "Could not find object" with the whole working tree gone and nothing
+        // saying it was in the stash list. The comment here claimed a borrow
+        // prevented the restore; `repo` is already &mut and autostash_failure
+        // takes &mut, so it does not. Resolved before the borrow below begins.
+        let find_error: Option<String> = match repo.find_object(target_oid, None) {
+            Ok(_) => None,
+            Err(e) => Some(format!("Could not find object: {}", e.message())),
+        };
+        if let Some(msg) = find_error {
+            return Err(autostash_failure(&mut repo, stashed, stash_oid, &msg));
+        }
 
-    // Set HEAD.
-    //
-    // Propagated, not swallowed. checkout_tree above has ALREADY rewritten the
-    // working tree to the target commit, so skipping set_head leaves HEAD and
-    // the working tree describing different commits — and this function went
-    // on to return success: true, so the UI toasted "Switched to <branch>" and
-    // the user was left on the old branch with the whole inter-branch diff
-    // showing as uncommitted modifications. `if let Ok(..)` made that the
-    // outcome whenever the branch was deleted from a terminal during the
-    // checkout. The plain `checkout` command has always used `?` here.
-    let set_head_result = (|| -> Result<()> {
-        if is_local_branch {
-            let branch = repo.find_branch(&ref_name, git2::BranchType::Local)?;
-            repo.set_head(branch.get().name().map_err(|_| {
-                LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
-            })?)?;
-        } else if is_remote_branch {
-            // Check out a remote branch by finding or creating a local tracking branch.
-            // e.g., "origin/feature-x" → local branch "feature-x" tracking "origin/feature-x"
+        // Create the local tracking branch BEFORE the working tree is rewritten.
+        //
+        // Creating it inside the set_head closure below put it AFTER checkout_tree,
+        // so a failure (invalid derived name such as "HEAD", or a D/F conflict
+        // against an existing refs/heads/<name>/*) reached autostash_failure with
+        // the tree already at the target commit — popping the auto-stash over the
+        // wrong tree while HEAD still named the old branch. Failing here leaves the
+        // working tree untouched, so the restore lands on the tree it came from.
+        // Records a branch created by THIS call, so a later failure can roll it back
+        // the way checkout() does. Without it a failing checkout_tree left the new
+        // tracking branch behind, making a failed checkout non-transactional.
+        let mut created_branch: Option<String> = None;
+
+        if is_remote_branch {
             let local_name = if let Some(pos) = ref_name.find('/') {
                 &ref_name[pos + 1..]
             } else {
-                &ref_name
+                ref_name.as_str()
             };
 
-            // Use existing local branch if it exists, otherwise create one
-            let local_branch =
-                if let Ok(existing) = repo.find_branch(local_name, git2::BranchType::Local) {
-                    existing
-                } else {
-                    let commit = repo.find_commit(target_oid)?;
-                    let mut new_branch = repo.branch(local_name, &commit, false)?;
-                    // Best effort: set upstream tracking (may fail if remote config is incomplete)
-                    let _ = new_branch.set_upstream(Some(&ref_name));
-                    new_branch
+            if repo
+                .find_branch(local_name, git2::BranchType::Local)
+                .is_err()
+            {
+                let create_error: Option<String> = match repo.find_commit(target_oid) {
+                    Ok(commit) => match repo.branch(local_name, &commit, false) {
+                        Ok(mut new_branch) => {
+                            // Best effort: tracking config must not abort the checkout.
+                            let _ = new_branch.set_upstream(Some(&ref_name));
+                            created_branch = Some(local_name.to_string());
+                            None
+                        }
+                        Err(e) => Some(format!(
+                            "Could not create local branch '{}': {}",
+                            local_name,
+                            e.message()
+                        )),
+                    },
+                    Err(e) => Some(format!("Could not find object: {}", e.message())),
                 };
 
-            let name = local_branch.get().name().map_err(|_| {
-                LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
-            })?;
-            repo.set_head(name)?;
-        } else {
-            repo.set_head_detached(target_oid)?;
-        }
-        Ok(())
-    })();
-
-    // Routed through the SAME restore path a failed checkout_tree takes.
-    // Propagating alone still left the auto-stash orphaned and unmentioned:
-    // the tree is at the target commit, HEAD is not, and the raw set_head
-    // error says nothing about where the user's changes went.
-    if let Err(err) = set_head_result {
-        rollback_created_branch(&repo, created_branch.as_deref());
-        return Err(autostash_failure(
-            &mut repo,
-            stashed,
-            stash_oid,
-            &err.to_string(),
-        ));
-    }
-
-    // HEAD/working tree switched — run post-checkout (flag=1), non-blocking.
-    // Runs before the stash re-apply so it fires even if re-applying conflicts.
-    let new_head = crate::commands::hooks::head_oid_string(&repo);
-    crate::commands::hooks::run_post_checkout(&repo, &old_head, &new_head, true);
-
-    // If we stashed, try to re-apply the stash.
-    if stashed {
-        // Use stash_APPLY (not stash_pop): the stash must survive until we KNOW
-        // the changes landed cleanly. git2's stash_pop is unsafe here in two
-        // empirically-verified ways:
-        //   - an UNSTAGED conflicting change makes apply return Ok while leaving
-        //     a conflicted index; stash_pop would then DROP the stash, destroying
-        //     the user's only copy of their work.
-        //   - a STAGED conflicting change makes apply fail with ECONFLICT.
-        // So we apply, then inspect the index ourselves and only drop the stash
-        // when it is genuinely clean.
-        //
-        // Reinstate the index so files the user had staged before the checkout
-        // come back staged instead of silently becoming unstaged.
-        let mut stash_apply_opts = git2::StashApplyOptions::new();
-        stash_apply_opts.reinstantiate_index();
-        let mut checkout_opts = git2::build::CheckoutBuilder::new();
-        checkout_opts.safe();
-        stash_apply_opts.checkout_options(checkout_opts);
-
-        let conflict_message = format!(
-            "Switched to {} but re-applying your stashed changes produced conflicts. \
-             Resolve them, then the stash will be dropped.",
-            ref_name
-        );
-
-        // Resolved by OID, not assumed to be 0 — see auto_stash_index.
-        let stash_idx = match auto_stash_index(&mut repo, stash_oid) {
-            Some(idx) => idx,
-            None => {
-                return Ok(CheckoutWithStashResult {
-                    success: true,
-                    stashed: true,
-                    stash_applied: false,
-                    stash_conflict: false,
-                    stash_oid: stash_oid.map(|o| o.to_string()),
-                    message: format!(
-                        "Switched to {}, but your stashed changes could not be found to \
-                         re-apply. They are still in the stash list — apply them manually.",
-                        ref_name
-                    ),
-                });
+                if let Some(msg) = create_error {
+                    return Err(autostash_failure(&mut repo, stashed, stash_oid, &msg));
+                }
             }
-        };
+        }
 
-        match repo.stash_apply(stash_idx, Some(&mut stash_apply_opts)) {
-            Ok(()) => {
-                // Apply reported success, but an unstaged conflicting change can
-                // land conflicts in the index while still returning Ok. Only drop
-                // the stash when the index is truly conflict-free.
-                if repo.index()?.has_conflicts() {
+        // Perform checkout using the OID
+        let checkout_error: Option<String> = {
+            let obj = repo.find_object(target_oid, None)?;
+            let mut checkout_opts = git2::build::CheckoutBuilder::new();
+            checkout_opts.safe();
+
+            match repo.checkout_tree(&obj, Some(&mut checkout_opts)) {
+                Ok(()) => None,
+                Err(e) => Some(e.message().to_string()),
+            }
+        }; // obj dropped here
+
+        if let Some(msg) = checkout_error {
+            // Roll back a branch this call created. The checkout failed, so the ref
+            // must not outlive it — otherwise a retry sees a branch that already
+            // exists and silently takes the "local branch exists" path instead.
+            rollback_created_branch(&repo, created_branch.as_deref());
+
+            // Restore the auto-stash now the checkout has failed.
+            //
+            // Resolved by oid rather than verified at index 0: `git stash push`
+            // prepends, so a stash created during the (multi-second) checkout
+            // pushes ours down a slot. The old check only compared against index 0,
+            // so it declined to restore and returned a bare "Checkout failed" —
+            // leaving the user with an empty working tree, their changes in the
+            // stash list, and nothing on screen saying so.
+            return Err(autostash_failure(&mut repo, stashed, stash_oid, &msg));
+        }
+
+        // Set HEAD.
+        //
+        // Propagated, not swallowed. checkout_tree above has ALREADY rewritten the
+        // working tree to the target commit, so skipping set_head leaves HEAD and
+        // the working tree describing different commits — and this function went
+        // on to return success: true, so the UI toasted "Switched to <branch>" and
+        // the user was left on the old branch with the whole inter-branch diff
+        // showing as uncommitted modifications. `if let Ok(..)` made that the
+        // outcome whenever the branch was deleted from a terminal during the
+        // checkout. The plain `checkout` command has always used `?` here.
+        let set_head_result = (|| -> Result<()> {
+            if is_local_branch {
+                let branch = repo.find_branch(&ref_name, git2::BranchType::Local)?;
+                repo.set_head(branch.get().name().map_err(|_| {
+                    LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
+                })?)?;
+            } else if is_remote_branch {
+                // Check out a remote branch by finding or creating a local tracking branch.
+                // e.g., "origin/feature-x" → local branch "feature-x" tracking "origin/feature-x"
+                let local_name = if let Some(pos) = ref_name.find('/') {
+                    &ref_name[pos + 1..]
+                } else {
+                    &ref_name
+                };
+
+                // Use existing local branch if it exists, otherwise create one
+                let local_branch =
+                    if let Ok(existing) = repo.find_branch(local_name, git2::BranchType::Local) {
+                        existing
+                    } else {
+                        let commit = repo.find_commit(target_oid)?;
+                        let mut new_branch = repo.branch(local_name, &commit, false)?;
+                        // Best effort: set upstream tracking (may fail if remote config is incomplete)
+                        let _ = new_branch.set_upstream(Some(&ref_name));
+                        new_branch
+                    };
+
+                let name = local_branch.get().name().map_err(|_| {
+                    LeviathanError::OperationFailed("Invalid reference name encoding".to_string())
+                })?;
+                repo.set_head(name)?;
+            } else {
+                repo.set_head_detached(target_oid)?;
+            }
+            Ok(())
+        })();
+
+        // Routed through the SAME restore path a failed checkout_tree takes.
+        // Propagating alone still left the auto-stash orphaned and unmentioned:
+        // the tree is at the target commit, HEAD is not, and the raw set_head
+        // error says nothing about where the user's changes went.
+        if let Err(err) = set_head_result {
+            rollback_created_branch(&repo, created_branch.as_deref());
+            return Err(autostash_failure(
+                &mut repo,
+                stashed,
+                stash_oid,
+                &err.to_string(),
+            ));
+        }
+
+        // HEAD/working tree switched — run post-checkout (flag=1), non-blocking.
+        // Runs before the stash re-apply so it fires even if re-applying conflicts.
+        let new_head = crate::commands::hooks::head_oid_string(&repo);
+        crate::commands::hooks::run_post_checkout(&repo, &old_head, &new_head, true);
+
+        // If we stashed, try to re-apply the stash.
+        if stashed {
+            // Use stash_APPLY (not stash_pop): the stash must survive until we KNOW
+            // the changes landed cleanly. git2's stash_pop is unsafe here in two
+            // empirically-verified ways:
+            //   - an UNSTAGED conflicting change makes apply return Ok while leaving
+            //     a conflicted index; stash_pop would then DROP the stash, destroying
+            //     the user's only copy of their work.
+            //   - a STAGED conflicting change makes apply fail with ECONFLICT.
+            // So we apply, then inspect the index ourselves and only drop the stash
+            // when it is genuinely clean.
+            //
+            // Reinstate the index so files the user had staged before the checkout
+            // come back staged instead of silently becoming unstaged.
+            let mut stash_apply_opts = git2::StashApplyOptions::new();
+            stash_apply_opts.reinstantiate_index();
+            let mut checkout_opts = git2::build::CheckoutBuilder::new();
+            checkout_opts.safe();
+            stash_apply_opts.checkout_options(checkout_opts);
+
+            let conflict_message = format!(
+                "Switched to {} but re-applying your stashed changes produced conflicts. \
+                 Resolve them, then the stash will be dropped.",
+                ref_name
+            );
+
+            // Resolved by OID, not assumed to be 0 — see auto_stash_index.
+            let stash_idx = match auto_stash_index(&mut repo, stash_oid) {
+                Some(idx) => idx,
+                None => {
                     return Ok(CheckoutWithStashResult {
                         success: true,
                         stashed: true,
                         stash_applied: false,
-                        stash_conflict: true,
+                        stash_conflict: false,
                         stash_oid: stash_oid.map(|o| o.to_string()),
-                        message: conflict_message,
+                        message: format!(
+                            "Switched to {}, but your stashed changes could not be found to \
+                             re-apply. They are still in the stash list — apply them manually.",
+                            ref_name
+                        ),
                     });
                 }
-                repo.stash_drop(stash_idx)?;
-                return Ok(CheckoutWithStashResult {
-                    success: true,
-                    stashed: true,
-                    stash_applied: true,
-                    stash_conflict: false,
-                    stash_oid: stash_oid.map(|o| o.to_string()),
-                    message: format!("Switched to {} and re-applied stashed changes", ref_name),
-                });
-            }
-            Err(e) => {
-                // git2 signals a stash-apply conflict as either MergeConflict
-                // (index-level) or Conflict (checkout-level, often with an empty
-                // message), so match both.
-                let has_conflicts = e.code() == git2::ErrorCode::MergeConflict
-                    || e.code() == git2::ErrorCode::Conflict
-                    || e.message().contains("conflict")
-                    || e.message().contains("CONFLICT");
+            };
 
-                if has_conflicts {
-                    // A staged conflicting change fails the reinstate-index apply.
-                    // Retry WITHOUT reinstating the index: applied unstaged-style,
-                    // the conflict lands in the index (mirroring `git stash apply`)
-                    // where the conflict-resolution flow can pick it up. The stash
-                    // is kept for that flow to drop after resolution.
-                    let mut retry_opts = git2::StashApplyOptions::new();
-                    let mut retry_checkout = git2::build::CheckoutBuilder::new();
-                    retry_checkout.safe();
-                    retry_opts.checkout_options(retry_checkout);
+            match repo.stash_apply(stash_idx, Some(&mut stash_apply_opts)) {
+                Ok(()) => {
+                    // Apply reported success, but an unstaged conflicting change can
+                    // land conflicts in the index while still returning Ok. Only drop
+                    // the stash when the index is truly conflict-free.
+                    if repo.index()?.has_conflicts() {
+                        return Ok(CheckoutWithStashResult {
+                            success: true,
+                            stashed: true,
+                            stash_applied: false,
+                            stash_conflict: true,
+                            stash_oid: stash_oid.map(|o| o.to_string()),
+                            message: conflict_message,
+                        });
+                    }
+                    repo.stash_drop(stash_idx)?;
+                    return Ok(CheckoutWithStashResult {
+                        success: true,
+                        stashed: true,
+                        stash_applied: true,
+                        stash_conflict: false,
+                        stash_oid: stash_oid.map(|o| o.to_string()),
+                        message: format!("Switched to {} and re-applied stashed changes", ref_name),
+                    });
+                }
+                Err(e) => {
+                    // git2 signals a stash-apply conflict as either MergeConflict
+                    // (index-level) or Conflict (checkout-level, often with an empty
+                    // message), so match both.
+                    let has_conflicts = e.code() == git2::ErrorCode::MergeConflict
+                        || e.code() == git2::ErrorCode::Conflict
+                        || e.message().contains("conflict")
+                        || e.message().contains("CONFLICT");
 
-                    // Re-resolved: the failed apply above may itself have
-                    // changed the stash list. A missing entry must produce the
-                    // same refusal the initial resolve gives — falling back to
-                    // the earlier position would apply and drop whatever now
-                    // occupies it, which is the exact bug auto_stash_index
-                    // exists to close.
-                    let retry_idx = match auto_stash_index(&mut repo, stash_oid) {
-                        Some(idx) => idx,
-                        None => {
+                    if has_conflicts {
+                        // A staged conflicting change fails the reinstate-index apply.
+                        // Retry WITHOUT reinstating the index: applied unstaged-style,
+                        // the conflict lands in the index (mirroring `git stash apply`)
+                        // where the conflict-resolution flow can pick it up. The stash
+                        // is kept for that flow to drop after resolution.
+                        let mut retry_opts = git2::StashApplyOptions::new();
+                        let mut retry_checkout = git2::build::CheckoutBuilder::new();
+                        retry_checkout.safe();
+                        retry_opts.checkout_options(retry_checkout);
+
+                        // Re-resolved: the failed apply above may itself have
+                        // changed the stash list. A missing entry must produce the
+                        // same refusal the initial resolve gives — falling back to
+                        // the earlier position would apply and drop whatever now
+                        // occupies it, which is the exact bug auto_stash_index
+                        // exists to close.
+                        let retry_idx = match auto_stash_index(&mut repo, stash_oid) {
+                            Some(idx) => idx,
+                            None => {
+                                return Ok(CheckoutWithStashResult {
+                                    success: true,
+                                    stashed: true,
+                                    stash_applied: false,
+                                    stash_conflict: false,
+                                    stash_oid: stash_oid.map(|o| o.to_string()),
+                                    message: format!(
+                                        "Switched to {}, but your stashed changes could not be \
+                                         found to re-apply. They are still in the stash list — \
+                                         apply them manually.",
+                                        ref_name
+                                    ),
+                                });
+                            }
+                        };
+                        if repo.stash_apply(retry_idx, Some(&mut retry_opts)).is_ok() {
+                            if repo.index()?.has_conflicts() {
+                                return Ok(CheckoutWithStashResult {
+                                    success: true,
+                                    stashed: true,
+                                    stash_applied: false,
+                                    stash_conflict: true,
+                                    stash_oid: stash_oid.map(|o| o.to_string()),
+                                    message: conflict_message,
+                                });
+                            }
+                            // The retry applied cleanly (no conflicts). The stashed
+                            // changes ARE now in the working tree, so the stash must be
+                            // dropped — otherwise it lingers and a later apply/pop would
+                            // duplicate or conflict with the already-applied changes.
+                            // The staged status could not be reinstated on this path, so
+                            // note that in the message.
+                            repo.stash_drop(retry_idx)?;
                             return Ok(CheckoutWithStashResult {
                                 success: true,
                                 stashed: true,
-                                stash_applied: false,
+                                stash_applied: true,
                                 stash_conflict: false,
                                 stash_oid: stash_oid.map(|o| o.to_string()),
                                 message: format!(
-                                    "Switched to {}, but your stashed changes could not be \
-                                     found to re-apply. They are still in the stash list — \
-                                     apply them manually.",
+                                    "Switched to {} and re-applied stashed changes (staged status was not preserved)",
                                     ref_name
                                 ),
                             });
                         }
-                    };
-                    if repo.stash_apply(retry_idx, Some(&mut retry_opts)).is_ok() {
-                        if repo.index()?.has_conflicts() {
-                            return Ok(CheckoutWithStashResult {
-                                success: true,
-                                stashed: true,
-                                stash_applied: false,
-                                stash_conflict: true,
-                                stash_oid: stash_oid.map(|o| o.to_string()),
-                                message: conflict_message,
-                            });
-                        }
-                        // The retry applied cleanly (no conflicts). The stashed
-                        // changes ARE now in the working tree, so the stash must be
-                        // dropped — otherwise it lingers and a later apply/pop would
-                        // duplicate or conflict with the already-applied changes.
-                        // The staged status could not be reinstated on this path, so
-                        // note that in the message.
-                        repo.stash_drop(retry_idx)?;
-                        return Ok(CheckoutWithStashResult {
-                            success: true,
-                            stashed: true,
-                            stash_applied: true,
-                            stash_conflict: false,
-                            stash_oid: stash_oid.map(|o| o.to_string()),
-                            message: format!(
-                                "Switched to {} and re-applied stashed changes (staged status was not preserved)",
-                                ref_name
-                            ),
-                        });
                     }
-                }
 
-                // Could not re-apply — the stash remains in the list untouched.
-                return Ok(CheckoutWithStashResult {
-                    success: true,
-                    stashed: true,
-                    stash_applied: false,
-                    stash_conflict: false,
-                    stash_oid: stash_oid.map(|o| o.to_string()),
-                    message: format!(
-                        "Switched to {} but failed to re-apply stash: {}. Your changes remain stashed.",
-                        ref_name,
-                        e.message()
-                    ),
-                });
+                    // Could not re-apply — the stash remains in the list untouched.
+                    return Ok(CheckoutWithStashResult {
+                        success: true,
+                        stashed: true,
+                        stash_applied: false,
+                        stash_conflict: false,
+                        stash_oid: stash_oid.map(|o| o.to_string()),
+                        message: format!(
+                            "Switched to {} but failed to re-apply stash: {}. Your changes remain stashed.",
+                            ref_name,
+                            e.message()
+                        ),
+                    });
+                }
             }
         }
-    }
 
-    Ok(CheckoutWithStashResult {
-        success: true,
-        stashed: false,
-        stash_applied: false,
-        stash_conflict: false,
-        stash_oid: stash_oid.map(|o| o.to_string()),
-        message: format!("Switched to {}", ref_name),
+        Ok(CheckoutWithStashResult {
+            success: true,
+            stashed: false,
+            stash_applied: false,
+            stash_conflict: false,
+            stash_oid: stash_oid.map(|o| o.to_string()),
+            message: format!("Switched to {}", ref_name),
+        })
     })
+    .await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/commit.rs
+++ b/src-tauri/src/commands/commit.rs
@@ -256,47 +256,50 @@ pub async fn get_commit_history(
     skip: Option<usize>,
     all_branches: Option<bool>,
 ) -> Result<Vec<Commit>> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let skip_count = skip.unwrap_or(0);
-    let limit_count = limit.unwrap_or(100);
+        let skip_count = skip.unwrap_or(0);
+        let limit_count = limit.unwrap_or(100);
 
-    if all_branches.unwrap_or(false) {
-        // All-branches graph walk: served from the cached walk so deep
-        // pagination doesn't re-walk from the roots on every page
-        let (page, _total) = cached_walk_page(&repo, &path, skip_count, limit_count)?;
-        let commits: Vec<Commit> = page
-            .into_iter()
-            .filter_map(|oid| repo.find_commit(oid).ok().map(|c| Commit::from_git2(&c)))
+        if all_branches.unwrap_or(false) {
+            // All-branches graph walk: served from the cached walk so deep
+            // pagination doesn't re-walk from the roots on every page
+            let (page, _total) = cached_walk_page(&repo, &path, skip_count, limit_count)?;
+            let commits: Vec<Commit> = page
+                .into_iter()
+                .filter_map(|oid| repo.find_commit(oid).ok().map(|c| Commit::from_git2(&c)))
+                .collect();
+            return Ok(commits);
+        }
+
+        let mut revwalk = repo.revwalk()?;
+        revwalk.set_sorting(git2::Sort::TIME | git2::Sort::TOPOLOGICAL)?;
+
+        if let Some(ref oid_str) = start_oid {
+            let start = git2::Oid::from_str(oid_str)?;
+            revwalk.push(start)?;
+        } else {
+            let start = repo
+                .head()?
+                .target()
+                .ok_or(LeviathanError::RepositoryNotOpen)?;
+            revwalk.push(start)?;
+        }
+
+        let commits: Vec<Commit> = revwalk
+            .skip(skip_count)
+            .take(limit_count)
+            .filter_map(|oid_result| {
+                oid_result
+                    .ok()
+                    .and_then(|oid| repo.find_commit(oid).ok().map(|c| Commit::from_git2(&c)))
+            })
             .collect();
-        return Ok(commits);
-    }
 
-    let mut revwalk = repo.revwalk()?;
-    revwalk.set_sorting(git2::Sort::TIME | git2::Sort::TOPOLOGICAL)?;
-
-    if let Some(ref oid_str) = start_oid {
-        let start = git2::Oid::from_str(oid_str)?;
-        revwalk.push(start)?;
-    } else {
-        let start = repo
-            .head()?
-            .target()
-            .ok_or(LeviathanError::RepositoryNotOpen)?;
-        revwalk.push(start)?;
-    }
-
-    let commits: Vec<Commit> = revwalk
-        .skip(skip_count)
-        .take(limit_count)
-        .filter_map(|oid_result| {
-            oid_result
-                .ok()
-                .and_then(|oid| repo.find_commit(oid).ok().map(|c| Commit::from_git2(&c)))
-        })
-        .collect();
-
-    Ok(commits)
+        Ok(commits)
+    })
+    .await
 }
 
 /// Get the total number of commits reachable from any ref (the size of the
@@ -304,21 +307,27 @@ pub async fn get_commit_history(
 /// `get_commit_history`, so it is O(1) when the cache is warm.
 #[command]
 pub async fn get_commit_total(path: String) -> Result<usize> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let (_page, total) = cached_walk_page(&repo, &path, 0, 0)?;
-    Ok(total)
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let (_page, total) = cached_walk_page(&repo, &path, 0, 0)?;
+        Ok(total)
+    })
+    .await
 }
 
 /// Get a single commit by OID
 #[command]
 pub async fn get_commit(path: String, oid: String) -> Result<Commit> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let oid = git2::Oid::from_str(&oid)?;
-    let commit = repo
-        .find_commit(oid)
-        .map_err(|_| LeviathanError::CommitNotFound(oid.to_string()))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let oid = git2::Oid::from_str(&oid)?;
+        let commit = repo
+            .find_commit(oid)
+            .map_err(|_| LeviathanError::CommitNotFound(oid.to_string()))?;
 
-    Ok(Commit::from_git2(&commit))
+        Ok(Commit::from_git2(&commit))
+    })
+    .await
 }
 
 /// Create a new commit
@@ -379,174 +388,177 @@ pub async fn create_commit(
         .await;
     }
 
-    // Use git2 for unsigned commits (faster)
-    let mut repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        // Use git2 for unsigned commits (faster)
+        let mut repo = git2::Repository::open(Path::new(&path))?;
 
-    // A commit created while a merge is in progress must include MERGE_HEAD
-    // as a parent, otherwise the merged branch is silently dropped and the
-    // repository stays stuck in MERGING state. Collect the merge heads up
-    // front (mergehead_foreach needs a unique borrow of the repo).
-    //
-    // Cherry-pick and revert also leave sequencer state (CHERRY_PICK_HEAD /
-    // REVERT_HEAD) that must be cleared after committing, or the app stays
-    // stuck showing the operation "in progress". Unlike a merge, though, the
-    // resulting commit keeps a SINGLE parent (HEAD only) — the picked/reverted
-    // commit is NOT an extra parent.
-    let state = repo.state();
-    let merging = state == git2::RepositoryState::Merge;
-    let needs_cleanup = matches!(
-        state,
-        git2::RepositoryState::Merge
-            | git2::RepositoryState::CherryPick
-            | git2::RepositoryState::Revert
-    );
-    let mut merge_oids: Vec<git2::Oid> = Vec::new();
-    if merging {
-        repo.mergehead_foreach(|oid| {
-            merge_oids.push(*oid);
-            true
-        })?;
-    }
-    let repo = repo;
-
-    // Run client-side hooks like canonical git does — the git2 commit path
-    // otherwise bypasses them entirely. pre-commit can veto the commit;
-    // commit-msg can veto or rewrite the message.
-    crate::commands::hooks::run_hook_blocking(&repo, "pre-commit", &[], None)?;
-    let message = crate::commands::hooks::run_commit_msg_hook(&repo, &message)?;
-
-    let default_signature = repo.signature()?;
-
-    // Build author and committer signatures, optionally with custom dates
-    let author_sig = if has_custom_dates {
-        signature_with_date(
-            default_signature.name().ok().unwrap_or("Unknown"),
-            default_signature.email().ok().unwrap_or(""),
-            author_date.as_deref(),
-        )?
-    } else {
-        default_signature.clone()
-    };
-
-    let committer_sig = if has_custom_dates {
-        signature_with_date(
-            default_signature.name().ok().unwrap_or("Unknown"),
-            default_signature.email().ok().unwrap_or(""),
-            committer_date.as_deref(),
-        )?
-    } else {
-        default_signature
-    };
-
-    let mut index = repo.index()?;
-    let tree_oid = index.write_tree()?;
-    let tree = repo.find_tree(tree_oid)?;
-
-    // `git commit` refuses a commit that changes nothing unless --allow-empty,
-    // and this path never checked. The only guard was the frontend's staged
-    // COUNT, which goes stale the moment anything unstages outside the app — a
-    // terminal, another tool, watcher lag — so pressing Commit then wrote a
-    // no-op commit into history with no warning at all.
-    //
-    // Not applied mid-merge: concluding a merge whose result happens to match
-    // HEAD's tree is a legitimate commit, and git allows that one too.
-    if !amend.unwrap_or(false) && merge_oids.is_empty() {
-        let head_tree_id = repo
-            .head()
-            .ok()
-            .and_then(|h| h.peel_to_commit().ok())
-            .map(|c| c.tree_id());
-        let nothing_staged = match head_tree_id {
-            Some(head_tree_id) => head_tree_id == tree_oid,
-            // Unborn HEAD: there is no parent tree to compare against, so
-            // "nothing staged" means the index itself is empty. Comparing
-            // against a None head tree could never match, which let the very
-            // first commit in a repository be created empty — `git commit`
-            // refuses that one too.
-            None => repo
-                .find_tree(tree_oid)
-                .map(|t| t.is_empty())
-                .unwrap_or(false),
-        };
-        if nothing_staged {
-            return Err(LeviathanError::OperationFailed(
-                "No staged changes to commit".to_string(),
-            ));
-        }
-    }
-
-    let commit_oid = if amend.unwrap_or(false) {
-        let head_commit = repo.head()?.peel_to_commit()?;
-
-        // `git commit --amend` PRESERVES the original author identity and author
-        // date; only `--reset-author` changes them. An explicitly supplied
-        // author date still applies, on top of the original identity.
+        // A commit created while a merge is in progress must include MERGE_HEAD
+        // as a parent, otherwise the merged branch is silently dropped and the
+        // repository stays stuck in MERGING state. Collect the merge heads up
+        // front (mergehead_foreach needs a unique borrow of the repo).
         //
-        // The signed path (`git commit --amend` via the CLI) and amend_commit
-        // both already preserve the author, so rebuilding it from
-        // repo.signature() here also made the result depend on whether
-        // commit.gpgsign happened to be enabled.
-        let amend_author: git2::Signature<'_> = if author_date.is_some() {
-            let original = head_commit.author();
+        // Cherry-pick and revert also leave sequencer state (CHERRY_PICK_HEAD /
+        // REVERT_HEAD) that must be cleared after committing, or the app stays
+        // stuck showing the operation "in progress". Unlike a merge, though, the
+        // resulting commit keeps a SINGLE parent (HEAD only) — the picked/reverted
+        // commit is NOT an extra parent.
+        let state = repo.state();
+        let merging = state == git2::RepositoryState::Merge;
+        let needs_cleanup = matches!(
+            state,
+            git2::RepositoryState::Merge
+                | git2::RepositoryState::CherryPick
+                | git2::RepositoryState::Revert
+        );
+        let mut merge_oids: Vec<git2::Oid> = Vec::new();
+        if merging {
+            repo.mergehead_foreach(|oid| {
+                merge_oids.push(*oid);
+                true
+            })?;
+        }
+        let repo = repo;
+
+        // Run client-side hooks like canonical git does — the git2 commit path
+        // otherwise bypasses them entirely. pre-commit can veto the commit;
+        // commit-msg can veto or rewrite the message.
+        crate::commands::hooks::run_hook_blocking(&repo, "pre-commit", &[], None)?;
+        let message = crate::commands::hooks::run_commit_msg_hook(&repo, &message)?;
+
+        let default_signature = repo.signature()?;
+
+        // Build author and committer signatures, optionally with custom dates
+        let author_sig = if has_custom_dates {
             signature_with_date(
-                original.name().ok().unwrap_or("Unknown"),
-                original.email().ok().unwrap_or(""),
+                default_signature.name().ok().unwrap_or("Unknown"),
+                default_signature.email().ok().unwrap_or(""),
                 author_date.as_deref(),
             )?
         } else {
-            head_commit.author()
+            default_signature.clone()
         };
 
-        // Commit::amend, not repo.commit(Some("HEAD"), .., parents).
+        let committer_sig = if has_custom_dates {
+            signature_with_date(
+                default_signature.name().ok().unwrap_or("Unknown"),
+                default_signature.email().ok().unwrap_or(""),
+                committer_date.as_deref(),
+            )?
+        } else {
+            default_signature
+        };
+
+        let mut index = repo.index()?;
+        let tree_oid = index.write_tree()?;
+        let tree = repo.find_tree(tree_oid)?;
+
+        // `git commit` refuses a commit that changes nothing unless --allow-empty,
+        // and this path never checked. The only guard was the frontend's staged
+        // COUNT, which goes stale the moment anything unstages outside the app — a
+        // terminal, another tool, watcher lag — so pressing Commit then wrote a
+        // no-op commit into history with no warning at all.
         //
-        // libgit2 validates that the updated ref's current tip IS the new
-        // commit's first parent. An amend replaces the tip, so that check can
-        // never pass and this path failed outright with "current tip is not the
-        // first parent" — meaning amend from the commit panel was broken for
-        // every repository without commit.gpgsign enabled. Commit::amend
-        // performs the replacement libgit2 expects and carries the original
-        // parents over unchanged.
-        head_commit.amend(
-            Some("HEAD"),
-            Some(&amend_author),
-            Some(&committer_sig),
-            None,
-            Some(&message),
-            Some(&tree),
-        )?
-    } else {
-        let mut parents: Vec<git2::Commit> = repo
-            .head()
-            .ok()
-            .and_then(|h| h.peel_to_commit().ok())
-            .into_iter()
-            .collect();
-
-        // Include MERGE_HEAD parents collected above when mid-merge
-        for oid in &merge_oids {
-            parents.push(repo.find_commit(*oid)?);
+        // Not applied mid-merge: concluding a merge whose result happens to match
+        // HEAD's tree is a legitimate commit, and git allows that one too.
+        if !amend.unwrap_or(false) && merge_oids.is_empty() {
+            let head_tree_id = repo
+                .head()
+                .ok()
+                .and_then(|h| h.peel_to_commit().ok())
+                .map(|c| c.tree_id());
+            let nothing_staged = match head_tree_id {
+                Some(head_tree_id) => head_tree_id == tree_oid,
+                // Unborn HEAD: there is no parent tree to compare against, so
+                // "nothing staged" means the index itself is empty. Comparing
+                // against a None head tree could never match, which let the very
+                // first commit in a repository be created empty — `git commit`
+                // refuses that one too.
+                None => repo
+                    .find_tree(tree_oid)
+                    .map(|t| t.is_empty())
+                    .unwrap_or(false),
+            };
+            if nothing_staged {
+                return Err(LeviathanError::OperationFailed(
+                    "No staged changes to commit".to_string(),
+                ));
+            }
         }
-        let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
 
-        let commit_oid = repo.commit(
-            Some("HEAD"),
-            &author_sig,
-            &committer_sig,
-            &message,
-            &tree,
-            &parent_refs,
-        )?;
-        if needs_cleanup {
-            repo.cleanup_state()?;
-        }
-        commit_oid
-    };
+        let commit_oid = if amend.unwrap_or(false) {
+            let head_commit = repo.head()?.peel_to_commit()?;
 
-    // post-commit runs after the commit is created and never blocks it.
-    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
+            // `git commit --amend` PRESERVES the original author identity and author
+            // date; only `--reset-author` changes them. An explicitly supplied
+            // author date still applies, on top of the original identity.
+            //
+            // The signed path (`git commit --amend` via the CLI) and amend_commit
+            // both already preserve the author, so rebuilding it from
+            // repo.signature() here also made the result depend on whether
+            // commit.gpgsign happened to be enabled.
+            let amend_author: git2::Signature<'_> = if author_date.is_some() {
+                let original = head_commit.author();
+                signature_with_date(
+                    original.name().ok().unwrap_or("Unknown"),
+                    original.email().ok().unwrap_or(""),
+                    author_date.as_deref(),
+                )?
+            } else {
+                head_commit.author()
+            };
 
-    let commit = repo.find_commit(commit_oid)?;
-    Ok(Commit::from_git2(&commit))
+            // Commit::amend, not repo.commit(Some("HEAD"), .., parents).
+            //
+            // libgit2 validates that the updated ref's current tip IS the new
+            // commit's first parent. An amend replaces the tip, so that check can
+            // never pass and this path failed outright with "current tip is not the
+            // first parent" — meaning amend from the commit panel was broken for
+            // every repository without commit.gpgsign enabled. Commit::amend
+            // performs the replacement libgit2 expects and carries the original
+            // parents over unchanged.
+            head_commit.amend(
+                Some("HEAD"),
+                Some(&amend_author),
+                Some(&committer_sig),
+                None,
+                Some(&message),
+                Some(&tree),
+            )?
+        } else {
+            let mut parents: Vec<git2::Commit> = repo
+                .head()
+                .ok()
+                .and_then(|h| h.peel_to_commit().ok())
+                .into_iter()
+                .collect();
+
+            // Include MERGE_HEAD parents collected above when mid-merge
+            for oid in &merge_oids {
+                parents.push(repo.find_commit(*oid)?);
+            }
+            let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+
+            let commit_oid = repo.commit(
+                Some("HEAD"),
+                &author_sig,
+                &committer_sig,
+                &message,
+                &tree,
+                &parent_refs,
+            )?;
+            if needs_cleanup {
+                repo.cleanup_state()?;
+            }
+            commit_oid
+        };
+
+        // post-commit runs after the commit is created and never blocks it.
+        crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
+
+        let commit = repo.find_commit(commit_oid)?;
+        Ok(Commit::from_git2(&commit))
+    })
+    .await
 }
 
 /// Check if a commit should be signed based on explicit parameter or repo config
@@ -620,67 +632,73 @@ async fn create_commit_with_git_cli(
 /// This only updates the commit message; the tree and parents remain the same.
 #[command]
 pub async fn amend_commit_message(path: String, message: String) -> Result<Commit> {
-    // libgit2's repo.commit() cannot sign and would strip any existing signature.
-    // When commit.gpgsign is enabled, amend via the CLI so the reworded commit is
-    // re-signed instead of silently emitted unsigned.
-    if should_sign_commit(&path, None)? {
-        let output = crate::utils::create_command("git")
-            .current_dir(&path)
-            .args(["commit", "--amend", "-S", "-m", &message])
-            .output()
-            .map_err(|e| {
-                LeviathanError::OperationFailed(format!("Failed to run git commit --amend: {}", e))
-            })?;
-        if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            return Err(LeviathanError::OperationFailed(format!(
-                "Git commit --amend failed: {}",
-                stderr.trim()
-            )));
+    crate::utils::blocking_git(move || {
+        // libgit2's repo.commit() cannot sign and would strip any existing signature.
+        // When commit.gpgsign is enabled, amend via the CLI so the reworded commit is
+        // re-signed instead of silently emitted unsigned.
+        if should_sign_commit(&path, None)? {
+            let output = crate::utils::create_command("git")
+                .current_dir(&path)
+                .args(["commit", "--amend", "-S", "-m", &message])
+                .output()
+                .map_err(|e| {
+                    LeviathanError::OperationFailed(format!(
+                        "Failed to run git commit --amend: {}",
+                        e
+                    ))
+                })?;
+            if !output.status.success() {
+                let stderr = String::from_utf8_lossy(&output.stderr);
+                return Err(LeviathanError::OperationFailed(format!(
+                    "Git commit --amend failed: {}",
+                    stderr.trim()
+                )));
+            }
+            let repo = git2::Repository::open(Path::new(&path))?;
+            let head_commit = repo.head()?.peel_to_commit()?;
+            return Ok(Commit::from_git2(&head_commit));
         }
+
         let repo = git2::Repository::open(Path::new(&path))?;
-        let head_commit = repo.head()?.peel_to_commit()?;
-        return Ok(Commit::from_git2(&head_commit));
-    }
 
-    let repo = git2::Repository::open(Path::new(&path))?;
+        // git runs pre-commit/commit-msg/post-commit for `git commit --amend` too;
+        // the git2 amend path otherwise bypasses them.
+        crate::commands::hooks::run_hook_blocking(&repo, "pre-commit", &[], None)?;
+        let message = crate::commands::hooks::run_commit_msg_hook(&repo, &message)?;
 
-    // git runs pre-commit/commit-msg/post-commit for `git commit --amend` too;
-    // the git2 amend path otherwise bypasses them.
-    crate::commands::hooks::run_hook_blocking(&repo, "pre-commit", &[], None)?;
-    let message = crate::commands::hooks::run_commit_msg_hook(&repo, &message)?;
+        let head_commit = repo
+            .head()?
+            .peel_to_commit()
+            .map_err(|_| LeviathanError::CommitNotFound("HEAD".to_string()))?;
 
-    let head_commit = repo
-        .head()?
-        .peel_to_commit()
-        .map_err(|_| LeviathanError::CommitNotFound("HEAD".to_string()))?;
+        let tree = head_commit.tree()?;
+        let signature = repo.signature()?;
 
-    let tree = head_commit.tree()?;
-    let signature = repo.signature()?;
+        // A reword changes only the message. Passing the fresh signature as AUTHOR
+        // as well re-attributed the commit to whoever reworded it and reset the
+        // author date to now — which also reorders it in date-sorted history views.
+        // git preserves the author across a reword; only the committer changes.
+        //
+        // Commit::amend, not repo.commit(Some("HEAD"), .., parents): libgit2 checks
+        // that the updated ref's tip is the new commit's first parent, which a
+        // reword never satisfies, so that call failed with "current tip is not the
+        // first parent". Commit::amend performs the replacement and carries the
+        // original parents over unchanged.
+        let new_oid = head_commit.amend(
+            Some("HEAD"),
+            Some(&head_commit.author()),
+            Some(&signature),
+            None,
+            Some(&message),
+            Some(&tree),
+        )?;
 
-    // A reword changes only the message. Passing the fresh signature as AUTHOR
-    // as well re-attributed the commit to whoever reworded it and reset the
-    // author date to now — which also reorders it in date-sorted history views.
-    // git preserves the author across a reword; only the committer changes.
-    //
-    // Commit::amend, not repo.commit(Some("HEAD"), .., parents): libgit2 checks
-    // that the updated ref's tip is the new commit's first parent, which a
-    // reword never satisfies, so that call failed with "current tip is not the
-    // first parent". Commit::amend performs the replacement and carries the
-    // original parents over unchanged.
-    let new_oid = head_commit.amend(
-        Some("HEAD"),
-        Some(&head_commit.author()),
-        Some(&signature),
-        None,
-        Some(&message),
-        Some(&tree),
-    )?;
+        crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
 
-    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
-
-    let new_commit = repo.find_commit(new_oid)?;
-    Ok(Commit::from_git2(&new_commit))
+        let new_commit = repo.find_commit(new_oid)?;
+        Ok(Commit::from_git2(&new_commit))
+    })
+    .await
 }
 
 /// Result of an amend operation
@@ -715,84 +733,87 @@ pub async fn amend_commit(
             .await;
     }
 
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    // git runs pre-commit for `git commit --amend`; the git2 path bypasses it.
-    crate::commands::hooks::run_hook_blocking(&repo, "pre-commit", &[], None)?;
+        // git runs pre-commit for `git commit --amend`; the git2 path bypasses it.
+        crate::commands::hooks::run_hook_blocking(&repo, "pre-commit", &[], None)?;
 
-    let head_commit = repo
-        .head()?
-        .peel_to_commit()
-        .map_err(|_| LeviathanError::CommitNotFound("HEAD".to_string()))?;
+        let head_commit = repo
+            .head()?
+            .peel_to_commit()
+            .map_err(|_| LeviathanError::CommitNotFound("HEAD".to_string()))?;
 
-    let old_oid = head_commit.id().to_string();
-    let tree = head_commit.tree()?;
-    let signature = repo.signature()?;
+        let old_oid = head_commit.id().to_string();
+        let tree = head_commit.tree()?;
+        let signature = repo.signature()?;
 
-    // Use the new message or keep the original
-    let commit_message =
-        message.unwrap_or_else(|| head_commit.message().ok().unwrap_or("").to_string());
-    // commit-msg may veto or rewrite the (possibly reused) message.
-    let commit_message = crate::commands::hooks::run_commit_msg_hook(&repo, &commit_message)?;
+        // Use the new message or keep the original
+        let commit_message =
+            message.unwrap_or_else(|| head_commit.message().ok().unwrap_or("").to_string());
+        // commit-msg may veto or rewrite the (possibly reused) message.
+        let commit_message = crate::commands::hooks::run_commit_msg_hook(&repo, &commit_message)?;
 
-    // Use new author if reset_author is true, otherwise keep original
-    let author = if reset_author.unwrap_or(false) {
-        signature.clone()
-    } else {
-        head_commit.author()
-    };
+        // Use new author if reset_author is true, otherwise keep original
+        let author = if reset_author.unwrap_or(false) {
+            signature.clone()
+        } else {
+            head_commit.author()
+        };
 
-    let parent_ids: Vec<git2::Oid> = head_commit.parent_ids().collect();
-    let parents: Vec<git2::Commit> = parent_ids
-        .iter()
-        .filter_map(|id| repo.find_commit(*id).ok())
-        .collect();
-    let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+        let parent_ids: Vec<git2::Oid> = head_commit.parent_ids().collect();
+        let parents: Vec<git2::Commit> = parent_ids
+            .iter()
+            .filter_map(|id| repo.find_commit(*id).ok())
+            .collect();
+        let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
 
-    // Create commit without updating ref (avoids git2 parent validation error
-    // for root commits), then manually update HEAD.
-    let new_oid = repo.commit(
-        None,
-        &author,
-        &signature,
-        &commit_message,
-        &tree,
-        &parent_refs,
-    )?;
-
-    // Update HEAD to point to the new commit
-    let head_ref = repo.head()?;
-    if head_ref.is_branch() {
-        let branch_name = head_ref
-            .name()
-            .map_err(|_| LeviathanError::OperationFailed("Invalid HEAD ref".to_string()))?;
-        repo.reference(
-            branch_name,
-            new_oid,
-            true,
-            &format!("amend: {}", &old_oid[..std::cmp::min(7, old_oid.len())]),
+        // Create commit without updating ref (avoids git2 parent validation error
+        // for root commits), then manually update HEAD.
+        let new_oid = repo.commit(
+            None,
+            &author,
+            &signature,
+            &commit_message,
+            &tree,
+            &parent_refs,
         )?;
-    } else {
-        repo.set_head_detached(new_oid)?;
-    }
 
-    crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
-    // The Hooks dialog advertises post-rewrite for "rebase, amend" and lets
-    // the user enable it, but nothing ran it — so the same Amend button fired
-    // it or not depending purely on whether GPG signing was on, since the
-    // signed path shells out to git and git runs it.
-    crate::commands::hooks::run_hook_noblock_with_stdin(
-        &repo,
-        "post-rewrite",
-        &["amend"],
-        Some(&format!("{} {}\n", old_oid, new_oid)),
-    );
+        // Update HEAD to point to the new commit
+        let head_ref = repo.head()?;
+        if head_ref.is_branch() {
+            let branch_name = head_ref
+                .name()
+                .map_err(|_| LeviathanError::OperationFailed("Invalid HEAD ref".to_string()))?;
+            repo.reference(
+                branch_name,
+                new_oid,
+                true,
+                &format!("amend: {}", &old_oid[..std::cmp::min(7, old_oid.len())]),
+            )?;
+        } else {
+            repo.set_head_detached(new_oid)?;
+        }
 
-    Ok(AmendResult {
-        new_oid: new_oid.to_string(),
-        old_oid,
-        success: true,
+        crate::commands::hooks::run_hook_noblock(&repo, "post-commit", &[]);
+        // The Hooks dialog advertises post-rewrite for "rebase, amend" and lets
+        // the user enable it, but nothing ran it — so the same Amend button fired
+        // it or not depending purely on whether GPG signing was on, since the
+        // signed path shells out to git and git runs it.
+        crate::commands::hooks::run_hook_noblock_with_stdin(
+            &repo,
+            "post-rewrite",
+            &["amend"],
+            Some(&format!("{} {}\n", old_oid, new_oid)),
+        );
+
+        Ok(AmendResult {
+            new_oid: new_oid.to_string(),
+            old_oid,
+            success: true,
+        })
     })
+    .await
 }
 
 /// Amend a commit using git CLI (supports GPG signing)
@@ -860,53 +881,59 @@ async fn amend_commit_with_git_cli(
 /// false — the check must never invent a warning for an ordinary local commit.
 #[command]
 pub async fn is_head_published(path: String) -> Result<bool> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let Ok(head) = repo.head() else {
-        return Ok(false); // Unborn HEAD: nothing to amend yet.
-    };
-    if repo.head_detached().unwrap_or(false) {
-        return Ok(false); // No upstream to diverge from.
-    }
-    let Some(head_oid) = head.target() else {
-        return Ok(false);
-    };
-    let Ok(branch_name) = head.shorthand() else {
-        return Ok(false);
-    };
+        let Ok(head) = repo.head() else {
+            return Ok(false); // Unborn HEAD: nothing to amend yet.
+        };
+        if repo.head_detached().unwrap_or(false) {
+            return Ok(false); // No upstream to diverge from.
+        }
+        let Some(head_oid) = head.target() else {
+            return Ok(false);
+        };
+        let Ok(branch_name) = head.shorthand() else {
+            return Ok(false);
+        };
 
-    let Ok(branch) = repo.find_branch(branch_name, git2::BranchType::Local) else {
-        return Ok(false);
-    };
-    // An upstream that is configured but pruned resolves to Err here, and that
-    // is the right answer: with no remote-tracking ref there is nothing local
-    // that can show the commit was published.
-    let Ok(upstream) = branch.upstream() else {
-        return Ok(false);
-    };
-    let Some(upstream_oid) = upstream.get().target() else {
-        return Ok(false);
-    };
+        let Ok(branch) = repo.find_branch(branch_name, git2::BranchType::Local) else {
+            return Ok(false);
+        };
+        // An upstream that is configured but pruned resolves to Err here, and that
+        // is the right answer: with no remote-tracking ref there is nothing local
+        // that can show the commit was published.
+        let Ok(upstream) = branch.upstream() else {
+            return Ok(false);
+        };
+        let Some(upstream_oid) = upstream.get().target() else {
+            return Ok(false);
+        };
 
-    if upstream_oid == head_oid {
-        return Ok(true);
-    }
-    // The upstream having moved PAST head still means head is published.
-    Ok(repo
-        .graph_descendant_of(upstream_oid, head_oid)
-        .unwrap_or(false))
+        if upstream_oid == head_oid {
+            return Ok(true);
+        }
+        // The upstream having moved PAST head still means head is published.
+        Ok(repo
+            .graph_descendant_of(upstream_oid, head_oid)
+            .unwrap_or(false))
+    })
+    .await
 }
 
 /// Get the full commit message for a commit
 #[command]
 pub async fn get_commit_message(path: String, oid: String) -> Result<String> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let oid = git2::Oid::from_str(&oid)?;
-    let commit = repo
-        .find_commit(oid)
-        .map_err(|_| LeviathanError::CommitNotFound(oid.to_string()))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let oid = git2::Oid::from_str(&oid)?;
+        let commit = repo
+            .find_commit(oid)
+            .map_err(|_| LeviathanError::CommitNotFound(oid.to_string()))?;
 
-    Ok(commit.message().ok().unwrap_or("").to_string())
+        Ok(commit.message().ok().unwrap_or("").to_string())
+    })
+    .await
 }
 
 /// Edit the author and/or committer date of an existing commit
@@ -948,131 +975,143 @@ pub async fn edit_commit_date(
         parent_ids: Vec<git2::Oid>,
     }
 
-    let info: std::result::Result<CommitDateInfo, LeviathanError> = (|| {
-        let repo = git2::Repository::open(Path::new(&path))?;
+    let info: std::result::Result<CommitDateInfo, LeviathanError> = {
+        let path = path.clone();
+        let oid = oid.clone();
+        crate::utils::blocking_git(move || {
+            let repo = git2::Repository::open(Path::new(&path))?;
 
-        let target_oid =
-            git2::Oid::from_str(&oid).map_err(|_| LeviathanError::CommitNotFound(oid.clone()))?;
-        let target_commit = repo
-            .find_commit(target_oid)
-            .map_err(|_| LeviathanError::CommitNotFound(oid.clone()))?;
+            let target_oid = git2::Oid::from_str(&oid)
+                .map_err(|_| LeviathanError::CommitNotFound(oid.clone()))?;
+            let target_commit = repo
+                .find_commit(target_oid)
+                .map_err(|_| LeviathanError::CommitNotFound(oid.clone()))?;
 
-        let head_oid = repo.head()?.peel_to_commit()?.id();
-        let is_head = head_oid == target_oid;
+            let head_oid = repo.head()?.peel_to_commit()?.id();
+            let is_head = head_oid == target_oid;
 
-        if repo.state() != git2::RepositoryState::Clean {
-            return Err(LeviathanError::OperationFailed(
-                "Another operation is in progress".to_string(),
-            ));
-        }
+            if repo.state() != git2::RepositoryState::Clean {
+                return Err(LeviathanError::OperationFailed(
+                    "Another operation is in progress".to_string(),
+                ));
+            }
 
-        // Extract all values from signatures before they are dropped
-        let author_name = target_commit
-            .author()
-            .name()
-            .ok()
-            .unwrap_or("Unknown")
-            .to_string();
-        let author_email = target_commit
-            .author()
-            .email()
-            .ok()
-            .unwrap_or("")
-            .to_string();
-        let committer_name = target_commit
-            .committer()
-            .name()
-            .ok()
-            .unwrap_or("Unknown")
-            .to_string();
-        let committer_email = target_commit
-            .committer()
-            .email()
-            .ok()
-            .unwrap_or("")
-            .to_string();
-        let message = target_commit.message().ok().unwrap_or("").to_string();
-        let parent_ids = target_commit.parent_ids().collect();
+            // Extract all values from signatures before they are dropped
+            let author_name = target_commit
+                .author()
+                .name()
+                .ok()
+                .unwrap_or("Unknown")
+                .to_string();
+            let author_email = target_commit
+                .author()
+                .email()
+                .ok()
+                .unwrap_or("")
+                .to_string();
+            let committer_name = target_commit
+                .committer()
+                .name()
+                .ok()
+                .unwrap_or("Unknown")
+                .to_string();
+            let committer_email = target_commit
+                .committer()
+                .email()
+                .ok()
+                .unwrap_or("")
+                .to_string();
+            let message = target_commit.message().ok().unwrap_or("").to_string();
+            let parent_ids = target_commit.parent_ids().collect();
 
-        Ok(CommitDateInfo {
-            is_head,
-            author_name,
-            author_email,
-            committer_name,
-            committer_email,
-            message,
-            parent_ids,
+            Ok(CommitDateInfo {
+                is_head,
+                author_name,
+                author_email,
+                committer_name,
+                committer_email,
+                message,
+                parent_ids,
+            })
         })
-    })();
+        .await
+    };
 
     let info = info?;
 
     if info.is_head {
-        // For HEAD commit, recreate it with updated dates using git2
-        let repo = git2::Repository::open(Path::new(&path))?;
-        let target_oid = git2::Oid::from_str(&oid)?;
-        let target_commit = repo.find_commit(target_oid)?;
+        let path = path.clone();
+        let oid = oid.clone();
+        let author_date = author_date.clone();
+        let committer_date = committer_date.clone();
+        crate::utils::blocking_git(move || {
+            // For HEAD commit, recreate it with updated dates using git2
+            let repo = git2::Repository::open(Path::new(&path))?;
+            let target_oid = git2::Oid::from_str(&oid)?;
+            let target_commit = repo.find_commit(target_oid)?;
 
-        let old_oid = target_oid.to_string();
+            let old_oid = target_oid.to_string();
 
-        // Build author signature with optional new date
-        let new_author = if let Some(ref ad) = author_date {
-            let time = parse_iso8601_to_git_time(ad)?;
-            git2::Signature::new(&info.author_name, &info.author_email, &time)?
-        } else {
-            target_commit.author()
-        };
+            // Build author signature with optional new date
+            let new_author = if let Some(ref ad) = author_date {
+                let time = parse_iso8601_to_git_time(ad)?;
+                git2::Signature::new(&info.author_name, &info.author_email, &time)?
+            } else {
+                target_commit.author()
+            };
 
-        // Build committer signature with optional new date
-        let new_committer = if let Some(ref cd) = committer_date {
-            let time = parse_iso8601_to_git_time(cd)?;
-            git2::Signature::new(&info.committer_name, &info.committer_email, &time)?
-        } else {
-            target_commit.committer()
-        };
+            // Build committer signature with optional new date
+            let new_committer = if let Some(ref cd) = committer_date {
+                let time = parse_iso8601_to_git_time(cd)?;
+                git2::Signature::new(&info.committer_name, &info.committer_email, &time)?
+            } else {
+                target_commit.committer()
+            };
 
-        let tree = target_commit.tree()?;
-        let parents: Vec<git2::Commit> = info
-            .parent_ids
-            .iter()
-            .filter_map(|id| repo.find_commit(*id).ok())
-            .collect();
-        let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
+            let tree = target_commit.tree()?;
+            let parents: Vec<git2::Commit> = info
+                .parent_ids
+                .iter()
+                .filter_map(|id| repo.find_commit(*id).ok())
+                .collect();
+            let parent_refs: Vec<&git2::Commit> = parents.iter().collect();
 
-        // Create commit without updating ref (avoids git2 parent validation error),
-        // then manually update HEAD to point to the new commit.
-        let new_oid = repo.commit(
-            None,
-            &new_author,
-            &new_committer,
-            &info.message,
-            &tree,
-            &parent_refs,
-        )?;
-
-        // Update HEAD to point to the new commit
-        let head_ref = repo.head()?;
-        if head_ref.is_branch() {
-            // HEAD points to a branch - update the branch target
-            let branch_name = head_ref
-                .name()
-                .map_err(|_| LeviathanError::OperationFailed("Invalid HEAD ref".to_string()))?;
-            repo.reference(
-                branch_name,
-                new_oid,
-                true,
-                &format!("edit_commit_date: updated {}", &old_oid[..7]),
+            // Create commit without updating ref (avoids git2 parent validation error),
+            // then manually update HEAD to point to the new commit.
+            let new_oid = repo.commit(
+                None,
+                &new_author,
+                &new_committer,
+                &info.message,
+                &tree,
+                &parent_refs,
             )?;
-        } else {
-            // Detached HEAD - update HEAD directly
-            repo.set_head_detached(new_oid)?;
-        }
 
-        Ok(AmendResult {
-            new_oid: new_oid.to_string(),
-            old_oid,
-            success: true,
+            // Update HEAD to point to the new commit
+            let head_ref = repo.head()?;
+            if head_ref.is_branch() {
+                // HEAD points to a branch - update the branch target
+                let branch_name = head_ref
+                    .name()
+                    .map_err(|_| LeviathanError::OperationFailed("Invalid HEAD ref".to_string()))?;
+                repo.reference(
+                    branch_name,
+                    new_oid,
+                    true,
+                    &format!("edit_commit_date: updated {}", &old_oid[..7]),
+                )?;
+            } else {
+                // Detached HEAD - update HEAD directly
+                repo.set_head_detached(new_oid)?;
+            }
+
+            Ok(AmendResult {
+                new_oid: new_oid.to_string(),
+                old_oid,
+                success: true,
+            })
         })
+        .await
     } else {
         // For non-HEAD commits, use git CLI with rebase and environment variables
         edit_commit_date_with_rebase(
@@ -1296,62 +1335,67 @@ async fn edit_commit_date_with_rebase(
 /// mean the reword a user can actually trigger is covered.
 #[command]
 pub async fn reword_commit(path: String, oid: String, message: String) -> Result<AmendResult> {
-    // Use a closure to ensure git2 objects are dropped before any .await
-    // This is necessary because git2 types are not Send
-    let result: std::result::Result<(bool, Option<git2::Oid>), LeviathanError> = (|| {
-        let repo = git2::Repository::open(Path::new(&path))?;
+    // Run the inspection on the blocking pool, and inside one closure: git2
+    // types are not Send, so no handle may cross the await that follows.
+    let result: std::result::Result<(bool, Option<git2::Oid>), LeviathanError> = {
+        let path = path.clone();
+        let oid = oid.clone();
+        crate::utils::blocking_git(move || {
+            let repo = git2::Repository::open(Path::new(&path))?;
 
-        // Verify the commit exists
-        let target_oid =
-            git2::Oid::from_str(&oid).map_err(|_| LeviathanError::CommitNotFound(oid.clone()))?;
-        let target_commit = repo
-            .find_commit(target_oid)
-            .map_err(|_| LeviathanError::CommitNotFound(oid.clone()))?;
+            // Verify the commit exists
+            let target_oid = git2::Oid::from_str(&oid)
+                .map_err(|_| LeviathanError::CommitNotFound(oid.clone()))?;
+            let target_commit = repo
+                .find_commit(target_oid)
+                .map_err(|_| LeviathanError::CommitNotFound(oid.clone()))?;
 
-        // Check if this is the HEAD commit - if so, use amend instead
-        let head_oid = repo.head()?.peel_to_commit()?.id();
-        let is_head = head_oid == target_oid;
+            // Check if this is the HEAD commit - if so, use amend instead
+            let head_oid = repo.head()?.peel_to_commit()?.id();
+            let is_head = head_oid == target_oid;
 
-        // Check for existing operations in progress
-        if repo.state() != git2::RepositoryState::Clean {
-            return Err(LeviathanError::OperationFailed(
-                "Another operation is in progress".to_string(),
-            ));
-        }
-
-        // For non-HEAD commits, we need to use git rebase
-        // Find the parent of the target commit to use as the base
-        let parent_oid = if !is_head {
-            // A merge commit never survives that rebase. `rebase -i <merge>^1`
-            // linearizes the range instead of listing the merge, so there is no
-            // `pick <oid>` for the sequence editor to turn into `reword`: git
-            // replays the side branch onto the first parent, exits 0, and the
-            // message is never touched. The loop below would then find no
-            // commit carrying the new message, keep its HEAD seed, and report
-            // success — for a reword that did not happen on a branch whose
-            // merge commit had just been destroyed. Refuse before anything is
-            // rewritten, matching the frontend's own refusal in
-            // `isMergeCommit`. (The `is_head` path amends in place and keeps
-            // every parent, so it stays allowed.)
-            if target_commit.parent_count() > 1 {
+            // Check for existing operations in progress
+            if repo.state() != git2::RepositoryState::Clean {
                 return Err(LeviathanError::OperationFailed(
-                    "Cannot reword a merge commit".to_string(),
+                    "Another operation is in progress".to_string(),
                 ));
             }
-            Some(
-                target_commit
-                    .parent(0)
-                    .map_err(|_| {
-                        LeviathanError::OperationFailed("Cannot reword root commit".to_string())
-                    })?
-                    .id(),
-            )
-        } else {
-            None
-        };
 
-        Ok((is_head, parent_oid))
-    })();
+            // For non-HEAD commits, we need to use git rebase
+            // Find the parent of the target commit to use as the base
+            let parent_oid = if !is_head {
+                // A merge commit never survives that rebase. `rebase -i <merge>^1`
+                // linearizes the range instead of listing the merge, so there is no
+                // `pick <oid>` for the sequence editor to turn into `reword`: git
+                // replays the side branch onto the first parent, exits 0, and the
+                // message is never touched. The loop below would then find no
+                // commit carrying the new message, keep its HEAD seed, and report
+                // success — for a reword that did not happen on a branch whose
+                // merge commit had just been destroyed. Refuse before anything is
+                // rewritten, matching the frontend's own refusal in
+                // `isMergeCommit`. (The `is_head` path amends in place and keeps
+                // every parent, so it stays allowed.)
+                if target_commit.parent_count() > 1 {
+                    return Err(LeviathanError::OperationFailed(
+                        "Cannot reword a merge commit".to_string(),
+                    ));
+                }
+                Some(
+                    target_commit
+                        .parent(0)
+                        .map_err(|_| {
+                            LeviathanError::OperationFailed("Cannot reword root commit".to_string())
+                        })?
+                        .id(),
+                )
+            } else {
+                None
+            };
+
+            Ok((is_head, parent_oid))
+        })
+        .await
+    };
 
     let (is_head, parent_oid) = result?;
 
@@ -1362,77 +1406,80 @@ pub async fn reword_commit(path: String, oid: String, message: String) -> Result
 
     let parent_oid = parent_oid.expect("parent_oid should be set for non-HEAD commits");
 
-    // Write the new message to a temporary file
-    let git_dir = git2::Repository::open(Path::new(&path))?
-        .path()
-        .to_path_buf();
-    let msg_file = git_dir.join("REWORD_MSG");
-    std::fs::write(&msg_file, &message)?;
+    crate::utils::blocking_git(move || {
+        // Write the new message to a temporary file
+        let git_dir = git2::Repository::open(Path::new(&path))?
+            .path()
+            .to_path_buf();
+        let msg_file = git_dir.join("REWORD_MSG");
+        std::fs::write(&msg_file, &message)?;
 
-    // Git evaluates both editor variables through a shell — the POSIX one Git
-    // for Windows bundles, not cmd.exe — and appends the file it wants edited,
-    // so hand it the commands directly. The per-platform scripts these replace
-    // interpolated the message path into a DOUBLE-quoted `cp`, so a repository
-    // whose path contained `$` or a quote made the shell rewrite the path and
-    // the reword died on a message file that was never there.
-    let sequence_editor = crate::utils::todo_action_editor_command(&oid[..7], "reword");
-    let commit_editor = crate::utils::copy_file_editor_command(&msg_file);
+        // Git evaluates both editor variables through a shell — the POSIX one Git
+        // for Windows bundles, not cmd.exe — and appends the file it wants edited,
+        // so hand it the commands directly. The per-platform scripts these replace
+        // interpolated the message path into a DOUBLE-quoted `cp`, so a repository
+        // whose path contained `$` or a quote made the shell rewrite the path and
+        // the reword died on a message file that was never there.
+        let sequence_editor = crate::utils::todo_action_editor_command(&oid[..7], "reword");
+        let commit_editor = crate::utils::copy_file_editor_command(&msg_file);
 
-    // Run the rebase
-    let output = crate::utils::create_command("git")
-        .current_dir(&path)
-        .env("GIT_SEQUENCE_EDITOR", &sequence_editor)
-        .env("GIT_EDITOR", &commit_editor)
-        .args(crate::utils::TODO_FORMAT_ARGS)
-        .args(["rebase", "-i", &parent_oid.to_string()])
-        .output()
-        .map_err(|e| LeviathanError::OperationFailed(e.to_string()))?;
+        // Run the rebase
+        let output = crate::utils::create_command("git")
+            .current_dir(&path)
+            .env("GIT_SEQUENCE_EDITOR", &sequence_editor)
+            .env("GIT_EDITOR", &commit_editor)
+            .args(crate::utils::TODO_FORMAT_ARGS)
+            .args(["rebase", "-i", &parent_oid.to_string()])
+            .output()
+            .map_err(|e| LeviathanError::OperationFailed(e.to_string()))?;
 
-    // Clean up temporary files
-    let _ = std::fs::remove_file(&msg_file);
+        // Clean up temporary files
+        let _ = std::fs::remove_file(&msg_file);
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        if stderr.contains("CONFLICT") || stderr.contains("conflict") {
-            return Err(LeviathanError::RebaseConflict);
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            if stderr.contains("CONFLICT") || stderr.contains("conflict") {
+                return Err(LeviathanError::RebaseConflict);
+            }
+            return Err(LeviathanError::OperationFailed(format!(
+                "Rebase failed: {}",
+                stderr
+            )));
         }
-        return Err(LeviathanError::OperationFailed(format!(
-            "Rebase failed: {}",
-            stderr
-        )));
-    }
 
-    // Reopen the repository to get the new state after rebase
-    let repo = git2::Repository::open(Path::new(&path))?;
+        // Reopen the repository to get the new state after rebase
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    // Get the new HEAD to find the reworded commit's new OID
-    let new_head = repo.head()?.peel_to_commit()?;
+        // Get the new HEAD to find the reworded commit's new OID
+        let new_head = repo.head()?.peel_to_commit()?;
 
-    // Walk back to find the commit that replaced our target
-    // The new commit will be at approximately the same position in history
-    let mut revwalk = repo.revwalk()?;
-    revwalk.push(new_head.id())?;
-    revwalk.set_sorting(git2::Sort::TOPOLOGICAL)?;
+        // Walk back to find the commit that replaced our target
+        // The new commit will be at approximately the same position in history
+        let mut revwalk = repo.revwalk()?;
+        revwalk.push(new_head.id())?;
+        revwalk.set_sorting(git2::Sort::TOPOLOGICAL)?;
 
-    let mut new_commit_oid = new_head.id().to_string();
-    for rev_oid in revwalk.flatten() {
-        let commit = repo.find_commit(rev_oid)?;
-        // The reworded commit will have our new message. Compared with the
-        // trailing whitespace off both sides: git normalizes a commit message
-        // to end in a newline, so an exact comparison against the argument
-        // never matched and `new_commit_oid` kept its seed — leaving the caller
-        // with the DESCENDANT's oid for the commit it had just reworded.
-        if commit.message().ok().unwrap_or("").trim_end() == message.trim_end() {
-            new_commit_oid = rev_oid.to_string();
-            break;
+        let mut new_commit_oid = new_head.id().to_string();
+        for rev_oid in revwalk.flatten() {
+            let commit = repo.find_commit(rev_oid)?;
+            // The reworded commit will have our new message. Compared with the
+            // trailing whitespace off both sides: git normalizes a commit message
+            // to end in a newline, so an exact comparison against the argument
+            // never matched and `new_commit_oid` kept its seed — leaving the caller
+            // with the DESCENDANT's oid for the commit it had just reworded.
+            if commit.message().ok().unwrap_or("").trim_end() == message.trim_end() {
+                new_commit_oid = rev_oid.to_string();
+                break;
+            }
         }
-    }
 
-    Ok(AmendResult {
-        new_oid: new_commit_oid,
-        old_oid: oid,
-        success: true,
+        Ok(AmendResult {
+            new_oid: new_commit_oid,
+            old_oid: oid,
+            success: true,
+        })
     })
+    .await
 }
 
 /// Search commits with filters
@@ -1448,109 +1495,112 @@ pub async fn search_commits(
     branch: Option<String>,
     limit: Option<usize>,
 ) -> Result<Vec<Commit>> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let mut revwalk = repo.revwalk()?;
-    revwalk.set_sorting(git2::Sort::TIME | git2::Sort::TOPOLOGICAL)?;
+        let mut revwalk = repo.revwalk()?;
+        revwalk.set_sorting(git2::Sort::TIME | git2::Sort::TOPOLOGICAL)?;
 
-    if let Some(ref branch_name) = branch {
-        // Push only the specified branch/ref
-        let reference = repo
-            .resolve_reference_from_short_name(branch_name)
-            .map_err(|_| crate::error::LeviathanError::BranchNotFound(branch_name.clone()))?;
-        if let Some(oid) = reference.target() {
-            revwalk.push(oid)?;
-        }
-    } else {
-        // Push all branch heads for complete search
-        for reference in repo.references()?.flatten() {
+        if let Some(ref branch_name) = branch {
+            // Push only the specified branch/ref
+            let reference = repo
+                .resolve_reference_from_short_name(branch_name)
+                .map_err(|_| crate::error::LeviathanError::BranchNotFound(branch_name.clone()))?;
             if let Some(oid) = reference.target() {
-                let _ = revwalk.push(oid);
+                revwalk.push(oid)?;
             }
-        }
-    }
-
-    let limit_count = limit.unwrap_or(500);
-    let query_lower = query.as_ref().map(|q| q.to_lowercase());
-    let author_lower = author.as_ref().map(|a| a.to_lowercase());
-
-    let mut results = Vec::new();
-
-    for oid_result in revwalk {
-        if results.len() >= limit_count {
-            break;
-        }
-
-        let oid = match oid_result {
-            Ok(oid) => oid,
-            Err(_) => continue,
-        };
-
-        let commit = match repo.find_commit(oid) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
-
-        // Check query filter (message, SHA)
-        if let Some(ref q) = query_lower {
-            let message = commit.message().ok().unwrap_or("").to_lowercase();
-            let sha = commit.id().to_string().to_lowercase();
-            if !message.contains(q) && !sha.starts_with(q) {
-                continue;
+        } else {
+            // Push all branch heads for complete search
+            for reference in repo.references()?.flatten() {
+                if let Some(oid) = reference.target() {
+                    let _ = revwalk.push(oid);
+                }
             }
         }
 
-        // Check author filter
-        if let Some(ref a) = author_lower {
-            let author_name = commit.author().name().ok().unwrap_or("").to_lowercase();
-            let author_email = commit.author().email().ok().unwrap_or("").to_lowercase();
-            if !author_name.contains(a) && !author_email.contains(a) {
-                continue;
+        let limit_count = limit.unwrap_or(500);
+        let query_lower = query.as_ref().map(|q| q.to_lowercase());
+        let author_lower = author.as_ref().map(|a| a.to_lowercase());
+
+        let mut results = Vec::new();
+
+        for oid_result in revwalk {
+            if results.len() >= limit_count {
+                break;
             }
-        }
 
-        // Check date range
-        let commit_time = commit.time().seconds();
-        if let Some(from) = date_from {
-            if commit_time < from {
-                continue;
-            }
-        }
-        if let Some(to) = date_to {
-            if commit_time > to {
-                continue;
-            }
-        }
-
-        // Check file path filter
-        if let Some(ref fp) = file_path {
-            let tree = match commit.tree() {
-                Ok(t) => t,
-                Err(_) => continue,
-            };
-            let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
-
-            let mut diff_opts = git2::DiffOptions::new();
-            diff_opts.pathspec(fp);
-
-            let diff = match repo.diff_tree_to_tree(
-                parent_tree.as_ref(),
-                Some(&tree),
-                Some(&mut diff_opts),
-            ) {
-                Ok(d) => d,
+            let oid = match oid_result {
+                Ok(oid) => oid,
                 Err(_) => continue,
             };
 
-            if diff.deltas().count() == 0 {
-                continue;
+            let commit = match repo.find_commit(oid) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
+
+            // Check query filter (message, SHA)
+            if let Some(ref q) = query_lower {
+                let message = commit.message().ok().unwrap_or("").to_lowercase();
+                let sha = commit.id().to_string().to_lowercase();
+                if !message.contains(q) && !sha.starts_with(q) {
+                    continue;
+                }
             }
+
+            // Check author filter
+            if let Some(ref a) = author_lower {
+                let author_name = commit.author().name().ok().unwrap_or("").to_lowercase();
+                let author_email = commit.author().email().ok().unwrap_or("").to_lowercase();
+                if !author_name.contains(a) && !author_email.contains(a) {
+                    continue;
+                }
+            }
+
+            // Check date range
+            let commit_time = commit.time().seconds();
+            if let Some(from) = date_from {
+                if commit_time < from {
+                    continue;
+                }
+            }
+            if let Some(to) = date_to {
+                if commit_time > to {
+                    continue;
+                }
+            }
+
+            // Check file path filter
+            if let Some(ref fp) = file_path {
+                let tree = match commit.tree() {
+                    Ok(t) => t,
+                    Err(_) => continue,
+                };
+                let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
+
+                let mut diff_opts = git2::DiffOptions::new();
+                diff_opts.pathspec(fp);
+
+                let diff = match repo.diff_tree_to_tree(
+                    parent_tree.as_ref(),
+                    Some(&tree),
+                    Some(&mut diff_opts),
+                ) {
+                    Ok(d) => d,
+                    Err(_) => continue,
+                };
+
+                if diff.deltas().count() == 0 {
+                    continue;
+                }
+            }
+
+            results.push(Commit::from_git2(&commit));
         }
 
-        results.push(Commit::from_git2(&commit));
-    }
-
-    Ok(results)
+        Ok(results)
+    })
+    .await
 }
 
 /// Get all commits that modified a specific file, each paired with the path
@@ -1567,151 +1617,157 @@ pub async fn get_file_history(
     limit: Option<usize>,
     follow_renames: Option<bool>,
 ) -> Result<Vec<FileHistoryEntry>> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let mut revwalk = repo.revwalk()?;
-    // TOPOLOGICAL as well as TIME. Following a rename rewrites current_path
-    // when the walk REACHES the renaming commit, so every commit before the
-    // rename must be visited after it. Sorting by time alone does not
-    // guarantee that — commits made within the same second (a scripted commit,
-    // a rebase, an import) tie, and a tie can put the renaming commit last, by
-    // which point the pre-rename history has already been tested against the
-    // new name and discarded. Topological order makes children precede parents
-    // no matter what the timestamps say.
-    revwalk.set_sorting(git2::Sort::TIME | git2::Sort::TOPOLOGICAL)?;
+        let mut revwalk = repo.revwalk()?;
+        // TOPOLOGICAL as well as TIME. Following a rename rewrites current_path
+        // when the walk REACHES the renaming commit, so every commit before the
+        // rename must be visited after it. Sorting by time alone does not
+        // guarantee that — commits made within the same second (a scripted commit,
+        // a rebase, an import) tie, and a tie can put the renaming commit last, by
+        // which point the pre-rename history has already been tested against the
+        // new name and discarded. Topological order makes children precede parents
+        // no matter what the timestamps say.
+        revwalk.set_sorting(git2::Sort::TIME | git2::Sort::TOPOLOGICAL)?;
 
-    // Start from HEAD
-    let head = repo
-        .head()?
-        .target()
-        .ok_or(LeviathanError::RepositoryNotOpen)?;
-    revwalk.push(head)?;
+        // Start from HEAD
+        let head = repo
+            .head()?
+            .target()
+            .ok_or(LeviathanError::RepositoryNotOpen)?;
+        revwalk.push(head)?;
 
-    let limit_count = limit.unwrap_or(500);
-    let should_follow = follow_renames.unwrap_or(true);
-    let mut entries: Vec<FileHistoryEntry> = Vec::new();
-    let mut current_path = file_path.clone();
+        let limit_count = limit.unwrap_or(500);
+        let should_follow = follow_renames.unwrap_or(true);
+        let mut entries: Vec<FileHistoryEntry> = Vec::new();
+        let mut current_path = file_path.clone();
 
-    for oid_result in revwalk {
-        if entries.len() >= limit_count {
-            break;
-        }
+        for oid_result in revwalk {
+            if entries.len() >= limit_count {
+                break;
+            }
 
-        let oid = match oid_result {
-            Ok(oid) => oid,
-            Err(_) => continue,
-        };
+            let oid = match oid_result {
+                Ok(oid) => oid,
+                Err(_) => continue,
+            };
 
-        let commit = match repo.find_commit(oid) {
-            Ok(c) => c,
-            Err(_) => continue,
-        };
+            let commit = match repo.find_commit(oid) {
+                Ok(c) => c,
+                Err(_) => continue,
+            };
 
-        let tree = match commit.tree() {
-            Ok(t) => t,
-            Err(_) => continue,
-        };
+            let tree = match commit.tree() {
+                Ok(t) => t,
+                Err(_) => continue,
+            };
 
-        // Check if file exists in this commit
-        let file_in_commit = tree.get_path(std::path::Path::new(&current_path)).is_ok();
+            // Check if file exists in this commit
+            let file_in_commit = tree.get_path(std::path::Path::new(&current_path)).is_ok();
 
-        if !file_in_commit && !should_follow {
-            continue;
-        }
+            if !file_in_commit && !should_follow {
+                continue;
+            }
 
-        // Get parent tree for diff
-        let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
+            // Get parent tree for diff
+            let parent_tree = commit.parent(0).ok().and_then(|p| p.tree().ok());
 
-        // Create diff options
-        let mut diff_opts = git2::DiffOptions::new();
-        diff_opts.pathspec(&current_path);
+            // Create diff options
+            let mut diff_opts = git2::DiffOptions::new();
+            diff_opts.pathspec(&current_path);
 
-        let diff =
-            match repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), Some(&mut diff_opts)) {
+            let diff = match repo.diff_tree_to_tree(
+                parent_tree.as_ref(),
+                Some(&tree),
+                Some(&mut diff_opts),
+            ) {
                 Ok(d) => d,
                 Err(_) => continue,
             };
 
-        // Check if file was modified in this commit
-        let mut file_modified;
-        let mut renamed_from: Option<String> = None;
+            // Check if file was modified in this commit
+            let mut file_modified;
+            let mut renamed_from: Option<String> = None;
 
-        if should_follow {
-            // The pathspec above filters deltas at diff-GENERATION time, so at
-            // the commit that renamed old -> current this diff holds only the
-            // Added(current) half. find_similar had no Deleted(old) to pair it
-            // with, delta.status() was therefore never Renamed, renamed_from
-            // was never set, and the walk stopped dead at the rename — the one
-            // thing follow_renames exists to get past.
-            //
-            // Detect the modification from the cheap filtered diff, then pay
-            // for an UNFILTERED diff only where a rename could actually be
-            // hiding: the commit that introduces the path. That is once per
-            // rename, not once per commit.
-            let introduced_here = diff
-                .deltas()
-                .any(|d| d.status() == git2::Delta::Added || d.status() == git2::Delta::Renamed);
-            file_modified = diff.deltas().count() > 0;
+            if should_follow {
+                // The pathspec above filters deltas at diff-GENERATION time, so at
+                // the commit that renamed old -> current this diff holds only the
+                // Added(current) half. find_similar had no Deleted(old) to pair it
+                // with, delta.status() was therefore never Renamed, renamed_from
+                // was never set, and the walk stopped dead at the rename — the one
+                // thing follow_renames exists to get past.
+                //
+                // Detect the modification from the cheap filtered diff, then pay
+                // for an UNFILTERED diff only where a rename could actually be
+                // hiding: the commit that introduces the path. That is once per
+                // rename, not once per commit.
+                let introduced_here = diff.deltas().any(|d| {
+                    d.status() == git2::Delta::Added || d.status() == git2::Delta::Renamed
+                });
+                file_modified = diff.deltas().count() > 0;
 
-            // `if let Ok`, not an early `continue`: the filtered diff has
-            // already established the file was touched by this commit. Skipping
-            // the iteration on a failed diff dropped the commit from the
-            // history entirely — losing a real entry to report a rename we
-            // could not look for. Without the unfiltered diff we simply do not
-            // detect a rename here, and the walk stops following the path,
-            // which is the old behaviour rather than a missing commit.
-            if introduced_here {
-                if let Ok(mut unfiltered) =
-                    repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), None)
-                {
-                    let mut find_opts = git2::DiffFindOptions::new();
-                    find_opts.renames(true);
-                    find_opts.copies(false);
-                    let _ = unfiltered.find_similar(Some(&mut find_opts));
+                // `if let Ok`, not an early `continue`: the filtered diff has
+                // already established the file was touched by this commit. Skipping
+                // the iteration on a failed diff dropped the commit from the
+                // history entirely — losing a real entry to report a rename we
+                // could not look for. Without the unfiltered diff we simply do not
+                // detect a rename here, and the walk stops following the path,
+                // which is the old behaviour rather than a missing commit.
+                if introduced_here {
+                    if let Ok(mut unfiltered) =
+                        repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&tree), None)
+                    {
+                        let mut find_opts = git2::DiffFindOptions::new();
+                        find_opts.renames(true);
+                        find_opts.copies(false);
+                        let _ = unfiltered.find_similar(Some(&mut find_opts));
 
-                    for delta in unfiltered.deltas() {
-                        if delta.status() != git2::Delta::Renamed {
-                            continue;
-                        }
-                        let is_ours = delta
-                            .new_file()
-                            .path()
-                            .is_some_and(|p| p.to_string_lossy() == current_path);
-                        if is_ours {
-                            file_modified = true;
-                            if let Some(old_file) = delta.old_file().path() {
-                                renamed_from = Some(old_file.to_string_lossy().to_string());
+                        for delta in unfiltered.deltas() {
+                            if delta.status() != git2::Delta::Renamed {
+                                continue;
                             }
-                            break;
+                            let is_ours = delta
+                                .new_file()
+                                .path()
+                                .is_some_and(|p| p.to_string_lossy() == current_path);
+                            if is_ours {
+                                file_modified = true;
+                                if let Some(old_file) = delta.old_file().path() {
+                                    renamed_from = Some(old_file.to_string_lossy().to_string());
+                                }
+                                break;
+                            }
                         }
                     }
                 }
+            } else {
+                file_modified = diff.deltas().count() > 0;
             }
-        } else {
-            file_modified = diff.deltas().count() > 0;
+
+            if file_modified {
+                // Recorded BEFORE the rename is followed: at the renaming commit
+                // the file already exists in that commit's tree under the NEW
+                // name, so the new name is the right path there. Only commits
+                // older than the rename get the old name. This is also the
+                // historical path a caller restoring the file to this commit must
+                // use — the file's CURRENT name is not in that commit's tree at
+                // all before the rename.
+                entries.push(FileHistoryEntry {
+                    commit: Commit::from_git2(&commit),
+                    path_at_commit: current_path.clone(),
+                });
+
+                // Follow the rename backwards
+                if let Some(old_path) = renamed_from {
+                    current_path = old_path;
+                }
+            }
         }
 
-        if file_modified {
-            // Recorded BEFORE the rename is followed: at the renaming commit
-            // the file already exists in that commit's tree under the NEW
-            // name, so the new name is the right path there. Only commits
-            // older than the rename get the old name. This is also the
-            // historical path a caller restoring the file to this commit must
-            // use — the file's CURRENT name is not in that commit's tree at
-            // all before the rename.
-            entries.push(FileHistoryEntry {
-                commit: Commit::from_git2(&commit),
-                path_at_commit: current_path.clone(),
-            });
-
-            // Follow the rename backwards
-            if let Some(old_path) = renamed_from {
-                current_path = old_path;
-            }
-        }
-    }
-
-    Ok(entries)
+        Ok(entries)
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/diff.rs
+++ b/src-tauri/src/commands/diff.rs
@@ -90,33 +90,36 @@ pub async fn get_diff(
     commit: Option<String>,
     compare_with: Option<String>,
 ) -> Result<Vec<DiffFile>> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let mut diff = if let Some(ref commit_oid) = commit {
-        // Diff between two commits or commit and parent
-        let commit = repo.find_commit(git2::Oid::from_str(commit_oid)?)?;
+        let mut diff = if let Some(ref commit_oid) = commit {
+            // Diff between two commits or commit and parent
+            let commit = repo.find_commit(git2::Oid::from_str(commit_oid)?)?;
 
-        if let Some(ref compare_oid) = compare_with {
-            let compare_commit = repo.find_commit(git2::Oid::from_str(compare_oid)?)?;
-            repo.diff_tree_to_tree(Some(&compare_commit.tree()?), Some(&commit.tree()?), None)?
+            if let Some(ref compare_oid) = compare_with {
+                let compare_commit = repo.find_commit(git2::Oid::from_str(compare_oid)?)?;
+                repo.diff_tree_to_tree(Some(&compare_commit.tree()?), Some(&commit.tree()?), None)?
+            } else {
+                let parent = commit.parent(0).ok();
+                let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
+                repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?
+            }
+        } else if staged.unwrap_or(false) {
+            // Staged changes (index vs HEAD, or the empty tree on an unborn HEAD)
+            let head_tree = head_tree_opt(&repo)?;
+            repo.diff_tree_to_index(head_tree.as_ref(), None, None)?
         } else {
-            let parent = commit.parent(0).ok();
-            let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
-            repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit.tree()?), None)?
-        }
-    } else if staged.unwrap_or(false) {
-        // Staged changes (index vs HEAD, or the empty tree on an unborn HEAD)
-        let head_tree = head_tree_opt(&repo)?;
-        repo.diff_tree_to_index(head_tree.as_ref(), None, None)?
-    } else {
-        // Unstaged changes (working directory vs index)
-        repo.diff_index_to_workdir(None, None)?
-    };
+            // Unstaged changes (working directory vs index)
+            repo.diff_index_to_workdir(None, None)?
+        };
 
-    // Detect renames/copies (git's default) so a move is one entry, not add+del.
-    detect_renames(&mut diff)?;
+        // Detect renames/copies (git's default) so a move is one entry, not add+del.
+        detect_renames(&mut diff)?;
 
-    parse_diff(&diff)
+        parse_diff(&diff)
+    })
+    .await
 }
 
 /// Get diff with advanced options (whitespace handling, context lines, algorithm)
@@ -141,68 +144,71 @@ pub async fn get_diff_with_options(
     histogram: Option<bool>,
     max_lines: Option<u32>,
 ) -> Result<Vec<DiffFile>> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let mut opts = git2::DiffOptions::new();
+        let mut opts = git2::DiffOptions::new();
 
-    // Apply file path filter if specified
-    if let Some(ref fp) = file_path {
-        let normalized = fp.replace('\\', "/");
-        opts.pathspec(&normalized);
-    }
-
-    // Apply whitespace, context, and algorithm options
-    apply_diff_options(
-        &mut opts,
-        &ignore_whitespace,
-        context_lines,
-        patience,
-        histogram,
-    );
-
-    // Include untracked files for working directory diffs
-    if commit.is_none() {
-        opts.include_untracked(true);
-        opts.recurse_untracked_dirs(true);
-        opts.show_untracked_content(true);
-    }
-
-    let mut diff = if let Some(ref commit_oid) = commit {
-        // Diff between two commits or commit and parent
-        let commit_obj = repo.find_commit(git2::Oid::from_str(commit_oid)?)?;
-
-        if let Some(ref compare_oid) = compare_with {
-            let compare_commit = repo.find_commit(git2::Oid::from_str(compare_oid)?)?;
-            repo.diff_tree_to_tree(
-                Some(&compare_commit.tree()?),
-                Some(&commit_obj.tree()?),
-                Some(&mut opts),
-            )?
-        } else {
-            let parent = commit_obj.parent(0).ok();
-            let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
-            repo.diff_tree_to_tree(
-                parent_tree.as_ref(),
-                Some(&commit_obj.tree()?),
-                Some(&mut opts),
-            )?
+        // Apply file path filter if specified
+        if let Some(ref fp) = file_path {
+            let normalized = fp.replace('\\', "/");
+            opts.pathspec(&normalized);
         }
-    } else if staged.unwrap_or(false) {
-        // Staged changes (index vs HEAD, or the empty tree on an unborn HEAD)
-        let head_tree = head_tree_opt(&repo)?;
-        repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut opts))?
-    } else {
-        // Unstaged changes (working directory vs index)
-        repo.diff_index_to_workdir(None, Some(&mut opts))?
-    };
 
-    detect_renames(&mut diff)?;
+        // Apply whitespace, context, and algorithm options
+        apply_diff_options(
+            &mut opts,
+            &ignore_whitespace,
+            context_lines,
+            patience,
+            histogram,
+        );
 
-    let files = parse_diff(&diff)?;
-    Ok(files
-        .into_iter()
-        .map(|f| maybe_truncate_diff(f, max_lines))
-        .collect())
+        // Include untracked files for working directory diffs
+        if commit.is_none() {
+            opts.include_untracked(true);
+            opts.recurse_untracked_dirs(true);
+            opts.show_untracked_content(true);
+        }
+
+        let mut diff = if let Some(ref commit_oid) = commit {
+            // Diff between two commits or commit and parent
+            let commit_obj = repo.find_commit(git2::Oid::from_str(commit_oid)?)?;
+
+            if let Some(ref compare_oid) = compare_with {
+                let compare_commit = repo.find_commit(git2::Oid::from_str(compare_oid)?)?;
+                repo.diff_tree_to_tree(
+                    Some(&compare_commit.tree()?),
+                    Some(&commit_obj.tree()?),
+                    Some(&mut opts),
+                )?
+            } else {
+                let parent = commit_obj.parent(0).ok();
+                let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
+                repo.diff_tree_to_tree(
+                    parent_tree.as_ref(),
+                    Some(&commit_obj.tree()?),
+                    Some(&mut opts),
+                )?
+            }
+        } else if staged.unwrap_or(false) {
+            // Staged changes (index vs HEAD, or the empty tree on an unborn HEAD)
+            let head_tree = head_tree_opt(&repo)?;
+            repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut opts))?
+        } else {
+            // Unstaged changes (working directory vs index)
+            repo.diff_index_to_workdir(None, Some(&mut opts))?
+        };
+
+        detect_renames(&mut diff)?;
+
+        let files = parse_diff(&diff)?;
+        Ok(files
+            .into_iter()
+            .map(|f| maybe_truncate_diff(f, max_lines))
+            .collect())
+    })
+    .await
 }
 
 /// Get diff for a specific file
@@ -213,141 +219,145 @@ pub async fn get_file_diff(
     staged: Option<bool>,
     max_lines: Option<u32>,
 ) -> Result<DiffFile> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    // Normalize path separators for git (always use forward slashes)
-    let normalized_file_path = file_path.replace('\\', "/");
+        // Normalize path separators for git (always use forward slashes)
+        let normalized_file_path = file_path.replace('\\', "/");
 
-    let mut opts = git2::DiffOptions::new();
-    opts.pathspec(&normalized_file_path);
-    // Include untracked files so we can show diff for new files
-    opts.include_untracked(true);
-    opts.recurse_untracked_dirs(true);
-    opts.show_untracked_content(true);
+        let mut opts = git2::DiffOptions::new();
+        opts.pathspec(&normalized_file_path);
+        // Include untracked files so we can show diff for new files
+        opts.include_untracked(true);
+        opts.recurse_untracked_dirs(true);
+        opts.show_untracked_content(true);
 
-    let is_staged = staged.unwrap_or(false);
+        let is_staged = staged.unwrap_or(false);
 
-    let mut diff = if is_staged {
-        // Staged changes: compare HEAD to index (empty tree on an unborn HEAD)
-        let head_tree = head_tree_opt(&repo)?;
-        repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut opts))?
-    } else {
-        // Unstaged changes: compare index to workdir
-        repo.diff_index_to_workdir(None, Some(&mut opts))?
-    };
+        let mut diff = if is_staged {
+            // Staged changes: compare HEAD to index (empty tree on an unborn HEAD)
+            let head_tree = head_tree_opt(&repo)?;
+            repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut opts))?
+        } else {
+            // Unstaged changes: compare index to workdir
+            repo.diff_index_to_workdir(None, Some(&mut opts))?
+        };
 
-    detect_renames(&mut diff)?;
+        detect_renames(&mut diff)?;
 
-    let files = parse_diff(&diff)?;
+        let files = parse_diff(&diff)?;
 
-    // If we found the file, return it
-    // pathspec should have filtered to just our file, but it may be empty
-    // if case-sensitivity caused a mismatch
-    if let Some(file) = files.into_iter().next() {
-        return Ok(maybe_truncate_diff(file, max_lines));
-    }
+        // If we found the file, return it
+        // pathspec should have filtered to just our file, but it may be empty
+        // if case-sensitivity caused a mismatch
+        if let Some(file) = files.into_iter().next() {
+            return Ok(maybe_truncate_diff(file, max_lines));
+        }
 
-    // Fallback: pathspec may have failed due to case sensitivity on Windows
-    // Try getting full diff and finding the file with case-insensitive match
-    let mut fallback_opts = git2::DiffOptions::new();
-    fallback_opts.include_untracked(true);
-    fallback_opts.recurse_untracked_dirs(true);
-    fallback_opts.show_untracked_content(true);
+        // Fallback: pathspec may have failed due to case sensitivity on Windows
+        // Try getting full diff and finding the file with case-insensitive match
+        let mut fallback_opts = git2::DiffOptions::new();
+        fallback_opts.include_untracked(true);
+        fallback_opts.recurse_untracked_dirs(true);
+        fallback_opts.show_untracked_content(true);
 
-    let mut fallback_diff = if is_staged {
-        let head_tree = head_tree_opt(&repo)?;
-        repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut fallback_opts))?
-    } else {
-        repo.diff_index_to_workdir(None, Some(&mut fallback_opts))?
-    };
+        let mut fallback_diff = if is_staged {
+            let head_tree = head_tree_opt(&repo)?;
+            repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut fallback_opts))?
+        } else {
+            repo.diff_index_to_workdir(None, Some(&mut fallback_opts))?
+        };
 
-    detect_renames(&mut fallback_diff)?;
+        detect_renames(&mut fallback_diff)?;
 
-    let all_files = parse_diff(&fallback_diff)?;
+        let all_files = parse_diff(&fallback_diff)?;
 
-    // Try exact match first
-    if let Some(file) = all_files.iter().find(|f| f.path == normalized_file_path) {
-        return Ok(maybe_truncate_diff(file.clone(), max_lines));
-    }
+        // Try exact match first
+        if let Some(file) = all_files.iter().find(|f| f.path == normalized_file_path) {
+            return Ok(maybe_truncate_diff(file.clone(), max_lines));
+        }
 
-    // Try case-insensitive match (handles case-sensitivity mismatches on
-    // Windows). We deliberately do NOT fall back to a filename-suffix match or
-    // to the opposite staging area: `git diff [--cached] -- <path>` is strict
-    // about the path and never substitutes a different file's diff. Doing so
-    // here previously returned an unrelated file (e.g. vendor/foo.c for a
-    // request of src/foo.c) or presented staged hunks as unstaged.
-    if let Some(file) = all_files
-        .iter()
-        .find(|f| f.path.eq_ignore_ascii_case(&normalized_file_path))
-    {
-        return Ok(maybe_truncate_diff(file.clone(), max_lines));
-    }
+        // Try case-insensitive match (handles case-sensitivity mismatches on
+        // Windows). We deliberately do NOT fall back to a filename-suffix match or
+        // to the opposite staging area: `git diff [--cached] -- <path>` is strict
+        // about the path and never substitutes a different file's diff. Doing so
+        // here previously returned an unrelated file (e.g. vendor/foo.c for a
+        // request of src/foo.c) or presented staged hunks as unstaged.
+        if let Some(file) = all_files
+            .iter()
+            .find(|f| f.path.eq_ignore_ascii_case(&normalized_file_path))
+        {
+            return Ok(maybe_truncate_diff(file.clone(), max_lines));
+        }
 
-    // Log available files for debugging
-    let available_paths: Vec<&str> = all_files.iter().map(|f| f.path.as_str()).collect();
-    tracing::warn!(
-        "File '{}' not found in diff. Staged: {}. Available files ({}):\n{}",
-        normalized_file_path,
-        is_staged,
-        available_paths.len(),
-        available_paths.join("\n")
-    );
+        // Log available files for debugging
+        let available_paths: Vec<&str> = all_files.iter().map(|f| f.path.as_str()).collect();
+        tracing::warn!(
+            "File '{}' not found in diff. Staged: {}. Available files ({}):\n{}",
+            normalized_file_path,
+            is_staged,
+            available_paths.len(),
+            available_paths.join("\n")
+        );
 
-    // File not found in diff - it might be untracked or have no changes
-    // Try to read the file and generate a synthetic diff for new/untracked files
-    let full_path = validate_path_within_repo(Path::new(&path), &normalized_file_path)?;
-    if full_path.exists() {
-        // Check if file is untracked
-        let statuses = repo.statuses(Some(
-            git2::StatusOptions::new()
-                .pathspec(&normalized_file_path)
-                .include_untracked(true)
-                .recurse_untracked_dirs(true),
-        ))?;
+        // File not found in diff - it might be untracked or have no changes
+        // Try to read the file and generate a synthetic diff for new/untracked files
+        let full_path = validate_path_within_repo(Path::new(&path), &normalized_file_path)?;
+        if full_path.exists() {
+            // Check if file is untracked
+            let statuses = repo.statuses(Some(
+                git2::StatusOptions::new()
+                    .pathspec(&normalized_file_path)
+                    .include_untracked(true)
+                    .recurse_untracked_dirs(true),
+            ))?;
 
-        for entry in statuses.iter() {
-            if let Ok(entry_path) = entry.path() {
-                let normalized_entry_path = entry_path.replace('\\', "/");
-                // Case-insensitive comparison on Windows
-                #[cfg(target_os = "windows")]
-                let paths_match = normalized_entry_path.eq_ignore_ascii_case(&normalized_file_path);
-                #[cfg(not(target_os = "windows"))]
-                let paths_match = normalized_entry_path == normalized_file_path;
+            for entry in statuses.iter() {
+                if let Ok(entry_path) = entry.path() {
+                    let normalized_entry_path = entry_path.replace('\\', "/");
+                    // Case-insensitive comparison on Windows
+                    #[cfg(target_os = "windows")]
+                    let paths_match =
+                        normalized_entry_path.eq_ignore_ascii_case(&normalized_file_path);
+                    #[cfg(not(target_os = "windows"))]
+                    let paths_match = normalized_entry_path == normalized_file_path;
 
-                if paths_match {
-                    let status = entry.status();
-                    if status.is_wt_new() || status.is_index_new() {
-                        // It's a new/untracked file - generate diff from file content
-                        return generate_new_file_diff(&full_path, &normalized_file_path)
-                            .map(|f| maybe_truncate_diff(f, max_lines));
+                    if paths_match {
+                        let status = entry.status();
+                        if status.is_wt_new() || status.is_index_new() {
+                            // It's a new/untracked file - generate diff from file content
+                            return generate_new_file_diff(&full_path, &normalized_file_path)
+                                .map(|f| maybe_truncate_diff(f, max_lines));
+                        }
                     }
                 }
             }
         }
-    }
 
-    // If we get here, the file might have changes that git considers empty
-    // (e.g., only whitespace/line-ending changes being ignored)
-    // Include debug info in error message for troubleshooting
-    let sample_paths: String = available_paths
-        .iter()
-        .take(10)
-        .cloned()
-        .collect::<Vec<_>>()
-        .join(", ");
-    let suffix = if available_paths.len() > 10 {
-        format!("... and {} more", available_paths.len() - 10)
-    } else {
-        String::new()
-    };
-    Err(crate::error::LeviathanError::OperationFailed(format!(
-        "File '{}' not found in diff. Staged: {}. Found {} files: [{}{}]",
-        normalized_file_path,
-        is_staged,
-        available_paths.len(),
-        sample_paths,
-        suffix
-    )))
+        // If we get here, the file might have changes that git considers empty
+        // (e.g., only whitespace/line-ending changes being ignored)
+        // Include debug info in error message for troubleshooting
+        let sample_paths: String = available_paths
+            .iter()
+            .take(10)
+            .cloned()
+            .collect::<Vec<_>>()
+            .join(", ");
+        let suffix = if available_paths.len() > 10 {
+            format!("... and {} more", available_paths.len() - 10)
+        } else {
+            String::new()
+        };
+        Err(crate::error::LeviathanError::OperationFailed(format!(
+            "File '{}' not found in diff. Staged: {}. Found {} files: [{}{}]",
+            normalized_file_path,
+            is_staged,
+            available_paths.len(),
+            sample_paths,
+            suffix
+        )))
+    })
+    .await
 }
 
 /// Generate a diff for a new/untracked file (entire content as additions)
@@ -549,71 +559,74 @@ pub struct CommitFileEntry {
 /// Get list of files changed in a commit
 #[command]
 pub async fn get_commit_files(path: String, commit_oid: String) -> Result<Vec<CommitFileEntry>> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let commit = repo.find_commit(git2::Oid::from_str(&commit_oid)?)?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let commit = repo.find_commit(git2::Oid::from_str(&commit_oid)?)?;
 
-    let parent = commit.parent(0).ok();
-    let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
-    let commit_tree = commit.tree()?;
+        let parent = commit.parent(0).ok();
+        let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
+        let commit_tree = commit.tree()?;
 
-    let mut diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)?;
+        let mut diff = repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)?;
 
-    // Detect renames/copies (git's default) so a moved file is a single
-    // "renamed" entry instead of a delete + add pair.
-    detect_renames(&mut diff)?;
+        // Detect renames/copies (git's default) so a moved file is a single
+        // "renamed" entry instead of a delete + add pair.
+        detect_renames(&mut diff)?;
 
-    // First pass: collect file info
-    let mut files: Vec<CommitFileEntry> = Vec::new();
-    for delta in diff.deltas() {
-        let file_path = delta
-            .new_file()
-            .path()
-            .or_else(|| delta.old_file().path())
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_default();
-
-        let status = match delta.status() {
-            git2::Delta::Added => FileStatus::New,
-            git2::Delta::Deleted => FileStatus::Deleted,
-            git2::Delta::Modified => FileStatus::Modified,
-            git2::Delta::Renamed => FileStatus::Renamed,
-            git2::Delta::Copied => FileStatus::Copied,
-            git2::Delta::Typechange => FileStatus::Typechange,
-            _ => FileStatus::Modified,
-        };
-
-        // Surface the previous path for renames/copies so the UI can show it.
-        let old_path = match delta.status() {
-            git2::Delta::Renamed | git2::Delta::Copied => delta
-                .old_file()
+        // First pass: collect file info
+        let mut files: Vec<CommitFileEntry> = Vec::new();
+        for delta in diff.deltas() {
+            let file_path = delta
+                .new_file()
                 .path()
-                .map(|p| p.to_string_lossy().to_string()),
-            _ => None,
-        };
+                .or_else(|| delta.old_file().path())
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_default();
 
-        files.push(CommitFileEntry {
-            path: file_path,
-            old_path,
-            status,
-            additions: 0,
-            deletions: 0,
-        });
-    }
+            let status = match delta.status() {
+                git2::Delta::Added => FileStatus::New,
+                git2::Delta::Deleted => FileStatus::Deleted,
+                git2::Delta::Modified => FileStatus::Modified,
+                git2::Delta::Renamed => FileStatus::Renamed,
+                git2::Delta::Copied => FileStatus::Copied,
+                git2::Delta::Typechange => FileStatus::Typechange,
+                _ => FileStatus::Modified,
+            };
 
-    // Second pass: count additions/deletions
-    let stats = diff.stats()?;
-    for i in 0..stats.files_changed() {
-        if i < files.len() {
-            // Get stats for this file from the diff
-            if let Some(patch) = git2::Patch::from_diff(&diff, i).ok().flatten() {
-                let (_, additions, deletions) = patch.line_stats()?;
-                files[i].additions = additions;
-                files[i].deletions = deletions;
+            // Surface the previous path for renames/copies so the UI can show it.
+            let old_path = match delta.status() {
+                git2::Delta::Renamed | git2::Delta::Copied => delta
+                    .old_file()
+                    .path()
+                    .map(|p| p.to_string_lossy().to_string()),
+                _ => None,
+            };
+
+            files.push(CommitFileEntry {
+                path: file_path,
+                old_path,
+                status,
+                additions: 0,
+                deletions: 0,
+            });
+        }
+
+        // Second pass: count additions/deletions
+        let stats = diff.stats()?;
+        for i in 0..stats.files_changed() {
+            if i < files.len() {
+                // Get stats for this file from the diff
+                if let Some(patch) = git2::Patch::from_diff(&diff, i).ok().flatten() {
+                    let (_, additions, deletions) = patch.line_stats()?;
+                    files[i].additions = additions;
+                    files[i].deletions = deletions;
+                }
             }
         }
-    }
 
-    Ok(files)
+        Ok(files)
+    })
+    .await
 }
 
 /// Stats for a single commit
@@ -630,100 +643,103 @@ pub struct CommitStats {
 /// This is optimized for the graph view to show commit sizes
 #[command]
 pub async fn get_commits_stats(path: String, commit_oids: Vec<String>) -> Result<Vec<CommitStats>> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let mut results = Vec::with_capacity(commit_oids.len());
-    let mut skipped_oid_parse = 0;
-    let mut skipped_commit_find = 0;
-    let mut skipped_tree = 0;
-    let mut skipped_diff = 0;
-    let mut skipped_stats = 0;
-    let mut zero_stats = 0;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let mut results = Vec::with_capacity(commit_oids.len());
+        let mut skipped_oid_parse = 0;
+        let mut skipped_commit_find = 0;
+        let mut skipped_tree = 0;
+        let mut skipped_diff = 0;
+        let mut skipped_stats = 0;
+        let mut zero_stats = 0;
 
-    for oid_str in &commit_oids {
-        let oid = match git2::Oid::from_str(oid_str) {
-            Ok(o) => o,
-            Err(_) => {
-                skipped_oid_parse += 1;
-                continue;
-            }
-        };
+        for oid_str in &commit_oids {
+            let oid = match git2::Oid::from_str(oid_str) {
+                Ok(o) => o,
+                Err(_) => {
+                    skipped_oid_parse += 1;
+                    continue;
+                }
+            };
 
-        let commit = match repo.find_commit(oid) {
-            Ok(c) => c,
-            Err(_) => {
-                skipped_commit_find += 1;
-                continue;
-            }
-        };
+            let commit = match repo.find_commit(oid) {
+                Ok(c) => c,
+                Err(_) => {
+                    skipped_commit_find += 1;
+                    continue;
+                }
+            };
 
-        let parent = commit.parent(0).ok();
-        let parent_tree = parent.as_ref().and_then(|p| p.tree().ok());
-        let commit_tree = match commit.tree() {
-            Ok(t) => t,
-            Err(_) => {
-                skipped_tree += 1;
-                continue;
-            }
-        };
+            let parent = commit.parent(0).ok();
+            let parent_tree = parent.as_ref().and_then(|p| p.tree().ok());
+            let commit_tree = match commit.tree() {
+                Ok(t) => t,
+                Err(_) => {
+                    skipped_tree += 1;
+                    continue;
+                }
+            };
 
-        let mut diff = match repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)
-        {
-            Ok(d) => d,
-            Err(_) => {
+            let mut diff = match repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)
+            {
+                Ok(d) => d,
+                Err(_) => {
+                    skipped_diff += 1;
+                    continue;
+                }
+            };
+
+            // Detect renames so a pure rename reports 0/0 like git, rather than
+            // over-counting the full file as +N/-N (delete + add).
+            if detect_renames(&mut diff).is_err() {
                 skipped_diff += 1;
                 continue;
             }
-        };
 
-        // Detect renames so a pure rename reports 0/0 like git, rather than
-        // over-counting the full file as +N/-N (delete + add).
-        if detect_renames(&mut diff).is_err() {
-            skipped_diff += 1;
-            continue;
-        }
+            let (additions, deletions, files_changed) = match diff.stats() {
+                Ok(s) => (s.insertions(), s.deletions(), s.files_changed()),
+                Err(e) => {
+                    // Stats can fail for binary-only diffs or very large diffs
+                    // Return 0/0/0 instead of skipping to avoid missing commits
+                    tracing::debug!("get_commits_stats: stats failed for {}: {}", oid_str, e);
+                    skipped_stats += 1;
+                    (0, 0, 0)
+                }
+            };
 
-        let (additions, deletions, files_changed) = match diff.stats() {
-            Ok(s) => (s.insertions(), s.deletions(), s.files_changed()),
-            Err(e) => {
-                // Stats can fail for binary-only diffs or very large diffs
-                // Return 0/0/0 instead of skipping to avoid missing commits
-                tracing::debug!("get_commits_stats: stats failed for {}: {}", oid_str, e);
-                skipped_stats += 1;
-                (0, 0, 0)
+            // Track commits with zero stats (may be merge commits or empty commits)
+            if additions == 0 && deletions == 0 && files_changed == 0 {
+                zero_stats += 1;
             }
-        };
 
-        // Track commits with zero stats (may be merge commits or empty commits)
-        if additions == 0 && deletions == 0 && files_changed == 0 {
-            zero_stats += 1;
+            results.push(CommitStats {
+                oid: oid_str.clone(),
+                additions,
+                deletions,
+                files_changed,
+            });
         }
 
-        results.push(CommitStats {
-            oid: oid_str.clone(),
-            additions,
-            deletions,
-            files_changed,
-        });
-    }
+        let total_skipped =
+            skipped_oid_parse + skipped_commit_find + skipped_tree + skipped_diff + skipped_stats;
+        if total_skipped > 0 || zero_stats > 0 {
+            tracing::warn!(
+                "get_commits_stats: processed {}/{} commits for {}. Skipped: oid_parse={}, commit_find={}, tree={}, diff={}, stats={}. Zero stats: {}",
+                results.len(),
+                commit_oids.len(),
+                path,
+                skipped_oid_parse,
+                skipped_commit_find,
+                skipped_tree,
+                skipped_diff,
+                skipped_stats,
+                zero_stats
+            );
+        }
 
-    let total_skipped =
-        skipped_oid_parse + skipped_commit_find + skipped_tree + skipped_diff + skipped_stats;
-    if total_skipped > 0 || zero_stats > 0 {
-        tracing::warn!(
-            "get_commits_stats: processed {}/{} commits for {}. Skipped: oid_parse={}, commit_find={}, tree={}, diff={}, stats={}. Zero stats: {}",
-            results.len(),
-            commit_oids.len(),
-            path,
-            skipped_oid_parse,
-            skipped_commit_find,
-            skipped_tree,
-            skipped_diff,
-            skipped_stats,
-            zero_stats
-        );
-    }
-
-    Ok(results)
+        Ok(results)
+    })
+    .await
 }
 
 /// Get diff for a specific file in a commit
@@ -734,117 +750,124 @@ pub async fn get_commit_file_diff(
     file_path: String,
     max_lines: Option<u32>,
 ) -> Result<DiffFile> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let commit = repo.find_commit(git2::Oid::from_str(&commit_oid)?)?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let commit = repo.find_commit(git2::Oid::from_str(&commit_oid)?)?;
 
-    let parent = commit.parent(0).ok();
-    let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
-    let commit_tree = commit.tree()?;
+        let parent = commit.parent(0).ok();
+        let parent_tree = parent.as_ref().map(|p| p.tree()).transpose()?;
+        let commit_tree = commit.tree()?;
 
-    // Normalize path separators for git (always use forward slashes)
-    let normalized_file_path = file_path.replace('\\', "/");
+        // Normalize path separators for git (always use forward slashes)
+        let normalized_file_path = file_path.replace('\\', "/");
 
-    let mut opts = git2::DiffOptions::new();
-    opts.pathspec(&normalized_file_path);
+        let mut opts = git2::DiffOptions::new();
+        opts.pathspec(&normalized_file_path);
 
-    let mut diff =
-        repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), Some(&mut opts))?;
+        let mut diff =
+            repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), Some(&mut opts))?;
 
-    detect_renames(&mut diff)?;
+        detect_renames(&mut diff)?;
 
-    let filtered = parse_diff(&diff)?.into_iter().next();
+        let filtered = parse_diff(&diff)?.into_iter().next();
 
-    // The two halves of a rename live at different paths, so the pathspec above
-    // keeps only one of them and `find_similar` has nothing left to pair it
-    // with: the file comes back as a whole-file add (or delete). Re-diff the
-    // whole tree, where both halves are present, and pick our file out of the
-    // rename-aware result — the same view the file list gets from
-    // `get_commit_files`. Only those two statuses can be half of a rename, so
-    // every other file still costs a single path-filtered diff.
-    //
-    // A root commit has no parent tree, so its diff holds nothing but `Added`
-    // deltas; a rename needs a deleted side, and `detect_renames` does not
-    // enable copy detection, so no `Renamed`/`Copied` delta can exist. Skip the
-    // whole fallback there rather than re-diffing the largest tree in the repo
-    // only to hand back what `filtered` already holds.
-    if parent_tree.is_some()
-        && filtered
-            .as_ref()
-            .is_some_and(|f| matches!(f.status, FileStatus::New | FileStatus::Deleted))
-    {
-        let mut full_diff =
-            repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)?;
-        detect_renames(&mut full_diff)?;
-
-        // Decide from delta metadata alone. `deltas()` walks the delta list
-        // without generating a patch, whereas `parse_diff` prints every hunk of
-        // every file in the commit — so resolving one path used to cost a full
-        // render of the whole commit, which `max_lines` (applied only after the
-        // parse) could not bound.
+        // The two halves of a rename live at different paths, so the pathspec above
+        // keeps only one of them and `find_similar` has nothing left to pair it
+        // with: the file comes back as a whole-file add (or delete). Re-diff the
+        // whole tree, where both halves are present, and pick our file out of the
+        // rename-aware result — the same view the file list gets from
+        // `get_commit_files`. Only those two statuses can be half of a rename, so
+        // every other file still costs a single path-filtered diff.
         //
-        // libgit2 reports the new path in `old_file()` for a plain addition, so
-        // the old-path match must stay gated on Renamed/Copied or unrelated
-        // added files would match it. Prefer a delta owning this path as its
-        // new path: only when that delta is itself a rename/copy, or no such
-        // delta exists, does the old-path side apply.
-        let target = normalized_file_path.as_str();
-        let rename_paths = full_diff
-            .deltas()
-            .find(|delta| {
-                delta
-                    .new_file()
-                    .path()
-                    .map(|p| p.to_string_lossy())
-                    .as_deref()
-                    == Some(target)
-            })
-            .filter(|delta| matches!(delta.status(), git2::Delta::Renamed | git2::Delta::Copied))
-            .or_else(|| {
-                full_diff.deltas().find(|delta| {
-                    matches!(delta.status(), git2::Delta::Renamed | git2::Delta::Copied)
-                        && delta
-                            .old_file()
-                            .path()
-                            .map(|p| p.to_string_lossy())
-                            .as_deref()
-                            == Some(target)
+        // A root commit has no parent tree, so its diff holds nothing but `Added`
+        // deltas; a rename needs a deleted side, and `detect_renames` does not
+        // enable copy detection, so no `Renamed`/`Copied` delta can exist. Skip the
+        // whole fallback there rather than re-diffing the largest tree in the repo
+        // only to hand back what `filtered` already holds.
+        if parent_tree.is_some()
+            && filtered
+                .as_ref()
+                .is_some_and(|f| matches!(f.status, FileStatus::New | FileStatus::Deleted))
+        {
+            let mut full_diff =
+                repo.diff_tree_to_tree(parent_tree.as_ref(), Some(&commit_tree), None)?;
+            detect_renames(&mut full_diff)?;
+
+            // Decide from delta metadata alone. `deltas()` walks the delta list
+            // without generating a patch, whereas `parse_diff` prints every hunk of
+            // every file in the commit — so resolving one path used to cost a full
+            // render of the whole commit, which `max_lines` (applied only after the
+            // parse) could not bound.
+            //
+            // libgit2 reports the new path in `old_file()` for a plain addition, so
+            // the old-path match must stay gated on Renamed/Copied or unrelated
+            // added files would match it. Prefer a delta owning this path as its
+            // new path: only when that delta is itself a rename/copy, or no such
+            // delta exists, does the old-path side apply.
+            let target = normalized_file_path.as_str();
+            let rename_paths = full_diff
+                .deltas()
+                .find(|delta| {
+                    delta
+                        .new_file()
+                        .path()
+                        .map(|p| p.to_string_lossy())
+                        .as_deref()
+                        == Some(target)
                 })
-            })
-            .and_then(|delta| {
-                let old_path = delta.old_file().path()?.to_string_lossy().into_owned();
-                let new_path = delta.new_file().path()?.to_string_lossy().into_owned();
-                Some((old_path, new_path))
-            });
+                .filter(|delta| {
+                    matches!(delta.status(), git2::Delta::Renamed | git2::Delta::Copied)
+                })
+                .or_else(|| {
+                    full_diff.deltas().find(|delta| {
+                        matches!(delta.status(), git2::Delta::Renamed | git2::Delta::Copied)
+                            && delta
+                                .old_file()
+                                .path()
+                                .map(|p| p.to_string_lossy())
+                                .as_deref()
+                                == Some(target)
+                    })
+                })
+                .and_then(|delta| {
+                    let old_path = delta.old_file().path()?.to_string_lossy().into_owned();
+                    let new_path = delta.new_file().path()?.to_string_lossy().into_owned();
+                    Some((old_path, new_path))
+                });
 
-        // Both halves of the pair are in this diff, so `find_similar` can still
-        // match them, but the patch we render is bounded to the one file.
-        if let Some((old_path, new_path)) = rename_paths {
-            let mut pair_opts = git2::DiffOptions::new();
-            pair_opts.pathspec(&old_path);
-            pair_opts.pathspec(&new_path);
-            let mut pair_diff = repo.diff_tree_to_tree(
-                parent_tree.as_ref(),
-                Some(&commit_tree),
-                Some(&mut pair_opts),
-            )?;
-            detect_renames(&mut pair_diff)?;
+            // Both halves of the pair are in this diff, so `find_similar` can still
+            // match them, but the patch we render is bounded to the one file.
+            if let Some((old_path, new_path)) = rename_paths {
+                let mut pair_opts = git2::DiffOptions::new();
+                pair_opts.pathspec(&old_path);
+                pair_opts.pathspec(&new_path);
+                let mut pair_diff = repo.diff_tree_to_tree(
+                    parent_tree.as_ref(),
+                    Some(&commit_tree),
+                    Some(&mut pair_opts),
+                )?;
+                detect_renames(&mut pair_diff)?;
 
-            let matched = parse_diff(&pair_diff)?.into_iter().find(|f| {
-                f.path == normalized_file_path
-                    || (matches!(f.status, FileStatus::Renamed | FileStatus::Copied)
-                        && f.old_path.as_deref() == Some(target))
-            });
-            if let Some(found) = matched {
-                return Ok(maybe_truncate_diff(found, max_lines));
+                let matched = parse_diff(&pair_diff)?.into_iter().find(|f| {
+                    f.path == normalized_file_path
+                        || (matches!(f.status, FileStatus::Renamed | FileStatus::Copied)
+                            && f.old_path.as_deref() == Some(target))
+                });
+                if let Some(found) = matched {
+                    return Ok(maybe_truncate_diff(found, max_lines));
+                }
             }
         }
-    }
 
-    filtered
-        .map(|f| maybe_truncate_diff(f, max_lines))
-        .ok_or_else(|| {
-            crate::error::LeviathanError::OperationFailed("File not found in commit".to_string())
-        })
+        filtered
+            .map(|f| maybe_truncate_diff(f, max_lines))
+            .ok_or_else(|| {
+                crate::error::LeviathanError::OperationFailed(
+                    "File not found in commit".to_string(),
+                )
+            })
+    })
+    .await
 }
 
 /// A single line of blame output
@@ -887,127 +910,130 @@ pub async fn get_file_blame(
     start_line: Option<u32>,
     end_line: Option<u32>,
 ) -> Result<BlameResult> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let mut blame_opts = git2::BlameOptions::new();
+        let mut blame_opts = git2::BlameOptions::new();
 
-    // If a specific commit is provided, blame up to that commit
-    if let Some(ref oid_str) = commit_oid {
-        let oid = git2::Oid::from_str(oid_str)?;
-        blame_opts.newest_commit(oid);
-    }
+        // If a specific commit is provided, blame up to that commit
+        if let Some(ref oid_str) = commit_oid {
+            let oid = git2::Oid::from_str(oid_str)?;
+            blame_opts.newest_commit(oid);
+        }
 
-    // Apply line range if provided (git2 uses 1-indexed lines)
-    if let Some(start) = start_line {
-        blame_opts.min_line(start as usize);
-    }
-    if let Some(end) = end_line {
-        blame_opts.max_line(end as usize);
-    }
+        // Apply line range if provided (git2 uses 1-indexed lines)
+        if let Some(start) = start_line {
+            blame_opts.min_line(start as usize);
+        }
+        if let Some(end) = end_line {
+            blame_opts.max_line(end as usize);
+        }
 
-    let blame = repo.blame_file(Path::new(&file_path), Some(&mut blame_opts))?;
+        let blame = repo.blame_file(Path::new(&file_path), Some(&mut blame_opts))?;
 
-    // Read the file content
-    let file_content = if let Some(ref oid_str) = commit_oid {
-        // Read from specific commit
-        let commit = repo.find_commit(git2::Oid::from_str(oid_str)?)?;
-        let tree = commit.tree()?;
-        let entry = tree.get_path(Path::new(&file_path))?;
-        let blob = repo.find_blob(entry.id())?;
-        String::from_utf8_lossy(blob.content()).to_string()
-    } else {
-        // Read from working directory
-        let full_path = validate_path_within_repo(Path::new(&path), &file_path)?;
-        std::fs::read_to_string(full_path).unwrap_or_default()
-    };
+        // Read the file content
+        let file_content = if let Some(ref oid_str) = commit_oid {
+            // Read from specific commit
+            let commit = repo.find_commit(git2::Oid::from_str(oid_str)?)?;
+            let tree = commit.tree()?;
+            let entry = tree.get_path(Path::new(&file_path))?;
+            let blob = repo.find_blob(entry.id())?;
+            String::from_utf8_lossy(blob.content()).to_string()
+        } else {
+            // Read from working directory
+            let full_path = validate_path_within_repo(Path::new(&path), &file_path)?;
+            std::fs::read_to_string(full_path).unwrap_or_default()
+        };
 
-    // For a working-tree blame (no explicit commit), libgit2 blamed the file
-    // as of HEAD, which misaligns with a modified working copy. Reconcile the
-    // committed blame with the actual working-tree buffer so inserted/deleted
-    // lines stay aligned and uncommitted lines are attributed to the zero OID
-    // (git's "Not Committed Yet"). libgit2 has no direct working-tree blame.
-    let buffer_blame = if commit_oid.is_none() {
-        Some(blame.blame_buffer(file_content.as_bytes())?)
-    } else {
-        None
-    };
-    let active_blame = buffer_blame.as_ref().unwrap_or(&blame);
+        // For a working-tree blame (no explicit commit), libgit2 blamed the file
+        // as of HEAD, which misaligns with a modified working copy. Reconcile the
+        // committed blame with the actual working-tree buffer so inserted/deleted
+        // lines stay aligned and uncommitted lines are attributed to the zero OID
+        // (git's "Not Committed Yet"). libgit2 has no direct working-tree blame.
+        let buffer_blame = if commit_oid.is_none() {
+            Some(blame.blame_buffer(file_content.as_bytes())?)
+        } else {
+            None
+        };
+        let active_blame = buffer_blame.as_ref().unwrap_or(&blame);
 
-    let content_lines: Vec<&str> = file_content.lines().collect();
-    let total_lines = content_lines.len() as u32;
+        let content_lines: Vec<&str> = file_content.lines().collect();
+        let total_lines = content_lines.len() as u32;
 
-    // Determine the line range to process
-    let start_idx = start_line
-        .map(|l| (l as usize).saturating_sub(1))
-        .unwrap_or(0);
-    let end_idx = end_line
-        .map(|l| (l as usize).min(content_lines.len()))
-        .unwrap_or(content_lines.len());
+        // Determine the line range to process
+        let start_idx = start_line
+            .map(|l| (l as usize).saturating_sub(1))
+            .unwrap_or(0);
+        let end_idx = end_line
+            .map(|l| (l as usize).min(content_lines.len()))
+            .unwrap_or(content_lines.len());
 
-    let mut lines = Vec::new();
+        let mut lines = Vec::new();
 
-    for (i, line_content) in content_lines
-        .iter()
-        .enumerate()
-        .skip(start_idx)
-        .take(end_idx - start_idx)
-    {
-        let line_num = i + 1;
+        for (i, line_content) in content_lines
+            .iter()
+            .enumerate()
+            .skip(start_idx)
+            .take(end_idx - start_idx)
+        {
+            let line_num = i + 1;
 
-        if let Some(hunk) = active_blame.get_line(line_num) {
-            let commit_id = hunk.final_commit_id();
-            let short_id = commit_id.to_string()[..7].to_string();
+            if let Some(hunk) = active_blame.get_line(line_num) {
+                let commit_id = hunk.final_commit_id();
+                let short_id = commit_id.to_string()[..7].to_string();
 
-            // A zero OID means the line differs from HEAD, i.e. it is not yet
-            // committed (git shows "Not Committed Yet").
-            if commit_id.is_zero() {
+                // A zero OID means the line differs from HEAD, i.e. it is not yet
+                // committed (git shows "Not Committed Yet").
+                if commit_id.is_zero() {
+                    lines.push(BlameLine {
+                        line_number: line_num,
+                        content: line_content.to_string(),
+                        commit_oid: commit_id.to_string(),
+                        commit_short_id: short_id,
+                        author_name: "Not Committed Yet".to_string(),
+                        author_email: String::new(),
+                        timestamp: 0,
+                        summary: String::new(),
+                        is_boundary: hunk.is_boundary(),
+                    });
+                    continue;
+                }
+
+                // Get commit details
+                let (author_name, author_email, timestamp, summary) =
+                    if let Ok(commit) = repo.find_commit(commit_id) {
+                        let author = commit.author();
+                        (
+                            author.name().unwrap_or("Unknown").to_string(),
+                            author.email().unwrap_or("").to_string(),
+                            author.when().seconds(),
+                            commit.summary().ok().flatten().unwrap_or("").to_string(),
+                        )
+                    } else {
+                        ("Unknown".to_string(), "".to_string(), 0, "".to_string())
+                    };
+
                 lines.push(BlameLine {
                     line_number: line_num,
                     content: line_content.to_string(),
                     commit_oid: commit_id.to_string(),
                     commit_short_id: short_id,
-                    author_name: "Not Committed Yet".to_string(),
-                    author_email: String::new(),
-                    timestamp: 0,
-                    summary: String::new(),
+                    author_name,
+                    author_email,
+                    timestamp,
+                    summary,
                     is_boundary: hunk.is_boundary(),
                 });
-                continue;
             }
-
-            // Get commit details
-            let (author_name, author_email, timestamp, summary) =
-                if let Ok(commit) = repo.find_commit(commit_id) {
-                    let author = commit.author();
-                    (
-                        author.name().unwrap_or("Unknown").to_string(),
-                        author.email().unwrap_or("").to_string(),
-                        author.when().seconds(),
-                        commit.summary().ok().flatten().unwrap_or("").to_string(),
-                    )
-                } else {
-                    ("Unknown".to_string(), "".to_string(), 0, "".to_string())
-                };
-
-            lines.push(BlameLine {
-                line_number: line_num,
-                content: line_content.to_string(),
-                commit_oid: commit_id.to_string(),
-                commit_short_id: short_id,
-                author_name,
-                author_email,
-                timestamp,
-                summary,
-                is_boundary: hunk.is_boundary(),
-            });
         }
-    }
 
-    Ok(BlameResult {
-        path: file_path,
-        lines,
-        total_lines,
+        Ok(BlameResult {
+            path: file_path,
+            lines,
+            total_lines,
+        })
     })
+    .await
 }
 
 /// Image version data for comparison
@@ -1030,37 +1056,26 @@ pub async fn get_image_versions(
     staged: Option<bool>,
     commit_oid: Option<String>,
 ) -> Result<ImageVersions> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let is_staged = staged.unwrap_or(false);
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let is_staged = staged.unwrap_or(false);
 
-    let image_type = get_image_type(&file_path);
+        let image_type = get_image_type(&file_path);
 
-    // Get old version (from HEAD or parent commit)
-    let old_data = if let Some(ref oid_str) = commit_oid {
-        // For commit diff, get from parent
-        let commit = repo.find_commit(git2::Oid::from_str(oid_str)?)?;
-        if let Ok(parent) = commit.parent(0) {
-            get_blob_base64(&repo, &parent.tree()?, &file_path)
-        } else {
-            None
-        }
-    } else if is_staged {
-        // For staged changes, old is from HEAD
-        if let Ok(head) = repo.head() {
-            if let Ok(tree) = head.peel_to_tree() {
-                get_blob_base64(&repo, &tree, &file_path)
+        // Get old version (from HEAD or parent commit)
+        let old_data = if let Some(ref oid_str) = commit_oid {
+            // For commit diff, get from parent
+            let commit = repo.find_commit(git2::Oid::from_str(oid_str)?)?;
+            if let Ok(parent) = commit.parent(0) {
+                get_blob_base64(&repo, &parent.tree()?, &file_path)
             } else {
                 None
             }
-        } else {
-            None
-        }
-    } else {
-        // For unstaged changes, old is from index
-        if let Ok(index) = repo.index() {
-            if let Some(entry) = index.get_path(Path::new(&file_path), 0) {
-                if let Ok(blob) = repo.find_blob(entry.id) {
-                    Some(STANDARD.encode(blob.content()))
+        } else if is_staged {
+            // For staged changes, old is from HEAD
+            if let Ok(head) = repo.head() {
+                if let Ok(tree) = head.peel_to_tree() {
+                    get_blob_base64(&repo, &tree, &file_path)
                 } else {
                     None
                 }
@@ -1068,49 +1083,63 @@ pub async fn get_image_versions(
                 None
             }
         } else {
-            None
-        }
-    };
+            // For unstaged changes, old is from index
+            if let Ok(index) = repo.index() {
+                if let Some(entry) = index.get_path(Path::new(&file_path), 0) {
+                    if let Ok(blob) = repo.find_blob(entry.id) {
+                        Some(STANDARD.encode(blob.content()))
+                    } else {
+                        None
+                    }
+                } else {
+                    None
+                }
+            } else {
+                None
+            }
+        };
 
-    // Get new version
-    let new_data = if let Some(ref oid_str) = commit_oid {
-        // For commit diff, get from commit tree
-        let commit = repo.find_commit(git2::Oid::from_str(oid_str)?)?;
-        get_blob_base64(&repo, &commit.tree()?, &file_path)
-    } else if is_staged {
-        // The staged diff is HEAD vs INDEX, so "after" is the index blob — not
-        // the file on disk.
-        //
-        // Reading from disk meant that staging an image and then editing it
-        // again showed the newer worktree pixels as the staged content: the user
-        // commits believing the image on screen is what will be committed, and
-        // it is not. The text path (diff_tree_to_index) reads the index, so the
-        // image view also contradicted the text view for the same file.
-        repo.index()
-            .ok()
-            .and_then(|index| index.get_path(Path::new(&file_path), 0))
-            .and_then(|entry| repo.find_blob(entry.id).ok())
-            .map(|blob| STANDARD.encode(blob.content()))
-    } else {
-        // For working directory changes, read from disk
-        let full_path = validate_path_within_repo(Path::new(&path), &file_path)?;
-        if full_path.exists() {
-            std::fs::read(&full_path)
+        // Get new version
+        let new_data = if let Some(ref oid_str) = commit_oid {
+            // For commit diff, get from commit tree
+            let commit = repo.find_commit(git2::Oid::from_str(oid_str)?)?;
+            get_blob_base64(&repo, &commit.tree()?, &file_path)
+        } else if is_staged {
+            // The staged diff is HEAD vs INDEX, so "after" is the index blob — not
+            // the file on disk.
+            //
+            // Reading from disk meant that staging an image and then editing it
+            // again showed the newer worktree pixels as the staged content: the user
+            // commits believing the image on screen is what will be committed, and
+            // it is not. The text path (diff_tree_to_index) reads the index, so the
+            // image view also contradicted the text view for the same file.
+            repo.index()
                 .ok()
-                .map(|data| STANDARD.encode(&data))
+                .and_then(|index| index.get_path(Path::new(&file_path), 0))
+                .and_then(|entry| repo.find_blob(entry.id).ok())
+                .map(|blob| STANDARD.encode(blob.content()))
         } else {
-            None
-        }
-    };
+            // For working directory changes, read from disk
+            let full_path = validate_path_within_repo(Path::new(&path), &file_path)?;
+            if full_path.exists() {
+                std::fs::read(&full_path)
+                    .ok()
+                    .map(|data| STANDARD.encode(&data))
+            } else {
+                None
+            }
+        };
 
-    Ok(ImageVersions {
-        path: file_path,
-        old_data,
-        new_data,
-        old_size: None, // Size detection would require image parsing
-        new_size: None,
-        image_type,
+        Ok(ImageVersions {
+            path: file_path,
+            old_data,
+            new_data,
+            old_size: None, // Size detection would require image parsing
+            new_size: None,
+            image_type,
+        })
     })
+    .await
 }
 
 /// Get base64-encoded blob content from a tree

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -33,49 +33,52 @@ pub struct CloneFilterInfo {
 /// Open an existing repository
 #[command]
 pub async fn open_repository(path: String) -> Result<Repository> {
-    let path = Path::new(&path);
+    crate::utils::blocking_git(move || {
+        let path = Path::new(&path);
 
-    if !path.exists() {
-        return Err(LeviathanError::RepositoryNotFound(
-            path.display().to_string(),
-        ));
-    }
+        if !path.exists() {
+            return Err(LeviathanError::RepositoryNotFound(
+                path.display().to_string(),
+            ));
+        }
 
-    let repo = git2::Repository::open(path)?;
-    let name = path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| "Unknown".to_string());
+        let repo = git2::Repository::open(path)?;
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "Unknown".to_string());
 
-    let head = repo.head().ok();
-    let head_ref = head.as_ref().map(|h| {
-        h.shorthand()
-            .ok()
-            .map(|s| s.to_string())
-            .unwrap_or_else(|| {
-                h.target()
-                    .map(|t| t.to_string()[..7].to_string())
-                    .unwrap_or_default()
-            })
-    });
-    let detached_head_oid = detached_head_oid(&repo, head.as_ref())?;
+        let head = repo.head().ok();
+        let head_ref = head.as_ref().map(|h| {
+            h.shorthand()
+                .ok()
+                .map(|s| s.to_string())
+                .unwrap_or_else(|| {
+                    h.target()
+                        .map(|t| t.to_string()[..7].to_string())
+                        .unwrap_or_default()
+                })
+        });
+        let detached_head_oid = detached_head_oid(&repo, head.as_ref())?;
 
-    // Detect shallow and partial clone status
-    let is_shallow = repo.is_shallow();
-    let (is_partial_clone, clone_filter) = detect_partial_clone_status(&repo);
+        // Detect shallow and partial clone status
+        let is_shallow = repo.is_shallow();
+        let (is_partial_clone, clone_filter) = detect_partial_clone_status(&repo);
 
-    Ok(Repository {
-        path: path.display().to_string(),
-        name,
-        is_valid: true,
-        is_bare: repo.is_bare(),
-        head_ref,
-        detached_head_oid,
-        state: RepositoryState::from(repo.state()),
-        is_shallow,
-        is_partial_clone,
-        clone_filter,
+        Ok(Repository {
+            path: path.display().to_string(),
+            name,
+            is_valid: true,
+            is_bare: repo.is_bare(),
+            head_ref,
+            detached_head_oid,
+            state: RepositoryState::from(repo.state()),
+            is_shallow,
+            is_partial_clone,
+            clone_filter,
+        })
     })
+    .await
 }
 
 /// Validate a clone URL: reject values that could be parsed as a CLI flag, and
@@ -848,7 +851,7 @@ pub async fn clone_repository(
 #[command]
 pub async fn get_clone_filter_info(path: String) -> Result<CloneFilterInfo> {
     let path_clone = path.clone();
-    tokio::task::spawn_blocking(move || {
+    crate::utils::blocking_git(move || {
         let repo = git2::Repository::open(&path_clone).map_err(|e| {
             LeviathanError::RepositoryNotFound(format!("Failed to open repository: {}", e))
         })?;
@@ -896,14 +899,13 @@ pub async fn get_clone_filter_info(path: String) -> Result<CloneFilterInfo> {
         })
     })
     .await
-    .map_err(|e| LeviathanError::Custom(format!("Task failed: {}", e)))?
 }
 
 /// List all tracked files in the repository
 #[command]
 pub async fn list_tracked_files(path: String) -> Result<Vec<String>> {
     let path_clone = path.clone();
-    tokio::task::spawn_blocking(move || {
+    crate::utils::blocking_git(move || {
         let output = std::process::Command::new("git")
             .arg("-C")
             .arg(&path_clone)
@@ -928,7 +930,6 @@ pub async fn list_tracked_files(path: String) -> Result<Vec<String>> {
         Ok(files)
     })
     .await
-    .map_err(|e| LeviathanError::Custom(format!("Task failed: {}", e)))?
 }
 
 /// Initialize a new repository
@@ -938,61 +939,64 @@ pub async fn init_repository(
     bare: Option<bool>,
     initial_branch: Option<String>,
 ) -> Result<Repository> {
-    let path = Path::new(&path);
+    crate::utils::blocking_git(move || {
+        let path = Path::new(&path);
 
-    let mut opts = git2::RepositoryInitOptions::new();
-    opts.bare(bare.unwrap_or(false));
+        let mut opts = git2::RepositoryInitOptions::new();
+        opts.bare(bare.unwrap_or(false));
 
-    // libgit2 writes the initial_head into HEAD verbatim and validates nothing,
-    // so a bad name here would produce a repository git itself cannot use.
-    // Reject it before anything is created on disk. An absent or blank value
-    // leaves initial_head unset so libgit2 keeps honouring the user's
-    // `init.defaultBranch` git config.
-    if let Some(branch) = initial_branch
-        .as_deref()
-        .map(str::trim)
-        .filter(|b| !b.is_empty())
-    {
-        // libgit2 only prefixes `refs/heads/` when the name does NOT already
-        // start with `refs/` — otherwise it uses it verbatim. Validating
-        // `refs/heads/{branch}` unconditionally would therefore check a
-        // different ref than the one written: `refs/tags/v1` would pass and
-        // then point HEAD outside the branch namespace. Build the exact ref
-        // libgit2 will use, require it to be a branch, and pass that.
-        let full_ref = if branch.starts_with("refs/") {
-            branch.to_string()
-        } else {
-            format!("refs/heads/{}", branch)
-        };
-        if !full_ref.starts_with("refs/heads/") || !git2::Reference::is_valid_name(&full_ref) {
-            return Err(LeviathanError::Custom(format!(
-                "Invalid initial branch name: {}",
-                branch
-            )));
+        // libgit2 writes the initial_head into HEAD verbatim and validates nothing,
+        // so a bad name here would produce a repository git itself cannot use.
+        // Reject it before anything is created on disk. An absent or blank value
+        // leaves initial_head unset so libgit2 keeps honouring the user's
+        // `init.defaultBranch` git config.
+        if let Some(branch) = initial_branch
+            .as_deref()
+            .map(str::trim)
+            .filter(|b| !b.is_empty())
+        {
+            // libgit2 only prefixes `refs/heads/` when the name does NOT already
+            // start with `refs/` — otherwise it uses it verbatim. Validating
+            // `refs/heads/{branch}` unconditionally would therefore check a
+            // different ref than the one written: `refs/tags/v1` would pass and
+            // then point HEAD outside the branch namespace. Build the exact ref
+            // libgit2 will use, require it to be a branch, and pass that.
+            let full_ref = if branch.starts_with("refs/") {
+                branch.to_string()
+            } else {
+                format!("refs/heads/{}", branch)
+            };
+            if !full_ref.starts_with("refs/heads/") || !git2::Reference::is_valid_name(&full_ref) {
+                return Err(LeviathanError::Custom(format!(
+                    "Invalid initial branch name: {}",
+                    branch
+                )));
+            }
+            opts.initial_head(&full_ref);
         }
-        opts.initial_head(&full_ref);
-    }
 
-    let repo = git2::Repository::init_opts(path, &opts)?;
+        let repo = git2::Repository::init_opts(path, &opts)?;
 
-    let name = path
-        .file_name()
-        .map(|n| n.to_string_lossy().to_string())
-        .unwrap_or_else(|| "Unknown".to_string());
+        let name = path
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "Unknown".to_string());
 
-    Ok(Repository {
-        path: path.display().to_string(),
-        name,
-        is_valid: true,
-        is_bare: repo.is_bare(),
-        head_ref: None,
-        // A fresh repository's HEAD is unborn, which is not detached.
-        detached_head_oid: None,
-        state: RepositoryState::Clean,
-        is_shallow: false,
-        is_partial_clone: false,
-        clone_filter: None,
+        Ok(Repository {
+            path: path.display().to_string(),
+            name,
+            is_valid: true,
+            is_bare: repo.is_bare(),
+            head_ref: None,
+            // A fresh repository's HEAD is unborn, which is not detached.
+            detached_head_oid: None,
+            state: RepositoryState::Clean,
+            is_shallow: false,
+            is_partial_clone: false,
+            clone_filter: None,
+        })
     })
+    .await
 }
 
 /// Get information about the current repository

--- a/src-tauri/src/commands/search.rs
+++ b/src-tauri/src/commands/search.rs
@@ -117,105 +117,109 @@ pub async fn search_in_files(
     file_pattern: Option<String>,
     max_results: Option<u32>,
 ) -> Result<Vec<SearchFileResult>> {
-    let case_sensitive = case_sensitive.unwrap_or(false);
-    let use_regex = regex.unwrap_or(false);
-    let max_results = max_results.unwrap_or(1000);
+    crate::utils::blocking_git(move || {
+        let case_sensitive = case_sensitive.unwrap_or(false);
+        let use_regex = regex.unwrap_or(false);
+        let max_results = max_results.unwrap_or(1000);
 
-    let mut cmd = Command::new("git");
-    // `--no-color` and `--no-column` because the output is parsed field by
-    // field: `color.grep` (or `color.ui`) set to `always` wraps the path and
-    // the line number in SGR escapes even into a pipe, so the line-number
-    // parse fails and every match is silently dropped, and `grep.column`
-    // inserts an extra column field that would end up prefixed to the reported
-    // line content. `-z` because the default `path:line:content` framing is
-    // ambiguous and lossy: a path containing a colon shifts every field (and
-    // the match is then dropped by the line-number parse), a path containing a
-    // newline splits one record into two, and `core.quotePath` — on by default
-    // — emits any path with a non-ASCII byte double-quoted and octal-escaped,
-    // which would be shown to the user and opened as a file that does not
-    // exist. `-I` because `git grep -z` still prints an unframed
-    // `Binary file <path> matches` line, which would desynchronise the
-    // NUL-framed reader. Kept in step with the workspace grep, which parses the
-    // same records.
-    cmd.arg("-C")
-        .arg(&path)
-        .arg("grep")
-        .arg("--no-color")
-        .arg("--no-column")
-        .arg("-n")
-        .arg("-z")
-        .arg("-I");
+        let mut cmd = Command::new("git");
+        // `--no-color` and `--no-column` because the output is parsed field by
+        // field: `color.grep` (or `color.ui`) set to `always` wraps the path and
+        // the line number in SGR escapes even into a pipe, so the line-number
+        // parse fails and every match is silently dropped, and `grep.column`
+        // inserts an extra column field that would end up prefixed to the reported
+        // line content. `-z` because the default `path:line:content` framing is
+        // ambiguous and lossy: a path containing a colon shifts every field (and
+        // the match is then dropped by the line-number parse), a path containing a
+        // newline splits one record into two, and `core.quotePath` — on by default
+        // — emits any path with a non-ASCII byte double-quoted and octal-escaped,
+        // which would be shown to the user and opened as a file that does not
+        // exist. `-I` because `git grep -z` still prints an unframed
+        // `Binary file <path> matches` line, which would desynchronise the
+        // NUL-framed reader. Kept in step with the workspace grep, which parses the
+        // same records.
+        cmd.arg("-C")
+            .arg(&path)
+            .arg("grep")
+            .arg("--no-color")
+            .arg("--no-column")
+            .arg("-n")
+            .arg("-z")
+            .arg("-I");
 
-    if !case_sensitive {
-        cmd.arg("-i");
-    }
+        if !case_sensitive {
+            cmd.arg("-i");
+        }
 
-    if use_regex {
-        cmd.arg("-E");
-    } else {
-        // Non-regex ("plain text") search must match the query literally, exactly
-        // like `git grep -F`. Without -F, git grep treats the pattern as a basic
-        // regular expression: literal queries like "a.c" over-match ("abc") and
-        // queries containing regex metacharacters like "a[" fatally error.
-        cmd.arg("-F");
-    }
+        if use_regex {
+            cmd.arg("-E");
+        } else {
+            // Non-regex ("plain text") search must match the query literally, exactly
+            // like `git grep -F`. Without -F, git grep treats the pattern as a basic
+            // regular expression: literal queries like "a.c" over-match ("abc") and
+            // queries containing regex metacharacters like "a[" fatally error.
+            cmd.arg("-F");
+        }
 
-    cmd.arg("--").arg(&query);
+        cmd.arg("--").arg(&query);
 
-    if let Some(ref pattern) = file_pattern {
-        cmd.arg(pattern);
-    }
+        if let Some(ref pattern) = file_pattern {
+            cmd.arg(pattern);
+        }
 
-    let output = cmd.output().map_err(|e| {
-        LeviathanError::OperationFailed(format!("Failed to execute git grep: {}", e))
-    })?;
+        let output = cmd.output().map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to execute git grep: {}", e))
+        })?;
 
-    // git grep returns exit code 1 when no matches are found (not an error)
-    if !output.status.success() && output.status.code() != Some(1) {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(LeviathanError::OperationFailed(format!(
-            "git grep failed: {}",
-            stderr
-        )));
-    }
+        // git grep returns exit code 1 when no matches are found (not an error)
+        if !output.status.success() && output.status.code() != Some(1) {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(LeviathanError::OperationFailed(format!(
+                "git grep failed: {}",
+                stderr
+            )));
+        }
 
-    let records = read_grep_records(
-        &mut std::io::Cursor::new(&output.stdout),
-        max_results as usize,
-    )
-    .map_err(|e| {
-        LeviathanError::OperationFailed(format!("Failed to read git grep output: {}", e))
-    })?;
+        let records = read_grep_records(
+            &mut std::io::Cursor::new(&output.stdout),
+            max_results as usize,
+        )
+        .map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to read git grep output: {}", e))
+        })?;
 
-    let mut file_map: HashMap<String, Vec<SearchResult>> = HashMap::new();
+        let mut file_map: HashMap<String, Vec<SearchResult>> = HashMap::new();
 
-    for (file_path, line_number, line_content) in records {
-        let (match_start, match_end) = find_match_position(&line_content, &query, case_sensitive);
+        for (file_path, line_number, line_content) in records {
+            let (match_start, match_end) =
+                find_match_position(&line_content, &query, case_sensitive);
 
-        let result = SearchResult {
-            file_path: file_path.clone(),
-            line_number,
-            line_content,
-            match_start,
-            match_end,
-        };
+            let result = SearchResult {
+                file_path: file_path.clone(),
+                line_number,
+                line_content,
+                match_start,
+                match_end,
+            };
 
-        file_map.entry(file_path).or_default().push(result);
-    }
+            file_map.entry(file_path).or_default().push(result);
+        }
 
-    let results: Vec<SearchFileResult> = file_map
-        .into_iter()
-        .map(|(file_path, matches)| {
-            let match_count = matches.len() as u32;
-            SearchFileResult {
-                file_path,
-                matches,
-                match_count,
-            }
-        })
-        .collect();
+        let results: Vec<SearchFileResult> = file_map
+            .into_iter()
+            .map(|(file_path, matches)| {
+                let match_count = matches.len() as u32;
+                SearchFileResult {
+                    file_path,
+                    matches,
+                    match_count,
+                }
+            })
+            .collect();
 
-    Ok(results)
+        Ok(results)
+    })
+    .await
 }
 
 /// Search for a pattern within the current diff (staged or unstaged)
@@ -225,116 +229,119 @@ pub async fn search_in_diff(
     query: String,
     staged: Option<bool>,
 ) -> Result<Vec<SearchResult>> {
-    let is_staged = staged.unwrap_or(false);
+    crate::utils::blocking_git(move || {
+        let is_staged = staged.unwrap_or(false);
 
-    let mut cmd = Command::new("git");
-    cmd.arg("-C").arg(&path).arg("diff").arg("--unified=0");
+        let mut cmd = Command::new("git");
+        cmd.arg("-C").arg(&path).arg("diff").arg("--unified=0");
 
-    if is_staged {
-        cmd.arg("--cached");
-    }
-
-    let output = cmd.output().map_err(|e| {
-        LeviathanError::OperationFailed(format!("Failed to execute git diff: {}", e))
-    })?;
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(LeviathanError::OperationFailed(format!(
-            "git diff failed: {}",
-            stderr
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let query_lower = query.to_lowercase();
-    let mut results: Vec<SearchResult> = Vec::new();
-    let mut current_file = String::new();
-    // The old-side path parsed from the "--- a/<path>" header. Needed for deleted
-    // files, whose new-side header is "+++ /dev/null" and thus carries no path.
-    let mut old_file = String::new();
-    // Separate counters for the two sides of the hunk: added lines advance the
-    // new-side counter, removed lines advance the old-side counter.
-    let mut current_new_line: u32 = 0;
-    let mut current_old_line: u32 = 0;
-
-    for line in stdout.lines() {
-        // Track the old-side path from the "--- a/<path>" header (or /dev/null
-        // for added files). Must be checked before the generic "-" line handling.
-        if let Some(rest) = line.strip_prefix("--- ") {
-            old_file = rest.strip_prefix("a/").unwrap_or(rest).to_string();
-            continue;
-        }
-        // Track the current file from the new-side header. Deleted files report
-        // "+++ /dev/null", so fall back to the old-side path parsed above.
-        if let Some(rest) = line.strip_prefix("+++ ") {
-            current_file = match rest.strip_prefix("b/") {
-                Some(path) => path.to_string(),
-                None => old_file.clone(),
-            };
-            continue;
+        if is_staged {
+            cmd.arg("--cached");
         }
 
-        // Parse hunk header for line numbers: @@ -oldStart,count +newStart,count @@
-        if line.starts_with("@@") {
-            let mut tokens = line.split(' ');
-            let _ = tokens.next(); // "@@"
-            if let Some(old_tok) = tokens.next() {
-                current_old_line = old_tok
-                    .trim_start_matches('-')
-                    .split(',')
-                    .next()
-                    .and_then(|n| n.parse().ok())
-                    .unwrap_or(0);
-            }
-            if let Some(new_tok) = tokens.next() {
-                current_new_line = new_tok
-                    .trim_start_matches('+')
-                    .split(',')
-                    .next()
-                    .and_then(|n| n.parse().ok())
-                    .unwrap_or(0);
-            }
-            continue;
+        let output = cmd.output().map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to execute git diff: {}", e))
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(LeviathanError::OperationFailed(format!(
+                "git diff failed: {}",
+                stderr
+            )));
         }
 
-        // Check added lines for the query (new-side numbering).
-        if line.starts_with('+') && !line.starts_with("+++") {
-            let content = &line[1..]; // Strip the '+' prefix
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let query_lower = query.to_lowercase();
+        let mut results: Vec<SearchResult> = Vec::new();
+        let mut current_file = String::new();
+        // The old-side path parsed from the "--- a/<path>" header. Needed for deleted
+        // files, whose new-side header is "+++ /dev/null" and thus carries no path.
+        let mut old_file = String::new();
+        // Separate counters for the two sides of the hunk: added lines advance the
+        // new-side counter, removed lines advance the old-side counter.
+        let mut current_new_line: u32 = 0;
+        let mut current_old_line: u32 = 0;
 
-            if content.to_lowercase().contains(&query_lower) {
-                let (match_start, match_end) = find_match_position(content, &query, false);
-
-                results.push(SearchResult {
-                    file_path: current_file.clone(),
-                    line_number: current_new_line,
-                    line_content: content.to_string(),
-                    match_start,
-                    match_end,
-                });
+        for line in stdout.lines() {
+            // Track the old-side path from the "--- a/<path>" header (or /dev/null
+            // for added files). Must be checked before the generic "-" line handling.
+            if let Some(rest) = line.strip_prefix("--- ") {
+                old_file = rest.strip_prefix("a/").unwrap_or(rest).to_string();
+                continue;
+            }
+            // Track the current file from the new-side header. Deleted files report
+            // "+++ /dev/null", so fall back to the old-side path parsed above.
+            if let Some(rest) = line.strip_prefix("+++ ") {
+                current_file = match rest.strip_prefix("b/") {
+                    Some(path) => path.to_string(),
+                    None => old_file.clone(),
+                };
+                continue;
             }
 
-            current_new_line += 1;
-        } else if line.starts_with('-') && !line.starts_with("---") {
-            let content = &line[1..]; // Strip the '-' prefix
-
-            if content.to_lowercase().contains(&query_lower) {
-                let (match_start, match_end) = find_match_position(content, &query, false);
-
-                results.push(SearchResult {
-                    file_path: current_file.clone(),
-                    line_number: current_old_line,
-                    line_content: content.to_string(),
-                    match_start,
-                    match_end,
-                });
+            // Parse hunk header for line numbers: @@ -oldStart,count +newStart,count @@
+            if line.starts_with("@@") {
+                let mut tokens = line.split(' ');
+                let _ = tokens.next(); // "@@"
+                if let Some(old_tok) = tokens.next() {
+                    current_old_line = old_tok
+                        .trim_start_matches('-')
+                        .split(',')
+                        .next()
+                        .and_then(|n| n.parse().ok())
+                        .unwrap_or(0);
+                }
+                if let Some(new_tok) = tokens.next() {
+                    current_new_line = new_tok
+                        .trim_start_matches('+')
+                        .split(',')
+                        .next()
+                        .and_then(|n| n.parse().ok())
+                        .unwrap_or(0);
+                }
+                continue;
             }
 
-            current_old_line += 1;
+            // Check added lines for the query (new-side numbering).
+            if line.starts_with('+') && !line.starts_with("+++") {
+                let content = &line[1..]; // Strip the '+' prefix
+
+                if content.to_lowercase().contains(&query_lower) {
+                    let (match_start, match_end) = find_match_position(content, &query, false);
+
+                    results.push(SearchResult {
+                        file_path: current_file.clone(),
+                        line_number: current_new_line,
+                        line_content: content.to_string(),
+                        match_start,
+                        match_end,
+                    });
+                }
+
+                current_new_line += 1;
+            } else if line.starts_with('-') && !line.starts_with("---") {
+                let content = &line[1..]; // Strip the '-' prefix
+
+                if content.to_lowercase().contains(&query_lower) {
+                    let (match_start, match_end) = find_match_position(content, &query, false);
+
+                    results.push(SearchResult {
+                        file_path: current_file.clone(),
+                        line_number: current_old_line,
+                        line_content: content.to_string(),
+                        match_start,
+                        match_end,
+                    });
+                }
+
+                current_old_line += 1;
+            }
         }
-    }
 
-    Ok(results)
+        Ok(results)
+    })
+    .await
 }
 
 /// Search for commits where a string was added or removed (pickaxe search)
@@ -344,68 +351,71 @@ pub async fn search_in_commits(
     query: String,
     max_commits: Option<u32>,
 ) -> Result<Vec<DiffSearchResult>> {
-    let max_commits = max_commits.unwrap_or(100);
+    crate::utils::blocking_git(move || {
+        let max_commits = max_commits.unwrap_or(100);
 
-    let mut cmd = Command::new("git");
-    cmd.arg("-C")
-        .arg(&path)
-        .arg("log")
-        .arg(format!("-S{}", query))
-        .arg("--format=%H|%an|%at|%s")
-        .arg(format!("-{}", max_commits))
-        .arg("--name-only");
+        let mut cmd = Command::new("git");
+        cmd.arg("-C")
+            .arg(&path)
+            .arg("log")
+            .arg(format!("-S{}", query))
+            .arg("--format=%H|%an|%at|%s")
+            .arg(format!("-{}", max_commits))
+            .arg("--name-only");
 
-    let output = cmd.output().map_err(|e| {
-        LeviathanError::OperationFailed(format!("Failed to execute git log: {}", e))
-    })?;
+        let output = cmd.output().map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to execute git log: {}", e))
+        })?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(LeviathanError::OperationFailed(format!(
-            "git log failed: {}",
-            stderr
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut results: Vec<DiffSearchResult> = Vec::new();
-    let mut current_commit_id = String::new();
-    let mut current_author = String::new();
-    let mut current_date: i64 = 0;
-    let mut current_message = String::new();
-
-    for line in stdout.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(LeviathanError::OperationFailed(format!(
+                "git log failed: {}",
+                stderr
+            )));
         }
 
-        // Check if this is a commit header line (contains | separators)
-        if line.contains('|') {
-            let parts: Vec<&str> = line.splitn(4, '|').collect();
-            if parts.len() == 4 {
-                current_commit_id = parts[0].to_string();
-                current_author = parts[1].to_string();
-                current_date = parts[2].parse().unwrap_or(0);
-                current_message = parts[3].to_string();
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut results: Vec<DiffSearchResult> = Vec::new();
+        let mut current_commit_id = String::new();
+        let mut current_author = String::new();
+        let mut current_date: i64 = 0;
+        let mut current_message = String::new();
+
+        for line in stdout.lines() {
+            let line = line.trim();
+            if line.is_empty() {
                 continue;
+            }
+
+            // Check if this is a commit header line (contains | separators)
+            if line.contains('|') {
+                let parts: Vec<&str> = line.splitn(4, '|').collect();
+                if parts.len() == 4 {
+                    current_commit_id = parts[0].to_string();
+                    current_author = parts[1].to_string();
+                    current_date = parts[2].parse().unwrap_or(0);
+                    current_message = parts[3].to_string();
+                    continue;
+                }
+            }
+
+            // Otherwise it's a file name
+            if !current_commit_id.is_empty() {
+                results.push(DiffSearchResult {
+                    commit_id: current_commit_id.clone(),
+                    author: current_author.clone(),
+                    date: current_date,
+                    message: current_message.clone(),
+                    file_path: line.to_string(),
+                    line_content: String::new(),
+                });
             }
         }
 
-        // Otherwise it's a file name
-        if !current_commit_id.is_empty() {
-            results.push(DiffSearchResult {
-                commit_id: current_commit_id.clone(),
-                author: current_author.clone(),
-                date: current_date,
-                message: current_message.clone(),
-                file_path: line.to_string(),
-                line_content: String::new(),
-            });
-        }
-    }
-
-    Ok(results)
+        Ok(results)
+    })
+    .await
 }
 
 /// Search in commit messages using git log --grep
@@ -415,56 +425,59 @@ pub async fn search_in_commit_messages(
     query: String,
     max_commits: Option<u32>,
 ) -> Result<Vec<DiffSearchResult>> {
-    let max_commits = max_commits.unwrap_or(100);
+    crate::utils::blocking_git(move || {
+        let max_commits = max_commits.unwrap_or(100);
 
-    let mut cmd = Command::new("git");
-    cmd.arg("-C")
-        .arg(&path)
-        .arg("log")
-        .arg(format!("--grep={}", query))
-        .arg("-i")
-        // Match the query literally (like `git log --grep=… -F`). Without -F the
-        // query is treated as a regex, so "v1.2" would spuriously match "v1x2"
-        // and invalid patterns like "fix a[" would make git log exit non-zero.
-        .arg("--fixed-strings")
-        .arg("--format=%H|%an|%at|%s")
-        .arg(format!("-{}", max_commits));
+        let mut cmd = Command::new("git");
+        cmd.arg("-C")
+            .arg(&path)
+            .arg("log")
+            .arg(format!("--grep={}", query))
+            .arg("-i")
+            // Match the query literally (like `git log --grep=… -F`). Without -F the
+            // query is treated as a regex, so "v1.2" would spuriously match "v1x2"
+            // and invalid patterns like "fix a[" would make git log exit non-zero.
+            .arg("--fixed-strings")
+            .arg("--format=%H|%an|%at|%s")
+            .arg(format!("-{}", max_commits));
 
-    let output = cmd.output().map_err(|e| {
-        LeviathanError::OperationFailed(format!("Failed to execute git log: {}", e))
-    })?;
+        let output = cmd.output().map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to execute git log: {}", e))
+        })?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(LeviathanError::OperationFailed(format!(
-            "git log failed: {}",
-            stderr
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut results: Vec<DiffSearchResult> = Vec::new();
-
-    for line in stdout.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            continue;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(LeviathanError::OperationFailed(format!(
+                "git log failed: {}",
+                stderr
+            )));
         }
 
-        let parts: Vec<&str> = line.splitn(4, '|').collect();
-        if parts.len() == 4 {
-            results.push(DiffSearchResult {
-                commit_id: parts[0].to_string(),
-                author: parts[1].to_string(),
-                date: parts[2].parse().unwrap_or(0),
-                message: parts[3].to_string(),
-                file_path: String::new(),
-                line_content: String::new(),
-            });
-        }
-    }
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut results: Vec<DiffSearchResult> = Vec::new();
 
-    Ok(results)
+        for line in stdout.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                continue;
+            }
+
+            let parts: Vec<&str> = line.splitn(4, '|').collect();
+            if parts.len() == 4 {
+                results.push(DiffSearchResult {
+                    commit_id: parts[0].to_string(),
+                    author: parts[1].to_string(),
+                    date: parts[2].parse().unwrap_or(0),
+                    message: parts[3].to_string(),
+                    file_path: String::new(),
+                    line_content: String::new(),
+                });
+            }
+        }
+
+        Ok(results)
+    })
+    .await
 }
 
 /// A commit returned from content/file search
@@ -501,99 +514,102 @@ pub async fn search_commits_by_content(
     ignore_case: Option<bool>,
     max_count: Option<u32>,
 ) -> Result<Vec<SearchCommit>> {
-    let max_count = max_count.unwrap_or(100);
-    let use_regex = regex.unwrap_or(false);
-    let case_insensitive = ignore_case.unwrap_or(false);
+    crate::utils::blocking_git(move || {
+        let max_count = max_count.unwrap_or(100);
+        let use_regex = regex.unwrap_or(false);
+        let case_insensitive = ignore_case.unwrap_or(false);
 
-    let mut cmd = Command::new("git");
-    cmd.arg("-C")
-        .arg(&path)
-        .arg("log")
-        // Use NUL (%x00) as the field separator so that a commit subject (%s) or
-        // author name (%an) containing '|' cannot be misparsed into the wrong
-        // field. File names from --name-only never contain NUL, so they remain
-        // unambiguously distinguishable from header lines.
-        .arg("--format=%H%x00%h%x00%s%x00%an%x00%at")
-        .arg("--name-only")
-        .arg(format!("-{}", max_count));
+        let mut cmd = Command::new("git");
+        cmd.arg("-C")
+            .arg(&path)
+            .arg("log")
+            // Use NUL (%x00) as the field separator so that a commit subject (%s) or
+            // author name (%an) containing '|' cannot be misparsed into the wrong
+            // field. File names from --name-only never contain NUL, so they remain
+            // unambiguously distinguishable from header lines.
+            .arg("--format=%H%x00%h%x00%s%x00%an%x00%at")
+            .arg("--name-only")
+            .arg(format!("-{}", max_count));
 
-    // Use -G for regex (grep in diff), -S for exact string match (pickaxe)
-    if use_regex {
-        cmd.arg(format!("-G{}", search_text));
-        if case_insensitive {
-            cmd.arg("-i");
+        // Use -G for regex (grep in diff), -S for exact string match (pickaxe)
+        if use_regex {
+            cmd.arg(format!("-G{}", search_text));
+            if case_insensitive {
+                cmd.arg("-i");
+            }
+        } else {
+            cmd.arg(format!("-S{}", search_text));
+            if case_insensitive {
+                cmd.arg("-i");
+            }
         }
-    } else {
-        cmd.arg(format!("-S{}", search_text));
-        if case_insensitive {
-            cmd.arg("-i");
+
+        let output = cmd.output().map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to execute git log: {}", e))
+        })?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(LeviathanError::OperationFailed(format!(
+                "git log failed: {}",
+                stderr
+            )));
         }
-    }
 
-    let output = cmd.output().map_err(|e| {
-        LeviathanError::OperationFailed(format!("Failed to execute git log: {}", e))
-    })?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut results: Vec<SearchCommit> = Vec::new();
+        let mut current_commit: Option<SearchCommit> = None;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(LeviathanError::OperationFailed(format!(
-            "git log failed: {}",
-            stderr
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut results: Vec<SearchCommit> = Vec::new();
-    let mut current_commit: Option<SearchCommit> = None;
-
-    for line in stdout.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            // Empty line can appear between the header and the file list,
-            // or after the file list. Only finalize if the commit has matches
-            // (to avoid finalizing before file names are parsed).
-            if let Some(ref commit) = current_commit {
-                if !commit.matches.is_empty() {
-                    results.push(current_commit.take().unwrap());
+        for line in stdout.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                // Empty line can appear between the header and the file list,
+                // or after the file list. Only finalize if the commit has matches
+                // (to avoid finalizing before file names are parsed).
+                if let Some(ref commit) = current_commit {
+                    if !commit.matches.is_empty() {
+                        results.push(current_commit.take().unwrap());
+                    }
                 }
-            }
-            continue;
-        }
-
-        // Header lines contain NUL field separators; file names never do.
-        if line.contains('\0') {
-            // Save previous commit if exists
-            if let Some(commit) = current_commit.take() {
-                results.push(commit);
+                continue;
             }
 
-            let parts: Vec<&str> = line.splitn(5, '\0').collect();
-            if parts.len() == 5 {
-                current_commit = Some(SearchCommit {
-                    oid: parts[0].to_string(),
-                    short_oid: parts[1].to_string(),
-                    message: parts[2].to_string(),
-                    author_name: parts[3].to_string(),
-                    author_date: parts[4].parse().unwrap_or(0),
-                    matches: Vec::new(),
+            // Header lines contain NUL field separators; file names never do.
+            if line.contains('\0') {
+                // Save previous commit if exists
+                if let Some(commit) = current_commit.take() {
+                    results.push(commit);
+                }
+
+                let parts: Vec<&str> = line.splitn(5, '\0').collect();
+                if parts.len() == 5 {
+                    current_commit = Some(SearchCommit {
+                        oid: parts[0].to_string(),
+                        short_oid: parts[1].to_string(),
+                        message: parts[2].to_string(),
+                        author_name: parts[3].to_string(),
+                        author_date: parts[4].parse().unwrap_or(0),
+                        matches: Vec::new(),
+                    });
+                }
+            } else if let Some(ref mut commit) = current_commit {
+                // This is a file name
+                commit.matches.push(SearchMatch {
+                    file_path: line.to_string(),
+                    line_number: None,
+                    line_content: None,
                 });
             }
-        } else if let Some(ref mut commit) = current_commit {
-            // This is a file name
-            commit.matches.push(SearchMatch {
-                file_path: line.to_string(),
-                line_number: None,
-                line_content: None,
-            });
         }
-    }
 
-    // Don't forget the last commit
-    if let Some(commit) = current_commit {
-        results.push(commit);
-    }
+        // Don't forget the last commit
+        if let Some(commit) = current_commit {
+            results.push(commit);
+        }
 
-    Ok(results)
+        Ok(results)
+    })
+    .await
 }
 
 /// Search for commits that touched files matching a pattern (git log -- <pattern>)
@@ -605,84 +621,87 @@ pub async fn search_commits_by_file(
     file_pattern: String,
     max_count: Option<u32>,
 ) -> Result<Vec<SearchCommit>> {
-    let max_count = max_count.unwrap_or(100);
+    crate::utils::blocking_git(move || {
+        let max_count = max_count.unwrap_or(100);
 
-    let mut cmd = Command::new("git");
-    cmd.arg("-C")
-        .arg(&path)
-        .arg("log")
-        // NUL-separated fields so a '|' in the subject/author cannot corrupt
-        // field parsing (see search_commits_by_content for details).
-        .arg("--format=%H%x00%h%x00%s%x00%an%x00%at")
-        .arg("--name-only")
-        .arg(format!("-{}", max_count))
-        .arg("--")
-        .arg(&file_pattern);
+        let mut cmd = Command::new("git");
+        cmd.arg("-C")
+            .arg(&path)
+            .arg("log")
+            // NUL-separated fields so a '|' in the subject/author cannot corrupt
+            // field parsing (see search_commits_by_content for details).
+            .arg("--format=%H%x00%h%x00%s%x00%an%x00%at")
+            .arg("--name-only")
+            .arg(format!("-{}", max_count))
+            .arg("--")
+            .arg(&file_pattern);
 
-    let output = cmd.output().map_err(|e| {
-        LeviathanError::OperationFailed(format!("Failed to execute git log: {}", e))
-    })?;
+        let output = cmd.output().map_err(|e| {
+            LeviathanError::OperationFailed(format!("Failed to execute git log: {}", e))
+        })?;
 
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(LeviathanError::OperationFailed(format!(
-            "git log failed: {}",
-            stderr
-        )));
-    }
-
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    let mut results: Vec<SearchCommit> = Vec::new();
-    let mut current_commit: Option<SearchCommit> = None;
-
-    for line in stdout.lines() {
-        let line = line.trim();
-        if line.is_empty() {
-            // Empty line can appear between the header and the file list,
-            // or after the file list. Only finalize if the commit has matches
-            // (to avoid finalizing before file names are parsed).
-            if let Some(ref commit) = current_commit {
-                if !commit.matches.is_empty() {
-                    results.push(current_commit.take().unwrap());
-                }
-            }
-            continue;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(LeviathanError::OperationFailed(format!(
+                "git log failed: {}",
+                stderr
+            )));
         }
 
-        // Header lines contain NUL field separators; file names never do.
-        if line.contains('\0') {
-            // Save previous commit if exists
-            if let Some(commit) = current_commit.take() {
-                results.push(commit);
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let mut results: Vec<SearchCommit> = Vec::new();
+        let mut current_commit: Option<SearchCommit> = None;
+
+        for line in stdout.lines() {
+            let line = line.trim();
+            if line.is_empty() {
+                // Empty line can appear between the header and the file list,
+                // or after the file list. Only finalize if the commit has matches
+                // (to avoid finalizing before file names are parsed).
+                if let Some(ref commit) = current_commit {
+                    if !commit.matches.is_empty() {
+                        results.push(current_commit.take().unwrap());
+                    }
+                }
+                continue;
             }
 
-            let parts: Vec<&str> = line.splitn(5, '\0').collect();
-            if parts.len() == 5 {
-                current_commit = Some(SearchCommit {
-                    oid: parts[0].to_string(),
-                    short_oid: parts[1].to_string(),
-                    message: parts[2].to_string(),
-                    author_name: parts[3].to_string(),
-                    author_date: parts[4].parse().unwrap_or(0),
-                    matches: Vec::new(),
+            // Header lines contain NUL field separators; file names never do.
+            if line.contains('\0') {
+                // Save previous commit if exists
+                if let Some(commit) = current_commit.take() {
+                    results.push(commit);
+                }
+
+                let parts: Vec<&str> = line.splitn(5, '\0').collect();
+                if parts.len() == 5 {
+                    current_commit = Some(SearchCommit {
+                        oid: parts[0].to_string(),
+                        short_oid: parts[1].to_string(),
+                        message: parts[2].to_string(),
+                        author_name: parts[3].to_string(),
+                        author_date: parts[4].parse().unwrap_or(0),
+                        matches: Vec::new(),
+                    });
+                }
+            } else if let Some(ref mut commit) = current_commit {
+                // This is a file name
+                commit.matches.push(SearchMatch {
+                    file_path: line.to_string(),
+                    line_number: None,
+                    line_content: None,
                 });
             }
-        } else if let Some(ref mut commit) = current_commit {
-            // This is a file name
-            commit.matches.push(SearchMatch {
-                file_path: line.to_string(),
-                line_number: None,
-                line_content: None,
-            });
         }
-    }
 
-    // Don't forget the last commit
-    if let Some(commit) = current_commit {
-        results.push(commit);
-    }
+        // Don't forget the last commit
+        if let Some(commit) = current_commit {
+            results.push(commit);
+        }
 
-    Ok(results)
+        Ok(results)
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/commands/staging.rs
+++ b/src-tauri/src/commands/staging.rs
@@ -15,41 +15,44 @@ use crate::utils::create_command;
 /// Get repository status
 #[command]
 pub async fn get_status(path: String) -> Result<Vec<StatusEntry>> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let mut opts = git2::StatusOptions::new();
-    // update_index(true): refresh racy-git entries so files whose content
-    // matches the index drop out of status. Without it, a rewrite with
-    // identical content (common after checkout/rebase) shows as "M" in the
-    // UI but produces an empty content-diff — the user then hits
-    // "File not found in diff" when they click it.
-    opts.include_untracked(true)
-        .recurse_untracked_dirs(true)
-        .include_ignored(false)
-        .include_unmodified(false)
-        .update_index(true);
+        let mut opts = git2::StatusOptions::new();
+        // update_index(true): refresh racy-git entries so files whose content
+        // matches the index drop out of status. Without it, a rewrite with
+        // identical content (common after checkout/rebase) shows as "M" in the
+        // UI but produces an empty content-diff — the user then hits
+        // "File not found in diff" when they click it.
+        opts.include_untracked(true)
+            .recurse_untracked_dirs(true)
+            .include_ignored(false)
+            .include_unmodified(false)
+            .update_index(true);
 
-    let statuses = repo.statuses(Some(&mut opts))?;
-    let mut entries = Vec::new();
+        let statuses = repo.statuses(Some(&mut opts))?;
+        let mut entries = Vec::new();
 
-    for entry in statuses.iter() {
-        let path = entry.path().unwrap_or("").to_string();
-        let status = entry.status();
+        for entry in statuses.iter() {
+            let path = entry.path().unwrap_or("").to_string();
+            let status = entry.status();
 
-        // A file can have both staged AND unstaged changes
-        // We need to return separate entries for each
-        let staged_entry = get_staged_status(status, &path);
-        let unstaged_entry = get_unstaged_status(status, &path);
+            // A file can have both staged AND unstaged changes
+            // We need to return separate entries for each
+            let staged_entry = get_staged_status(status, &path);
+            let unstaged_entry = get_unstaged_status(status, &path);
 
-        if let Some(entry) = staged_entry {
-            entries.push(entry);
+            if let Some(entry) = staged_entry {
+                entries.push(entry);
+            }
+            if let Some(entry) = unstaged_entry {
+                entries.push(entry);
+            }
         }
-        if let Some(entry) = unstaged_entry {
-            entries.push(entry);
-        }
-    }
 
-    Ok(entries)
+        Ok(entries)
+    })
+    .await
 }
 
 /// Get sorted file status with enriched metadata for file tree display
@@ -332,184 +335,193 @@ fn get_unstaged_status(status: git2::Status, path: &str) -> Option<StatusEntry> 
 /// Stage files
 #[command]
 pub async fn stage_files(path: String, paths: Vec<String>) -> Result<()> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let mut index = repo.index()?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let mut index = repo.index()?;
 
-    for file_path in paths {
-        let full_path = validate_path_within_repo(Path::new(&path), &file_path)?;
-        // Use symlink_metadata (does NOT follow symlinks) rather than
-        // Path::exists (which follows them). A dangling symlink — one whose
-        // target does not exist — must still be staged as a 120000 blob
-        // containing the link target, exactly as `git add` does; treating it
-        // as a deletion would silently stage the symlink's removal.
-        if std::fs::symlink_metadata(&full_path).is_ok() {
-            index.add_path(Path::new(&file_path))?;
-        } else {
-            index.remove_path(Path::new(&file_path))?;
+        for file_path in paths {
+            let full_path = validate_path_within_repo(Path::new(&path), &file_path)?;
+            // Use symlink_metadata (does NOT follow symlinks) rather than
+            // Path::exists (which follows them). A dangling symlink — one whose
+            // target does not exist — must still be staged as a 120000 blob
+            // containing the link target, exactly as `git add` does; treating it
+            // as a deletion would silently stage the symlink's removal.
+            if std::fs::symlink_metadata(&full_path).is_ok() {
+                index.add_path(Path::new(&file_path))?;
+            } else {
+                index.remove_path(Path::new(&file_path))?;
+            }
         }
-    }
 
-    index.write()?;
-    Ok(())
+        index.write()?;
+        Ok(())
+    })
+    .await
 }
 
 /// Unstage files
 #[command]
 pub async fn unstage_files(path: String, paths: Vec<String>) -> Result<()> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    // Resolve the HEAD commit. On an unborn branch (a freshly initialized
-    // repository with no commits yet) there is no HEAD, and `git reset --
-    // <paths>` resolves against the empty tree — equivalent to removing the
-    // requested paths from the index. Propagating repo.head()'s error here
-    // would wrongly make unstaging impossible until the first commit exists.
-    let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
+        // Resolve the HEAD commit. On an unborn branch (a freshly initialized
+        // repository with no commits yet) there is no HEAD, and `git reset --
+        // <paths>` resolves against the empty tree — equivalent to removing the
+        // requested paths from the index. Propagating repo.head()'s error here
+        // would wrongly make unstaging impossible until the first commit exists.
+        let head_commit = repo.head().ok().and_then(|h| h.peel_to_commit().ok());
 
-    let mut index = repo.index()?;
+        let mut index = repo.index()?;
 
-    for file_path in paths {
-        let path_obj = Path::new(&file_path);
+        for file_path in paths {
+            let path_obj = Path::new(&file_path);
 
-        match &head_commit {
-            Some(commit) => {
-                let head_tree = commit.tree()?;
-                if head_tree.get_path(path_obj).is_ok() {
-                    // Reset to HEAD version
-                    repo.reset_default(Some(commit.as_object()), [path_obj])?;
-                } else {
-                    // Remove from index (was newly added)
+            match &head_commit {
+                Some(commit) => {
+                    let head_tree = commit.tree()?;
+                    if head_tree.get_path(path_obj).is_ok() {
+                        // Reset to HEAD version
+                        repo.reset_default(Some(commit.as_object()), [path_obj])?;
+                    } else {
+                        // Remove from index (was newly added)
+                        index.remove_path(path_obj)?;
+                    }
+                }
+                None => {
+                    // Unborn HEAD: reset against the empty tree == drop from index.
                     index.remove_path(path_obj)?;
                 }
             }
-            None => {
-                // Unborn HEAD: reset against the empty tree == drop from index.
-                index.remove_path(path_obj)?;
-            }
         }
-    }
 
-    index.write()?;
-    Ok(())
+        index.write()?;
+        Ok(())
+    })
+    .await
 }
 
 /// Discard changes in working directory
 #[command]
 pub async fn discard_changes(path: String, paths: Vec<String>) -> Result<()> {
-    let repo = git2::Repository::open(Path::new(&path))?;
-    let repo_path = Path::new(&path);
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
+        let repo_path = Path::new(&path);
 
-    // Get HEAD tree (may not exist for initial commit)
-    let head_tree = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
-    let index = repo.index()?;
+        // Get HEAD tree (may not exist for initial commit)
+        let head_tree = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
+        let index = repo.index()?;
 
-    // "Discard changes" mirrors `git checkout -- <pathspec>`, which restores
-    // the working tree from the INDEX — never from HEAD. Restoring from HEAD
-    // would silently overwrite staged content (e.g. a file with staged edits
-    // plus later unstaged edits would lose the staged version, which is never
-    // committed and has no reflog: unrecoverable data loss). So:
-    //   1. Tracked (present in the index): restore the worktree from the index.
-    //   2. Untracked (not in the index and not in HEAD): delete it.
-    // A path in HEAD but absent from the index is a staged deletion; there is
-    // no worktree change to discard, so it is left untouched.
-    let mut index_paths: Vec<&str> = Vec::new();
-    let mut untracked_paths: Vec<std::path::PathBuf> = Vec::new();
+        // "Discard changes" mirrors `git checkout -- <pathspec>`, which restores
+        // the working tree from the INDEX — never from HEAD. Restoring from HEAD
+        // would silently overwrite staged content (e.g. a file with staged edits
+        // plus later unstaged edits would lose the staged version, which is never
+        // committed and has no reflog: unrecoverable data loss). So:
+        //   1. Tracked (present in the index): restore the worktree from the index.
+        //   2. Untracked (not in the index and not in HEAD): delete it.
+        // A path in HEAD but absent from the index is a staged deletion; there is
+        // no worktree change to discard, so it is left untouched.
+        let mut index_paths: Vec<&str> = Vec::new();
+        let mut untracked_paths: Vec<std::path::PathBuf> = Vec::new();
 
-    for file_path in &paths {
-        // Validate BEFORE any git2 lookup. git2's Index::get_path panics
-        // outright on a path beginning with `..`, so an unvalidated traversal
-        // crashes this command across the IPC boundary rather than returning an
-        // error. It also guards the untracked branch below, which is the only
-        // place in this file that deletes recursively.
-        let full_path = validate_path_within_repo(repo_path, file_path)?;
+        for file_path in &paths {
+            // Validate BEFORE any git2 lookup. git2's Index::get_path panics
+            // outright on a path beginning with `..`, so an unvalidated traversal
+            // crashes this command across the IPC boundary rather than returning an
+            // error. It also guards the untracked branch below, which is the only
+            // place in this file that deletes recursively.
+            let full_path = validate_path_within_repo(repo_path, file_path)?;
 
-        let path_obj = Path::new(file_path);
+            let path_obj = Path::new(file_path);
 
-        // Check if file exists in HEAD
-        let in_head = head_tree
-            .as_ref()
-            .map(|t| t.get_path(path_obj).is_ok())
-            .unwrap_or(false);
+            // Check if file exists in HEAD
+            let in_head = head_tree
+                .as_ref()
+                .map(|t| t.get_path(path_obj).is_ok())
+                .unwrap_or(false);
 
-        // Check if file exists in index
-        let in_index = index.get_path(path_obj, 0).is_some();
+            // Check if file exists in index
+            let in_index = index.get_path(path_obj, 0).is_some();
 
-        if in_index {
-            // Tracked - restore the worktree from the staged (index) version.
-            index_paths.push(file_path);
-        } else if !in_head {
-            // Untracked - need to delete it.
-            untracked_paths.push(full_path);
-        }
-        // in_head && !in_index: staged deletion, nothing to discard.
-    }
-
-    // An untracked ENTRY can be an entire repository: libgit2 does not descend
-    // into a directory holding .git, so a nested repo surfaces in the file list
-    // as one ordinary row. Discarding it would remove its objects, refs and
-    // unpushed commits with nothing recoverable — and unlike Clean, which is a
-    // deliberate confirmed dialog, discarding a row in the sidebar reads as
-    // "throw away my edit".
-    //
-    // Scanned for ALL selected paths BEFORE anything is deleted, the same
-    // all-or-nothing shape clean_files uses for its containment validation.
-    // The check used to live inside the deletion loop, so a ten-file
-    // "Discard all selected" whose fifth entry was a nested repo deleted the
-    // first four — untracked, so no object, no reflog, no trash — and then
-    // returned the error, while the user read "would destroy its history" and
-    // reasonably concluded nothing had happened.
-    for full_path in &untracked_paths {
-        // symlink_metadata, not is_dir(): a symlink to a directory must never
-        // be descended into, only unlinked.
-        let is_dir = std::fs::symlink_metadata(full_path)
-            .map(|m| m.file_type().is_dir())
-            .unwrap_or(false);
-        if is_dir && crate::utils::contains_nested_repo(full_path) {
-            return Err(crate::error::LeviathanError::OperationFailed(format!(
-                "'{}' contains a git repository — discarding it would destroy its history. \
-                 Nothing was discarded. Use the Clean Working Directory dialog, which asks \
-                 for confirmation before removing a nested repository.",
-                full_path.display()
-            )));
-        }
-    }
-
-    // Restore tracked files from the index (matches `git checkout -- <path>`).
-    if !index_paths.is_empty() {
-        let mut checkout_opts = git2::build::CheckoutBuilder::new();
-        checkout_opts.force();
-        checkout_opts.remove_untracked(false);
-        // CheckoutBuilder::path() adds a PATHSPEC, not a literal path: without
-        // this, a filename containing a glob metacharacter (`*`, `?`, `[`, `\`)
-        // also matches its neighbours. Discarding `report[1].md` would then
-        // force-restore `report1.md` too, silently destroying uncommitted work
-        // in a file the confirm never named.
-        checkout_opts.disable_pathspec_match(true);
-
-        for file_path in &index_paths {
-            checkout_opts.path(file_path);
+            if in_index {
+                // Tracked - restore the worktree from the staged (index) version.
+                index_paths.push(file_path);
+            } else if !in_head {
+                // Untracked - need to delete it.
+                untracked_paths.push(full_path);
+            }
+            // in_head && !in_index: staged deletion, nothing to discard.
         }
 
-        let mut fresh_index = repo.index()?;
-        repo.checkout_index(Some(&mut fresh_index), Some(&mut checkout_opts))?;
-    }
-
-    // Delete untracked files. symlink_metadata, not exists()/is_dir(): both
-    // FOLLOW symlinks, so a dangling link would be skipped (left on disk)
-    // and a link to a directory would be reported as a directory. The
-    // symlink itself is what must go — never its target.
-    // Paths were containment-checked during classification above, and
-    // nested-repo-checked immediately above.
-    for full_path in untracked_paths {
-        if let Ok(meta) = std::fs::symlink_metadata(&full_path) {
-            if meta.file_type().is_dir() {
-                std::fs::remove_dir_all(&full_path)?;
-            } else {
-                std::fs::remove_file(&full_path)?;
+        // An untracked ENTRY can be an entire repository: libgit2 does not descend
+        // into a directory holding .git, so a nested repo surfaces in the file list
+        // as one ordinary row. Discarding it would remove its objects, refs and
+        // unpushed commits with nothing recoverable — and unlike Clean, which is a
+        // deliberate confirmed dialog, discarding a row in the sidebar reads as
+        // "throw away my edit".
+        //
+        // Scanned for ALL selected paths BEFORE anything is deleted, the same
+        // all-or-nothing shape clean_files uses for its containment validation.
+        // The check used to live inside the deletion loop, so a ten-file
+        // "Discard all selected" whose fifth entry was a nested repo deleted the
+        // first four — untracked, so no object, no reflog, no trash — and then
+        // returned the error, while the user read "would destroy its history" and
+        // reasonably concluded nothing had happened.
+        for full_path in &untracked_paths {
+            // symlink_metadata, not is_dir(): a symlink to a directory must never
+            // be descended into, only unlinked.
+            let is_dir = std::fs::symlink_metadata(full_path)
+                .map(|m| m.file_type().is_dir())
+                .unwrap_or(false);
+            if is_dir && crate::utils::contains_nested_repo(full_path) {
+                return Err(crate::error::LeviathanError::OperationFailed(format!(
+                    "'{}' contains a git repository — discarding it would destroy its history. \
+                     Nothing was discarded. Use the Clean Working Directory dialog, which asks \
+                     for confirmation before removing a nested repository.",
+                    full_path.display()
+                )));
             }
         }
-    }
 
-    Ok(())
+        // Restore tracked files from the index (matches `git checkout -- <path>`).
+        if !index_paths.is_empty() {
+            let mut checkout_opts = git2::build::CheckoutBuilder::new();
+            checkout_opts.force();
+            checkout_opts.remove_untracked(false);
+            // CheckoutBuilder::path() adds a PATHSPEC, not a literal path: without
+            // this, a filename containing a glob metacharacter (`*`, `?`, `[`, `\`)
+            // also matches its neighbours. Discarding `report[1].md` would then
+            // force-restore `report1.md` too, silently destroying uncommitted work
+            // in a file the confirm never named.
+            checkout_opts.disable_pathspec_match(true);
+
+            for file_path in &index_paths {
+                checkout_opts.path(file_path);
+            }
+
+            let mut fresh_index = repo.index()?;
+            repo.checkout_index(Some(&mut fresh_index), Some(&mut checkout_opts))?;
+        }
+
+        // Delete untracked files. symlink_metadata, not exists()/is_dir(): both
+        // FOLLOW symlinks, so a dangling link would be skipped (left on disk)
+        // and a link to a directory would be reported as a directory. The
+        // symlink itself is what must go — never its target.
+        // Paths were containment-checked during classification above, and
+        // nested-repo-checked immediately above.
+        for full_path in untracked_paths {
+            if let Ok(meta) = std::fs::symlink_metadata(&full_path) {
+                if meta.file_type().is_dir() {
+                    std::fs::remove_dir_all(&full_path)?;
+                } else {
+                    std::fs::remove_file(&full_path)?;
+                }
+            }
+        }
+
+        Ok(())
+    })
+    .await
 }
 
 /// Apply a patch to the index. Internal helper shared by stage_hunk /
@@ -551,7 +563,7 @@ fn apply_patch_to_index(repo_path: &str, patch: &str, reverse: bool) -> Result<(
 /// and applies it to the index using git apply --cached
 #[command]
 pub async fn stage_hunk(repo_path: String, patch: String) -> Result<()> {
-    apply_patch_to_index(&repo_path, &patch, false)
+    crate::utils::blocking_git(move || apply_patch_to_index(&repo_path, &patch, false)).await
 }
 
 /// Unstage a specific hunk from the index
@@ -559,7 +571,7 @@ pub async fn stage_hunk(repo_path: String, patch: String) -> Result<()> {
 /// Takes a patch string and applies it in reverse to unstage
 #[command]
 pub async fn unstage_hunk(repo_path: String, patch: String) -> Result<()> {
-    apply_patch_to_index(&repo_path, &patch, true)
+    crate::utils::blocking_git(move || apply_patch_to_index(&repo_path, &patch, true)).await
 }
 
 /// Write content to a file and optionally stage it
@@ -571,25 +583,28 @@ pub async fn write_file_content(
     content: String,
     stage_after: Option<bool>,
 ) -> Result<()> {
-    let full_path = validate_path_within_repo(Path::new(&repo_path), &file_path)?;
+    crate::utils::blocking_git(move || {
+        let full_path = validate_path_within_repo(Path::new(&repo_path), &file_path)?;
 
-    // Ensure parent directory exists
-    if let Some(parent) = full_path.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
+        // Ensure parent directory exists
+        if let Some(parent) = full_path.parent() {
+            std::fs::create_dir_all(parent)?;
+        }
 
-    // Write content to file
-    std::fs::write(&full_path, content)?;
+        // Write content to file
+        std::fs::write(&full_path, content)?;
 
-    // Optionally stage the file
-    if stage_after.unwrap_or(false) {
-        let repo = git2::Repository::open(Path::new(&repo_path))?;
-        let mut index = repo.index()?;
-        index.add_path(Path::new(&file_path))?;
-        index.write()?;
-    }
+        // Optionally stage the file
+        if stage_after.unwrap_or(false) {
+            let repo = git2::Repository::open(Path::new(&repo_path))?;
+            let mut index = repo.index()?;
+            index.add_path(Path::new(&file_path))?;
+            index.write()?;
+        }
 
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 /// Read file content from working directory or index
@@ -599,32 +614,35 @@ pub async fn read_file_content(
     file_path: String,
     from_index: Option<bool>,
 ) -> Result<String> {
-    if from_index.unwrap_or(false) {
-        // Read from index
-        let repo = git2::Repository::open(Path::new(&repo_path))?;
-        let index = repo.index()?;
+    crate::utils::blocking_git(move || {
+        if from_index.unwrap_or(false) {
+            // Read from index
+            let repo = git2::Repository::open(Path::new(&repo_path))?;
+            let index = repo.index()?;
 
-        if let Some(entry) = index.get_path(Path::new(&file_path), 0) {
-            let blob = repo.find_blob(entry.id)?;
-            let content = String::from_utf8_lossy(blob.content()).to_string();
-            return Ok(content);
-        }
+            if let Some(entry) = index.get_path(Path::new(&file_path), 0) {
+                let blob = repo.find_blob(entry.id)?;
+                let content = String::from_utf8_lossy(blob.content()).to_string();
+                return Ok(content);
+            }
 
-        Err(crate::error::LeviathanError::OperationFailed(
-            "File not found in index".to_string(),
-        ))
-    } else {
-        // Read from working directory. A MISSING file gets its own error
-        // code — callers must be able to tell "the file is gone" (e.g. a
-        // staged deletion) from "the file exists but could not be decoded"
-        // (legacy encoding), which are presented very differently.
-        let full_path = validate_path_within_repo(Path::new(&repo_path), &file_path)?;
-        if !full_path.exists() {
-            return Err(crate::error::LeviathanError::FileNotFound(file_path));
+            Err(crate::error::LeviathanError::OperationFailed(
+                "File not found in index".to_string(),
+            ))
+        } else {
+            // Read from working directory. A MISSING file gets its own error
+            // code — callers must be able to tell "the file is gone" (e.g. a
+            // staged deletion) from "the file exists but could not be decoded"
+            // (legacy encoding), which are presented very differently.
+            let full_path = validate_path_within_repo(Path::new(&repo_path), &file_path)?;
+            if !full_path.exists() {
+                return Err(crate::error::LeviathanError::FileNotFound(file_path));
+            }
+            let content = std::fs::read_to_string(&full_path)?;
+            Ok(content)
         }
-        let content = std::fs::read_to_string(&full_path)?;
-        Ok(content)
-    }
+    })
+    .await
 }
 
 /// Strip trailing whitespace from files
@@ -632,34 +650,37 @@ pub async fn read_file_content(
 /// Reads each file, removes trailing whitespace from every line, and writes it back.
 #[command]
 pub async fn strip_trailing_whitespace(path: String, file_paths: Vec<String>) -> Result<()> {
-    let repo_path = Path::new(&path);
+    crate::utils::blocking_git(move || {
+        let repo_path = Path::new(&path);
 
-    for file_path in &file_paths {
-        let full_path = validate_path_within_repo(repo_path, file_path)?;
+        for file_path in &file_paths {
+            let full_path = validate_path_within_repo(repo_path, file_path)?;
 
-        if !full_path.exists() || !full_path.is_file() {
-            continue;
+            if !full_path.exists() || !full_path.is_file() {
+                continue;
+            }
+
+            let content = std::fs::read_to_string(&full_path)?;
+
+            let stripped: String = content
+                .lines()
+                .map(|line| line.trim_end())
+                .collect::<Vec<&str>>()
+                .join("\n");
+
+            // Preserve final newline if original file had one
+            let result = if content.ends_with('\n') {
+                format!("{}\n", stripped)
+            } else {
+                stripped
+            };
+
+            std::fs::write(&full_path, result)?;
         }
 
-        let content = std::fs::read_to_string(&full_path)?;
-
-        let stripped: String = content
-            .lines()
-            .map(|line| line.trim_end())
-            .collect::<Vec<&str>>()
-            .join("\n");
-
-        // Preserve final newline if original file had one
-        let result = if content.ends_with('\n') {
-            format!("{}\n", stripped)
-        } else {
-            stripped
-        };
-
-        std::fs::write(&full_path, result)?;
-    }
-
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 /// Get hunks for a file diff (staged or unstaged)
@@ -667,83 +688,87 @@ pub async fn strip_trailing_whitespace(path: String, file_paths: Vec<String>) ->
 /// Returns structured hunk information for partial staging UI.
 #[command]
 pub async fn get_file_hunks(path: String, file_path: String, staged: bool) -> Result<FileHunks> {
-    let repo = git2::Repository::open(Path::new(&path))?;
+    crate::utils::blocking_git(move || {
+        let repo = git2::Repository::open(Path::new(&path))?;
 
-    let diff = if staged {
-        // Staged: diff between HEAD and index
-        let head_tree = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
-        let mut opts = git2::DiffOptions::new();
-        opts.pathspec(&file_path);
-        repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut opts))?
-    } else {
-        // Unstaged: diff between index and working directory
-        let mut opts = git2::DiffOptions::new();
-        opts.pathspec(&file_path);
-        repo.diff_index_to_workdir(None, Some(&mut opts))?
-    };
+        let diff = if staged {
+            // Staged: diff between HEAD and index
+            let head_tree = repo.head().ok().and_then(|h| h.peel_to_tree().ok());
+            let mut opts = git2::DiffOptions::new();
+            opts.pathspec(&file_path);
+            repo.diff_tree_to_index(head_tree.as_ref(), None, Some(&mut opts))?
+        } else {
+            // Unstaged: diff between index and working directory
+            let mut opts = git2::DiffOptions::new();
+            opts.pathspec(&file_path);
+            repo.diff_index_to_workdir(None, Some(&mut opts))?
+        };
 
-    let mut hunks: Vec<IndexedDiffHunk> = Vec::new();
-    let mut total_additions: u32 = 0;
-    let mut total_deletions: u32 = 0;
+        let mut hunks: Vec<IndexedDiffHunk> = Vec::new();
+        let mut total_additions: u32 = 0;
+        let mut total_deletions: u32 = 0;
 
-    // Iterate through patches for each delta
-    let num_deltas = diff.deltas().len();
-    for delta_idx in 0..num_deltas {
-        if let Ok(Some(patch)) = git2::Patch::from_diff(&diff, delta_idx) {
-            let num_hunks = patch.num_hunks();
-            for hunk_idx in 0..num_hunks {
-                if let Ok((hunk, num_lines)) = patch.hunk(hunk_idx) {
-                    let header = String::from_utf8_lossy(hunk.header()).trim().to_string();
-                    let mut lines = Vec::new();
+        // Iterate through patches for each delta
+        let num_deltas = diff.deltas().len();
+        for delta_idx in 0..num_deltas {
+            if let Ok(Some(patch)) = git2::Patch::from_diff(&diff, delta_idx) {
+                let num_hunks = patch.num_hunks();
+                for hunk_idx in 0..num_hunks {
+                    if let Ok((hunk, num_lines)) = patch.hunk(hunk_idx) {
+                        let header = String::from_utf8_lossy(hunk.header()).trim().to_string();
+                        let mut lines = Vec::new();
 
-                    for line_idx in 0..num_lines {
-                        if let Ok(diff_line) = patch.line_in_hunk(hunk_idx, line_idx) {
-                            let origin = diff_line.origin();
-                            let content = String::from_utf8_lossy(diff_line.content()).to_string();
+                        for line_idx in 0..num_lines {
+                            if let Ok(diff_line) = patch.line_in_hunk(hunk_idx, line_idx) {
+                                let origin = diff_line.origin();
+                                let content =
+                                    String::from_utf8_lossy(diff_line.content()).to_string();
 
-                            let line_type = match origin {
-                                '+' => {
-                                    total_additions += 1;
-                                    "addition"
-                                }
-                                '-' => {
-                                    total_deletions += 1;
-                                    "deletion"
-                                }
-                                ' ' => "context",
-                                _ => continue,
-                            };
+                                let line_type = match origin {
+                                    '+' => {
+                                        total_additions += 1;
+                                        "addition"
+                                    }
+                                    '-' => {
+                                        total_deletions += 1;
+                                        "deletion"
+                                    }
+                                    ' ' => "context",
+                                    _ => continue,
+                                };
 
-                            lines.push(HunkDiffLine {
-                                line_type: line_type.to_string(),
-                                content,
-                                old_line_number: diff_line.old_lineno(),
-                                new_line_number: diff_line.new_lineno(),
-                            });
+                                lines.push(HunkDiffLine {
+                                    line_type: line_type.to_string(),
+                                    content,
+                                    old_line_number: diff_line.old_lineno(),
+                                    new_line_number: diff_line.new_lineno(),
+                                });
+                            }
                         }
-                    }
 
-                    hunks.push(IndexedDiffHunk {
-                        index: hunks.len() as u32,
-                        old_start: hunk.old_start(),
-                        old_lines: hunk.old_lines(),
-                        new_start: hunk.new_start(),
-                        new_lines: hunk.new_lines(),
-                        header,
-                        lines,
-                        is_staged: staged,
-                    });
+                        hunks.push(IndexedDiffHunk {
+                            index: hunks.len() as u32,
+                            old_start: hunk.old_start(),
+                            old_lines: hunk.old_lines(),
+                            new_start: hunk.new_start(),
+                            new_lines: hunk.new_lines(),
+                            header,
+                            lines,
+                            is_staged: staged,
+                        });
+                    }
                 }
             }
         }
-    }
 
-    Ok(FileHunks {
-        file_path,
-        hunks,
-        total_additions,
-        total_deletions,
+        Ok(FileHunks {
+            file_path,
+            hunks,
+            total_additions,
+            total_deletions,
+        })
     })
+    .await
 }
 
 /// Append one unified-diff line (`prefix` + `content`) to `patch`.
@@ -800,19 +825,22 @@ pub async fn stage_hunk_by_index(path: String, file_path: String, hunk_index: u3
     // Get the unstaged hunks
     let file_hunks = get_file_hunks(path.clone(), file_path.clone(), false).await?;
 
-    let hunk = file_hunks
-        .hunks
-        .iter()
-        .find(|h| h.index == hunk_index)
-        .ok_or_else(|| {
-            crate::error::LeviathanError::OperationFailed(format!(
-                "Hunk index {} not found for file {}",
-                hunk_index, file_path
-            ))
-        })?;
+    crate::utils::blocking_git(move || {
+        let hunk = file_hunks
+            .hunks
+            .iter()
+            .find(|h| h.index == hunk_index)
+            .ok_or_else(|| {
+                crate::error::LeviathanError::OperationFailed(format!(
+                    "Hunk index {} not found for file {}",
+                    hunk_index, file_path
+                ))
+            })?;
 
-    let patch = build_hunk_patch(&file_path, hunk);
-    apply_patch_to_index(&path, &patch, false)
+        let patch = build_hunk_patch(&file_path, hunk);
+        apply_patch_to_index(&path, &patch, false)
+    })
+    .await
 }
 
 /// Unstage a specific hunk by index
@@ -824,19 +852,22 @@ pub async fn unstage_hunk_by_index(path: String, file_path: String, hunk_index: 
     // Get the staged hunks
     let file_hunks = get_file_hunks(path.clone(), file_path.clone(), true).await?;
 
-    let hunk = file_hunks
-        .hunks
-        .iter()
-        .find(|h| h.index == hunk_index)
-        .ok_or_else(|| {
-            crate::error::LeviathanError::OperationFailed(format!(
-                "Hunk index {} not found for file {}",
-                hunk_index, file_path
-            ))
-        })?;
+    crate::utils::blocking_git(move || {
+        let hunk = file_hunks
+            .hunks
+            .iter()
+            .find(|h| h.index == hunk_index)
+            .ok_or_else(|| {
+                crate::error::LeviathanError::OperationFailed(format!(
+                    "Hunk index {} not found for file {}",
+                    hunk_index, file_path
+                ))
+            })?;
 
-    let patch = build_hunk_patch(&file_path, hunk);
-    apply_patch_to_index(&path, &patch, true)
+        let patch = build_hunk_patch(&file_path, hunk);
+        apply_patch_to_index(&path, &patch, true)
+    })
+    .await
 }
 
 /// Stage specific lines from a diff
@@ -853,109 +884,112 @@ pub async fn stage_lines(
     // Get the unstaged hunks to find lines
     let file_hunks = get_file_hunks(path.clone(), file_path.clone(), false).await?;
 
-    // Collect all lines across all hunks with a global index
-    let mut global_line_idx: u32 = 0;
-    let mut selected_hunks: Vec<(IndexedDiffHunk, Vec<usize>)> = Vec::new();
+    crate::utils::blocking_git(move || {
+        // Collect all lines across all hunks with a global index
+        let mut global_line_idx: u32 = 0;
+        let mut selected_hunks: Vec<(IndexedDiffHunk, Vec<usize>)> = Vec::new();
 
-    for hunk in &file_hunks.hunks {
-        let mut selected_line_indices = Vec::new();
-        for (local_idx, _line) in hunk.lines.iter().enumerate() {
-            if global_line_idx >= start_line && global_line_idx <= end_line {
-                selected_line_indices.push(local_idx);
+        for hunk in &file_hunks.hunks {
+            let mut selected_line_indices = Vec::new();
+            for (local_idx, _line) in hunk.lines.iter().enumerate() {
+                if global_line_idx >= start_line && global_line_idx <= end_line {
+                    selected_line_indices.push(local_idx);
+                }
+                global_line_idx += 1;
             }
-            global_line_idx += 1;
+            if !selected_line_indices.is_empty() {
+                selected_hunks.push((hunk.clone(), selected_line_indices));
+            }
         }
-        if !selected_line_indices.is_empty() {
-            selected_hunks.push((hunk.clone(), selected_line_indices));
+
+        if selected_hunks.is_empty() {
+            return Err(crate::error::LeviathanError::OperationFailed(
+                "No lines found in the specified range".to_string(),
+            ));
         }
-    }
 
-    if selected_hunks.is_empty() {
-        return Err(crate::error::LeviathanError::OperationFailed(
-            "No lines found in the specified range".to_string(),
-        ));
-    }
+        // Build a patch that includes only the selected lines
+        // For lines not selected, we convert additions to nothing (skip them)
+        // and deletions to context lines
+        let mut patch = String::new();
+        patch.push_str(&format!("--- a/{}\n", file_path));
+        patch.push_str(&format!("+++ b/{}\n", file_path));
 
-    // Build a patch that includes only the selected lines
-    // For lines not selected, we convert additions to nothing (skip them)
-    // and deletions to context lines
-    let mut patch = String::new();
-    patch.push_str(&format!("--- a/{}\n", file_path));
-    patch.push_str(&format!("+++ b/{}\n", file_path));
+        for (hunk, selected_indices) in &selected_hunks {
+            // Rebuild the hunk with only selected changes
+            let mut hunk_body = String::new();
+            let mut old_count: u32 = 0;
+            let mut new_count: u32 = 0;
 
-    for (hunk, selected_indices) in &selected_hunks {
-        // Rebuild the hunk with only selected changes
-        let mut hunk_body = String::new();
-        let mut old_count: u32 = 0;
-        let mut new_count: u32 = 0;
+            for (idx, line) in hunk.lines.iter().enumerate() {
+                let is_selected = selected_indices.contains(&idx);
 
-        for (idx, line) in hunk.lines.iter().enumerate() {
-            let is_selected = selected_indices.contains(&idx);
-
-            match line.line_type.as_str() {
-                "context" => {
-                    push_diff_line(&mut hunk_body, ' ', &line.content);
-                    old_count += 1;
-                    new_count += 1;
-                }
-                "addition" if is_selected => {
-                    push_diff_line(&mut hunk_body, '+', &line.content);
-                    new_count += 1;
-                }
-                // Not-selected additions fall through to _ => {} (omitted)
-                "deletion" => {
-                    if is_selected {
-                        push_diff_line(&mut hunk_body, '-', &line.content);
-                        old_count += 1;
-                    } else {
-                        // Not selected deletions become context lines
+                match line.line_type.as_str() {
+                    "context" => {
                         push_diff_line(&mut hunk_body, ' ', &line.content);
                         old_count += 1;
                         new_count += 1;
                     }
+                    "addition" if is_selected => {
+                        push_diff_line(&mut hunk_body, '+', &line.content);
+                        new_count += 1;
+                    }
+                    // Not-selected additions fall through to _ => {} (omitted)
+                    "deletion" => {
+                        if is_selected {
+                            push_diff_line(&mut hunk_body, '-', &line.content);
+                            old_count += 1;
+                        } else {
+                            // Not selected deletions become context lines
+                            push_diff_line(&mut hunk_body, ' ', &line.content);
+                            old_count += 1;
+                            new_count += 1;
+                        }
+                    }
+                    _ => {}
                 }
-                _ => {}
             }
+
+            // Write hunk header
+            patch.push_str(&format!(
+                "@@ -{},{} +{},{} @@\n",
+                hunk.old_start, old_count, hunk.new_start, new_count
+            ));
+
+            patch.push_str(&hunk_body);
         }
 
-        // Write hunk header
-        patch.push_str(&format!(
-            "@@ -{},{} +{},{} @@\n",
-            hunk.old_start, old_count, hunk.new_start, new_count
+        // Apply the patch
+        let temp_dir = std::env::temp_dir();
+        let patch_file = temp_dir.join(format!(
+            "leviathan_stage_lines_{}.patch",
+            std::process::id()
         ));
 
-        patch.push_str(&hunk_body);
-    }
+        let mut file = std::fs::File::create(&patch_file)?;
+        file.write_all(patch.as_bytes())?;
+        file.flush()?;
+        drop(file);
 
-    // Apply the patch
-    let temp_dir = std::env::temp_dir();
-    let patch_file = temp_dir.join(format!(
-        "leviathan_stage_lines_{}.patch",
-        std::process::id()
-    ));
+        let output = create_command("git")
+            .args(["apply", "--cached", "--unidiff-zero"])
+            .arg(&patch_file)
+            .current_dir(&path)
+            .output()?;
 
-    let mut file = std::fs::File::create(&patch_file)?;
-    file.write_all(patch.as_bytes())?;
-    file.flush()?;
-    drop(file);
+        let _ = std::fs::remove_file(&patch_file);
 
-    let output = create_command("git")
-        .args(["apply", "--cached", "--unidiff-zero"])
-        .arg(&patch_file)
-        .current_dir(&path)
-        .output()?;
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(crate::error::LeviathanError::OperationFailed(format!(
+                "Failed to stage lines: {}",
+                stderr
+            )));
+        }
 
-    let _ = std::fs::remove_file(&patch_file);
-
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(crate::error::LeviathanError::OperationFailed(format!(
-            "Failed to stage lines: {}",
-            stderr
-        )));
-    }
-
-    Ok(())
+        Ok(())
+    })
+    .await
 }
 
 #[cfg(test)]

--- a/src-tauri/src/utils/blocking.rs
+++ b/src-tauri/src/utils/blocking.rs
@@ -1,0 +1,144 @@
+//! Running synchronous git work off the async runtime's worker threads.
+
+use crate::error::{LeviathanError, Result};
+
+/// Run a synchronous, potentially slow git operation on tokio's blocking pool.
+///
+/// Almost every Tauri command here is `async fn`, but the body is pure
+/// `git2` — a revwalk, a diff, an index write, a status scan. Run directly,
+/// that work occupies a tokio WORKER thread for its whole duration, and the
+/// runtime has a small, fixed number of those. While one command walks a
+/// 200k-commit history, the tasks sharing those workers make no progress:
+/// auto-fetch, the file watcher's event pump, the MCP server, and every other
+/// in-flight command sit behind it. The UI's next request is not merely queued
+/// behind one slow request — it cannot even start being polled.
+///
+/// The blocking pool exists for exactly this: it grows on demand, so parking a
+/// thread there for a second costs latency on that one request and nothing
+/// else.
+///
+/// `git2` handles (`Repository`, `Commit`, `Diff`, …) are NOT `Send`, so the
+/// repository must be opened INSIDE `f` and only owned values returned.
+///
+/// A panic inside `f` is turned into an error rather than being left to
+/// unwind out of a detached task: the caller gets a failed command it can
+/// report, and the runtime keeps running.
+pub async fn blocking_git<T, F>(f: F) -> Result<T>
+where
+    F: FnOnce() -> Result<T> + Send + 'static,
+    T: Send + 'static,
+{
+    match tokio::task::spawn_blocking(f).await {
+        Ok(result) => result,
+        Err(join_error) => {
+            if join_error.is_panic() {
+                let payload = join_error.into_panic();
+                Err(LeviathanError::Custom(format!(
+                    "Git operation panicked: {}",
+                    panic_message(payload.as_ref())
+                )))
+            } else {
+                // Only reachable if the task was aborted; nothing here aborts
+                // one, but report it rather than silently succeeding.
+                Err(LeviathanError::Custom(format!(
+                    "Git operation did not complete: {}",
+                    join_error
+                )))
+            }
+        }
+    }
+}
+
+/// Best-effort text of a caught panic payload.
+fn panic_message(payload: &(dyn std::any::Any + Send)) -> String {
+    if let Some(s) = payload.downcast_ref::<&'static str>() {
+        (*s).to_string()
+    } else if let Some(s) = payload.downcast_ref::<String>() {
+        s.clone()
+    } else {
+        "unknown panic".to_string()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::blocking_git;
+    use crate::error::LeviathanError;
+
+    #[tokio::test]
+    async fn returns_the_closure_value() {
+        let value = blocking_git(|| Ok(21 * 2)).await.unwrap();
+        assert_eq!(value, 42);
+    }
+
+    #[tokio::test]
+    async fn propagates_the_closure_error_unchanged() {
+        let err = blocking_git::<(), _>(|| Err(LeviathanError::CommitNotFound("abc".into())))
+            .await
+            .unwrap_err();
+        assert!(matches!(err, LeviathanError::CommitNotFound(oid) if oid == "abc"));
+    }
+
+    /// A panicking git operation must surface as an ordinary command error.
+    /// Left unhandled it would resolve as a `JoinError` the caller cannot
+    /// report and the command would look like an unexplained IPC failure.
+    #[tokio::test]
+    async fn turns_a_panic_into_an_error_carrying_its_message() {
+        let err = blocking_git::<(), _>(|| panic!("index is corrupt"))
+            .await
+            .unwrap_err();
+        let message = err.to_string();
+        assert!(
+            message.contains("panicked") && message.contains("index is corrupt"),
+            "unexpected message: {}",
+            message
+        );
+    }
+
+    /// A `String` payload (`panic!("{}", x)`) must be reported too, not
+    /// flattened to "unknown panic".
+    #[tokio::test]
+    async fn reports_a_formatted_panic_payload() {
+        let detail = "HEAD is unborn".to_string();
+        let err = blocking_git::<(), _>(move || panic!("{}", detail))
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("HEAD is unborn"));
+    }
+
+    /// The runtime keeps working after a panicking task: the next call runs
+    /// normally rather than inheriting a poisoned pool.
+    #[tokio::test]
+    async fn the_runtime_survives_a_panicking_operation() {
+        let _ = blocking_git::<(), _>(|| panic!("boom")).await;
+        assert_eq!(blocking_git(|| Ok(7)).await.unwrap(), 7);
+    }
+
+    /// The work really does leave the worker threads: a single-worker runtime
+    /// stays responsive while a long blocking call is in flight. Run inline in
+    /// the `async fn`, the second task could not be polled at all.
+    #[test]
+    fn other_tasks_progress_while_a_blocking_operation_runs() {
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
+            .enable_all()
+            .build()
+            .unwrap();
+
+        runtime.block_on(async {
+            let slow = tokio::spawn(blocking_git(|| {
+                std::thread::sleep(std::time::Duration::from_millis(300));
+                Ok(1)
+            }));
+            let quick = tokio::spawn(async { 2 });
+
+            // The quick task finishes long before the blocking one.
+            let quick_value = tokio::time::timeout(std::time::Duration::from_millis(200), quick)
+                .await
+                .expect("a worker thread was starved by the blocking operation")
+                .unwrap();
+            assert_eq!(quick_value, 2);
+            assert_eq!(slow.await.unwrap().unwrap(), 1);
+        });
+    }
+}

--- a/src-tauri/src/utils/mod.rs
+++ b/src-tauri/src/utils/mod.rs
@@ -1,9 +1,11 @@
 //! Utility modules
 
+mod blocking;
 pub mod cli_safety;
 mod command;
 mod editor_command;
 
+pub use blocking::blocking_git;
 pub use cli_safety::reject_flag_like;
 pub use command::{apply_token_credential_helper, create_command};
 pub use editor_command::{copy_file_editor_command, todo_action_editor_command, TODO_FORMAT_ARGS};


### PR DESCRIPTION
## Summary

- Adds `utils::blocking_git` (`src-tauri/src/utils/blocking.rs`): a small helper that runs a synchronous git closure on tokio's blocking pool, turns a panic inside it into an ordinary command error, and reports an aborted task rather than silently succeeding.
- Converts the interactive hot path to use it — `commit.rs`, `diff.rs`, `staging.rs`, `branch.rs`, `repository.rs` and `search.rs` — so history walks, diffs, blame, status, staging, checkout and grep no longer occupy a tokio *worker* thread.
- Every `git2::Repository` is opened INSIDE the closure and only owned/`Send` values cross the await, because git2 handles are not `Send`. Commands that already split their git2 work into a sync closure to keep handles off an await (`edit_commit_date`, `reword_commit`, `set_upstream_branch`) now hand that closure to the pool instead of running it inline.
- Latency/responsiveness fix only: **no user-visible behaviour change.** No command signature, argument name or return shape changed, and every existing guard (state checks, `ensure_checkoutable`, `ensure_not_checked_out_elsewhere`, the amend-during-merge refusal, the merge-commit reword refusal) keeps its exact position relative to the git work.

## Review finding

Of roughly 512 `pub async fn` Tauri commands in `src-tauri/src/commands/`, only about 20 used `spawn_blocking`. The rest opened a git2 `Repository` and did fully synchronous, potentially slow work directly inside an `async fn` — for example `get_commit_history` in `src-tauri/src/commands/commit.rs`, which called `git2::Repository::open` and walked the revwalk synchronously. Tokio's multi-thread runtime has a small, fixed number of **worker** threads; a task that blocks one holds it for the whole duration, and every task scheduled onto that worker makes no progress in the meantime — it cannot even be polled. So one history page, blame, or `git grep` over a large repository stalled auto-fetch, the file watcher's event pump, the MCP server and any other in-flight command, and the UI's next request was not merely queued behind one slow request but unschedulable. The blocking pool exists for exactly this: it grows on demand, so parking a thread there costs latency on that one request and nothing else.

### Modules converted

`commit.rs`, `diff.rs`, `staging.rs`, `branch.rs`, `repository.rs`, `search.rs` — all `#[command]` functions in those files whose slow part is git2 or a git subprocess. `repository.rs`'s two existing raw `spawn_blocking` sites (`get_clone_filter_info`, `list_tracked_files`) were moved onto the shared helper so the JoinError/panic handling is uniform.

### Deliberately not converted (follow-up scope)

- All other command modules: `remote.rs`, `stash.rs`, `merge.rs`, `rebase.rs`, `tag.rs`, `blame.rs`, `worktree.rs`, `submodule.rs`, `hooks.rs`, `bisect.rs`, `reflog.rs`, `notes.rs`, `lfs.rs`, `gitflow.rs`, `config.rs`, `mcp.rs`, `ai.rs` and the rest. `remote.rs` and the clone path already use `spawn_blocking` with their own cancellation/deadline handling and were left alone.
- `staging.rs::get_sorted_file_status` — its git work is entirely inside `get_status`, which is now pooled; the remainder is pure in-memory sorting.
- Commands that are `async` only to `.await` an emit, a lock or another command (`get_repository_info`, `cancel_clone`, `stage_hunk_by_index`'s `get_file_hunks` call) were left as awaits; only their synchronous git sections moved.

## Test plan

- [ ] `cargo test --lib` — **2611 passed, 0 failed, 1 ignored** (includes 6 new tests for `blocking_git`: value pass-through, error pass-through, `&'static str` panic payload, `String` panic payload, runtime survives a panic, and a single-worker-runtime test asserting an unrelated task still makes progress while a blocking call is in flight — the actual starvation regression guard).
- [ ] `cargo fmt --check` — clean.
- [ ] `cargo clippy --all-targets -- -D warnings` — clean.
- [ ] `npm run lint` — 0 errors, 204 pre-existing warnings (unchanged).
- [ ] `npm run typecheck` — clean.
- [ ] `npm run test:contract` — 15/15 pass, so the IPC contract is unchanged.
- [ ] `npm test` — 5496 passed; the only 2 failures are the two known-flaky `network gate coverage` timeouts in `src/services/__tests__/network-gate-coverage.test.ts`, unrelated to this change (no frontend file is touched).
- [ ] A reviewer can confirm the change is mechanical with `git diff -w` — almost every hunk is a `crate::utils::blocking_git(move || {` / `}).await` pair plus reindentation, with no signature line changed (`git diff -U0 | grep '^[-+].*pub async fn'` is empty).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_