### PR TITLE
refactor: dialog store + palette command module for app-shell

### DIFF
--- a/e2e/fixtures/test-helpers.ts
+++ b/e2e/fixtures/test-helpers.ts
@@ -322,3 +322,42 @@ export async function emitBackendEvent(
     { event, payload }
   );
 }
+
+/**
+ * Open one of app-shell's dialogs/views through the dialog store.
+ *
+ * A few specs need a pane on screen that has no reachable UI affordance in a
+ * mocked run (file history and blame are opened from a context menu that needs
+ * a real commit selection). They used to set app-shell's `show*` properties
+ * directly; those live in the dialog store now, so this goes through the store
+ * the app itself uses. Prefer a real user gesture where one exists.
+ */
+export async function openAppDialog(
+  page: Page,
+  id: string,
+  context?: Record<string, unknown>
+): Promise<void> {
+  await page.evaluate(
+    ({ id: dialogId, context: ctx }) => {
+      const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as {
+        dialogStore: {
+          getState: () => { open: (id: string, context?: unknown) => void };
+        };
+      };
+      if (!stores?.dialogStore) throw new Error('dialog store is not exposed');
+      stores.dialogStore.getState().open(dialogId, ctx);
+    },
+    { id, context }
+  );
+}
+
+/** Whether one of app-shell's dialogs/views is currently open. */
+export async function isAppDialogOpen(page: Page, id: string): Promise<boolean> {
+  return page.evaluate((dialogId) => {
+    const stores = (window as unknown as Record<string, unknown>).__LEVIATHAN_STORES__ as {
+      dialogStore: { getState: () => { isOpen: (id: string) => boolean } };
+    };
+    if (!stores?.dialogStore) throw new Error('dialog store is not exposed');
+    return stores.dialogStore.getState().isOpen(dialogId);
+  }, id);
+}

--- a/e2e/tests/blame-view.spec.ts
+++ b/e2e/tests/blame-view.spec.ts
@@ -3,14 +3,15 @@ import { setupOpenRepository } from '../fixtures/tauri-mock';
 import {
   startCommandCaptureWithMocks,
   injectCommandError,
+  openAppDialog,
 } from '../fixtures/test-helpers';
 
 /**
  * E2E tests for Blame View
  * Tests blame display, context menus, line groups, and keyboard interactions.
  *
- * The blame view is conditionally rendered by app-shell when showBlame is true.
- * We open it by setting app-shell state and mocking the get_file_blame command
+ * The blame view is conditionally rendered by app-shell when the `blame` dialog
+ * is open. We open it through the dialog store and mock the get_file_blame command
  * to return deterministic blame data.
  */
 
@@ -75,19 +76,20 @@ async function openBlameView(page: import('@playwright/test').Page): Promise<voi
     get_file_blame: BLAME_MOCK_DATA,
   });
 
-  // Set app-shell properties to show the blame view
+  // Show the blame view. blameFile/blameCommitOid are still app-shell fields
+  // (they are re-derived per refresh, not open-time context); the open flag
+  // lives in the dialog store.
   await page.evaluate(() => {
     const appShell = document.querySelector('lv-app-shell') as HTMLElement & {
-      showBlame: boolean;
       blameFile: string | null;
       blameCommitOid: string | null;
     };
     if (appShell) {
       appShell.blameFile = 'src/main.ts';
       appShell.blameCommitOid = null;
-      appShell.showBlame = true;
     }
   });
+  await openAppDialog(page, 'blame');
 
   // Wait for the blame view to become visible
   await page.locator('lv-blame-view').waitFor({ state: 'visible', timeout: 5000 });
@@ -210,19 +212,18 @@ test.describe('Blame View - Error Scenarios', () => {
     // Now inject the error so the next call to get_file_blame will fail
     await injectCommandError(page, 'get_file_blame', 'Failed to get blame');
 
-    // Set app-shell properties to show the blame view (triggers get_file_blame)
+    // Show the blame view (triggers get_file_blame)
     await page.evaluate(() => {
       const appShell = document.querySelector('lv-app-shell') as HTMLElement & {
-        showBlame: boolean;
         blameFile: string | null;
         blameCommitOid: string | null;
       };
       if (appShell) {
         appShell.blameFile = 'src/main.ts';
         appShell.blameCommitOid = null;
-        appShell.showBlame = true;
       }
     });
+    await openAppDialog(page, 'blame');
 
     // Wait for the blame view to appear in the DOM
     await page.locator('lv-blame-view').waitFor({ state: 'attached', timeout: 5000 });
@@ -239,19 +240,18 @@ test.describe('Blame View - Error Scenarios', () => {
       get_file_blame: { path: 'src/main.ts', lines: [], totalLines: 0 },
     });
 
-    // Set app-shell properties to show the blame view
+    // Show the blame view
     await page.evaluate(() => {
       const appShell = document.querySelector('lv-app-shell') as HTMLElement & {
-        showBlame: boolean;
         blameFile: string | null;
         blameCommitOid: string | null;
       };
       if (appShell) {
         appShell.blameFile = 'src/main.ts';
         appShell.blameCommitOid = null;
-        appShell.showBlame = true;
       }
     });
+    await openAppDialog(page, 'blame');
 
     // Wait for the blame view to appear
     await page.locator('lv-blame-view').waitFor({ state: 'attached', timeout: 5000 });

--- a/e2e/tests/config-dialogs.spec.ts
+++ b/e2e/tests/config-dialogs.spec.ts
@@ -7,6 +7,7 @@ import {
   injectCommandMock,
   openViaCommandPalette,
   autoConfirmDialogs,
+  isAppDialogOpen,
 } from '../fixtures/test-helpers';
 
 /**
@@ -507,19 +508,15 @@ test.describe('Config Dialog - Tab Navigation', () => {
     await expect(page.locator('lv-config-dialog .alias-list, lv-config-dialog .add-alias-form').first()).toBeVisible();
   });
 
-  test('dialog should close when modal close event fires', async ({ page }) => {
-    await page.evaluate(() => {
-      const el = document.querySelector('lv-config-dialog');
-      if (el) {
-        el.dispatchEvent(new CustomEvent('close', { bubbles: true }));
-      }
-    });
+  test('dialog should close when the modal close button is pressed', async ({ page }) => {
+    // Driven through the real affordance: the modal's × dispatches `close`,
+    // which app-shell's binding turns into a dialog-store close. The previous
+    // version of this test dispatched the event at `document.querySelector`,
+    // which never pierces app-shell's shadow root, so it asserted nothing.
+    await page.locator('lv-config-dialog lv-modal .close-btn').click();
 
-    const isOpen = await page.evaluate(() => {
-      const appShell = document.querySelector('app-shell') as HTMLElement & { showConfig: boolean };
-      return appShell?.showConfig ?? false;
-    });
-    expect(isOpen).toBe(false);
+    await expect(page.locator('lv-config-dialog .tab').first()).toBeHidden();
+    expect(await isAppDialogOpen(page, 'config')).toBe(false);
   });
 });
 

--- a/e2e/tests/file-history.spec.ts
+++ b/e2e/tests/file-history.spec.ts
@@ -6,13 +6,14 @@ import {
   findCommand,
   injectCommandError,
   waitForCommand,
+  openAppDialog,
 } from '../fixtures/test-helpers';
 
 /**
  * E2E tests for the File History Panel (lv-file-history).
  *
- * The panel is rendered by the app shell in the main area when
- * showFileHistory is true and fileHistoryPath is set. It loads commits
+ * The panel is rendered by the app shell in the main area when the
+ * `fileHistory` dialog is open with a file path. It loads commits
  * via get_file_history and shows them in a scrollable list with:
  * - Header showing "File History" title, file path, commit count, and close button
  * - Commit items with short OID, summary, author, date, and "View" button
@@ -21,7 +22,7 @@ import {
  * - Empty state when no history exists
  *
  * Tests trigger the component through the app shell's real rendering flow
- * (setting showFileHistory/fileHistoryPath state) so that event wiring and
+ * (opening the `fileHistory` dialog in the store) so that event wiring and
  * store connections work correctly. Playwright locators pierce shadow DOM
  * to access internal elements.
  */
@@ -75,7 +76,7 @@ const MOCK_ENTRIES = [
 ];
 
 /**
- * Trigger file history display by setting app-shell state directly.
+ * Trigger file history display through the dialog store.
  * This mirrors the pattern used by the blame-view tests and reliably
  * triggers Lit's reactive update cycle.
  */
@@ -83,17 +84,7 @@ async function showFileHistory(
   page: import('@playwright/test').Page,
   filePath = 'src/main.ts'
 ): Promise<void> {
-  // Set app-shell properties directly to show the file history panel
-  await page.evaluate((fp) => {
-    const appShell = document.querySelector('lv-app-shell') as HTMLElement & {
-      showFileHistory: boolean;
-      fileHistoryPath: string | null;
-    };
-    if (appShell) {
-      appShell.fileHistoryPath = fp;
-      appShell.showFileHistory = true;
-    }
-  }, filePath);
+  await openAppDialog(page, 'fileHistory', { filePath });
 
   await page.locator('lv-file-history').waitFor({ state: 'attached', timeout: 5000 });
   await waitForCommand(page, 'get_file_history');
@@ -224,7 +215,7 @@ test.describe('File History - Close', () => {
 
   test('clicking close button should remove file history panel', async ({ page }) => {
     // In the real app tree, the close event is handled by the app shell
-    // which sets showFileHistory=false, removing the component from the DOM
+    // which closes the fileHistory dialog, removing the component from the DOM
     await page.locator('lv-file-history .close-btn').click();
     await expect(page.locator('lv-file-history')).not.toBeAttached();
   });
@@ -625,16 +616,7 @@ test.describe('File History - Error Scenarios', () => {
     await injectCommandError(page, 'get_file_history', 'Failed to get history');
 
     // Trigger the file history panel (which will call get_file_history and get the error)
-    await page.evaluate(() => {
-      const appShell = document.querySelector('lv-app-shell') as HTMLElement & {
-        showFileHistory: boolean;
-        fileHistoryPath: string | null;
-      };
-      if (appShell) {
-        appShell.fileHistoryPath = 'src/main.ts';
-        appShell.showFileHistory = true;
-      }
-    });
+    await openAppDialog(page, 'fileHistory', { filePath: 'src/main.ts' });
 
     // Wait for the file history panel to appear in the DOM
     await page.locator('lv-file-history').waitFor({ state: 'attached', timeout: 5000 });

--- a/src/__tests__/app-shell-destructive-guards.test.ts
+++ b/src/__tests__/app-shell-destructive-guards.test.ts
@@ -29,6 +29,7 @@ let cbId = 0;
 import { expect } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import '../app-shell.ts';
+import { dialogs } from '../stores/dialog.store.ts';
 // Side-effect import so showPrompt finds the singleton already in the DOM.
 import '../components/dialogs/lv-prompt-dialog.ts';
 import type { LvPromptDialog } from '../components/dialogs/lv-prompt-dialog.ts';
@@ -90,6 +91,14 @@ function emptyRepoData(repo: Repository) {
 function commit(oid: string) {
   return { oid, summary: `summary of ${oid}`, body: null };
 }
+
+// Which dialogs are open is module state, and several tests here drive a shell
+// that is never connected to the document (so its connectedCallback reset never
+// runs). Clear it per test to keep the isolation each instance used to get for
+// free from its own `@state()` flags.
+beforeEach(() => {
+  dialogs.reset();
+});
 
 describe('app-shell destructive guards', () => {
   beforeEach(() => {
@@ -316,7 +325,7 @@ describe('app-shell destructive guards', () => {
         configurable: true,
         get: () => ({ hasUnsavedEdits: true, editingPath: path }),
       });
-      (el as any).showDiff = true;
+      dialogs.open('diff');
       return el;
     }
 
@@ -334,7 +343,7 @@ describe('app-shell destructive guards', () => {
       const warning = uiStore.getState().toasts.find((t) => t.type === 'warning');
       expect(warning, 'the loss is reported').to.not.be.undefined;
       expect(warning!.message).to.contain('src/main.ts');
-      expect((el as any).showDiff, 'and the pane still closes').to.equal(false);
+      expect(dialogs.isOpen('diff'), 'and the pane still closes').to.equal(false);
     });
 
     it('a clean editor closes quietly', async () => {
@@ -343,7 +352,7 @@ describe('app-shell destructive guards', () => {
         configurable: true,
         get: () => ({ hasUnsavedEdits: false, editingPath: null }),
       });
-      (el as any).showDiff = true;
+      dialogs.open('diff');
       uiStore.setState({ toasts: [] });
 
       (el as any).handleCloseDiff();
@@ -365,7 +374,7 @@ describe('app-shell destructive guards', () => {
       const warning = uiStore.getState().toasts.find((t) => t.type === 'warning');
       expect(warning, 'the loss is reported').to.not.be.undefined;
       expect(warning!.message).to.contain('src/main.ts');
-      expect((el as any).showBlame, 'and blame still opens').to.equal(true);
+      expect(dialogs.isOpen('blame'), 'and blame still opens').to.equal(true);
     });
 
     it('opening file history from the commit panel warns the same way', async () => {
@@ -381,7 +390,7 @@ describe('app-shell destructive guards', () => {
       const warning = uiStore.getState().toasts.find((t) => t.type === 'warning');
       expect(warning, 'the loss is reported').to.not.be.undefined;
       expect(warning!.message).to.contain('src/main.ts');
-      expect((el as any).showFileHistory, 'and the history pane still opens').to.equal(true);
+      expect(dialogs.isOpen('fileHistory'), 'and the history pane still opens').to.equal(true);
     });
 
     it('closing with no diff open says nothing', async () => {

--- a/src/__tests__/app-shell-model-download-alerts.test.ts
+++ b/src/__tests__/app-shell-model-download-alerts.test.ts
@@ -54,6 +54,7 @@ function emit(event: string, payload: unknown): void {
 import { expect, fixture, html } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import '../app-shell.ts';
+import { dialogs } from '../stores/dialog.store.ts';
 import { uiStore } from '../stores/index.ts';
 
 async function shell(): Promise<AppShell> {
@@ -80,6 +81,14 @@ function errorToasts() {
   return uiStore.getState().toasts.filter((t) => t.type === 'error');
 }
 
+// Which dialogs are open is module state, and several tests here drive a shell
+// that is never connected to the document (so its connectedCallback reset never
+// runs). Clear it per test to keep the isolation each instance used to get for
+// free from its own `@state()` flags.
+beforeEach(() => {
+  dialogs.reset();
+});
+
 describe('app-shell model download alerts', () => {
   beforeEach(() => {
     uiStore.setState({ toasts: [] });
@@ -93,9 +102,9 @@ describe('app-shell model download alerts', () => {
   });
 
   it('surfaces a background download failure while Settings is closed', async () => {
-    const el = await shell();
+    await shell();
     expect(
-      (el as unknown as { showSettings: boolean }).showSettings,
+      dialogs.isOpen('settings'),
       'Settings must be closed for this to be the reported bug'
     ).to.be.false;
 

--- a/src/__tests__/app-shell-multi-repo.test.ts
+++ b/src/__tests__/app-shell-multi-repo.test.ts
@@ -26,6 +26,7 @@ let cbId = 0;
 import { expect, waitUntil } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import '../app-shell.ts';
+import { dialogs, type DialogId } from '../stores/dialog.store.ts';
 import { uiStore, repositoryStore, settingsStore } from '../stores/index.ts';
 import { searchIndexService } from '../services/search-index.service.ts';
 import type { Repository } from '../types/git.types.ts';
@@ -116,6 +117,14 @@ function stubPinnedDialog(
   return { closed: () => closed };
 }
 
+
+// Which dialogs are open is module state, and several tests here drive a shell
+// that is never connected to the document (so its connectedCallback reset never
+// runs). Clear it per test to keep the isolation each instance used to get for
+// free from its own `@state()` flags.
+beforeEach(() => {
+  dialogs.reset();
+});
 
 describe('app-shell multi-repo behavior', () => {
   beforeEach(() => {
@@ -1306,7 +1315,7 @@ describe('app-shell multi-repo behavior', () => {
         );
         await el.updateComplete;
 
-        expect((el as any).showConflictDialog).to.be.false;
+        expect(dialogs.isOpen('conflict')).to.be.false;
         expect(el.shadowRoot!.querySelector('lv-conflict-resolution-dialog')).to.be.null;
         const toasts = uiStore.getState().toasts;
         expect(toasts.some((t) => t.type === 'warning' && t.message.includes('tab was closed')))
@@ -1327,14 +1336,14 @@ describe('app-shell multi-repo behavior', () => {
 
         (el as any).openConflictDialogFromState();
         await el.updateComplete;
-        expect((el as any).showConflictDialog).to.be.true;
+        expect(dialogs.isOpen('conflict')).to.be.true;
 
         // The user clicks the × on repo A's tab with the dialog up. The
         // dialog must not stay floating over whatever renders next.
         repositoryStore.getState().removeRepository('/repo/a');
         await el.updateComplete;
 
-        expect((el as any).showConflictDialog).to.be.false;
+        expect(dialogs.isOpen('conflict')).to.be.false;
         expect(el.shadowRoot!.querySelector('lv-conflict-resolution-dialog')).to.be.null;
         const toasts = uiStore.getState().toasts;
         expect(
@@ -1359,7 +1368,7 @@ describe('app-shell multi-repo behavior', () => {
         repositoryStore.getState().removeRepository('/repo/b');
         await el.updateComplete;
 
-        expect((el as any).showConflictDialog).to.be.true;
+        expect(dialogs.isOpen('conflict')).to.be.true;
       } finally {
         el.remove();
       }
@@ -1446,7 +1455,7 @@ describe('app-shell multi-repo behavior', () => {
         // A is backgrounded — it must be marked stale (refreshed when
         // re-activated) so its tab doesn't keep showing merge state.
         expect((el as any).staleRepoPaths.has('/repo/a')).to.be.true;
-        expect((el as any).showConflictDialog).to.be.false;
+        expect(dialogs.isOpen('conflict')).to.be.false;
       } finally {
         el.remove();
       }
@@ -1664,7 +1673,7 @@ describe('app-shell multi-repo behavior', () => {
     it('does NOT dismiss — or claim to cancel — a clean that is mid-delete', async () => {
       // The repro: select thousands of untracked files, Delete, confirm, then
       // close the tab while clean_files runs. The sweep used to set
-      // `showClean = false` directly, bypassing the dialog's own `cleaning`
+      // the clean dialog's flag directly, bypassing its own `cleaning`
       // guard, and toast "clean cancelled" — seconds before "Deleted 4,913
       // items" landed. Untracked files have no trash and no recovery path.
       const el = createAppShell();
@@ -1675,7 +1684,7 @@ describe('app-shell multi-repo behavior', () => {
         repositoryStore.getState().setActiveByPath('/repo/b');
         await el.updateComplete;
 
-        (el as any).showClean = true;
+        dialogs.open('clean');
         await el.updateComplete;
         const clean = stubPinnedDialog(el, 'lv-clean-dialog', '/repo/a', true);
         uiStore.setState({ toasts: [] });
@@ -1685,7 +1694,7 @@ describe('app-shell multi-repo behavior', () => {
 
         expect(clean.closed(), 'an in-flight clean is not force-dismissed').to.be.false;
         expect(
-          (el as any).showClean,
+          dialogs.isOpen('clean'),
           'the host flag stays set — clearing it unmounts the dialog and orphans the delete',
         ).to.be.true;
         const messages = uiStore.getState().toasts.map((t) => t.message);
@@ -1713,7 +1722,7 @@ describe('app-shell multi-repo behavior', () => {
         repositoryStore.getState().setActiveByPath('/repo/b');
         await el.updateComplete;
 
-        (el as any).showClean = true;
+        dialogs.open('clean');
         await el.updateComplete;
         const clean = stubPinnedDialog(el, 'lv-clean-dialog', '/repo/a', false);
         uiStore.setState({ toasts: [] });
@@ -1722,7 +1731,7 @@ describe('app-shell multi-repo behavior', () => {
         await el.updateComplete;
 
         expect(clean.closed(), 'an idle clean dialog is dismissed').to.be.true;
-        expect((el as any).showClean, 'and its host flag cleared').to.be.false;
+        expect(dialogs.isOpen('clean'), 'and its host flag cleared').to.be.false;
         const messages = uiStore.getState().toasts.map((t) => t.message);
         expect(
           messages.some((m) => /clean cancelled/i.test(m)),
@@ -1772,11 +1781,11 @@ describe('app-shell multi-repo behavior', () => {
       // the host flag unconditionally: worktree remove --force, submodule
       // deinit -f, git lfs prune, and the reflog hard reset all kept running
       // behind a toast saying they had been closed.
-      const cases: Array<[string, string, string]> = [
-        ['lv-worktree-dialog', 'showWorktrees', 'worktree removal'],
-        ['lv-submodule-dialog', 'showSubmodules', 'submodule removal'],
-        ['lv-lfs-dialog', 'showLfs', 'LFS prune'],
-        ['lv-reflog-dialog', 'showReflog', 'reset'],
+      const cases: Array<[string, DialogId, string]> = [
+        ['lv-worktree-dialog', 'worktrees', 'worktree removal'],
+        ['lv-submodule-dialog', 'submodules', 'submodule removal'],
+        ['lv-lfs-dialog', 'lfs', 'LFS prune'],
+        ['lv-reflog-dialog', 'reflog', 'reset'],
       ];
       for (const [tag, flag, running] of cases) {
         const el = createAppShell();
@@ -1788,7 +1797,7 @@ describe('app-shell multi-repo behavior', () => {
           repositoryStore.getState().setActiveByPath('/repo/b');
           await el.updateComplete;
 
-          (el as any)[flag] = true;
+          dialogs.open(flag);
           await el.updateComplete;
           stubPinnedDialog(el, tag, '/repo/a', true);
           uiStore.setState({ toasts: [] });
@@ -1796,7 +1805,7 @@ describe('app-shell multi-repo behavior', () => {
           repositoryStore.getState().removeRepository('/repo/a');
           await el.updateComplete;
 
-          expect((el as any)[flag], `${tag}: host flag survives an in-flight operation`).to.be.true;
+          expect(dialogs.isOpen(flag), `${tag}: host flag survives an in-flight operation`).to.be.true;
           const messages = uiStore.getState().toasts.map((t) => t.message);
           expect(
             messages.some((m) => m.includes(`the ${running} is still running`)),
@@ -1818,7 +1827,7 @@ describe('app-shell multi-repo behavior', () => {
         repositoryStore.getState().addRepository(mockRepo('/repo/a', 'a'), { activate: true });
         await el.updateComplete;
 
-        (el as any).showClean = true;
+        dialogs.open('clean');
         await el.updateComplete;
         stubPinnedDialog(el, 'lv-clean-dialog', '/repo/a', true);
         uiStore.setState({ toasts: [] });
@@ -2129,7 +2138,7 @@ describe('app-shell multi-repo behavior', () => {
           (el as any).openConflictDialogFromState();
           await el.updateComplete;
 
-          expect((el as any).showConflictDialog).to.be.false;
+          expect(dialogs.isOpen('conflict')).to.be.false;
           expect(el.shadowRoot!.querySelector('lv-conflict-resolution-dialog')).to.be.null;
           const toasts = uiStore.getState().toasts;
           expect(toasts.some((t) => t.type === 'warning' && t.message.includes(state))).to.be
@@ -2148,7 +2157,7 @@ describe('app-shell multi-repo behavior', () => {
         await el.updateComplete;
         (el as any).openConflictDialogFromState();
         await el.updateComplete;
-        expect((el as any).showConflictDialog).to.be.true;
+        expect(dialogs.isOpen('conflict')).to.be.true;
         expect((el as any).conflictOperationType).to.equal('stash');
       } finally {
         el.remove();
@@ -2178,21 +2187,20 @@ describe('closing the last repository closes its dialogs', () => {
     });
     await el.updateComplete;
 
-    const internal = el as unknown as Record<string, unknown>;
-    internal.showBisect = true;
-    internal.showWorktrees = true;
-    internal.showLfs = true;
+    dialogs.open('bisect');
+    dialogs.open('worktrees');
+    dialogs.open('lfs');
     // Not repo-scoped — must survive.
-    internal.showSettings = true;
+    dialogs.open('settings');
     await el.updateComplete;
 
     repositoryStore.setState({ openRepositories: [] as never, activeIndex: -1 });
     await el.updateComplete;
 
-    expect(internal.showBisect, 'bisect must not outlive its repository').to.be.false;
-    expect(internal.showWorktrees, 'worktrees must not outlive its repository').to.be.false;
-    expect(internal.showLfs, 'LFS must not outlive its repository').to.be.false;
-    expect(internal.showSettings, 'settings is not repo-scoped').to.be.true;
+    expect(dialogs.isOpen('bisect'), 'bisect must not outlive its repository').to.be.false;
+    expect(dialogs.isOpen('worktrees'), 'worktrees must not outlive its repository').to.be.false;
+    expect(dialogs.isOpen('lfs'), 'LFS must not outlive its repository').to.be.false;
+    expect(dialogs.isOpen('settings'), 'settings is not repo-scoped').to.be.true;
 
     el.remove();
   });
@@ -2216,30 +2224,29 @@ describe('closing the last repository closes its dialogs', () => {
     });
     await el.updateComplete;
 
-    const repoIndependent = [
-      'showSsh',
-      'showProfileManager',
-      'showMigrationDialog',
-      'showGitHub',
-      'showGitLab',
-      'showBitbucket',
-      'showAzureDevOps',
-      'showOidc',
+    const repoIndependent: DialogId[] = [
+      'ssh',
+      'profileManager',
+      'migration',
+      'gitHub',
+      'gitLab',
+      'bitbucket',
+      'azureDevOps',
+      'oidc',
     ];
-    const internal = el as unknown as Record<string, unknown>;
-    for (const key of repoIndependent) internal[key] = true;
+    for (const key of repoIndependent) dialogs.open(key);
     // Control: GPG renders inside the activeRepository block, so it must still
     // be swept — proof the exclusion did not simply disable the sweep.
-    internal.showGpg = true;
+    dialogs.open('gpg');
     await el.updateComplete;
 
     repositoryStore.setState({ openRepositories: [] as never, activeIndex: -1 });
     await el.updateComplete;
 
     for (const key of repoIndependent) {
-      expect(internal[key], `${key} is not repo-scoped`).to.be.true;
+      expect(dialogs.isOpen(key), `${key} is not repo-scoped`).to.be.true;
     }
-    expect(internal.showGpg, 'GPG must not outlive its repository').to.be.false;
+    expect(dialogs.isOpen('gpg'), 'GPG must not outlive its repository').to.be.false;
 
     el.remove();
   });
@@ -2258,7 +2265,7 @@ describe('closing the last repository closes its dialogs', () => {
     await el.updateComplete;
 
     const internal = el as unknown as Record<string, unknown>;
-    internal.showProfileManager = true;
+    dialogs.open('profileManager');
     await el.updateComplete;
 
     // Drive the REAL handler: the manager stacks a provider dialog on itself to
@@ -2277,7 +2284,7 @@ describe('closing the last repository closes its dialogs', () => {
     );
     await el.updateComplete;
 
-    expect(internal.showGitHub, 'the connect flow opened the provider dialog').to.be.true;
+    expect(dialogs.isOpen('gitHub'), 'the connect flow opened the provider dialog').to.be.true;
     expect(internal.integrationContext, 'the connect flow recorded its return context').to.not.be
       .null;
 
@@ -2314,36 +2321,35 @@ describe('closing the last repository closes its dialogs', () => {
     });
     await el.updateComplete;
 
-    const repoScoped = [
-      'showRemotes',
-      'showClean',
-      'showBisect',
-      'showSubmodules',
-      'showWorktrees',
-      'showLfs',
-      'showGpg',
-      'showConfig',
-      'showCredentials',
-      'showHooksDialog',
-      'showRepositoryHealth',
-      'showReflog',
+    const repoScoped: DialogId[] = [
+      'remotes',
+      'clean',
+      'bisect',
+      'submodules',
+      'worktrees',
+      'lfs',
+      'gpg',
+      'config',
+      'credentials',
+      'hooks',
+      'repositoryHealth',
+      'reflog',
     ];
-    const internal = el as unknown as Record<string, unknown>;
-    for (const key of repoScoped) internal[key] = true;
+    for (const key of repoScoped) dialogs.open(key);
     await el.updateComplete;
 
     repositoryStore.setState({ openRepositories: [] as never, activeIndex: -1 });
     await el.updateComplete;
 
     for (const key of repoScoped) {
-      expect(internal[key], `${key} must not outlive its repository`).to.be.false;
+      expect(dialogs.isOpen(key), `${key} must not outlive its repository`).to.be.false;
     }
 
     el.remove();
   });
 });
 describe('the toolbar command-palette button loads the active repo', () => {
-  // Setting showCommandPalette directly skipped openCommandPalette(), the only
+  // Opening the palette dialog directly skipped openCommandPalette(), the only
   // place branches and files are loaded. Cold start: a palette with no branch
   // entries at all. After a tab switch: the PREVIOUS repo's branches, offering
   // "Switch to <current branch>" and running a checkout against the wrong repo.
@@ -2362,7 +2368,6 @@ describe('the toolbar command-palette button loads the active repo', () => {
 
     const internal = el as unknown as {
       paletteBranches: unknown[];
-      showCommandPalette: boolean;
     };
     internal.paletteBranches = [];
     invokeCallArgs.length = 0;
@@ -2375,7 +2380,7 @@ describe('the toolbar command-palette button loads the active repo', () => {
     await el.updateComplete;
     await new Promise((r) => setTimeout(r, 0));
 
-    expect(internal.showCommandPalette, 'the palette opens').to.be.true;
+    expect(dialogs.isOpen('commandPalette'), 'the palette opens').to.be.true;
     expect(
       // list_tracked_files is loaded ONLY by openCommandPalette, so it is the
       // unambiguous signal that the loader ran (get_branches is also issued by
@@ -2414,7 +2419,6 @@ describe('the toolbar command-palette button loads the active repo', () => {
     const internal = el as unknown as {
       paletteBranches: Array<{ name: string }>;
       paletteTrackedFiles: string[];
-      showCommandPalette: boolean;
       openCommandPalette: () => Promise<void>;
     };
     const pendingOpen = internal.openCommandPalette();
@@ -2427,7 +2431,7 @@ describe('the toolbar command-palette button loads the active repo', () => {
     await pendingOpen;
     await el.updateComplete;
 
-    expect(internal.showCommandPalette, 'the stale request must not reopen the overlay').to.be.false;
+    expect(dialogs.isOpen('commandPalette'), 'the stale request must not reopen the overlay').to.be.false;
     expect(internal.paletteBranches.some((branch) => branch.name === 'only-in-a')).to.be.false;
     expect(internal.paletteTrackedFiles).not.to.include('only-in-a.txt');
 
@@ -2487,12 +2491,11 @@ describe('the toolbar command-palette button loads the active repo', () => {
     await el.updateComplete;
 
     const internal = el as unknown as {
-      showCommandPalette: boolean;
       openCommandPalette: () => Promise<void>;
     };
     await internal.openCommandPalette();
     await el.updateComplete;
-    expect(internal.showCommandPalette, 'the palette is up to begin with').to.be.true;
+    expect(dialogs.isOpen('commandPalette'), 'the palette is up to begin with').to.be.true;
 
     deferLoads = true;
     const pendingOpen = internal.openCommandPalette();
@@ -2503,14 +2506,14 @@ describe('the toolbar command-palette button loads the active repo', () => {
     expect(palette, 'the palette must be rendered').to.not.be.null;
     (palette as unknown as { close: () => void }).close();
     await el.updateComplete;
-    expect(internal.showCommandPalette, 'the dismissal takes effect').to.be.false;
+    expect(dialogs.isOpen('commandPalette'), 'the dismissal takes effect').to.be.false;
 
     branchResolvers.forEach((resolve) => resolve([]));
     fileResolvers.forEach((resolve) => resolve([]));
     await pendingOpen;
     await el.updateComplete;
 
-    expect(internal.showCommandPalette, 'the superseded load must not reopen it').to.be.false;
+    expect(dialogs.isOpen('commandPalette'), 'the superseded load must not reopen it').to.be.false;
     expect(
       (palette as unknown as { open: boolean }).open,
       'and the overlay itself stays down'
@@ -2535,17 +2538,16 @@ describe('the toolbar command-palette button loads the active repo', () => {
     await el.updateComplete;
 
     const internal = el as unknown as {
-      showCommandPalette: boolean;
       openCommandPalette: () => Promise<void>;
     };
     await internal.openCommandPalette();
     await el.updateComplete;
-    expect(internal.showCommandPalette).to.be.true;
+    expect(dialogs.isOpen('commandPalette')).to.be.true;
 
     repositoryStore.setState({ activeIndex: 1 });
     await el.updateComplete;
 
-    expect(internal.showCommandPalette).to.be.false;
+    expect(dialogs.isOpen('commandPalette')).to.be.false;
     el.remove();
   });
 
@@ -2618,7 +2620,6 @@ describe('the toolbar command-palette button loads the active repo', () => {
     const internal = el as unknown as {
       paletteBranches: unknown[];
       paletteTrackedFiles: string[];
-      showCommandPalette: boolean;
       openCommandPalette: () => Promise<void>;
     };
     uiStore.setState({ toasts: [] });
@@ -2627,7 +2628,7 @@ describe('the toolbar command-palette button loads the active repo', () => {
 
     expect(internal.paletteBranches).to.deep.equal([]);
     expect(internal.paletteTrackedFiles).to.deep.equal([]);
-    expect(internal.showCommandPalette).to.be.true;
+    expect(dialogs.isOpen('commandPalette')).to.be.true;
     expect(uiStore.getState().toasts).to.deep.equal([]);
   });
 });

--- a/src/__tests__/app-shell-output-panel.test.ts
+++ b/src/__tests__/app-shell-output-panel.test.ts
@@ -19,6 +19,7 @@ const mockInvoke: MockInvoke = () => Promise.resolve(null);
 import { expect } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import '../app-shell.ts';
+import { dialogs } from '../stores/dialog.store.ts';
 
 interface PaletteCommandLike {
   id: string;
@@ -35,6 +36,14 @@ function getPaletteCommands(el: AppShell): PaletteCommandLike[] {
   return (el as any).getPaletteCommands();
 }
 
+// Which dialogs are open is module state, and several tests here drive a shell
+// that is never connected to the document (so its connectedCallback reset never
+// runs). Clear it per test to keep the isolation each instance used to get for
+// free from its own `@state()` flags.
+beforeEach(() => {
+  dialogs.reset();
+});
+
 describe('app-shell output panel wiring', () => {
   it('exposes a Toggle Output Panel palette command', () => {
     const el = createAppShell();
@@ -47,13 +56,10 @@ describe('app-shell output panel wiring', () => {
     const el = createAppShell();
     const cmd = getPaletteCommands(el).find((c) => c.id === 'toggle-output-panel')!;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any).showOutputPanel).to.be.false;
+    expect(dialogs.isOpen('outputPanel')).to.be.false;
     cmd.action();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any).showOutputPanel).to.be.true;
+    expect(dialogs.isOpen('outputPanel')).to.be.true;
     cmd.action();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    expect((el as any).showOutputPanel).to.be.false;
+    expect(dialogs.isOpen('outputPanel')).to.be.false;
   });
 });

--- a/src/__tests__/app-shell-palette-integrations.integration.test.ts
+++ b/src/__tests__/app-shell-palette-integrations.integration.test.ts
@@ -23,6 +23,7 @@ import { expect } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import { uiStore } from '../stores/ui.store.ts';
 import '../app-shell.ts';
+import { dialogs, type DialogId } from '../stores/dialog.store.ts';
 
 interface PaletteCommand {
   id: string;
@@ -45,18 +46,26 @@ function getCommand(el: AppShell, id: string): PaletteCommand {
   return cmd;
 }
 
+// Which dialogs are open is module state, and several tests here drive a shell
+// that is never connected to the document (so its connectedCallback reset never
+// runs). Clear it per test to keep the isolation each instance used to get for
+// free from its own `@state()` flags.
+beforeEach(() => {
+  dialogs.reset();
+});
+
 describe('app-shell palette integration entries (no repo required)', () => {
   beforeEach(() => {
     uiStore.setState({ toasts: [] });
   });
 
-  const cases: Array<{ id: string; flag: string }> = [
-    { id: 'github', flag: 'showGitHub' },
-    { id: 'gitlab', flag: 'showGitLab' },
-    { id: 'bitbucket', flag: 'showBitbucket' },
-    { id: 'azure-devops', flag: 'showAzureDevOps' },
-    { id: 'oidc', flag: 'showOidc' },
-    { id: 'profiles', flag: 'showProfileManager' },
+  const cases: Array<{ id: string; flag: DialogId }> = [
+    { id: 'github', flag: 'gitHub' },
+    { id: 'gitlab', flag: 'gitLab' },
+    { id: 'bitbucket', flag: 'bitbucket' },
+    { id: 'azure-devops', flag: 'azureDevOps' },
+    { id: 'oidc', flag: 'oidc' },
+    { id: 'profiles', flag: 'profileManager' },
   ];
 
   for (const { id, flag } of cases) {
@@ -64,13 +73,11 @@ describe('app-shell palette integration entries (no repo required)', () => {
       const el = createAppShellNoRepo();
       const cmd = getCommand(el, id);
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any)[flag], `${flag} starts false`).to.not.equal(true);
+      expect(dialogs.isOpen(flag), `${flag} starts closed`).to.equal(false);
 
       cmd.action();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any)[flag], `${flag} set true`).to.equal(true);
+      expect(dialogs.isOpen(flag), `${flag} opened`).to.equal(true);
       const warnings = uiStore.getState().toasts.filter(
         (t) => t.message === 'Please open a repository first',
       );
@@ -107,7 +114,7 @@ describe('app-shell explicit integration navigation', () => {
   it('standalone open sets no return context → no Back arrow, no attach name', () => {
     const el = createAppShellNoRepo();
     getCommand(el, 'github').action();
-    expect((el as any).showGitHub).to.equal(true);
+    expect(dialogs.isOpen('gitHub')).to.equal(true);
     expect((el as any).integrationContext, 'no context standalone').to.equal(null);
     expect((el as any).integrationBackButton, 'no back arrow').to.equal(false);
     expect((el as any).integrationAttachName, 'no breadcrumb').to.equal('');
@@ -123,7 +130,7 @@ describe('app-shell explicit integration navigation', () => {
       attach: true,
     };
     (el as any).handleOpenIntegrationFromManager('github', { detail: context });
-    expect((el as any).showGitHub).to.equal(true);
+    expect(dialogs.isOpen('gitHub')).to.equal(true);
     expect((el as any).integrationContext).to.deep.equal(context);
     expect((el as any).integrationBackButton, 'back arrow shown').to.equal(true);
     expect((el as any).integrationAttachName, 'breadcrumb name shown').to.equal('Work');
@@ -164,7 +171,7 @@ describe('app-shell explicit integration navigation', () => {
     });
 
     (el as any).handleIntegrationDialogClose('github');
-    expect((el as any).showGitHub, 'provider dialog closed').to.equal(false);
+    expect(dialogs.isOpen('gitHub'), 'provider dialog closed').to.equal(false);
     expect((el as any).integrationContext, 'context cleared').to.equal(null);
     expect(revealed, 'manager revealed with the explicit context').to.deep.equal(context);
   });
@@ -178,35 +185,38 @@ describe('app-shell explicit integration navigation', () => {
       get currentView() { return 'list'; },
     });
     (el as any).handleIntegrationDialogClose('gitlab');
-    expect((el as any).showGitLab).to.equal(false);
+    expect(dialogs.isOpen('gitLab')).to.equal(false);
     expect(revealedCalled, 'no reveal for standalone close').to.equal(false);
   });
 
   it('Manage Accounts is reversible: closing the Accounts view reopens the provider', () => {
     const el = createAppShellNoRepo();
     // Simulate a provider dialog open, then "Manage Accounts" from it.
-    (el as any).showGitHub = true;
+    dialogs.open('gitHub');
     (el as any).handleManageAccounts({ detail: { integrationType: 'github' } });
-    expect((el as any).showGitHub, 'provider dialog closed').to.equal(false);
-    expect((el as any).showProfileManager, 'manager opened').to.equal(true);
-    expect((el as any).profileManagerView, 'lands on Accounts view').to.equal('accounts');
+    expect(dialogs.isOpen('gitHub'), 'provider dialog closed').to.equal(false);
+    expect(dialogs.isOpen('profileManager'), 'manager opened').to.equal(true);
+    expect(
+      dialogs.context('profileManager')?.initialView,
+      'lands on Accounts view',
+    ).to.equal('accounts');
     // Not demoted — the manager is shown ON TOP (no stacked-overlay context).
     expect((el as any).profileManagerDemoted).to.equal(false);
 
     // Closing OUT OF the Accounts view returns to the provider dialog.
     (el as any).handleProfileManagerClose({ detail: { fromView: 'accounts' } });
-    expect((el as any).showProfileManager).to.equal(false);
-    expect((el as any).showGitHub, 'returned to the provider dialog').to.equal(true);
+    expect(dialogs.isOpen('profileManager')).to.equal(false);
+    expect(dialogs.isOpen('gitHub'), 'returned to the provider dialog').to.equal(true);
   });
 
   it('Manage Accounts close does NOT reopen the provider if user navigated off Accounts', () => {
     const el = createAppShellNoRepo();
-    (el as any).showGitHub = true;
+    dialogs.open('gitHub');
     (el as any).handleManageAccounts({ detail: { integrationType: 'github' } });
     // User navigated into the profile list; closing should NOT bounce back.
     (el as any).handleProfileManagerClose({ detail: { fromView: 'list' } });
-    expect((el as any).showProfileManager).to.equal(false);
-    expect((el as any).showGitHub, 'no surprise reopen off Accounts').to.equal(false);
+    expect(dialogs.isOpen('profileManager')).to.equal(false);
+    expect(dialogs.isOpen('gitHub'), 'no surprise reopen off Accounts').to.equal(false);
   });
   /* eslint-enable @typescript-eslint/no-explicit-any */
 });

--- a/src/__tests__/app-shell-pull-stash-copy.integration.test.ts
+++ b/src/__tests__/app-shell-pull-stash-copy.integration.test.ts
@@ -36,6 +36,7 @@ import { uiStore } from '../stores/ui.store.ts';
 
 // Import the real component
 import '../app-shell.ts';
+import { dialogs } from '../stores/dialog.store.ts';
 
 // Side-effect import so showPrompt finds the singleton already in the DOM.
 import '../components/dialogs/lv-prompt-dialog.ts';
@@ -117,6 +118,14 @@ function createAppShell(): AppShell {
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
+// Which dialogs are open is module state, and several tests here drive a shell
+// that is never connected to the document (so its connectedCallback reset never
+// runs). Clear it per test to keep the isolation each instance used to get for
+// free from its own `@state()` flags.
+beforeEach(() => {
+  dialogs.reset();
+});
+
 describe('app-shell pull/stash/copy handlers (integration)', () => {
   beforeEach(() => {
     clearHistory();
@@ -138,8 +147,7 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       expect(findCommands('pull').length).to.equal(1);
       // handleRefresh -> open_repository
       expect(findCommands('open_repository').length).to.be.greaterThan(0);
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any).showConflictDialog).to.be.false;
+      expect(dialogs.isOpen('conflict')).to.be.false;
     });
 
     it('opens the merge conflict dialog on MERGE_CONFLICT', async () => {
@@ -153,8 +161,7 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (el as any).handlePull();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any).showConflictDialog).to.be.true;
+      expect(dialogs.isOpen('conflict')).to.be.true;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((el as any).conflictOperationType).to.equal('merge');
       // Still refreshes so the working tree reflects the conflicted state
@@ -172,8 +179,7 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (el as any).handlePull();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any).showConflictDialog).to.be.true;
+      expect(dialogs.isOpen('conflict')).to.be.true;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((el as any).conflictOperationType).to.equal('rebase');
     });
@@ -188,8 +194,7 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (el as any).handlePull();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any).showConflictDialog).to.be.false;
+      expect(dialogs.isOpen('conflict')).to.be.false;
       const toasts = uiStore.getState().toasts;
       expect(toasts.some((t) => t.type === 'error' && /Could not reach remote/.test(t.message))).to.be.true;
     });
@@ -349,17 +354,17 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       const el = createAppShell();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const shell = el as any;
-      shell.showDiff = true;
+      dialogs.open('diff');
       shell.diffFile = { path: 'src/x.ts', status: 'modified', isStaged: false, isConflicted: false };
 
       shell.handleShowBlame(
         new CustomEvent('show-blame', { detail: { filePath: 'src/x.ts', commitOid: 'abc123' } })
       );
 
-      expect(shell.showBlame).to.be.true;
+      expect(dialogs.isOpen('blame')).to.be.true;
       expect(shell.blameFile).to.equal('src/x.ts');
       expect(shell.blameCommitOid).to.equal('abc123');
-      expect(shell.showDiff).to.be.false;
+      expect(dialogs.isOpen('diff')).to.be.false;
       expect(shell.diffFile).to.be.null;
     });
   });
@@ -372,16 +377,16 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       const el = createAppShell();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const shell = el as any;
-      shell.showDiff = true;
+      dialogs.open('diff');
       shell.diffFile = { path: 'src/x.ts', status: 'modified', isStaged: false, isConflicted: false };
 
       shell.handleShowFileHistory(
         new CustomEvent('show-file-history', { detail: { filePath: 'src/x.ts' } })
       );
 
-      expect(shell.showFileHistory).to.be.true;
+      expect(dialogs.isOpen('fileHistory')).to.be.true;
       expect(shell.fileHistoryPath).to.equal('src/x.ts');
-      expect(shell.showDiff, 'the diff no longer covers the history pane').to.be.false;
+      expect(dialogs.isOpen('diff'), 'the diff no longer covers the history pane').to.be.false;
       expect(shell.diffFile).to.be.null;
     });
 
@@ -389,10 +394,10 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       const el = createAppShell();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const shell = el as any;
-      shell.showDiff = true;
+      dialogs.open('diff');
       shell.diffFile = null;
       shell.diffCommitFile = { commitOid: 'abc123', filePath: 'src/x.ts' };
-      shell.showBlame = true;
+      dialogs.open('blame');
       shell.blameFile = 'src/y.ts';
       shell.blameCommitOid = 'abc123';
 
@@ -400,12 +405,12 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
         new CustomEvent('show-file-history', { detail: { filePath: 'src/z.ts' } })
       );
 
-      expect(shell.showFileHistory).to.be.true;
+      expect(dialogs.isOpen('fileHistory')).to.be.true;
       expect(shell.fileHistoryPath).to.equal('src/z.ts');
-      expect(shell.showDiff).to.be.false;
+      expect(dialogs.isOpen('diff')).to.be.false;
       expect(shell.diffCommitFile).to.be.null;
       // Blame also outranks file history in the center pane
-      expect(shell.showBlame).to.be.false;
+      expect(dialogs.isOpen('blame')).to.be.false;
       expect(shell.blameFile).to.be.null;
       expect(shell.blameCommitOid).to.be.null;
     });
@@ -419,10 +424,10 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
         new CustomEvent('show-file-history', { detail: { filePath: 'src/a.ts' } })
       );
 
-      expect(shell.showFileHistory).to.be.true;
+      expect(dialogs.isOpen('fileHistory')).to.be.true;
       expect(shell.fileHistoryPath).to.equal('src/a.ts');
-      expect(shell.showDiff).to.be.false;
-      expect(shell.showBlame).to.be.false;
+      expect(dialogs.isOpen('diff')).to.be.false;
+      expect(dialogs.isOpen('blame')).to.be.false;
       expect(uiStore.getState().toasts.length, 'nothing was lost, so nothing is said').to.equal(0);
     });
   });
@@ -431,13 +436,12 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
     it('handleFileSelected clears the history pane so closing the diff does not uncover it', () => {
       // Open history for one file, then click a different file in Changes.
       // The diff outranks history in the center pane, so a stale
-      // showFileHistory is invisible right up until the diff closes — and
+      // open file-history pane is invisible right up until the diff closes — and
       // then the old file's history appears unbidden.
       const el = createAppShell();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const shell = el as any;
-      shell.showFileHistory = true;
-      shell.fileHistoryPath = 'src/old.ts';
+      dialogs.open('fileHistory', { filePath: 'src/old.ts' });
 
       shell.handleFileSelected(
         new CustomEvent('file-selected', {
@@ -447,22 +451,21 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
         })
       );
 
-      expect(shell.showDiff).to.be.true;
-      expect(shell.showFileHistory, 'the unrelated history pane is gone').to.be.false;
+      expect(dialogs.isOpen('diff')).to.be.true;
+      expect(dialogs.isOpen('fileHistory'), 'the unrelated history pane is gone').to.be.false;
       expect(shell.fileHistoryPath).to.be.null;
 
       // Closing the diff must leave the center pane empty, not reveal history.
       shell.handleCloseDiff();
-      expect(shell.showDiff).to.be.false;
-      expect(shell.showFileHistory).to.be.false;
+      expect(dialogs.isOpen('diff')).to.be.false;
+      expect(dialogs.isOpen('fileHistory')).to.be.false;
     });
 
     it('handleCommitFileSelected clears the history pane too', () => {
       const el = createAppShell();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const shell = el as any;
-      shell.showFileHistory = true;
-      shell.fileHistoryPath = 'src/old.ts';
+      dialogs.open('fileHistory', { filePath: 'src/old.ts' });
 
       shell.handleCommitFileSelected(
         new CustomEvent('commit-file-selected', {
@@ -470,9 +473,9 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
         })
       );
 
-      expect(shell.showDiff).to.be.true;
+      expect(dialogs.isOpen('diff')).to.be.true;
       expect(shell.diffCommitFile).to.deep.equal({ commitOid: 'abc123', filePath: 'src/new.ts' });
-      expect(shell.showFileHistory, 'the unrelated history pane is gone').to.be.false;
+      expect(dialogs.isOpen('fileHistory'), 'the unrelated history pane is gone').to.be.false;
       expect(shell.fileHistoryPath).to.be.null;
     });
 
@@ -483,8 +486,7 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       const el = createAppShell();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const shell = el as any;
-      shell.showFileHistory = true;
-      shell.fileHistoryPath = 'src/old.ts';
+      dialogs.open('fileHistory', { filePath: 'src/old.ts' });
       let openedPath: string | null = null;
       shell.openConflictDialogFromState = (path: string) => {
         openedPath = path;
@@ -499,8 +501,8 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       );
 
       expect(openedPath).to.equal('src/conflict.ts');
-      expect(shell.showDiff, 'no diff was opened').to.be.false;
-      expect(shell.showFileHistory).to.be.true;
+      expect(dialogs.isOpen('diff'), 'no diff was opened').to.be.false;
+      expect(dialogs.isOpen('fileHistory')).to.be.true;
       expect(shell.fileHistoryPath).to.equal('src/old.ts');
     });
   });
@@ -510,13 +512,13 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       const el = createAppShell();
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const shell = el as any;
-      shell.showDiff = true;
+      dialogs.open('diff');
       shell.diffFile = { path: 'src/x.ts', status: 'modified', isStaged: false, isConflicted: false };
       shell.diffCommitFile = null;
 
       shell.handleCloseDiff();
 
-      expect(shell.showDiff).to.be.false;
+      expect(dialogs.isOpen('diff')).to.be.false;
       expect(shell.diffFile).to.be.null;
       expect(shell.diffCommitFile).to.be.null;
     });
@@ -533,8 +535,7 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       // Let the async handleRefresh run
       await new Promise((r) => setTimeout(r, 0));
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any).showConflictDialog).to.be.true;
+      expect(dialogs.isOpen('conflict')).to.be.true;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((el as any).conflictOperationType).to.equal('rebase');
       expect(findCommands('open_repository').length).to.be.greaterThan(0);
@@ -548,8 +549,7 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       );
       await new Promise((r) => setTimeout(r, 0));
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any).showConflictDialog).to.be.true;
+      expect(dialogs.isOpen('conflict')).to.be.true;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((el as any).conflictOperationType).to.equal('stash');
     });
@@ -623,8 +623,7 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       );
       await new Promise((r) => setTimeout(r, 0));
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any).showConflictDialog).to.be.true;
+      expect(dialogs.isOpen('conflict')).to.be.true;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((el as any).conflictOperationType).to.equal('stash');
       // Warns the user AND opens the dialog.
@@ -658,8 +657,7 @@ describe('app-shell pull/stash/copy handlers (integration)', () => {
       );
       await new Promise((r) => setTimeout(r, 0));
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any).showConflictDialog).to.be.false;
+      expect(dialogs.isOpen('conflict')).to.be.false;
     });
   });
 });

--- a/src/__tests__/app-shell-ref-context-menu.integration.test.ts
+++ b/src/__tests__/app-shell-ref-context-menu.integration.test.ts
@@ -32,6 +32,7 @@ import { repositoryStore } from '../stores/repository.store.ts';
 
 // Import the real component
 import '../app-shell.ts';
+import { dialogs } from '../stores/dialog.store.ts';
 
 // ── Test data ──────────────────────────────────────────────────────────────
 const REPO_PATH = '/test/repo';
@@ -152,6 +153,14 @@ function setRefContextMenu(
 }
 
 // ── Tests ──────────────────────────────────────────────────────────────────
+// Which dialogs are open is module state, and several tests here drive a shell
+// that is never connected to the document (so its connectedCallback reset never
+// runs). Clear it per test to keep the isolation each instance used to get for
+// free from its own `@state()` flags.
+beforeEach(() => {
+  dialogs.reset();
+});
+
 describe('app-shell ref context menu handlers (integration)', () => {
   beforeEach(() => {
     clearHistory();
@@ -300,8 +309,7 @@ describe('app-shell ref context menu handlers (integration)', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (el as any).handleRefMerge();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any).showConflictDialog).to.be.true;
+      expect(dialogs.isOpen('conflict')).to.be.true;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((el as any).conflictOperationType).to.equal('merge');
     });
@@ -397,8 +405,7 @@ describe('app-shell ref context menu handlers (integration)', () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       await (el as any).handleRefRebase();
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      expect((el as any).showConflictDialog).to.be.true;
+      expect(dialogs.isOpen('conflict')).to.be.true;
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       expect((el as any).conflictOperationType).to.equal('rebase');
     });

--- a/src/__tests__/app-shell-revert-precondition.test.ts
+++ b/src/__tests__/app-shell-revert-precondition.test.ts
@@ -27,6 +27,7 @@ let cbId = 0;
 import { expect } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import '../app-shell.ts';
+import { dialogs } from '../stores/dialog.store.ts';
 import { uiStore, repositoryStore } from '../stores/index.ts';
 import type { Repository } from '../types/git.types.ts';
 import { resetRefOpLocks } from '../utils/ref-lock.ts';
@@ -51,6 +52,14 @@ function mockRepo(): Repository {
     cloneFilter: null,
   } as Repository;
 }
+
+// Which dialogs are open is module state, and several tests here drive a shell
+// that is never connected to the document (so its connectedCallback reset never
+// runs). Clear it per test to keep the isolation each instance used to get for
+// free from its own `@state()` flags.
+beforeEach(() => {
+  dialogs.reset();
+});
 
 describe('app-shell revert precondition failures', () => {
   beforeEach(() => {
@@ -98,7 +107,7 @@ describe('app-shell revert precondition failures', () => {
         )}`,
       ).to.equal(true);
       expect(
-        (el as any).showConflictDialog,
+        dialogs.isOpen('conflict'),
         'nothing is in progress, so there is no conflict to resolve',
       ).to.not.equal(true);
     });
@@ -119,7 +128,7 @@ describe('app-shell revert precondition failures', () => {
 
     await (el as any).revertCommit();
 
-    expect((el as any).showConflictDialog).to.equal(true);
+    expect(dialogs.isOpen('conflict')).to.equal(true);
     expect((el as any).conflictOperationType).to.equal('revert');
   });
 });

--- a/src/__tests__/app-shell-search-dialog.test.ts
+++ b/src/__tests__/app-shell-search-dialog.test.ts
@@ -24,6 +24,7 @@ import { expect } from '@open-wc/testing';
 import type { AppShell } from '../app-shell.ts';
 import { uiStore } from '../stores/ui.store.ts';
 import '../app-shell.ts';
+import { dialogs } from '../stores/dialog.store.ts';
 
 interface PaletteCommand {
   id: string;
@@ -60,6 +61,14 @@ const MODES: Array<{ id: string; mode: string }> = [
   { id: 'search-commit-content', mode: 'commits' },
 ];
 
+// Which dialogs are open is module state, and several tests here drive a shell
+// that is never connected to the document (so its connectedCallback reset never
+// runs). Clear it per test to keep the isolation each instance used to get for
+// free from its own `@state()` flags.
+beforeEach(() => {
+  dialogs.reset();
+});
+
 describe('app-shell search dialog wiring', () => {
   beforeEach(() => {
     uiStore.setState({ toasts: [] });
@@ -70,7 +79,7 @@ describe('app-shell search dialog wiring', () => {
       const el = createAppShell(true);
       getCommand(el, id).action();
 
-      expect((el as any).showSearchDialog, 'dialog opened').to.equal(true);
+      expect(dialogs.isOpen('search'), 'dialog opened').to.equal(true);
       expect((el as any).searchDialogMode, 'mode preselected').to.equal(mode);
     });
 
@@ -78,7 +87,7 @@ describe('app-shell search dialog wiring', () => {
       const el = createAppShell(false);
       getCommand(el, id).action();
 
-      expect((el as any).showSearchDialog, 'dialog stays shut').to.not.equal(true);
+      expect(dialogs.isOpen('search'), 'dialog stays shut').to.not.equal(true);
       const warnings = uiStore
         .getState()
         .toasts.filter((t) => t.message === 'Please open a repository first');
@@ -116,7 +125,7 @@ describe('app-shell search dialog wiring', () => {
       new CustomEvent('show-working-diff', { detail: { filePath: 'src/a.ts', staged: false } })
     );
 
-    expect((el as any).showDiff, 'diff pane opened').to.equal(true);
+    expect(dialogs.isOpen('diff'), 'diff pane opened').to.equal(true);
     expect((el as any).diffFile?.path).to.equal('src/a.ts');
     expect((el as any).diffFile?.isStaged, 'matched the staged flag from the search').to.equal(false);
   });
@@ -137,7 +146,7 @@ describe('app-shell search dialog wiring', () => {
       new CustomEvent('show-working-diff', { detail: { filePath: 'gone.ts', staged: false } })
     );
 
-    expect((el as any).showDiff, 'no diff opened').to.not.equal(true);
+    expect(dialogs.isOpen('diff'), 'no diff opened').to.not.equal(true);
     const infos = uiStore
       .getState()
       .toasts.filter((t) => t.message.includes('no longer in the working-tree changes'));

--- a/src/app-shell.ts
+++ b/src/app-shell.ts
@@ -2,6 +2,11 @@ import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state, query } from 'lit/decorators.js';
 import { sharedStyles } from './styles/shared-styles.ts';
 import { repositoryStore, uiStore, type OpenRepository } from './stores/index.ts';
+import {
+  dialogStore,
+  dialogs,
+  type ConflictDialogContext,
+} from './stores/dialog.store.ts';
 import { registerDefaultShortcuts, keyboardService } from './services/keyboard.service.ts';
 import { loggers } from './utils/logger.ts';
 import { sweepRepoScopedDialogs } from './utils/repo-scoped-dialogs.ts';
@@ -124,6 +129,7 @@ import type { IntegrationOpenContext, IntegrationType } from './types/integratio
 import type { Commit, RefInfo, StatusEntry, Tag, Branch, RepositoryState } from './types/git.types.ts';
 import type { SearchFilter } from './components/toolbar/lv-search-bar.ts';
 import type { PaletteCommand } from './components/dialogs/lv-command-palette.ts';
+import { buildPaletteCommands, type PaletteCommandHost } from './palette-commands.ts';
 import * as gitService from './services/git.service.ts';
 import * as updateService from './services/update.service.ts';
 import * as unifiedProfileService from './services/unified-profile.service.ts';
@@ -133,11 +139,6 @@ import * as workspaceService from './services/workspace.service.ts';
 import { listenToEvent } from './services/tauri-api.ts';
 import { showToast, notifyWarning } from './services/notification.service.ts';
 import { showErrorWithSuggestion } from './services/error-suggestion.service.ts';
-import {
-  openRepositoryInTerminal,
-  openRepositoryInFileManager,
-  openRepositoryInEditor,
-} from './services/open-location.service.ts';
 import { showConfirm, showPrompt } from './services/dialog.service.ts';
 import {
   confirmGarbageCollection,
@@ -599,18 +600,18 @@ export class AppShell extends LitElement {
     `,
   ];
 
-  @state() private activeRepository: OpenRepository | null = null;
-  @state() private selectedCommit: Commit | null = null;
+  @state() activeRepository: OpenRepository | null = null;
+  @state() selectedCommit: Commit | null = null;
   @state() private selectedCommitRefs: RefInfo[] = [];
 
-  // Diff view state
-  @state() private showDiff = false;
+  // Diff view state. Whether the pane is up lives in the dialog store
+  // (`dialogs.isOpen('diff')`); these payload fields stay here because they are
+  // re-derived from every status refresh, not fixed at open time.
   @state() private diffFile: StatusEntry | null = null;
   @state() private diffCommitFile: { commitOid: string; filePath: string } | null = null;
   @state() private diffFilePartiallyStaged = false;
 
-  // Blame view state
-  @state() private showBlame = false;
+  // Blame view state. Open-ness lives in the dialog store, as for the diff.
   @state() private blameFile: string | null = null;
   @state() private blameCommitOid: string | null = null;
 
@@ -618,8 +619,6 @@ export class AppShell extends LitElement {
   @state() private progressOperations: ProgressOperation[] = [];
   private progressUnsubscribe?: () => void;
 
-  // Settings dialog
-  @state() private showSettings = false;
   /** True while an abort is in flight — blocks a double-click firing two. */
   @state() private abortInProgress = false;
   @state() private skipInProgress = false;
@@ -655,28 +654,10 @@ export class AppShell extends LitElement {
     isHead: false,
   };
 
-  // Conflict resolution dialog
-  @state() private showConflictDialog = false;
-  /**
-   * The open dialog's inputs, SNAPSHOTTED at open time. The dialog must
-   * keep operating on the repository and operation it was opened for even
-   * if the user switches repo tabs (Ctrl+Tab still works behind the
-   * full-screen dialog) or another conflicting operation fires while it is
-   * up — live-binding the loose fields below would let a second conflict
-   * source retarget an in-flight resolution's repo/operation, aiming its
-   * abort/resolve/stage commands at the wrong repository.
-   */
-  @state() private conflictDialogConfig: {
-    repoPath: string;
-    operationType: 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash';
-    initialFilePath: string | null;
-    stashSourceCertain: boolean;
-    stashIndex: number;
-    stashOid: string | null;
-    dropStashOnComplete: boolean;
-    squashMerge: boolean;
-    gitflowFinish: GitflowFinishContext | null;
-  } | null = null;
+  // Conflict resolution dialog. Its open flag AND its snapshotted inputs live
+  // in the dialog store as the `conflict` dialog's context — see
+  // ConflictDialogContext there for why they are snapshotted rather than
+  // live-bound to the loose staging fields below.
   @state() private conflictOperationType: 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash' = 'merge';
   // Stash-completion semantics for the conflict dialog (which entry to drop and
   // whether to drop it at all — pop drops, plain apply keeps).
@@ -697,104 +678,24 @@ export class AppShell extends LitElement {
   @state() private conflictStashSourceCertain = true;
 
   // Command palette
-  @state() private showCommandPalette = false;
-  @state() private showOutputPanel = false;
   @state() private paletteBranches: Branch[] = [];
   @state() private paletteTrackedFiles: string[] = [];
   private commandPaletteRepositoryPath: string | null = null;
   private commandPaletteRequestId = 0;
 
-  // File history
-  @state() private showFileHistory = false;
-  @state() private fileHistoryPath: string | null = null;
-
-  // Reflog dialog
-  @state() private showReflog = false;
-
-  // Content/diff/pickaxe search dialog. The `show[A-Z]` name is load-bearing:
-  // closeRepoScopedDialogs() enumerates Lit's reactive properties for it.
-  @state() private showSearchDialog = false;
-  @state() private searchDialogMode: SearchDialogMode = 'files';
-
-  // Keyboard shortcuts dialog
-  @state() private showShortcuts = false;
   @state() private vimMode = false;
-
-  // Remote management dialog
-  @state() private showRemotes = false;
-
-  // Clean dialog
-  @state() private showClean = false;
-
-  // Repository health dialog
-  @state() private showRepositoryHealth = false;
-
-  // Bisect dialog
-  @state() private showBisect = false;
-
-  // Submodule dialog
-  @state() private showSubmodules = false;
-
-  // Worktree dialog
-  @state() private showWorktrees = false;
-
-  // LFS dialog
-  @state() private showLfs = false;
-
-  // Changelog dialog
-
-  // GPG dialog
-  @state() private showGpg = false;
-
-  // SSH dialog
-  @state() private showSsh = false;
-
-  // Config dialog
-  @state() private showConfig = false;
-
-  // Credentials dialog
-  @state() private showCredentials = false;
-
-  // GitHub dialog
-  @state() private showGitHub = false;
-
-  // GitLab dialog
-  @state() private showGitLab = false;
-
-  // Bitbucket dialog
-  @state() private showBitbucket = false;
-
-  // Azure DevOps dialog
-  @state() private showAzureDevOps = false;
-
-  // OIDC / Enterprise SSO dialog
-  @state() private showOidc = false;
-
-  // Profile Manager dialog
-  @state() private showProfileManager = false;
-  // Which view the Profile Manager should open to. 'accounts' is set when the
-  // user picks "Manage Accounts" from an integration dialog; reset on close.
-  @state() private profileManagerView: '' | 'accounts' = '';
 
   // EXPLICIT navigation context for a provider/OIDC dialog opened FROM the
   // profile manager's "Connect a new account" flow. Non-null ONLY while such a
   // dialog is open: it drives the Back arrow, the "Adding to <name>" breadcrumb,
   // and the deterministic return + attach-after-connect. Cleared on every
   // standalone open (command palette/dashboard/toolbar) so those never show a
-  // back arrow or auto-attach. Replaces the old `showProfileManager` inference.
+  // back arrow or auto-attach. Replaces the old open-profile-manager inference.
   @state() private integrationContext: IntegrationOpenContext | null = null;
   // When "Manage Accounts" is opened from a provider dialog, remember which
   // provider so closing the Accounts view can return there — making that
   // navigation reversible rather than a one-way teleport.
   private manageAccountsReturnProvider: IntegrationType | null = null;
-
-  // Migration dialog
-  @state() private showMigrationDialog = false;
-
-  // Workspace Manager dialog
-  @state() private showWorkspaceManager = false;
-  @state() private showHooksDialog = false;
-  @state() private showGitignoreDialog = false;
 
   // Right panel tab tracking
   @state() private activeRightPanelTab: string | undefined;
@@ -813,17 +714,17 @@ export class AppShell extends LitElement {
   private resizeStartPos = 0;
   private resizeStartValue = 0;
 
-  @query('lv-graph-canvas') private graphCanvas?: LvGraphCanvas;
+  @query('lv-graph-canvas') graphCanvas?: LvGraphCanvas;
   @query('lv-diff-view') private diffView?: LvDiffView;
-  @query('lv-create-tag-dialog') private createTagDialog?: LvCreateTagDialog;
-  @query('lv-create-branch-dialog') private createBranchDialog?: LvCreateBranchDialog;
+  @query('lv-create-tag-dialog') createTagDialog?: LvCreateTagDialog;
+  @query('lv-create-branch-dialog') createBranchDialog?: LvCreateBranchDialog;
   @query('lv-cherry-pick-dialog') private cherryPickDialog?: LvCherryPickDialog;
-  @query('lv-export-import-dialog') private exportImportDialog?: LvExportImportDialog;
+  @query('lv-export-import-dialog') exportImportDialog?: LvExportImportDialog;
   @query('#app-rebase-dialog') private interactiveRebaseDialog?: LvInteractiveRebaseDialog;
   @query('lv-profile-manager-dialog') private profileManagerDialog?: LvProfileManagerDialog;
   @query('lv-reflog-dialog') private reflogDialog?: LvReflogDialog;
-  @query('lv-describe-dialog') private describeDialog?: LvDescribeDialog;
-  @query('lv-compare-branches-dialog') private compareBranchesDialog?: LvCompareBranchesDialog;
+  @query('lv-describe-dialog') describeDialog?: LvDescribeDialog;
+  @query('lv-compare-branches-dialog') compareBranchesDialog?: LvCompareBranchesDialog;
   @query('lv-clean-dialog') private cleanDialog?: LvCleanDialog;
   @query('lv-remote-dialog') private remoteDialog?: LvRemoteDialog;
   @query('lv-repository-health-dialog') private repositoryHealthDialog?: LvRepositoryHealthDialog;
@@ -854,6 +755,17 @@ export class AppShell extends LitElement {
    * rather than mutated so Lit sees the change and re-renders the menus. */
   @state() private refOpsVersion = 0;
   private unsubscribeRefOps?: () => void;
+  /**
+   * Re-render trigger for the dialog store.
+   *
+   * Which dialogs are open is module state now (see stores/dialog.store.ts), so
+   * Lit has nothing of its own to observe. Bumping this from the store
+   * subscription is the same trick `refOpsVersion` above uses for the ref lock,
+   * and it keeps `await el.updateComplete` after a `dialogs.open(...)` working
+   * exactly as it did when each dialog had its own `@state()` flag.
+   */
+  @state() private dialogVersion = 0;
+  private unsubscribeDialogs?: () => void;
   /**
    * Keys for destructive actions already running.
    *
@@ -895,7 +807,7 @@ export class AppShell extends LitElement {
   }
 
   /** The one refusal message every busy-repo path shows. */
-  private warnRepositoryBusy(): void {
+  warnRepositoryBusy(): void {
     warnRepositoryBusy();
   }
 
@@ -924,11 +836,11 @@ export class AppShell extends LitElement {
   }
 
   /** Claim the lock for `repoPath`; false when it is already held. */
-  private claimRefOperation(repoPath: string): boolean {
+  claimRefOperation(repoPath: string): boolean {
     return tryAcquireRefOp(repoPath);
   }
 
-  private releaseRefOperation(repoPath: string): void {
+  releaseRefOperation(repoPath: string): void {
     releaseRefOp(repoPath);
   }
 
@@ -1044,7 +956,7 @@ export class AppShell extends LitElement {
    * its branch list to render — `lv-branch-list` registers the window listener
    * in connectedCallback, so dispatching before it exists is the same dead end.
    */
-  private async openBranchCleanup(): Promise<void> {
+  async openBranchCleanup(): Promise<void> {
     if (!this.leftPanelVisible) {
       uiStore.getState().togglePanel('left');
       await this.updateComplete;
@@ -1392,14 +1304,14 @@ export class AppShell extends LitElement {
       );
       return;
     }
-    if (this.showConflictDialog) {
+    if (dialogs.isOpen('conflict')) {
       showToast(
         'A conflict resolution is already in progress — finish or close it first',
         'warning',
       );
       return;
     }
-    this.conflictDialogConfig = {
+    dialogs.open('conflict', {
       repoPath,
       operationType: this.conflictOperationType,
       initialFilePath: this.conflictInitialFilePath,
@@ -1409,67 +1321,38 @@ export class AppShell extends LitElement {
       dropStashOnComplete: this.conflictDropStashOnComplete,
       squashMerge: this.conflictSquashMerge,
       gitflowFinish: this.conflictGitflowFinish,
-    };
-    this.showConflictDialog = true;
+    });
   }
 
   /**
-   * Dialog flags that are NOT tied to an open repository.
+   * The conflict dialog's snapshotted inputs, or null while it is shut.
    *
-   * The criterion is where the dialog RENDERS. The sweep exists because a
-   * dialog inside the `${this.activeRepository ? ...}` block has its ELEMENT
-   * destroyed while its flag stays true, so it springs back open over the next
-   * repository. A dialog rendered outside that block is never destroyed and has
-   * no such problem: clearing its flag just kills a session the user started,
-   * and skips the `@close` binding that unwinds its navigation state
-   * (`integrationContext`, `manageAccountsReturnProvider`).
-   *
-   * Every flag below is reachable with zero repositories open — the welcome
-   * screen offers the profile manager, and the palette's SSH, profiles and
-   * provider entries are deliberately not wrapped in `requiresRepository`.
+   * Read through the store rather than a field of its own: the snapshot IS the
+   * dialog's open-time context, so it is created and dropped by the same
+   * `dialogs.open('conflict', …)` / `dialogs.close('conflict')` calls and
+   * cannot drift out of step with the flag the way two fields could.
    */
-  private static readonly REPO_INDEPENDENT_DIALOGS = new Set([
-    'showSettings',
-    'showShortcuts',
-    'showOutputPanel',
-    'showCommandPalette',
-    'showWorkspaceManager',
-    'showSsh',
-    'showProfileManager',
-    // Fires from checkUnifiedProfilesMigration on startup, before any repo.
-    'showMigrationDialog',
-    // Account connection is repo-independent; only the PR/issue/pipeline tabs
-    // inside these dialogs guard themselves on a repository.
-    'showGitHub',
-    'showGitLab',
-    'showBitbucket',
-    'showAzureDevOps',
-    'showOidc',
-  ]);
-
-  /**
-   * Clear every repo-scoped `show*` flag. See the call site for why this is an
-   * exclusion list: an inclusion list has gone stale here more than once.
-   */
-  private closeRepoScopedDialogs(): void {
-    // Enumerated from Lit's own reactive-property map, NOT Object.keys: an
-    // @state() field is an accessor on the prototype backed by a private slot,
-    // so it never appears as an own enumerable key.
-    const self = this as unknown as Record<string, unknown>;
-    const declared = (this.constructor as unknown as {
-      elementProperties: Map<PropertyKey, unknown>;
-    }).elementProperties;
-    for (const key of declared.keys()) {
-      if (typeof key !== 'string') continue;
-      if (!/^show[A-Z]/.test(key)) continue;
-      if (AppShell.REPO_INDEPENDENT_DIALOGS.has(key)) continue;
-      if (self[key] === true) self[key] = false;
-    }
+  private get conflictDialogConfig(): ConflictDialogContext | null {
+    return dialogs.context('conflict');
   }
 
   private closeConflictDialog(): void {
-    this.showConflictDialog = false;
-    this.conflictDialogConfig = null;
+    dialogs.close('conflict');
+  }
+
+  /** The file the history pane is showing, or null while it is shut. */
+  private get fileHistoryPath(): string | null {
+    return dialogs.context('fileHistory')?.filePath ?? null;
+  }
+
+  /** Which mode the search dialog opened in. */
+  private get searchDialogMode(): SearchDialogMode {
+    return dialogs.context('search')?.mode ?? 'files';
+  }
+
+  /** Which view the Profile Manager should open to. */
+  private get profileManagerView(): '' | 'accounts' {
+    return dialogs.context('profileManager')?.initialView ?? '';
   }
 
   // Reset the conflict-dialog completion semantics to defaults so a value set by a
@@ -1515,28 +1398,40 @@ export class AppShell extends LitElement {
       this.refOpsVersion++;
     });
 
+    // A freshly mounted shell shows nothing, exactly as it did when every
+    // dialog was a `@state()` flag initialised to false on the instance. The
+    // store is module state and outlives an instance, so it is cleared here
+    // rather than inherited from whatever the previous shell left open.
+    dialogs.reset();
+    this.unsubscribeDialogs = dialogStore.subscribe(() => {
+      this.dialogVersion++;
+    });
+
     this.unsubscribe = repositoryStore.subscribe((state) => {
       const newActiveRepo = state.getActiveRepository();
       const repoChanged = this.activeRepository?.repository.path !== newActiveRepo?.repository.path;
       this.activeRepository = newActiveRepo;
 
-      // Every repo-scoped dialog flag must die with the last repository.
+      // Every repo-scoped dialog must die with the last repository.
       //
       // These dialogs render inside the `${this.activeRepository ? ...}` block,
-      // so closing the last tab destroys the ELEMENT while its `show*` flag
-      // stays true. Open the next repository and the element is reconstructed
-      // with ?open=true — a full-screen overlay springing up unbidden over a
-      // repo the user just opened, freshly constructed with every button
+      // so closing the last tab destroys the ELEMENT while its open flag stays
+      // set. Open the next repository and the element is reconstructed with
+      // ?open=true — a full-screen overlay springing up unbidden over a repo
+      // the user just opened, freshly constructed with every button
       // re-enabled. lv-repository-health-dialog carries that exact story, and
       // lv-bisect-dialog then reproduced it because it has no pinned path and
       // so was in neither hand-written sweep.
       //
-      // Written as an EXCLUSION list, not an inclusion one. A list of dialogs
-      // to close goes stale every time one is added — which is how this keeps
-      // recurring — whereas the handful that are genuinely not repo-scoped is
-      // stable, and a new dialog defaults to the safe behaviour.
+      // This used to reflect over Lit's reactive-property map and match field
+      // names against /^show[A-Z]/, minus a hand-kept exclusion list, because
+      // nothing enumerated the dialogs. DIALOG_REGISTRY does, so it is now a
+      // plain loop over the dialogs declared `repoScoped` — and repo-scoping is
+      // a property of the dialog rather than of how its field was named. The
+      // default is still the safe one: a newly declared dialog is repo-scoped
+      // unless it says otherwise.
       if (state.openRepositories.length === 0) {
-        this.closeRepoScopedDialogs();
+        dialogs.closeRepoScoped();
       }
 
       // Closing the pinned repo's TAB while its conflict dialog is up
@@ -1546,7 +1441,7 @@ export class AppShell extends LitElement {
       // explanation — the operation itself persists on disk and resurfaces
       // when the repo is reopened.
       if (
-        this.showConflictDialog &&
+        dialogs.isOpen('conflict') &&
         this.conflictDialogConfig &&
         !state.openRepositories.some(
           (r) => r.repository.path === this.conflictDialogConfig!.repoPath,
@@ -1602,7 +1497,7 @@ export class AppShell extends LitElement {
           'lv-clean-dialog': {
             dismissed: 'clean cancelled',
             running: 'clean',
-            clearFlag: () => { this.showClean = false; },
+            clearFlag: () => { dialogs.close('clean'); },
           },
           // No clearFlag: this dialog owns its own open state via open()/close(),
           // like lv-create-branch-dialog.
@@ -1613,7 +1508,7 @@ export class AppShell extends LitElement {
           'lv-reflog-dialog': {
             dismissed: 'undo history closed',
             running: 'reset',
-            clearFlag: () => { this.showReflog = false; },
+            clearFlag: () => { dialogs.close('reflog'); },
           },
           // Read-only: it never reports work in flight, so the sweep always
           // takes the dismissal branch here.
@@ -1628,60 +1523,60 @@ export class AppShell extends LitElement {
           'lv-search-dialog': {
             dismissed: 'search closed',
             running: 'search',
-            clearFlag: () => { this.showSearchDialog = false; },
+            clearFlag: () => { dialogs.close('search'); },
           },
           'lv-remote-dialog': {
             dismissed: 'remote management closed',
             running: 'remote update',
-            clearFlag: () => { this.showRemotes = false; },
+            clearFlag: () => { dialogs.close('remotes'); },
           },
           // Closing this one DESTROYS the element (its render block is gated on
-          // showRepositoryHealth), so it implements closeWhenIdle() and the
+          // the repositoryHealth dialog), so it implements closeWhenIdle() and the
           // sweep hands the close over rather than orphaning a running gc.
           'lv-repository-health-dialog': {
             dismissed: 'repository health closed',
             running: 'maintenance operation',
-            clearFlag: () => { this.showRepositoryHealth = false; },
+            clearFlag: () => { dialogs.close('repositoryHealth'); },
           },
           'lv-worktree-dialog': {
             dismissed: 'worktrees closed',
             running: 'worktree removal',
-            clearFlag: () => { this.showWorktrees = false; },
+            clearFlag: () => { dialogs.close('worktrees'); },
           },
           'lv-submodule-dialog': {
             dismissed: 'submodules closed',
             running: 'submodule removal',
-            clearFlag: () => { this.showSubmodules = false; },
+            clearFlag: () => { dialogs.close('submodules'); },
           },
           'lv-lfs-dialog': {
             dismissed: 'Git LFS closed',
             running: 'LFS prune',
-            clearFlag: () => { this.showLfs = false; },
+            clearFlag: () => { dialogs.close('lfs'); },
           },
           'lv-gpg-dialog': {
             dismissed: 'signing settings closed',
             running: 'signing update',
-            clearFlag: () => { this.showGpg = false; },
+            clearFlag: () => { dialogs.close('gpg'); },
           },
           'lv-config-dialog': {
             dismissed: 'configuration closed',
             running: 'configuration save',
-            clearFlag: () => { this.showConfig = false; },
+            clearFlag: () => { dialogs.close('config'); },
           },
           'lv-credentials-dialog': {
             dismissed: 'credentials closed',
             running: 'credential test',
-            clearFlag: () => { this.showCredentials = false; },
+            clearFlag: () => { dialogs.close('credentials'); },
           },
           'lv-hooks-dialog': {
             dismissed: 'hooks closed',
             running: 'hook save',
-            clearFlag: () => { this.showHooksDialog = false; },
+            clearFlag: () => { dialogs.close('hooks'); },
           },
           'lv-gitignore-dialog': {
             dismissed: 'ignore rules closed',
             running: 'ignore rule update',
-            clearFlag: () => { this.showGitignoreDialog = false; },
+            clearFlag: () => { dialogs.close('gitignore'); },
           },
           'lv-changelog-dialog': {
             dismissed: 'changelog closed',
@@ -1716,7 +1611,7 @@ export class AppShell extends LitElement {
           // that file the typed text goes with the pane, so say so.
           this.warnIfDiscardingEdits();
           this.diffFile = null;
-          this.showDiff = false;
+          dialogs.close('diff');
         }
       }
 
@@ -1749,7 +1644,7 @@ export class AppShell extends LitElement {
       // Clear view state when switching repositories
       if (repoChanged) {
         this.commandPaletteRequestId++;
-        this.showCommandPalette = false;
+        dialogs.close('commandPalette');
         this.commandPaletteRepositoryPath = null;
         this.paletteBranches = [];
         this.paletteTrackedFiles = [];
@@ -1762,14 +1657,13 @@ export class AppShell extends LitElement {
         this.warnIfDiscardingEdits();
 
         // Close any open overlays
-        this.showDiff = false;
+        dialogs.close('diff');
         this.diffFile = null;
         this.diffCommitFile = null;
-        this.showBlame = false;
+        dialogs.close('blame');
         this.blameFile = null;
         this.blameCommitOid = null;
-        this.showFileHistory = false;
-        this.fileHistoryPath = null;
+        dialogs.close('fileHistory');
 
         // Graph context-menu entries are scoped to the repository that
         // produced their commit/ref. Leaving either menu open across a tab
@@ -1916,12 +1810,12 @@ export class AppShell extends LitElement {
       commit: () => {/* handled by commit panel */},
       refresh: () => this.handleRefresh(),
       search: () => this.handleToggleSearch(),
-      openSettings: () => { this.showSettings = true; },
-      openShortcuts: () => { this.showShortcuts = true; },
+      openSettings: () => { dialogs.open('settings'); },
+      openShortcuts: () => { dialogs.open('shortcuts'); },
       toggleLeftPanel: () => this.toggleLeftPanel(),
       toggleRightPanel: () => uiStore.getState().togglePanel('right'),
       openCommandPalette: () => this.openCommandPalette(),
-      openReflog: this.requiresRepository(() => { this.showReflog = true; }),
+      openReflog: this.requiresRepository(() => { dialogs.open('reflog'); }),
       // Wrapped like the palette entries: pressing Ctrl+Shift+F on the welcome
       // screen used to do nothing at all while the same command from the
       // palette explained that a repository is needed.
@@ -1948,6 +1842,8 @@ export class AppShell extends LitElement {
     super.disconnectedCallback();
     this.unsubscribeRefOps?.();
     this.unsubscribeRefOps = undefined;
+    this.unsubscribeDialogs?.();
+    this.unsubscribeDialogs = undefined;
     this.unsubscribe?.();
     this.unsubscribeUi?.();
     this.unsubscribeWatcher?.();
@@ -2011,7 +1907,7 @@ export class AppShell extends LitElement {
       if (needsMigration) {
         // Show migration dialog after a short delay to let the UI settle
         setTimeout(() => {
-          this.showMigrationDialog = true;
+          dialogs.open('migration');
         }, 500);
       }
     } catch (error) {
@@ -2179,7 +2075,7 @@ export class AppShell extends LitElement {
    * Hiding the left panel is refused while it hosts an open dialog — see
    * hasSidebarDialogOpen. Revealing it is always allowed.
    */
-  private toggleLeftPanel(): void {
+  toggleLeftPanel(): void {
     if (this.leftPanelVisible && this.hasSidebarDialogOpen()) {
       showToast('Close the open dialog before hiding the sidebar', 'info');
       return;
@@ -2200,7 +2096,7 @@ export class AppShell extends LitElement {
       if (modal) (modal as HTMLElement & { open: boolean }).open = true;
       return;
     }
-    this.showRepositoryHealth = false;
+    dialogs.close('repositoryHealth');
   };
 
   private handleCloseOverlay(): void {
@@ -2209,7 +2105,7 @@ export class AppShell extends LitElement {
       // A modal owns this Escape and dismisses itself, through lv-modal's
       // handler or its own — each now gated on being the TOPMOST overlay.
       //
-      // This arm is FIRST. The showShortcuts and showCommandPalette arms used
+      // This arm is FIRST. The shortcuts and command-palette arms used
       // to precede it and closed unconditionally, without consulting the
       // stack: opening the undo-history dialog over the shortcuts dialog and
       // pressing Escape once closed BOTH. Both dialogs clear their own flag
@@ -2219,20 +2115,20 @@ export class AppShell extends LitElement {
       // so a dialog that deliberately blocks dismissal mid-operation does not
       // leak the key either.
       //
-      // This subsumes the old showReflog arm, which assumed reflog was always
+      // This subsumes the old reflog arm, which assumed reflog was always
       // topmost: a dialog opened over it (via the palette) made Escape discard
       // the reflog session underneath. The dialog's own handler applies the
-      // isResetting guard and its `close` event clears showReflog.
+      // isResetting guard and its `close` event closes the reflog dialog.
       return;
     } else if (this.contextMenu.visible) {
       this.contextMenu = { ...this.contextMenu, visible: false };
     } else if (this.refContextMenu.visible) {
       this.refContextMenu = { ...this.refContextMenu, visible: false };
-    } else if (this.showDiff) {
+    } else if (dialogs.isOpen('diff')) {
       this.handleCloseDiff();
-    } else if (this.showBlame) {
+    } else if (dialogs.isOpen('blame')) {
       this.handleCloseBlame();
-    } else if (this.showFileHistory) {
+    } else if (dialogs.isOpen('fileHistory')) {
       this.handleCloseFileHistory();
     }
   }
@@ -3076,12 +2972,12 @@ export class AppShell extends LitElement {
   };
 
   private handleOpenSettings = (): void => {
-    this.showSettings = true;
+    dialogs.open('settings');
   };
 
   // True while any integration dialog is open.
   private get integrationDialogOpen(): boolean {
-    return this.showGitHub || this.showGitLab || this.showBitbucket || this.showAzureDevOps || this.showOidc;
+    return dialogs.isOpen('gitHub') || dialogs.isOpen('gitLab') || dialogs.isOpen('bitbucket') || dialogs.isOpen('azureDevOps') || dialogs.isOpen('oidc');
   }
 
   // True only while a provider/OIDC dialog is open ON TOP of the profile manager
@@ -3120,7 +3016,7 @@ export class AppShell extends LitElement {
    * Clears any return context so the dialog shows no Back arrow and never
    * auto-attaches to a profile.
    */
-  private openIntegrationStandalone(type: IntegrationType): void {
+  openIntegrationStandalone(type: IntegrationType): void {
     this.integrationContext = null;
     this.setIntegrationDialogOpen(type, true);
   }
@@ -3138,11 +3034,11 @@ export class AppShell extends LitElement {
 
   private setIntegrationDialogOpen(type: IntegrationType, open: boolean): void {
     switch (type) {
-      case 'github': this.showGitHub = open; break;
-      case 'gitlab': this.showGitLab = open; break;
-      case 'bitbucket': this.showBitbucket = open; break;
-      case 'azure-devops': this.showAzureDevOps = open; break;
-      case 'oidc': this.showOidc = open; break;
+      case 'github': dialogs.setOpen('gitHub', open); break;
+      case 'gitlab': dialogs.setOpen('gitLab', open); break;
+      case 'bitbucket': dialogs.setOpen('bitbucket', open); break;
+      case 'azure-devops': dialogs.setOpen('azureDevOps', open); break;
+      case 'oidc': dialogs.setOpen('oidc', open); break;
     }
   }
 
@@ -3712,7 +3608,7 @@ export class AppShell extends LitElement {
    * (plus a badge hydration so its tab updates promptly) when it is
    * backgrounded.
    */
-  private refreshConflictDialogRepo(pinnedPath: string | null): void {
+  refreshConflictDialogRepo(pinnedPath: string | null): void {
     if (!pinnedPath || pinnedPath === this.activeRepository?.repository.path) {
       this.handleRefresh();
       return;
@@ -3849,7 +3745,7 @@ export class AppShell extends LitElement {
       return;
     }
     // Close blame if open
-    this.showBlame = false;
+    dialogs.close('blame');
     this.blameFile = null;
     this.blameCommitOid = null;
     // Close file history if open. It sits last in the center pane's
@@ -3858,31 +3754,29 @@ export class AppShell extends LitElement {
     // the diff is closed. Unlike the diff a file-history pane opens
     // (`handleFileHistoryViewDiff`), this selection comes from the right
     // panel, not from history, so there is no drill-down to return to.
-    this.showFileHistory = false;
-    this.fileHistoryPath = null;
+    dialogs.close('fileHistory');
     // Working directory file selected - show diff
     this.diffFile = file;
     this.diffFilePartiallyStaged = isPartiallyStaged;
     this.diffCommitFile = null;
-    this.showDiff = true;
+    dialogs.open('diff');
   }
 
   private handleCommitFileSelected(e: CustomEvent<{ commitOid: string; filePath: string }>): void {
     // Close blame if open
-    this.showBlame = false;
+    dialogs.close('blame');
     this.blameFile = null;
     this.blameCommitOid = null;
     // Close file history if open — same reason as handleFileSelected: it
     // would otherwise reappear under the user when this diff is closed.
-    this.showFileHistory = false;
-    this.fileHistoryPath = null;
+    dialogs.close('fileHistory');
     // Commit file selected - show diff
     this.diffCommitFile = {
       commitOid: e.detail.commitOid,
       filePath: e.detail.filePath,
     };
     this.diffFile = null;
-    this.showDiff = true;
+    dialogs.open('diff');
   }
 
   /**
@@ -3890,7 +3784,7 @@ export class AppShell extends LitElement {
    *
    * The editor guards every teardown it can see — Cancel confirms, a file
    * change warns — but the × button, Escape and a repository tab switch are all
-   * owned by app-shell and simply set `showDiff = false`, dropping typed text
+   * owned by app-shell and simply close the diff, dropping typed text
    * with no confirm and no message. Escape is the sharpest case: the editor's
    * own indicator says "Esc to cancel" while the header says "Close diff (Esc)",
    * and which one won depended purely on whether the caret was in the textarea.
@@ -3907,7 +3801,7 @@ export class AppShell extends LitElement {
 
   private handleCloseDiff(): void {
     this.warnIfDiscardingEdits();
-    this.showDiff = false;
+    dialogs.close('diff');
     this.diffFile = null;
     this.diffCommitFile = null;
   }
@@ -3946,11 +3840,11 @@ export class AppShell extends LitElement {
     return '';
   }
 
-  private handleStageAll(): void {
+  handleStageAll(): void {
     void this.dispatchToFileStatus('stage-all');
   }
 
-  private handleUnstageAll(): void {
+  handleUnstageAll(): void {
     void this.dispatchToFileStatus('unstage-all');
   }
 
@@ -4027,7 +3921,7 @@ export class AppShell extends LitElement {
   private refreshInFlight = false;
   private refreshQueued = false;
 
-  private async handleRefresh(): Promise<void> {
+  async handleRefresh(): Promise<void> {
     if (this.refreshInFlight) {
       this.refreshQueued = true;
       return;
@@ -4085,27 +3979,27 @@ export class AppShell extends LitElement {
   // there (see handleProfileManagerClose), instead of a one-way teleport.
   private handleManageAccounts(e: CustomEvent<{ integrationType?: IntegrationType }>): void {
     const from = e.detail?.integrationType ?? null;
-    this.showGitHub = false;
-    this.showGitLab = false;
-    this.showBitbucket = false;
-    this.showAzureDevOps = false;
-    this.showOidc = false;
+    dialogs.close('gitHub');
+    dialogs.close('gitLab');
+    dialogs.close('bitbucket');
+    dialogs.close('azureDevOps');
+    dialogs.close('oidc');
     // If we're pivoting from a provider dialog that was stacked on top of the manager,
     // preserve the integrationContext so we can restore the stacked state later.
-    if (!this.showProfileManager) {
+    if (!dialogs.isOpen('profileManager')) {
       this.integrationContext = null;
     }
     this.manageAccountsReturnProvider = from;
-    this.profileManagerView = 'accounts';
+    dialogs.setContext('profileManager', { initialView: 'accounts' });
     // If the manager is ALREADY open (the provider dialog was launched FROM it,
     // so it's open & demoted), the `open` property won't transition false→true and
     // the manager's willUpdate/open-transition logic that applies `initialView`
     // never runs — it would reveal on its prior view (select-account/edit). Drive
     // the Accounts view explicitly instead so the click isn't a no-op.
-    if (this.showProfileManager) {
+    if (dialogs.isOpen('profileManager')) {
       this.profileManagerDialog?.showAccountsView(true);
     } else {
-      this.showProfileManager = true;
+      dialogs.open('profileManager');
     }
   }
 
@@ -4117,8 +4011,7 @@ export class AppShell extends LitElement {
   private handleProfileManagerClose(e: CustomEvent<{ fromView?: string }>): void {
     const returnProvider = this.manageAccountsReturnProvider;
     const closedFromAccounts = e.detail?.fromView === 'accounts';
-    this.showProfileManager = false;
-    this.profileManagerView = '';
+    dialogs.close('profileManager');
     this.manageAccountsReturnProvider = null;
     if (returnProvider && closedFromAccounts) {
       this.openIntegrationStandalone(returnProvider);
@@ -4150,7 +4043,7 @@ export class AppShell extends LitElement {
     }
   }
 
-  private handleToggleSearch(): void {
+  handleToggleSearch(): void {
     const toolbar = this.shadowRoot?.querySelector('lv-toolbar');
     if (toolbar) {
       (toolbar as HTMLElement).dispatchEvent(new CustomEvent('focus-search'));
@@ -4158,16 +4051,16 @@ export class AppShell extends LitElement {
   }
 
   private handleCloseSettings(): void {
-    this.showSettings = false;
+    dialogs.close('settings');
   }
 
   private handleBlameCommitClick(e: CustomEvent<{ oid: string }>): void {
-    this.showBlame = false;
+    dialogs.close('blame');
     this.revealCommitInGraph(e.detail.oid);
   }
 
   private handleCloseBlame(): void {
-    this.showBlame = false;
+    dialogs.close('blame');
     this.blameFile = null;
     this.blameCommitOid = null;
   }
@@ -4177,18 +4070,17 @@ export class AppShell extends LitElement {
     // inline editor with it — same teardown as the × and a tab switch.
     this.warnIfDiscardingEdits();
     // Close diff if open
-    this.showDiff = false;
+    dialogs.close('diff');
     this.diffFile = null;
     this.diffCommitFile = null;
     // Open blame
     this.blameFile = e.detail.filePath;
     this.blameCommitOid = e.detail.commitOid ?? null;
-    this.showBlame = true;
+    dialogs.open('blame');
   }
 
-  private openSearchDialog(mode: SearchDialogMode): void {
-    this.searchDialogMode = mode;
-    this.showSearchDialog = true;
+  openSearchDialog(mode: SearchDialogMode): void {
+    dialogs.open('search', { mode });
   }
 
   /**
@@ -4265,7 +4157,7 @@ export class AppShell extends LitElement {
       this.commandPaletteRepositoryPath = null;
     }
     if (requestId !== this.commandPaletteRequestId) return;
-    this.showCommandPalette = true;
+    dialogs.open('commandPalette');
   }
 
   /**
@@ -4278,10 +4170,10 @@ export class AppShell extends LitElement {
    */
   private handleCommandPaletteClose(): void {
     this.commandPaletteRequestId++;
-    this.showCommandPalette = false;
+    dialogs.close('commandPalette');
   }
 
-  private requiresRepository(action: () => void): () => void {
+  requiresRepository(action: () => void): () => void {
     return () => {
       if (!this.activeRepository) {
         uiStore.getState().addToast({
@@ -4295,520 +4187,15 @@ export class AppShell extends LitElement {
     };
   }
 
+  /**
+   * The palette command table lives in palette-commands.ts — it is a long,
+   * flat list rather than behaviour, and the native menu bar resolves its own
+   * item ids against these entries' `action`s, so the ids and shapes here are
+   * a contract. The members it reaches for are declared by PaletteCommandHost,
+   * which is why they are not private on this class.
+   */
   private getPaletteCommands(): PaletteCommand[] {
-    const isMac = navigator.platform.includes('Mac');
-    const mod = isMac ? '⌘' : 'Ctrl';
-
-    const commands: PaletteCommand[] = [
-      {
-        id: 'fetch',
-        label: 'Fetch from remote',
-        category: 'action',
-        icon: 'fetch',
-        action: this.requiresRepository(() => this.handleFetch()),
-      },
-      {
-        id: 'pull',
-        label: 'Pull from remote',
-        category: 'action',
-        icon: 'pull',
-        action: this.requiresRepository(() => this.handlePull()),
-      },
-      {
-        id: 'push',
-        label: 'Push to remote',
-        category: 'action',
-        icon: 'push',
-        action: this.requiresRepository(() => this.handlePush()),
-      },
-      {
-        id: 'refresh',
-        label: 'Refresh repository',
-        category: 'action',
-        icon: 'refresh',
-        shortcut: `${mod}R`,
-        action: () => this.handleRefresh(),
-      },
-      {
-        id: 'graph-jump-head',
-        label: 'Graph: Jump to HEAD',
-        category: 'navigation',
-        icon: 'commit',
-        action: this.requiresRepository(() => {
-          if (this.graphCanvas?.jumpToHead()) {
-            return;
-          }
-          // Route the miss through the shared reveal helper so the toast
-          // distinguishes loaded-but-filtered from not-loaded
-          const headOid = this.graphCanvas?.getHeadOid();
-          if (headOid !== undefined) {
-            this.revealCommitInGraph(headOid);
-          } else {
-            showToast('HEAD commit is not loaded in the graph', 'info', 4000);
-          }
-        }),
-      },
-      {
-        id: 'toggle-output-panel',
-        label: 'Toggle Output Panel',
-        category: 'action',
-        icon: 'terminal',
-        action: () => { this.showOutputPanel = !this.showOutputPanel; },
-      },
-      {
-        id: 'stash',
-        label: 'Create stash',
-        category: 'action',
-        icon: 'stash',
-        action: this.requiresRepository(() => this.handleCreateStash()),
-      },
-      {
-        id: 'create-branch',
-        label: 'Create branch',
-        category: 'action',
-        icon: 'branch',
-        shortcut: `${mod}⇧N`,
-        action: this.requiresRepository(() => this.createBranchDialog?.open()),
-      },
-      {
-        id: 'create-tag',
-        label: 'Create tag',
-        category: 'action',
-        icon: 'tag',
-        action: this.requiresRepository(() => this.createTagDialog?.open()),
-      },
-      {
-        id: 'export-archive',
-        label: 'Export archive…',
-        category: 'action',
-        icon: 'file',
-        action: this.requiresRepository(() => this.exportImportDialog?.open({ tab: 'archive' })),
-      },
-      {
-        id: 'create-patch',
-        label: 'Create patch from commits…',
-        category: 'action',
-        icon: 'commit',
-        action: this.requiresRepository(() =>
-          this.exportImportDialog?.open({
-            tab: 'patch',
-            patchMode: 'create',
-            commitOid: this.selectedCommit?.oid,
-          }),
-        ),
-      },
-      {
-        id: 'apply-patch',
-        label: 'Apply patch file…',
-        category: 'action',
-        icon: 'commit',
-        action: this.requiresRepository(() =>
-          this.exportImportDialog?.open({ tab: 'patch', patchMode: 'apply' }),
-        ),
-      },
-      {
-        id: 'create-bundle',
-        label: 'Create bundle…',
-        category: 'action',
-        icon: 'file',
-        action: this.requiresRepository(() =>
-          this.exportImportDialog?.open({ tab: 'bundle', bundleMode: 'create' }),
-        ),
-      },
-      {
-        id: 'import-bundle',
-        label: 'Import bundle…',
-        category: 'action',
-        icon: 'file',
-        action: this.requiresRepository(() =>
-          this.exportImportDialog?.open({ tab: 'bundle', bundleMode: 'import' }),
-        ),
-      },
-      {
-        id: 'settings',
-        label: 'Open settings',
-        category: 'action',
-        icon: 'settings',
-        shortcut: `${mod},`,
-        action: () => { this.showSettings = true; },
-      },
-      {
-        id: 'remotes',
-        label: 'Manage remotes',
-        category: 'action',
-        icon: 'globe',
-        action: this.requiresRepository(() => { this.showRemotes = true; }),
-      },
-      {
-        id: 'changelog',
-        label: 'Generate Changelog',
-        category: 'action',
-        icon: 'tag',
-        action: this.requiresRepository(() => {
-          const dialog = this.shadowRoot?.querySelector('lv-changelog-dialog');
-          if (dialog) (dialog as import('./components/dialogs/lv-changelog-dialog.ts').LvChangelogDialog).open();
-        }),
-      },
-      {
-        id: 'smart-undo',
-        label: 'Smart Undo (AI)',
-        category: 'action',
-        icon: 'undo',
-        action: this.requiresRepository(async () => {
-          // Captured BEFORE the prompt/AI/confirm awaits (all yield): the
-          // reflog reset must run on the repo it was invoked on, even if the
-          // user switches tabs while any of those dialogs/calls are pending.
-          const repoPath = this.activeRepository!.repository.path;
-          const query = await showPrompt('Smart Undo (AI)', 'Describe what you want to undo (e.g., "before the rebase", "undo last 3 commits"):');
-          if (!query) return;
-
-          const result = await import('./services/ai.service.ts').then(m =>
-            m.findReflogEntry(repoPath, query)
-          );
-
-          if (result.success && result.data) {
-            const match = result.data;
-
-            // Resolve the index to a commit BEFORE the confirm. An AI round
-            // trip plus a prompt plus a confirm all elapse between the reflog
-            // being read and the reset firing, and any commit or checkout in
-            // that window renumbers every entry. Pinning the oid means the
-            // reset either lands on the commit named here or is refused.
-            const git = await import('./services/git.service.ts');
-            const reflog = await git.getReflog(repoPath);
-            const target = reflog.success ? reflog.data?.[match.index] : undefined;
-
-            if (!target) {
-              showToast('Could not resolve that reflog entry — try again', 'error');
-              return;
-            }
-
-            const confirmed = await showConfirm(
-              'Smart Undo',
-              `${match.description}\n\nReset to ${target.shortId} (HEAD@{${match.index}})?\n\n` +
-                `This branch will point at ${target.shortId}. Any commit no longer ` +
-                `reachable from it is recoverable only through the reflog. Your ` +
-                `changes remain staged.`,
-              'warning'
-            );
-            if (confirmed) {
-              // The other caller of reset_to_reflog — lv-reflog-dialog — claims
-              // the shared working-tree lock; this palette route to the same
-              // command was missed by that sweep. The expected_oid pin guards
-              // against a STALE index, not against a checkout moving the branch
-              // underneath the reset.
-              // runRefExclusive returns silently when the lock is held, which
-              // suits context-menu items whose buttons carry a ?disabled
-              // binding. This one sits behind a prompt, an AI call and a
-              // confirm, so a silent return reads as "the reset happened".
-              if (!this.claimRefOperation(repoPath)) {
-                this.warnRepositoryBusy();
-                return;
-              }
-              try {
-                const resetResult = await git.resetToReflog(
-                  repoPath,
-                  match.index,
-                  'soft',
-                  target.oid
-                );
-                if (resetResult.success) {
-                  showToast('Undo successful', 'success');
-                  this.refreshConflictDialogRepo(repoPath);
-                } else {
-                  showToast(resetResult.error?.message ?? 'Undo failed', 'error');
-                }
-              } finally {
-                this.releaseRefOperation(repoPath);
-              }
-            }
-          } else {
-            showToast(result.error?.message ?? 'Could not find matching reflog entry', 'error');
-          }
-        }),
-      },
-      {
-        id: 'clean',
-        label: 'Clean working directory',
-        category: 'action',
-        icon: 'trash',
-        action: this.requiresRepository(() => { this.showClean = true; }),
-      },
-      {
-        id: 'branch-cleanup',
-        label: 'Clean up branches',
-        category: 'action',
-        icon: 'git-branch',
-        action: this.requiresRepository(() => { void this.openBranchCleanup(); }),
-      },
-      {
-        id: 'bisect',
-        label: 'Start bisect (find bug)',
-        category: 'action',
-        icon: 'search',
-        action: this.requiresRepository(() => { this.showBisect = true; }),
-      },
-      {
-        id: 'submodules',
-        label: 'Manage submodules',
-        category: 'action',
-        icon: 'folder',
-        action: this.requiresRepository(() => { this.showSubmodules = true; }),
-      },
-      {
-        id: 'worktrees',
-        label: 'Manage worktrees',
-        category: 'action',
-        icon: 'folder',
-        action: this.requiresRepository(() => { this.showWorktrees = true; }),
-      },
-      {
-        id: 'lfs',
-        label: 'Manage Git LFS',
-        category: 'action',
-        icon: 'folder',
-        action: this.requiresRepository(() => { this.showLfs = true; }),
-      },
-      {
-        id: 'gpg',
-        label: 'GPG Signing Settings',
-        category: 'action',
-        icon: 'key',
-        action: this.requiresRepository(() => { this.showGpg = true; }),
-      },
-      {
-        id: 'ssh',
-        label: 'SSH Key Management',
-        category: 'action',
-        icon: 'key',
-        action: () => { this.showSsh = true; },
-      },
-      {
-        id: 'config',
-        label: 'Git Configuration',
-        category: 'action',
-        icon: 'settings',
-        action: this.requiresRepository(() => { this.showConfig = true; }),
-      },
-      {
-        id: 'credentials',
-        label: 'Credential Management',
-        category: 'action',
-        icon: 'key',
-        action: this.requiresRepository(() => { this.showCredentials = true; }),
-      },
-      {
-        id: 'gc',
-        label: 'Run Garbage Collection',
-        category: 'action',
-        icon: 'trash',
-        action: this.requiresRepository(() => this.handleRunGc()),
-      },
-      {
-        id: 'gc-aggressive',
-        label: 'Run Garbage Collection (Aggressive)',
-        category: 'action',
-        icon: 'trash',
-        action: this.requiresRepository(() => this.handleRunGc(true)),
-      },
-      {
-        id: 'fsck',
-        label: 'Check Repository Integrity',
-        category: 'action',
-        icon: 'search',
-        action: this.requiresRepository(() => this.handleRunFsck()),
-      },
-      {
-        id: 'prune',
-        label: 'Prune Unreachable Objects',
-        category: 'action',
-        icon: 'trash',
-        action: this.requiresRepository(() => this.handleRunPrune()),
-      },
-      {
-        id: 'repository-health',
-        label: 'Repository Health & Maintenance',
-        category: 'action',
-        icon: 'activity',
-        action: this.requiresRepository(() => { this.showRepositoryHealth = true; }),
-      },
-      {
-        id: 'github',
-        label: 'GitHub Integration',
-        category: 'action',
-        icon: 'github',
-        // Account connection is repo-independent; only PR/issue/pipeline tabs guard themselves.
-        action: () => this.openIntegrationStandalone('github'),
-      },
-      {
-        id: 'gitlab',
-        label: 'GitLab Integration',
-        category: 'action',
-        icon: 'gitlab',
-        action: () => this.openIntegrationStandalone('gitlab'),
-      },
-      {
-        id: 'bitbucket',
-        label: 'Bitbucket Integration',
-        category: 'action',
-        icon: 'bitbucket',
-        action: () => this.openIntegrationStandalone('bitbucket'),
-      },
-      {
-        id: 'azure-devops',
-        label: 'Azure DevOps Integration',
-        category: 'action',
-        icon: 'azure',
-        action: () => this.openIntegrationStandalone('azure-devops'),
-      },
-      {
-        id: 'oidc',
-        label: 'Enterprise SSO (OIDC) Integration',
-        category: 'action',
-        icon: 'key',
-        action: () => this.openIntegrationStandalone('oidc'),
-      },
-      {
-        id: 'profiles',
-        label: 'Profiles & Accounts',
-        category: 'action',
-        icon: 'user',
-        action: () => { this.showProfileManager = true; },
-      },
-      {
-        id: 'search',
-        label: 'Search commits',
-        category: 'action',
-        icon: 'search',
-        shortcut: `${mod}F`,
-        action: () => this.handleToggleSearch(),
-      },
-      {
-        id: 'search-in-files',
-        label: 'Search in files',
-        category: 'action',
-        icon: 'search',
-        action: this.requiresRepository(() => this.openSearchDialog('files')),
-      },
-      {
-        id: 'search-in-diff',
-        label: 'Search in current diff',
-        category: 'action',
-        icon: 'search',
-        action: this.requiresRepository(() => this.openSearchDialog('diff')),
-      },
-      {
-        id: 'search-commit-content',
-        label: 'Find commits that changed text',
-        category: 'action',
-        icon: 'search',
-        action: this.requiresRepository(() => this.openSearchDialog('commits')),
-      },
-      {
-        id: 'stage-all',
-        label: 'Stage all changes',
-        category: 'action',
-        icon: 'commit',
-        action: this.requiresRepository(() => this.handleStageAll()),
-      },
-      {
-        id: 'unstage-all',
-        label: 'Unstage all changes',
-        category: 'action',
-        icon: 'commit',
-        action: this.requiresRepository(() => this.handleUnstageAll()),
-      },
-      {
-        id: 'toggle-left-panel',
-        label: 'Toggle left panel',
-        category: 'navigation',
-        shortcut: `${mod}B`,
-        action: () => this.toggleLeftPanel(),
-      },
-      {
-        id: 'toggle-right-panel',
-        label: 'Toggle right panel',
-        category: 'navigation',
-        shortcut: `${mod}J`,
-        action: () => uiStore.getState().togglePanel('right'),
-      },
-      {
-        id: 'undo',
-        label: 'Undo (open reflog)',
-        category: 'action',
-        icon: 'refresh',
-        shortcut: `${mod}Z`,
-        action: this.requiresRepository(() => { this.showReflog = true; }),
-      },
-      {
-        id: 'describe',
-        label: 'Describe commit (git describe)',
-        category: 'action',
-        icon: 'tag',
-        action: this.requiresRepository(() => { this.describeDialog?.open(); }),
-      },
-      {
-        id: 'compare-branches',
-        label: 'Compare branches',
-        category: 'action',
-        icon: 'branch',
-        action: this.requiresRepository(() => { this.compareBranchesDialog?.open(); }),
-      },
-      {
-        id: 'workspaces',
-        label: 'Manage workspaces',
-        category: 'action',
-        icon: 'folder',
-        action: () => { this.showWorkspaceManager = true; },
-      },
-      {
-        id: 'hooks',
-        label: 'Manage git hooks',
-        category: 'action',
-        icon: 'terminal',
-        action: this.requiresRepository(() => { this.showHooksDialog = true; }),
-      },
-      {
-        id: 'gitignore',
-        label: 'Edit .gitignore & .gitattributes',
-        category: 'action',
-        icon: 'file',
-        action: this.requiresRepository(() => { this.showGitignoreDialog = true; }),
-      },
-      // The palette acts on the ACTIVE repository; the same three actions are
-      // on the repository tab context menu for any open tab. Failures (no
-      // terminal emulator, a path that has gone away, an editor that cannot be
-      // spawned) are toasted by the shared service with the backend message.
-      {
-        id: 'open-in-terminal',
-        label: 'Open in Terminal',
-        category: 'action',
-        icon: 'terminal',
-        action: this.requiresRepository(() => {
-          void openRepositoryInTerminal(this.activeRepository!.repository.path);
-        }),
-      },
-      {
-        id: 'reveal-in-file-manager',
-        label: 'Reveal in File Manager',
-        category: 'action',
-        icon: 'folder',
-        action: this.requiresRepository(() => {
-          void openRepositoryInFileManager(this.activeRepository!.repository.path);
-        }),
-      },
-      {
-        id: 'open-in-editor',
-        label: 'Open in Editor',
-        category: 'action',
-        icon: 'file',
-        action: this.requiresRepository(() => {
-          void openRepositoryInEditor(this.activeRepository!.repository.path);
-        }),
-      },
-    ];
-
-    return commands;
+    return buildPaletteCommands(this satisfies PaletteCommandHost);
   }
 
   private async restorePersistedRepositories(): Promise<void> {
@@ -5102,7 +4489,7 @@ export class AppShell extends LitElement {
     }
   }
 
-  private async handleFetch(): Promise<void> {
+  async handleFetch(): Promise<void> {
     if (!this.activeRepository) return;
     // Coalesced like its pull and push siblings. keyboardService has no
     // e.repeat guard, so HOLDING Ctrl+Shift+F fires many times a second and
@@ -5154,7 +4541,7 @@ export class AppShell extends LitElement {
     }
   }
 
-  private handlePull(pinnedRepoPath?: string): Promise<void> {
+  handlePull(pinnedRepoPath?: string): Promise<void> {
     // pinnedRepoPath comes from a suggestion toast's Pull Now, which must pull
     // the repo whose push failed even if the user has since switched tabs.
     const repoPath = pinnedRepoPath ?? this.activeRepository?.repository.path;
@@ -5224,7 +4611,7 @@ export class AppShell extends LitElement {
     }
   }
 
-  private handlePush(): Promise<void> {
+  handlePush(): Promise<void> {
     const repoPath = this.activeRepository?.repository.path;
     if (!repoPath) return Promise.resolve();
     // Keyed like the force-push sibling, which was hardened against exactly
@@ -5275,7 +4662,7 @@ export class AppShell extends LitElement {
     progressService.cancelOperation(e.detail.id);
   }
 
-  private handleCreateStash(): Promise<void> {
+  handleCreateStash(): Promise<void> {
     if (!this.activeRepository) return Promise.resolve();
     // Pinned: if the user switches tabs while the stash is being created, the
     // refresh must target the repo that was stashed, not the active tab.
@@ -5329,7 +4716,7 @@ export class AppShell extends LitElement {
     }
   }
 
-  private async handleRunGc(aggressive = false): Promise<void> {
+  async handleRunGc(aggressive = false): Promise<void> {
     if (!this.activeRepository) return;
 
     // Pinned before the confirm await, like every other destructive handler —
@@ -5387,7 +4774,7 @@ export class AppShell extends LitElement {
     }
   }
 
-  private async handleRunFsck(): Promise<void> {
+  async handleRunFsck(): Promise<void> {
     if (!this.activeRepository) return;
 
     const repoPath = this.activeRepository.repository.path;
@@ -5416,7 +4803,7 @@ export class AppShell extends LitElement {
     );
   }
 
-  private async handleRunPrune(): Promise<void> {
+  async handleRunPrune(): Promise<void> {
     if (!this.activeRepository) return;
 
     const repoPath = this.activeRepository.repository.path;
@@ -5511,7 +4898,7 @@ export class AppShell extends LitElement {
     const { repoPath, filePath, lineNumber } = e.detail;
 
     // Close the workspace manager
-    this.showWorkspaceManager = false;
+    dialogs.close('workspaceManager');
 
     try {
       const currentRepoPath = this.activeRepository?.repository.path;
@@ -5530,7 +4917,7 @@ export class AppShell extends LitElement {
       // Show blame view for the file
       this.blameFile = filePath;
       this.blameCommitOid = null;
-      this.showBlame = true;
+      dialogs.open('blame');
     } catch (error) {
       showToast(error instanceof Error ? error.message : 'Failed to open repository', 'error');
     }
@@ -5541,7 +4928,7 @@ export class AppShell extends LitElement {
    * (below the paginated window or hidden by a branch filter) instead of
    * silently doing nothing. ALL reveal-in-graph flows must go through this.
    */
-  private revealCommitInGraph(oid: string): void {
+  revealCommitInGraph(oid: string): void {
     if (this.graphCanvas?.selectCommit(oid)) {
       return;
     }
@@ -5571,21 +4958,19 @@ export class AppShell extends LitElement {
     // unmounts the inline editor with it, same teardown as the x button.
     this.warnIfDiscardingEdits();
     // Close diff if open
-    this.showDiff = false;
+    dialogs.close('diff');
     this.diffFile = null;
     this.diffCommitFile = null;
     // Close blame if open
-    this.showBlame = false;
+    dialogs.close('blame');
     this.blameFile = null;
     this.blameCommitOid = null;
     // Open file history
-    this.fileHistoryPath = e.detail.filePath;
-    this.showFileHistory = true;
+    dialogs.open('fileHistory', { filePath: e.detail.filePath });
   }
 
   private handleCloseFileHistory(): void {
-    this.showFileHistory = false;
-    this.fileHistoryPath = null;
+    dialogs.close('fileHistory');
   }
 
   private handleFileHistoryCommitSelected(e: CustomEvent<{ commit: Commit }>): void {
@@ -5600,7 +4985,7 @@ export class AppShell extends LitElement {
       commitOid: e.detail.commitOid,
       filePath: e.detail.filePath,
     };
-    this.showDiff = true;
+    dialogs.open('diff');
   }
 
   private handleVimModeChange(e: CustomEvent<{ enabled: boolean }>): void {
@@ -5656,8 +5041,8 @@ export class AppShell extends LitElement {
       ${this.globalLoading ? html`<div class="global-loading-bar"></div>` : ''}
 
       <lv-toolbar
-        @open-settings=${() => { this.showSettings = true; }}
-        @open-shortcuts=${() => { this.showShortcuts = true; }}
+        @open-settings=${() => { dialogs.open('settings'); }}
+        @open-shortcuts=${() => { dialogs.open('shortcuts'); }}
         @open-command-palette=${() => {
             // Through openCommandPalette, like Ctrl+P. Setting the flag alone
             // skipped the loader, so the toolbar button opened a palette with
@@ -5668,15 +5053,15 @@ export class AppShell extends LitElement {
             // branch>" — the no-op the palette excludes on purpose.
             void this.openCommandPalette();
           }}
-        @open-profile-manager=${() => { this.showProfileManager = true; }}
-        @open-workspace-manager=${() => { this.showWorkspaceManager = true; }}
+        @open-profile-manager=${() => { dialogs.open('profileManager'); }}
+        @open-workspace-manager=${() => { dialogs.open('workspaceManager'); }}
         @search-change=${this.handleSearchChange}
       ></lv-toolbar>
 
       ${this.activeRepository
         ? html`
             <lv-context-dashboard
-              @open-profile-manager=${() => { this.showProfileManager = true; }}
+              @open-profile-manager=${() => { dialogs.open('profileManager'); }}
               @open-github=${() => this.openIntegrationStandalone('github')}
               @open-gitlab=${() => this.openIntegrationStandalone('gitlab')}
               @open-bitbucket=${() => this.openIntegrationStandalone('bitbucket')}
@@ -5774,7 +5159,7 @@ export class AppShell extends LitElement {
                             ? html`
                                 <button
                                   class="operation-btn operation-btn-primary"
-                                  @click=${() => { this.showBisect = true; }}
+                                  @click=${() => { dialogs.open('bisect'); }}
                                 >
                                   Manage Bisect
                                 </button>
@@ -5797,7 +5182,7 @@ export class AppShell extends LitElement {
                   ></lv-graph-canvas>
                 </div>
 
-                ${this.showDiff
+                ${dialogs.isOpen('diff')
                   ? html`
                       <div class="diff-area">
                         <div class="diff-header">
@@ -5829,7 +5214,7 @@ export class AppShell extends LitElement {
                         </div>
                       </div>
                     `
-                  : this.showBlame && this.blameFile
+                  : dialogs.isOpen('blame') && this.blameFile
                     ? html`
                         <div class="diff-area">
                           <lv-blame-view
@@ -5841,7 +5226,7 @@ export class AppShell extends LitElement {
                           ></lv-blame-view>
                         </div>
                       `
-                    : this.showFileHistory && this.fileHistoryPath
+                    : dialogs.isOpen('fileHistory') && this.fileHistoryPath
                       ? html`
                           <div class="diff-area">
                             <lv-file-history
@@ -5855,13 +5240,13 @@ export class AppShell extends LitElement {
                           </div>
                         `
                       : ''}
-                ${this.showOutputPanel
+                ${dialogs.isOpen('outputPanel')
                   ? html`
                       <div class="output-panel-container">
                         <lv-output-panel
                           closable
                           .repositoryPath=${this.activeRepository.repository.path}
-                          @close=${() => { this.showOutputPanel = false; }}
+                          @close=${() => { dialogs.close('outputPanel'); }}
                         ></lv-output-panel>
                       </div>
                     `
@@ -5889,7 +5274,7 @@ export class AppShell extends LitElement {
                   <lv-right-panel
                     .commit=${this.selectedCommit}
                     .refs=${this.selectedCommitRefs}
-                    @open-settings=${() => { this.showSettings = true; }}
+                    @open-settings=${() => { dialogs.open('settings'); }}
                     @tab-changed=${(e: CustomEvent) => { this.activeRightPanelTab = e.detail?.tab; }}
                   ></lv-right-panel>
                 </aside>
@@ -5902,11 +5287,11 @@ export class AppShell extends LitElement {
             </footer>
           `
         : html`<lv-welcome
-            @open-workspace-manager=${() => { this.showWorkspaceManager = true; }}
-            @open-profile-manager=${() => { this.showProfileManager = true; }}
+            @open-workspace-manager=${() => { dialogs.open('workspaceManager'); }}
+            @open-profile-manager=${() => { dialogs.open('profileManager'); }}
           ></lv-welcome>`}
 
-      ${this.showSettings
+      ${dialogs.isOpen('settings')
         ? html`
             <lv-modal
               open
@@ -5915,13 +5300,13 @@ export class AppShell extends LitElement {
             >
               <lv-settings-dialog
                 @close=${this.handleCloseSettings}
-                @open-profile-manager=${() => { this.showProfileManager = true; }}
+                @open-profile-manager=${() => { dialogs.open('profileManager'); }}
               ></lv-settings-dialog>
             </lv-modal>
           `
         : ''}
 
-      ${this.showConflictDialog && this.conflictDialogConfig
+      ${dialogs.isOpen('conflict') && this.conflictDialogConfig
         ? html`
             <lv-conflict-resolution-dialog
               open
@@ -6197,7 +5582,7 @@ export class AppShell extends LitElement {
         : ''}
 
       <lv-command-palette
-        ?open=${this.showCommandPalette}
+        ?open=${dialogs.isOpen('commandPalette')}
         .repositoryPath=${this.commandPaletteRepositoryPath ?? ''}
         .commands=${this.getPaletteCommands()}
         .branches=${this.paletteBranches}
@@ -6212,48 +5597,48 @@ export class AppShell extends LitElement {
 
       ${this.activeRepository ? html`
         <lv-reflog-dialog
-          ?open=${this.showReflog}
+          ?open=${dialogs.isOpen('reflog')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showReflog = false; }}
+          @close=${() => { dialogs.close('reflog'); }}
           @undo-complete=${(e: CustomEvent<{ repositoryPath?: string }>) => {
-            this.showReflog = false;
+            dialogs.close('reflog');
             this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null);
           }}
-          @show-commit=${(e: CustomEvent<{ oid: string }>) => { this.showReflog = false; this.revealCommitInGraph(e.detail.oid); }}
+          @show-commit=${(e: CustomEvent<{ oid: string }>) => { dialogs.close('reflog'); this.revealCommitInGraph(e.detail.oid); }}
         ></lv-reflog-dialog>
 
         <lv-search-dialog
-          ?open=${this.showSearchDialog}
+          ?open=${dialogs.isOpen('search')}
           .mode=${this.searchDialogMode}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showSearchDialog = false; }}
-          @mode-changed=${(e: CustomEvent<{ mode: SearchDialogMode }>) => { this.searchDialogMode = e.detail.mode; }}
+          @close=${() => { dialogs.close('search'); }}
+          @mode-changed=${(e: CustomEvent<{ mode: SearchDialogMode }>) => { dialogs.setContext('search', { mode: e.detail.mode }); }}
           @show-blame=${this.handleShowBlame}
           @show-working-diff=${this.handleShowWorkingDiff}
         ></lv-search-dialog>
       ` : ''}
 
       <lv-keyboard-shortcuts-dialog
-        ?open=${this.showShortcuts}
+        ?open=${dialogs.isOpen('shortcuts')}
         ?vimMode=${this.vimMode}
-        @close=${() => { this.showShortcuts = false; }}
+        @close=${() => { dialogs.close('shortcuts'); }}
         @vim-mode-change=${this.handleVimModeChange}
       ></lv-keyboard-shortcuts-dialog>
 
       ${this.activeRepository ? html`
         <lv-remote-dialog
-          ?open=${this.showRemotes}
+          ?open=${dialogs.isOpen('remotes')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showRemotes = false; }}
+          @close=${() => { dialogs.close('remotes'); }}
           @remotes-changed=${() => this.handleRefresh()}
         ></lv-remote-dialog>
       ` : ''}
 
       ${this.activeRepository ? html`
         <lv-clean-dialog
-          ?open=${this.showClean}
+          ?open=${dialogs.isOpen('clean')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showClean = false; }}
+          @close=${() => { dialogs.close('clean'); }}
           @files-cleaned=${(e: CustomEvent<{ repositoryPath?: string }>) =>
             this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null)}
         ></lv-clean-dialog>
@@ -6265,10 +5650,10 @@ export class AppShell extends LitElement {
         ></lv-changelog-dialog>
       ` : ''}
 
-      ${this.activeRepository && this.showRepositoryHealth ? html`
+      ${this.activeRepository && dialogs.isOpen('repositoryHealth') ? html`
         <lv-modal
           modalTitle="Repository Health"
-          ?open=${this.showRepositoryHealth}
+          ?open=${dialogs.isOpen('repositoryHealth')}
           @close=${this.handleRepositoryHealthClose}
         >
           <lv-repository-health-dialog
@@ -6280,13 +5665,13 @@ export class AppShell extends LitElement {
 
       ${this.activeRepository ? html`
         <lv-bisect-dialog
-          ?open=${this.showBisect}
+          ?open=${dialogs.isOpen('bisect')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showBisect = false; }}
+          @close=${() => { dialogs.close('bisect'); }}
           @bisect-step=${(e: CustomEvent<{ repositoryPath?: string }>) =>
             this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null)}
           @bisect-complete=${(e: CustomEvent<{ repositoryPath?: string }>) => {
-            this.showBisect = false;
+            dialogs.close('bisect');
             this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null);
           }}
         ></lv-bisect-dialog>
@@ -6294,9 +5679,9 @@ export class AppShell extends LitElement {
 
       ${this.activeRepository ? html`
         <lv-submodule-dialog
-          ?open=${this.showSubmodules}
+          ?open=${dialogs.isOpen('submodules')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showSubmodules = false; }}
+          @close=${() => { dialogs.close('submodules'); }}
           @submodules-changed=${(e: CustomEvent<{ repositoryPath?: string }>) =>
             // Routed to the repo the operation RAN ON. handleRefresh resolves
             // activeRepository at call time, so a Ctrl+Tab during a slow
@@ -6308,9 +5693,9 @@ export class AppShell extends LitElement {
 
       ${this.activeRepository ? html`
         <lv-worktree-dialog
-          ?open=${this.showWorktrees}
+          ?open=${dialogs.isOpen('worktrees')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showWorktrees = false; }}
+          @close=${() => { dialogs.close('worktrees'); }}
           @worktrees-changed=${(e: CustomEvent<{ repositoryPath?: string }>) =>
             // Routed to the repo the operation RAN ON. handleRefresh resolves
             // activeRepository at call time, so a Ctrl+Tab during a slow
@@ -6322,9 +5707,9 @@ export class AppShell extends LitElement {
 
       ${this.activeRepository ? html`
         <lv-lfs-dialog
-          ?open=${this.showLfs}
+          ?open=${dialogs.isOpen('lfs')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showLfs = false; }}
+          @close=${() => { dialogs.close('lfs'); }}
           @lfs-changed=${(e: CustomEvent<{ repositoryPath?: string }>) =>
             // Routed to the repo the operation RAN ON. handleRefresh resolves
             // activeRepository at call time, so a Ctrl+Tab during a slow
@@ -6336,37 +5721,37 @@ export class AppShell extends LitElement {
 
       ${this.activeRepository ? html`
         <lv-gpg-dialog
-          ?open=${this.showGpg}
+          ?open=${dialogs.isOpen('gpg')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showGpg = false; }}
+          @close=${() => { dialogs.close('gpg'); }}
           @gpg-changed=${(e: CustomEvent<{ repositoryPath?: string }>) =>
             this.refreshConflictDialogRepo(e.detail?.repositoryPath ?? null)}
         ></lv-gpg-dialog>
       ` : ''}
 
       <lv-ssh-dialog
-        ?open=${this.showSsh}
-        @close=${() => { this.showSsh = false; }}
+        ?open=${dialogs.isOpen('ssh')}
+        @close=${() => { dialogs.close('ssh'); }}
       ></lv-ssh-dialog>
 
       ${this.activeRepository ? html`
         <lv-config-dialog
-          ?open=${this.showConfig}
+          ?open=${dialogs.isOpen('config')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showConfig = false; }}
+          @close=${() => { dialogs.close('config'); }}
         ></lv-config-dialog>
       ` : ''}
 
       ${this.activeRepository ? html`
         <lv-credentials-dialog
-          ?open=${this.showCredentials}
+          ?open=${dialogs.isOpen('credentials')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showCredentials = false; }}
+          @close=${() => { dialogs.close('credentials'); }}
         ></lv-credentials-dialog>
       ` : ''}
 
       <lv-github-dialog
-        ?open=${this.showGitHub}
+        ?open=${dialogs.isOpen('gitHub')}
         ?backButton=${this.integrationBackButton}
         .attachToProfileName=${this.integrationAttachName}
         .repositoryPath=${this.activeRepository?.repository.path ?? ''}
@@ -6375,7 +5760,7 @@ export class AppShell extends LitElement {
       ></lv-github-dialog>
 
       <lv-gitlab-dialog
-        ?open=${this.showGitLab}
+        ?open=${dialogs.isOpen('gitLab')}
         ?backButton=${this.integrationBackButton}
         .attachToProfileName=${this.integrationAttachName}
         .repositoryPath=${this.activeRepository?.repository.path ?? ''}
@@ -6384,7 +5769,7 @@ export class AppShell extends LitElement {
       ></lv-gitlab-dialog>
 
       <lv-bitbucket-dialog
-        ?open=${this.showBitbucket}
+        ?open=${dialogs.isOpen('bitbucket')}
         ?backButton=${this.integrationBackButton}
         .attachToProfileName=${this.integrationAttachName}
         .repositoryPath=${this.activeRepository?.repository.path ?? ''}
@@ -6393,7 +5778,7 @@ export class AppShell extends LitElement {
       ></lv-bitbucket-dialog>
 
       <lv-azure-devops-dialog
-        ?open=${this.showAzureDevOps}
+        ?open=${dialogs.isOpen('azureDevOps')}
         ?backButton=${this.integrationBackButton}
         .attachToProfileName=${this.integrationAttachName}
         .repositoryPath=${this.activeRepository?.repository.path ?? ''}
@@ -6402,7 +5787,7 @@ export class AppShell extends LitElement {
       ></lv-azure-devops-dialog>
 
       <lv-oidc-dialog
-        ?open=${this.showOidc}
+        ?open=${dialogs.isOpen('oidc')}
         ?backButton=${this.integrationBackButton}
         .attachToProfileName=${this.integrationAttachName}
         @close=${() => this.handleIntegrationDialogClose('oidc')}
@@ -6410,7 +5795,7 @@ export class AppShell extends LitElement {
       ></lv-oidc-dialog>
 
       <lv-profile-manager-dialog
-        ?open=${this.showProfileManager}
+        ?open=${dialogs.isOpen('profileManager')}
         ?demoted=${this.profileManagerDemoted}
         .repoPath=${this.activeRepository?.repository.path ?? ''}
         .initialView=${this.profileManagerView}
@@ -6420,35 +5805,35 @@ export class AppShell extends LitElement {
         @open-bitbucket=${(e: CustomEvent<IntegrationOpenContext>) => this.handleOpenIntegrationFromManager('bitbucket', e)}
         @open-azure-devops=${(e: CustomEvent<IntegrationOpenContext>) => this.handleOpenIntegrationFromManager('azure-devops', e)}
         @open-oidc=${(e: CustomEvent<IntegrationOpenContext>) => this.handleOpenIntegrationFromManager('oidc', e)}
-        @migration-needed=${() => { this.showMigrationDialog = true; }}
+        @migration-needed=${() => { dialogs.open('migration'); }}
         @request-restore-provider=${this.handleRestoreProvider}
       ></lv-profile-manager-dialog>
 
       <lv-migration-dialog
-        ?open=${this.showMigrationDialog}
-        @close=${() => { this.showMigrationDialog = false; }}
-        @open-profile-manager=${() => { this.showProfileManager = true; }}
+        ?open=${dialogs.isOpen('migration')}
+        @close=${() => { dialogs.close('migration'); }}
+        @open-profile-manager=${() => { dialogs.open('profileManager'); }}
       ></lv-migration-dialog>
 
       <lv-workspace-manager-dialog
-        ?open=${this.showWorkspaceManager}
-        @close=${() => { this.showWorkspaceManager = false; }}
+        ?open=${dialogs.isOpen('workspaceManager')}
+        @close=${() => { dialogs.close('workspaceManager'); }}
         @open-repo-file=${this.handleWorkspaceOpenRepoFile}
       ></lv-workspace-manager-dialog>
 
       ${this.activeRepository ? html`
         <lv-hooks-dialog
-          ?open=${this.showHooksDialog}
+          ?open=${dialogs.isOpen('hooks')}
           .repoPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showHooksDialog = false; }}
+          @close=${() => { dialogs.close('hooks'); }}
         ></lv-hooks-dialog>
       ` : ''}
 
       ${this.activeRepository ? html`
         <lv-gitignore-dialog
-          ?open=${this.showGitignoreDialog}
+          ?open=${dialogs.isOpen('gitignore')}
           .repositoryPath=${this.activeRepository.repository.path}
-          @close=${() => { this.showGitignoreDialog = false; }}
+          @close=${() => { dialogs.close('gitignore'); }}
           @ignore-rules-changed=${(e: CustomEvent<{ repositoryPath?: string }>) =>
             // Writing .gitignore/.gitattributes changes the working tree, so the
             // file list must be reloaded. Routed to the repo the write RAN ON:

--- a/src/palette-commands.ts
+++ b/src/palette-commands.ts
@@ -1,0 +1,589 @@
+import type { Commit } from './types/git.types.ts';
+import type { IntegrationType } from './types/integration-accounts.types.ts';
+import type { OpenRepository } from './stores/index.ts';
+import type { PaletteCommand } from './components/dialogs/lv-command-palette.ts';
+import type { SearchDialogMode } from './components/dialogs/lv-search-dialog.ts';
+import type { LvGraphCanvas } from './components/graph/lv-graph-canvas.ts';
+import type { LvCreateTagDialog } from './components/dialogs/lv-create-tag-dialog.ts';
+import type { LvCreateBranchDialog } from './components/dialogs/lv-create-branch-dialog.ts';
+import type { LvExportImportDialog } from './components/dialogs/lv-export-import-dialog.ts';
+import type { LvDescribeDialog } from './components/dialogs/lv-describe-dialog.ts';
+import type { LvCompareBranchesDialog } from './components/dialogs/lv-compare-branches-dialog.ts';
+import { dialogs } from './stores/dialog.store.ts';
+import { uiStore } from './stores/index.ts';
+import { showToast } from './services/notification.service.ts';
+import { showConfirm, showPrompt } from './services/dialog.service.ts';
+import {
+  openRepositoryInEditor,
+  openRepositoryInFileManager,
+  openRepositoryInTerminal,
+} from './services/open-location.service.ts';
+
+/**
+ * What the command table needs from app-shell.
+ *
+ * The table is ~500 lines of the shell's own operations wrapped in palette
+ * entries; lifting it out keeps app-shell to the behaviour and leaves one
+ * place to read the full list of commands. This interface is the exact
+ * dependency surface — the members it names are the only reason those
+ * app-shell members are not private.
+ */
+export interface PaletteCommandHost {
+  readonly activeRepository: OpenRepository | null;
+  readonly selectedCommit: Commit | null;
+  readonly shadowRoot: ShadowRoot | null;
+
+  readonly graphCanvas?: LvGraphCanvas;
+  readonly createTagDialog?: LvCreateTagDialog;
+  readonly createBranchDialog?: LvCreateBranchDialog;
+  readonly exportImportDialog?: LvExportImportDialog;
+  readonly describeDialog?: LvDescribeDialog;
+  readonly compareBranchesDialog?: LvCompareBranchesDialog;
+
+  /** Wrap an action so it toasts "open a repository first" when there is none. */
+  requiresRepository(action: () => void): () => void;
+  warnRepositoryBusy(): void;
+  claimRefOperation(repoPath: string): boolean;
+  releaseRefOperation(repoPath: string): void;
+
+  handleFetch(): Promise<void>;
+  handlePull(pinnedRepoPath?: string): Promise<void>;
+  handlePush(): Promise<void>;
+  handleRefresh(): Promise<void>;
+  handleStageAll(): void;
+  handleUnstageAll(): void;
+  handleCreateStash(): Promise<void>;
+  handleToggleSearch(): void;
+  handleRunGc(aggressive?: boolean): Promise<void>;
+  handleRunFsck(): Promise<void>;
+  handleRunPrune(): Promise<void>;
+  openBranchCleanup(): Promise<void>;
+  openSearchDialog(mode: SearchDialogMode): void;
+  openIntegrationStandalone(type: IntegrationType): void;
+  refreshConflictDialogRepo(pinnedPath: string | null): void;
+  revealCommitInGraph(oid: string): void;
+  toggleLeftPanel(): void;
+}
+
+/**
+ * Every entry of the command palette, in display order.
+ *
+ * Also the source of truth the native menu bar resolves its item ids against,
+ * so an entry's `id` and its `action` are a contract, not an implementation
+ * detail: renaming an id here silently unwires the menu item that points at it.
+ */
+export function buildPaletteCommands(shell: PaletteCommandHost): PaletteCommand[] {
+  const isMac = navigator.platform.includes('Mac');
+  const mod = isMac ? '⌘' : 'Ctrl';
+
+  const commands: PaletteCommand[] = [
+    {
+      id: 'fetch',
+      label: 'Fetch from remote',
+      category: 'action',
+      icon: 'fetch',
+      action: shell.requiresRepository(() => shell.handleFetch()),
+    },
+    {
+      id: 'pull',
+      label: 'Pull from remote',
+      category: 'action',
+      icon: 'pull',
+      action: shell.requiresRepository(() => shell.handlePull()),
+    },
+    {
+      id: 'push',
+      label: 'Push to remote',
+      category: 'action',
+      icon: 'push',
+      action: shell.requiresRepository(() => shell.handlePush()),
+    },
+    {
+      id: 'refresh',
+      label: 'Refresh repository',
+      category: 'action',
+      icon: 'refresh',
+      shortcut: `${mod}R`,
+      action: () => shell.handleRefresh(),
+    },
+    {
+      id: 'graph-jump-head',
+      label: 'Graph: Jump to HEAD',
+      category: 'navigation',
+      icon: 'commit',
+      action: shell.requiresRepository(() => {
+        if (shell.graphCanvas?.jumpToHead()) {
+          return;
+        }
+        // Route the miss through the shared reveal helper so the toast
+        // distinguishes loaded-but-filtered from not-loaded
+        const headOid = shell.graphCanvas?.getHeadOid();
+        if (headOid !== undefined) {
+          shell.revealCommitInGraph(headOid);
+        } else {
+          showToast('HEAD commit is not loaded in the graph', 'info', 4000);
+        }
+      }),
+    },
+    {
+      id: 'toggle-output-panel',
+      label: 'Toggle Output Panel',
+      category: 'action',
+      icon: 'terminal',
+      action: () => { dialogs.setOpen('outputPanel', !dialogs.isOpen('outputPanel')); },
+    },
+    {
+      id: 'stash',
+      label: 'Create stash',
+      category: 'action',
+      icon: 'stash',
+      action: shell.requiresRepository(() => shell.handleCreateStash()),
+    },
+    {
+      id: 'create-branch',
+      label: 'Create branch',
+      category: 'action',
+      icon: 'branch',
+      shortcut: `${mod}⇧N`,
+      action: shell.requiresRepository(() => shell.createBranchDialog?.open()),
+    },
+    {
+      id: 'create-tag',
+      label: 'Create tag',
+      category: 'action',
+      icon: 'tag',
+      action: shell.requiresRepository(() => shell.createTagDialog?.open()),
+    },
+    {
+      id: 'export-archive',
+      label: 'Export archive…',
+      category: 'action',
+      icon: 'file',
+      action: shell.requiresRepository(() => shell.exportImportDialog?.open({ tab: 'archive' })),
+    },
+    {
+      id: 'create-patch',
+      label: 'Create patch from commits…',
+      category: 'action',
+      icon: 'commit',
+      action: shell.requiresRepository(() =>
+        shell.exportImportDialog?.open({
+          tab: 'patch',
+          patchMode: 'create',
+          commitOid: shell.selectedCommit?.oid,
+        }),
+      ),
+    },
+    {
+      id: 'apply-patch',
+      label: 'Apply patch file…',
+      category: 'action',
+      icon: 'commit',
+      action: shell.requiresRepository(() =>
+        shell.exportImportDialog?.open({ tab: 'patch', patchMode: 'apply' }),
+      ),
+    },
+    {
+      id: 'create-bundle',
+      label: 'Create bundle…',
+      category: 'action',
+      icon: 'file',
+      action: shell.requiresRepository(() =>
+        shell.exportImportDialog?.open({ tab: 'bundle', bundleMode: 'create' }),
+      ),
+    },
+    {
+      id: 'import-bundle',
+      label: 'Import bundle…',
+      category: 'action',
+      icon: 'file',
+      action: shell.requiresRepository(() =>
+        shell.exportImportDialog?.open({ tab: 'bundle', bundleMode: 'import' }),
+      ),
+    },
+    {
+      id: 'settings',
+      label: 'Open settings',
+      category: 'action',
+      icon: 'settings',
+      shortcut: `${mod},`,
+      action: () => { dialogs.open('settings'); },
+    },
+    {
+      id: 'remotes',
+      label: 'Manage remotes',
+      category: 'action',
+      icon: 'globe',
+      action: shell.requiresRepository(() => { dialogs.open('remotes'); }),
+    },
+    {
+      id: 'changelog',
+      label: 'Generate Changelog',
+      category: 'action',
+      icon: 'tag',
+      action: shell.requiresRepository(() => {
+        const dialog = shell.shadowRoot?.querySelector('lv-changelog-dialog');
+        if (dialog) (dialog as import('./components/dialogs/lv-changelog-dialog.ts').LvChangelogDialog).open();
+      }),
+    },
+    {
+      id: 'smart-undo',
+      label: 'Smart Undo (AI)',
+      category: 'action',
+      icon: 'undo',
+      action: shell.requiresRepository(async () => {
+        // Captured BEFORE the prompt/AI/confirm awaits (all yield): the
+        // reflog reset must run on the repo it was invoked on, even if the
+        // user switches tabs while any of those dialogs/calls are pending.
+        const repoPath = shell.activeRepository!.repository.path;
+        const query = await showPrompt('Smart Undo (AI)', 'Describe what you want to undo (e.g., "before the rebase", "undo last 3 commits"):');
+        if (!query) return;
+
+        const result = await import('./services/ai.service.ts').then(m =>
+          m.findReflogEntry(repoPath, query)
+        );
+
+        if (result.success && result.data) {
+          const match = result.data;
+
+          // Resolve the index to a commit BEFORE the confirm. An AI round
+          // trip plus a prompt plus a confirm all elapse between the reflog
+          // being read and the reset firing, and any commit or checkout in
+          // that window renumbers every entry. Pinning the oid means the
+          // reset either lands on the commit named here or is refused.
+          const git = await import('./services/git.service.ts');
+          const reflog = await git.getReflog(repoPath);
+          const target = reflog.success ? reflog.data?.[match.index] : undefined;
+
+          if (!target) {
+            showToast('Could not resolve that reflog entry — try again', 'error');
+            return;
+          }
+
+          const confirmed = await showConfirm(
+            'Smart Undo',
+            `${match.description}\n\nReset to ${target.shortId} (HEAD@{${match.index}})?\n\n` +
+              `This branch will point at ${target.shortId}. Any commit no longer ` +
+              `reachable from it is recoverable only through the reflog. Your ` +
+              `changes remain staged.`,
+            'warning'
+          );
+          if (confirmed) {
+            // The other caller of reset_to_reflog — lv-reflog-dialog — claims
+            // the shared working-tree lock; this palette route to the same
+            // command was missed by that sweep. The expected_oid pin guards
+            // against a STALE index, not against a checkout moving the branch
+            // underneath the reset.
+            // runRefExclusive returns silently when the lock is held, which
+            // suits context-menu items whose buttons carry a ?disabled
+            // binding. This one sits behind a prompt, an AI call and a
+            // confirm, so a silent return reads as "the reset happened".
+            if (!shell.claimRefOperation(repoPath)) {
+              shell.warnRepositoryBusy();
+              return;
+            }
+            try {
+              const resetResult = await git.resetToReflog(
+                repoPath,
+                match.index,
+                'soft',
+                target.oid
+              );
+              if (resetResult.success) {
+                showToast('Undo successful', 'success');
+                shell.refreshConflictDialogRepo(repoPath);
+              } else {
+                showToast(resetResult.error?.message ?? 'Undo failed', 'error');
+              }
+            } finally {
+              shell.releaseRefOperation(repoPath);
+            }
+          }
+        } else {
+          showToast(result.error?.message ?? 'Could not find matching reflog entry', 'error');
+        }
+      }),
+    },
+    {
+      id: 'clean',
+      label: 'Clean working directory',
+      category: 'action',
+      icon: 'trash',
+      action: shell.requiresRepository(() => { dialogs.open('clean'); }),
+    },
+    {
+      id: 'branch-cleanup',
+      label: 'Clean up branches',
+      category: 'action',
+      icon: 'git-branch',
+      action: shell.requiresRepository(() => { void shell.openBranchCleanup(); }),
+    },
+    {
+      id: 'bisect',
+      label: 'Start bisect (find bug)',
+      category: 'action',
+      icon: 'search',
+      action: shell.requiresRepository(() => { dialogs.open('bisect'); }),
+    },
+    {
+      id: 'submodules',
+      label: 'Manage submodules',
+      category: 'action',
+      icon: 'folder',
+      action: shell.requiresRepository(() => { dialogs.open('submodules'); }),
+    },
+    {
+      id: 'worktrees',
+      label: 'Manage worktrees',
+      category: 'action',
+      icon: 'folder',
+      action: shell.requiresRepository(() => { dialogs.open('worktrees'); }),
+    },
+    {
+      id: 'lfs',
+      label: 'Manage Git LFS',
+      category: 'action',
+      icon: 'folder',
+      action: shell.requiresRepository(() => { dialogs.open('lfs'); }),
+    },
+    {
+      id: 'gpg',
+      label: 'GPG Signing Settings',
+      category: 'action',
+      icon: 'key',
+      action: shell.requiresRepository(() => { dialogs.open('gpg'); }),
+    },
+    {
+      id: 'ssh',
+      label: 'SSH Key Management',
+      category: 'action',
+      icon: 'key',
+      action: () => { dialogs.open('ssh'); },
+    },
+    {
+      id: 'config',
+      label: 'Git Configuration',
+      category: 'action',
+      icon: 'settings',
+      action: shell.requiresRepository(() => { dialogs.open('config'); }),
+    },
+    {
+      id: 'credentials',
+      label: 'Credential Management',
+      category: 'action',
+      icon: 'key',
+      action: shell.requiresRepository(() => { dialogs.open('credentials'); }),
+    },
+    {
+      id: 'gc',
+      label: 'Run Garbage Collection',
+      category: 'action',
+      icon: 'trash',
+      action: shell.requiresRepository(() => shell.handleRunGc()),
+    },
+    {
+      id: 'gc-aggressive',
+      label: 'Run Garbage Collection (Aggressive)',
+      category: 'action',
+      icon: 'trash',
+      action: shell.requiresRepository(() => shell.handleRunGc(true)),
+    },
+    {
+      id: 'fsck',
+      label: 'Check Repository Integrity',
+      category: 'action',
+      icon: 'search',
+      action: shell.requiresRepository(() => shell.handleRunFsck()),
+    },
+    {
+      id: 'prune',
+      label: 'Prune Unreachable Objects',
+      category: 'action',
+      icon: 'trash',
+      action: shell.requiresRepository(() => shell.handleRunPrune()),
+    },
+    {
+      id: 'repository-health',
+      label: 'Repository Health & Maintenance',
+      category: 'action',
+      icon: 'activity',
+      action: shell.requiresRepository(() => { dialogs.open('repositoryHealth'); }),
+    },
+    {
+      id: 'github',
+      label: 'GitHub Integration',
+      category: 'action',
+      icon: 'github',
+      // Account connection is repo-independent; only PR/issue/pipeline tabs guard themselves.
+      action: () => shell.openIntegrationStandalone('github'),
+    },
+    {
+      id: 'gitlab',
+      label: 'GitLab Integration',
+      category: 'action',
+      icon: 'gitlab',
+      action: () => shell.openIntegrationStandalone('gitlab'),
+    },
+    {
+      id: 'bitbucket',
+      label: 'Bitbucket Integration',
+      category: 'action',
+      icon: 'bitbucket',
+      action: () => shell.openIntegrationStandalone('bitbucket'),
+    },
+    {
+      id: 'azure-devops',
+      label: 'Azure DevOps Integration',
+      category: 'action',
+      icon: 'azure',
+      action: () => shell.openIntegrationStandalone('azure-devops'),
+    },
+    {
+      id: 'oidc',
+      label: 'Enterprise SSO (OIDC) Integration',
+      category: 'action',
+      icon: 'key',
+      action: () => shell.openIntegrationStandalone('oidc'),
+    },
+    {
+      id: 'profiles',
+      label: 'Profiles & Accounts',
+      category: 'action',
+      icon: 'user',
+      action: () => { dialogs.open('profileManager'); },
+    },
+    {
+      id: 'search',
+      label: 'Search commits',
+      category: 'action',
+      icon: 'search',
+      shortcut: `${mod}F`,
+      action: () => shell.handleToggleSearch(),
+    },
+    {
+      id: 'search-in-files',
+      label: 'Search in files',
+      category: 'action',
+      icon: 'search',
+      action: shell.requiresRepository(() => shell.openSearchDialog('files')),
+    },
+    {
+      id: 'search-in-diff',
+      label: 'Search in current diff',
+      category: 'action',
+      icon: 'search',
+      action: shell.requiresRepository(() => shell.openSearchDialog('diff')),
+    },
+    {
+      id: 'search-commit-content',
+      label: 'Find commits that changed text',
+      category: 'action',
+      icon: 'search',
+      action: shell.requiresRepository(() => shell.openSearchDialog('commits')),
+    },
+    {
+      id: 'stage-all',
+      label: 'Stage all changes',
+      category: 'action',
+      icon: 'commit',
+      action: shell.requiresRepository(() => shell.handleStageAll()),
+    },
+    {
+      id: 'unstage-all',
+      label: 'Unstage all changes',
+      category: 'action',
+      icon: 'commit',
+      action: shell.requiresRepository(() => shell.handleUnstageAll()),
+    },
+    {
+      id: 'toggle-left-panel',
+      label: 'Toggle left panel',
+      category: 'navigation',
+      shortcut: `${mod}B`,
+      action: () => shell.toggleLeftPanel(),
+    },
+    {
+      id: 'toggle-right-panel',
+      label: 'Toggle right panel',
+      category: 'navigation',
+      shortcut: `${mod}J`,
+      action: () => uiStore.getState().togglePanel('right'),
+    },
+    {
+      id: 'undo',
+      label: 'Undo (open reflog)',
+      category: 'action',
+      icon: 'refresh',
+      shortcut: `${mod}Z`,
+      action: shell.requiresRepository(() => { dialogs.open('reflog'); }),
+    },
+    {
+      id: 'describe',
+      label: 'Describe commit (git describe)',
+      category: 'action',
+      icon: 'tag',
+      action: shell.requiresRepository(() => { shell.describeDialog?.open(); }),
+    },
+    {
+      id: 'compare-branches',
+      label: 'Compare branches',
+      category: 'action',
+      icon: 'branch',
+      action: shell.requiresRepository(() => { shell.compareBranchesDialog?.open(); }),
+    },
+    {
+      id: 'workspaces',
+      label: 'Manage workspaces',
+      category: 'action',
+      icon: 'folder',
+      action: () => { dialogs.open('workspaceManager'); },
+    },
+    {
+      id: 'hooks',
+      label: 'Manage git hooks',
+      category: 'action',
+      icon: 'terminal',
+      action: shell.requiresRepository(() => { dialogs.open('hooks'); }),
+    },
+    {
+      id: 'gitignore',
+      label: 'Edit .gitignore & .gitattributes',
+      category: 'action',
+      icon: 'file',
+      action: shell.requiresRepository(() => { dialogs.open('gitignore'); }),
+    },
+    // The palette acts on the ACTIVE repository; the same three actions are
+    // on the repository tab context menu for any open tab. Failures (no
+    // terminal emulator, a path that has gone away, an editor that cannot be
+    // spawned) are toasted by the shared service with the backend message.
+    {
+      id: 'open-in-terminal',
+      label: 'Open in Terminal',
+      category: 'action',
+      icon: 'terminal',
+      action: shell.requiresRepository(() => {
+        void openRepositoryInTerminal(shell.activeRepository!.repository.path);
+      }),
+    },
+    {
+      id: 'reveal-in-file-manager',
+      label: 'Reveal in File Manager',
+      category: 'action',
+      icon: 'folder',
+      action: shell.requiresRepository(() => {
+        void openRepositoryInFileManager(shell.activeRepository!.repository.path);
+      }),
+    },
+    {
+      id: 'open-in-editor',
+      label: 'Open in Editor',
+      category: 'action',
+      icon: 'file',
+      action: shell.requiresRepository(() => {
+        void openRepositoryInEditor(shell.activeRepository!.repository.path);
+      }),
+    },
+  ];
+
+  return commands;
+}

--- a/src/services/__tests__/git.service.late-remote-completion.test.ts
+++ b/src/services/__tests__/git.service.late-remote-completion.test.ts
@@ -60,6 +60,8 @@ type UiStoreModule = typeof import('../../stores/ui.store.ts');
 let uiStore: UiStoreModule['uiStore'];
 type GitServiceModule = typeof import('../git.service.ts');
 let gitService: GitServiceModule;
+type DialogStoreModule = typeof import('../../stores/dialog.store.ts');
+let dialogs: DialogStoreModule['dialogs'];
 
 /**
  * The tag AppShell is registered under (`@customElement` in app-shell.ts).
@@ -76,7 +78,6 @@ const REPO_PATH = '/repos/alpha';
 
 /** The private conflict-dialog state the real AppShell drives. */
 interface ShellConflictState {
-  showConflictDialog: boolean;
   conflictDialogConfig?: { repoPath?: string; operationType?: string };
 }
 
@@ -135,6 +136,7 @@ describe('git.service late remote-operation completions', () => {
   before(async () => {
     gitService = await import('../git.service.ts');
     ({ uiStore } = await import('../../stores/ui.store.ts'));
+    ({ dialogs } = await import('../../stores/dialog.store.ts'));
     // The REAL component, not a stand-in: the conflict route hangs off a
     // querySelector for its tag, so mounting anything else would let a wrong
     // selector — or a shell that never listens — pass unnoticed.
@@ -221,7 +223,7 @@ describe('git.service late remote-operation completions', () => {
         { repositoryPath: REPO_PATH, operationType: 'merge' },
       ]);
       // ...and the real handler must have acted on it, not just received it.
-      expect(shellState(shell).showConflictDialog, 'the dialog is open').to.equal(true);
+      expect(dialogs.isOpen('conflict'), 'the dialog is open').to.equal(true);
       expect(shellState(shell).conflictDialogConfig?.repoPath).to.equal(REPO_PATH);
       expect(shellState(shell).conflictDialogConfig?.operationType).to.equal('merge');
       // Not an error: the pull landed and now needs resolving.
@@ -256,7 +258,7 @@ describe('git.service late remote-operation completions', () => {
   });
 
   it('still refreshes a late failure that is not a conflict', async () => {
-    const { shell, conflicts, cleanup } = await mountShell();
+    const { conflicts, cleanup } = await mountShell();
 
     try {
       emit('remote-operation-completed', {
@@ -270,7 +272,7 @@ describe('git.service late remote-operation completions', () => {
       });
 
       expect(conflicts, 'only a conflict opens the conflict dialog').to.deep.equal([]);
-      expect(shellState(shell).showConflictDialog).to.equal(false);
+      expect(dialogs.isOpen('conflict')).to.equal(false);
       expect(refreshes).to.deep.equal([REPO_PATH]);
       expect(newestToast()?.type).to.equal('error');
     } finally {

--- a/src/stores/__tests__/dialog.store.test.ts
+++ b/src/stores/__tests__/dialog.store.test.ts
@@ -1,0 +1,212 @@
+import { expect } from '@open-wc/testing';
+import {
+  dialogStore,
+  dialogs,
+  DIALOG_REGISTRY,
+  type DialogId,
+} from '../dialog.store.ts';
+
+describe('dialog.store', () => {
+  beforeEach(() => {
+    dialogs.reset();
+  });
+
+  describe('open / close / isOpen', () => {
+    it('starts with nothing open', () => {
+      for (const id of Object.keys(DIALOG_REGISTRY) as DialogId[]) {
+        expect(dialogs.isOpen(id), `${id} starts closed`).to.equal(false);
+      }
+    });
+
+    it('opens and closes a dialog', () => {
+      dialogs.open('clean');
+      expect(dialogs.isOpen('clean')).to.equal(true);
+      dialogs.close('clean');
+      expect(dialogs.isOpen('clean')).to.equal(false);
+    });
+
+    it('keeps dialogs independent of one another', () => {
+      dialogs.open('clean');
+      dialogs.open('settings');
+      dialogs.close('clean');
+      expect(dialogs.isOpen('clean')).to.equal(false);
+      expect(dialogs.isOpen('settings'), 'closing one must not close another').to.equal(true);
+    });
+
+    it('setOpen routes to open/close', () => {
+      dialogs.setOpen('gitHub', true);
+      expect(dialogs.isOpen('gitHub')).to.equal(true);
+      dialogs.setOpen('gitHub', false);
+      expect(dialogs.isOpen('gitHub')).to.equal(false);
+    });
+
+    it('opening twice does not double-register', () => {
+      dialogs.open('bisect');
+      dialogs.open('bisect');
+      dialogs.close('bisect');
+      expect(dialogs.isOpen('bisect'), 'one close is enough').to.equal(false);
+    });
+
+    it('closing a dialog that is already shut is a no-op that notifies nobody', () => {
+      let notifications = 0;
+      const unsubscribe = dialogStore.subscribe(() => {
+        notifications++;
+      });
+      dialogs.close('lfs');
+      unsubscribe();
+      expect(dialogs.isOpen('lfs')).to.equal(false);
+      expect(notifications, 'no spurious re-render for a no-op close').to.equal(0);
+    });
+  });
+
+  describe('subscription', () => {
+    it('notifies subscribers on open and on close', () => {
+      const seen: boolean[] = [];
+      const unsubscribe = dialogStore.subscribe((state) => {
+        seen.push(state.isOpen('remotes'));
+      });
+      dialogs.open('remotes');
+      dialogs.close('remotes');
+      unsubscribe();
+      expect(seen).to.deep.equal([true, false]);
+    });
+  });
+
+  describe('context payloads', () => {
+    it('stores and returns a dialog context', () => {
+      dialogs.open('fileHistory', { filePath: 'src/main.ts' });
+      expect(dialogs.context('fileHistory')?.filePath).to.equal('src/main.ts');
+    });
+
+    it('drops the context when the dialog closes', () => {
+      dialogs.open('search', { mode: 'commits' });
+      dialogs.close('search');
+      expect(dialogs.context('search'), 'a stale payload must not outlive its dialog').to.equal(
+        null,
+      );
+    });
+
+    it('keeps an existing context when reopened without one', () => {
+      // handleManageAccounts sets the view, then opens the manager bare.
+      dialogs.setContext('profileManager', { initialView: 'accounts' });
+      dialogs.open('profileManager');
+      expect(dialogs.context('profileManager')?.initialView).to.equal('accounts');
+    });
+
+    it('replaces the context when reopened with one', () => {
+      dialogs.open('search', { mode: 'files' });
+      dialogs.open('search', { mode: 'diff' });
+      expect(dialogs.context('search')?.mode).to.equal('diff');
+    });
+
+    it('returns null for a dialog that carries no context', () => {
+      dialogs.open('clean');
+      expect(dialogs.context('clean')).to.equal(null);
+    });
+
+    it('setContext updates the payload of an open dialog', () => {
+      dialogs.open('search', { mode: 'files' });
+      dialogs.setContext('search', { mode: 'commits' });
+      expect(dialogs.isOpen('search'), 'the dialog stays open').to.equal(true);
+      expect(dialogs.context('search')?.mode).to.equal('commits');
+    });
+  });
+
+  describe('closeRepoScoped', () => {
+    it('closes every dialog declared repo-scoped and no others', () => {
+      for (const id of Object.keys(DIALOG_REGISTRY) as DialogId[]) dialogs.open(id);
+
+      dialogs.closeRepoScoped();
+
+      for (const id of Object.keys(DIALOG_REGISTRY) as DialogId[]) {
+        expect(dialogs.isOpen(id), `${id} after the sweep`).to.equal(
+          !DIALOG_REGISTRY[id].repoScoped,
+        );
+      }
+    });
+
+    it('drops the contexts of the dialogs it closes', () => {
+      dialogs.open('fileHistory', { filePath: 'src/main.ts' });
+      dialogs.open('search', { mode: 'diff' });
+      dialogs.closeRepoScoped();
+      expect(dialogs.context('fileHistory')).to.equal(null);
+      expect(dialogs.context('search')).to.equal(null);
+    });
+
+    it('leaves a repo-independent dialog and its context alone', () => {
+      dialogs.open('profileManager', { initialView: 'accounts' });
+      dialogs.closeRepoScoped();
+      expect(dialogs.isOpen('profileManager')).to.equal(true);
+      expect(dialogs.context('profileManager')?.initialView).to.equal('accounts');
+    });
+
+    it('notifies nobody when nothing repo-scoped is open', () => {
+      dialogs.open('settings');
+      let notifications = 0;
+      const unsubscribe = dialogStore.subscribe(() => {
+        notifications++;
+      });
+      dialogs.closeRepoScoped();
+      unsubscribe();
+      expect(notifications).to.equal(0);
+    });
+  });
+
+  describe('the registry', () => {
+    // The sweep's whole point: repo-scoping is DECLARED, not inferred from a
+    // field name. A dialog rendered inside app-shell's activeRepository block
+    // must be repo-scoped or it springs back open over the next repository.
+    it('declares the dialogs reachable with no repository open as repo-independent', () => {
+      const repoIndependent: DialogId[] = [
+        'settings',
+        'shortcuts',
+        'outputPanel',
+        'commandPalette',
+        'workspaceManager',
+        'ssh',
+        'profileManager',
+        'migration',
+        'gitHub',
+        'gitLab',
+        'bitbucket',
+        'azureDevOps',
+        'oidc',
+      ];
+      for (const id of repoIndependent) {
+        expect(DIALOG_REGISTRY[id].repoScoped, `${id} is usable with no repository`).to.equal(
+          false,
+        );
+      }
+      // Everything else must default to the safe side.
+      for (const id of Object.keys(DIALOG_REGISTRY) as DialogId[]) {
+        if (repoIndependent.includes(id)) continue;
+        expect(DIALOG_REGISTRY[id].repoScoped, `${id} must be swept with its repository`).to.equal(
+          true,
+        );
+      }
+    });
+  });
+
+  describe('reset', () => {
+    it('clears every open dialog and context', () => {
+      dialogs.open('settings');
+      dialogs.open('conflict', {
+        repoPath: '/repo/a',
+        operationType: 'merge',
+        initialFilePath: null,
+        stashSourceCertain: true,
+        stashIndex: 0,
+        stashOid: null,
+        dropStashOnComplete: true,
+        squashMerge: false,
+        gitflowFinish: null,
+      });
+
+      dialogs.reset();
+
+      expect(dialogs.isOpen('settings')).to.equal(false);
+      expect(dialogs.isOpen('conflict')).to.equal(false);
+      expect(dialogs.context('conflict')).to.equal(null);
+    });
+  });
+});

--- a/src/stores/dialog.store.ts
+++ b/src/stores/dialog.store.ts
@@ -1,0 +1,258 @@
+import { createStore } from 'zustand/vanilla';
+import type { GitflowFinishContext } from '../components/dialogs/lv-conflict-resolution-dialog.ts';
+import type { SearchDialogMode } from '../components/dialogs/lv-search-dialog.ts';
+
+/**
+ * Which overlay app-shell has on screen, and its open-time payload.
+ *
+ * app-shell used to carry one `show*` boolean per dialog — thirty-one of them,
+ * plus loose payload fields beside each. Nothing enumerated them, so every
+ * rule that had to apply to "all dialogs" (close them when the last repository
+ * tab goes away, most of all) was written by REFLECTING over Lit's
+ * `elementProperties` and pattern-matching `/^show[A-Z]/` at runtime, with a
+ * hand-maintained exclusion list of the ones that are not repo-scoped. That
+ * worked, but it meant the set of dialogs existed nowhere a reader could see
+ * it, and a dialog's repo-scoping was decided by a string match on its field
+ * name.
+ *
+ * The registry below IS that set. It is the single place a dialog is declared,
+ * so the sweep is a plain loop over it (see `closeRepoScoped`) instead of a
+ * reflective scan, and `repoScoped` is a declared property of the dialog
+ * rather than an inference from how it was named.
+ */
+export interface DialogDescriptor {
+  /**
+   * True when the dialog renders INSIDE app-shell's
+   * `${this.activeRepository ? ...}` block, so closing the last repository tab
+   * destroys its element while its open flag would otherwise stay set — and
+   * the next repository opened reconstructs it as a full-screen overlay
+   * springing up unbidden. Those must be closed with the last tab.
+   *
+   * False for the handful that render outside that block: their element is
+   * never destroyed, they are all reachable with zero repositories open (the
+   * welcome screen offers the profile manager; the palette's SSH, profiles and
+   * provider entries are deliberately not repo-guarded), and closing them
+   * would only kill a session the user deliberately started — skipping the
+   * `@close` binding that unwinds their navigation state along the way.
+   *
+   * `true` is the safe default, and the default a newly added dialog should
+   * take unless it is genuinely usable with no repository open.
+   */
+  repoScoped: boolean;
+}
+
+/**
+ * Every dialog and full-screen view app-shell owns.
+ *
+ * `diff`, `blame` and `fileHistory` are panes rather than modals, but they are
+ * gated on the same kind of flag, render inside the repository block, and were
+ * swept by the same rule — so they are declared here too rather than being a
+ * second, invisible category.
+ */
+export const DIALOG_REGISTRY = {
+  // --- Repo-independent: usable with no repository open. ---
+  settings: { repoScoped: false },
+  shortcuts: { repoScoped: false },
+  outputPanel: { repoScoped: false },
+  commandPalette: { repoScoped: false },
+  workspaceManager: { repoScoped: false },
+  ssh: { repoScoped: false },
+  profileManager: { repoScoped: false },
+  /** Fires from checkUnifiedProfilesMigration on startup, before any repo. */
+  migration: { repoScoped: false },
+  // Account connection is repo-independent; only the PR/issue/pipeline tabs
+  // inside these dialogs guard themselves on a repository.
+  gitHub: { repoScoped: false },
+  gitLab: { repoScoped: false },
+  bitbucket: { repoScoped: false },
+  azureDevOps: { repoScoped: false },
+  oidc: { repoScoped: false },
+
+  // --- Repo-scoped: must not outlive the repository they were opened for. ---
+  diff: { repoScoped: true },
+  blame: { repoScoped: true },
+  fileHistory: { repoScoped: true },
+  conflict: { repoScoped: true },
+  reflog: { repoScoped: true },
+  search: { repoScoped: true },
+  remotes: { repoScoped: true },
+  clean: { repoScoped: true },
+  repositoryHealth: { repoScoped: true },
+  bisect: { repoScoped: true },
+  submodules: { repoScoped: true },
+  worktrees: { repoScoped: true },
+  lfs: { repoScoped: true },
+  gpg: { repoScoped: true },
+  config: { repoScoped: true },
+  credentials: { repoScoped: true },
+  hooks: { repoScoped: true },
+  gitignore: { repoScoped: true },
+} as const satisfies Record<string, DialogDescriptor>;
+
+export type DialogId = keyof typeof DIALOG_REGISTRY;
+
+/**
+ * The conflict dialog's inputs, SNAPSHOTTED at open time.
+ *
+ * The dialog must keep operating on the repository and operation it was opened
+ * for even if the user switches repo tabs (Ctrl+Tab still works behind the
+ * full-screen dialog) or another conflicting operation fires while it is up —
+ * live-binding app-shell's loose staging fields would let a second conflict
+ * source retarget an in-flight resolution's repo/operation, aiming its
+ * abort/resolve/stage commands at the wrong repository.
+ */
+export interface ConflictDialogContext {
+  repoPath: string;
+  operationType: 'merge' | 'rebase' | 'cherry-pick' | 'revert' | 'stash';
+  initialFilePath: string | null;
+  stashSourceCertain: boolean;
+  stashIndex: number;
+  stashOid: string | null;
+  dropStashOnComplete: boolean;
+  squashMerge: boolean;
+  gitflowFinish: GitflowFinishContext | null;
+}
+
+export interface FileHistoryContext {
+  filePath: string;
+}
+
+export interface SearchDialogContext {
+  mode: SearchDialogMode;
+}
+
+export interface ProfileManagerContext {
+  /** Which view the manager opens to. 'accounts' comes from "Manage Accounts". */
+  initialView: '' | 'accounts';
+}
+
+/**
+ * Open-time payloads, by dialog.
+ *
+ * Only dialogs listed here take a context; `open()` refuses one for any other
+ * id. The diff and blame panes keep their payload fields on app-shell: those
+ * are re-derived from every status refresh rather than being fixed at open
+ * time, so they are not open-time context.
+ */
+export interface DialogContexts {
+  conflict: ConflictDialogContext;
+  fileHistory: FileHistoryContext;
+  search: SearchDialogContext;
+  profileManager: ProfileManagerContext;
+}
+
+export type DialogContextOf<Id extends DialogId> = Id extends keyof DialogContexts
+  ? DialogContexts[Id]
+  : never;
+
+export interface DialogState {
+  /** Open dialogs, by id. Absent key means closed. */
+  openDialogs: Readonly<Partial<Record<DialogId, true>>>;
+  /** Open-time payloads, cleared with their dialog. */
+  contexts: Readonly<Partial<DialogContexts>>;
+
+  isOpen(id: DialogId): boolean;
+  /** Open `id`, replacing any previous context with `context`. */
+  open<Id extends DialogId>(id: Id, context?: DialogContextOf<Id>): void;
+  /** Close `id` and drop its context. Closing a closed dialog is a no-op. */
+  close(id: DialogId): void;
+  /** `open`/`close` chosen by a boolean — for the `open` flag of a toggle. */
+  setOpen(id: DialogId, open: boolean): void;
+  /** Replace the context of an ALREADY OPEN (or about to open) dialog. */
+  setContext<Id extends keyof DialogContexts>(id: Id, context: DialogContexts[Id]): void;
+  context<Id extends DialogId>(id: Id): DialogContextOf<Id> | null;
+  /**
+   * Close every dialog declared `repoScoped`. The whole reason the registry
+   * exists: this used to reflect over Lit's reactive properties and match
+   * field names against `/^show[A-Z]/`.
+   */
+  closeRepoScoped(): void;
+  /** Close everything and drop every context. */
+  reset(): void;
+}
+
+export const dialogStore = createStore<DialogState>((set, get) => ({
+  openDialogs: {},
+  contexts: {},
+
+  isOpen: (id) => get().openDialogs[id] === true,
+
+  open: (id, context) => {
+    set((state) => ({
+      openDialogs: { ...state.openDialogs, [id]: true },
+      contexts:
+        context === undefined
+          ? state.contexts
+          : { ...state.contexts, [id]: context },
+    }));
+  },
+
+  close: (id) => {
+    set((state) => {
+      if (state.openDialogs[id] !== true && !(id in state.contexts)) return state;
+      const openDialogs = { ...state.openDialogs };
+      delete openDialogs[id];
+      const contexts = { ...state.contexts } as Record<string, unknown>;
+      delete contexts[id];
+      return { openDialogs, contexts: contexts as Partial<DialogContexts> };
+    });
+  },
+
+  setOpen: (id, open) => {
+    if (open) get().open(id);
+    else get().close(id);
+  },
+
+  setContext: (id, context) => {
+    set((state) => ({ contexts: { ...state.contexts, [id]: context } }));
+  },
+
+  context: (id) =>
+    ((get().contexts as Record<string, unknown>)[id] ?? null) as
+      | DialogContextOf<typeof id>
+      | null,
+
+  closeRepoScoped: () => {
+    set((state) => {
+      const openDialogs = { ...state.openDialogs };
+      const contexts = { ...state.contexts } as Record<string, unknown>;
+      let changed = false;
+      for (const id of Object.keys(DIALOG_REGISTRY) as DialogId[]) {
+        if (!DIALOG_REGISTRY[id].repoScoped) continue;
+        if (openDialogs[id] === true) {
+          delete openDialogs[id];
+          changed = true;
+        }
+        if (id in contexts) {
+          delete contexts[id];
+          changed = true;
+        }
+      }
+      if (!changed) return state;
+      return { openDialogs, contexts: contexts as Partial<DialogContexts> };
+    });
+  },
+
+  reset: () => set({ openDialogs: {}, contexts: {} }),
+}));
+
+/**
+ * Call-site facade.
+ *
+ * `dialogs.isOpen('clean')` at the ~150 app-shell call sites that used to read
+ * `this.showClean`, without spelling `dialogStore.getState()` at every one.
+ * The store itself stays the subscribable object.
+ */
+export const dialogs = {
+  isOpen: (id: DialogId): boolean => dialogStore.getState().isOpen(id),
+  open: <Id extends DialogId>(id: Id, context?: DialogContextOf<Id>): void =>
+    dialogStore.getState().open(id, context),
+  close: (id: DialogId): void => dialogStore.getState().close(id),
+  setOpen: (id: DialogId, open: boolean): void => dialogStore.getState().setOpen(id, open),
+  setContext: <Id extends keyof DialogContexts>(id: Id, context: DialogContexts[Id]): void =>
+    dialogStore.getState().setContext(id, context),
+  context: <Id extends DialogId>(id: Id): DialogContextOf<Id> | null =>
+    dialogStore.getState().context(id),
+  closeRepoScoped: (): void => dialogStore.getState().closeRepoScoped(),
+  reset: (): void => dialogStore.getState().reset(),
+};

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -5,6 +5,16 @@ export { settingsStore, type SettingsState, type Theme, type FontSize } from './
 export { workflowStore, type WorkflowState, getProfileById, getDefaultProfile, hasProfiles } from './workflow.store.ts';
 export { unifiedProfileStore, type UnifiedProfileState } from './unified-profile.store.ts';
 export { workspaceStore, type WorkspaceState } from './workspace.store.ts';
+export {
+  dialogStore,
+  dialogs,
+  DIALOG_REGISTRY,
+  type DialogState,
+  type DialogId,
+  type DialogDescriptor,
+  type DialogContexts,
+  type ConflictDialogContext,
+} from './dialog.store.ts';
 
 // Re-import stores for test exposure
 import { repositoryStore as repoStore } from './repository.store.ts';
@@ -12,6 +22,7 @@ import { commitsStore as cStore } from './commits.store.ts';
 import { uiStore as uStore } from './ui.store.ts';
 import { settingsStore as sStore } from './settings.store.ts';
 import { unifiedProfileStore as upStore } from './unified-profile.store.ts';
+import { dialogStore as dStore } from './dialog.store.ts';
 
 // Expose stores on window for E2E testing (only in dev mode)
 if (import.meta.env?.DEV) {
@@ -21,5 +32,6 @@ if (import.meta.env?.DEV) {
     uiStore: uStore,
     settingsStore: sStore,
     unifiedProfileStore: upStore,
+    dialogStore: dStore,
   };
 }


### PR DESCRIPTION
> **⚠️ Please merge this LAST.** Five other open PRs (#490, #495, #504, #505, #509) also modify `src/app-shell.ts`. This one moves ~1,100 lines out of that file, so merging it first would force a rebase on every one of them; merging it last means the conflicts land here once.

## Summary

- Moves the 31 `show*` dialog booleans out of the 6,500-line `src/app-shell.ts` into a new Zustand store, `src/stores/dialog.store.ts`, keyed by dialog id.
- `DIALOG_REGISTRY` in that store is now the single declared list of every dialog the shell owns, with `repoScoped` as a declared property of each one — so closing the last repository tab is a plain loop (`dialogs.closeRepoScoped()`) over that list instead of a runtime reflection over Lit's `elementProperties` matching `/^show[A-Z]/` against a hand-kept exclusion set.
- Open-time payloads that used to be loose sibling fields (the conflict dialog's snapshot, `fileHistoryPath`, `searchDialogMode`, `profileManagerView`) become the dialog's *context*, created and dropped by the same `open`/`close` call so they can no longer drift out of step with the flag they belonged to.
- Extracts the ~500-line palette command table into `src/palette-commands.ts` behind an explicit `PaletteCommandHost` interface — the exact dependency surface app-shell exposes to it. All 56 command ids, labels, shortcuts and actions are unchanged.
- Pure refactor: no user-visible behaviour change. `src/app-shell.ts` loses ~1,100 lines.

## Review finding

`src/app-shell.ts` had grown to ~6,500 lines, and roughly 35 of its `@state()` fields were one-per-dialog `show*` booleans with payload fields scattered beside them. Because nothing enumerated that set, any rule that had to apply to *all* dialogs was forced to discover them at runtime: `closeRepoScopedDialogs()` (old `src/app-shell.ts:1451-1468`) walked Lit's `elementProperties` map, pattern-matched field names against `/^show[A-Z]/`, and subtracted a hand-maintained `REPO_INDEPENDENT_DIALOGS` string set. A dialog's repo-scoping was therefore decided by how its field happened to be named, and the set of dialogs existed nowhere a reader could see it — the comment on `showSearchDialog` even warned that its name was "load-bearing". The same file also inlined the entire command-palette table (~500 lines of flat data) inside `getPaletteCommands()`.

## What is deliberately preserved

- **The DOM-driven sweep is untouched.** `src/utils/repo-scoped-dialogs.ts` keeps its exact semantics — it still discovers dialogs from the DOM via `pinnedRepositoryPathIfOpen`, still consults `operationInFlight`, and still never announces a dismissal that did not happen. Its `clearFlag` callbacks now call `dialogs.close(id)` instead of assigning a `show*` field; all 13 entries and their wording are unchanged.
- **The overlay/escape stack** (`src/utils/overlay-stack.ts`) is not touched at all — it lives in the child dialogs, and `handleCloseOverlay()`'s priority order (topmost overlay → context menu → ref context menu → diff → blame → file history) is byte-for-byte the same logic.
- **The repo-independent set** is the same thirteen dialogs the old exclusion list named, now declared as `repoScoped: false` with the original justification comment carried over. `true` remains the safe default for a newly added dialog.
- Lit reactivity is preserved with a `dialogVersion` counter bumped from a store subscription, the same pattern `refOpsVersion` already uses for the ref lock — so `await el.updateComplete` after opening a dialog still works as it did.

## Test plan

- [x] `npm run lint` — 0 errors, 204 warnings (matches the pre-existing baseline; two new warnings introduced by the refactor were fixed).
- [x] `npm run typecheck` — clean (`tsc --noEmit` and the e2e tsconfig).
- [x] `npm test` (includes `npm run test:contract`) — 5515 passed, 2 failed. The two failures are the known `network gate coverage` timeouts already present on `main`.
- [x] `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` — both clean (no Rust changed).
- [x] Broad E2E sweep, 514 tests passing across 21 spec files: `dialogs`, `command-palette`, `context-menus`, `keyboard`, `repo-tabs`, `graph`, `welcome` (221 passed), plus `blame-view`, `config-dialogs`, `file-history`, `search-dialog`, `reflog-dialog`, `output-panel`, `repository-health-dialog`, `profiles-integrations`, `gitignore`, `bisect-dialog`, `submodule-dialog`, `remote-dialog`, `credentials-dialog`, `gpg-dialog` (293 passed).
- [x] New unit suite `src/stores/__tests__/dialog.store.test.ts` (19 tests) covers open/close/`isOpen`, subscriber notification (including that a no-op close notifies nobody), context lifetime, `closeRepoScoped` closing exactly the repo-scoped set and dropping their contexts, and an assertion that the declared repo-independent set is the one reachable with no repository open.
- [ ] Reviewer check: open several dialogs (settings, clean, bisect, repository health), close the last repository tab, and confirm the repo-scoped ones do not spring back when the next repository is opened, while settings/SSH/profile manager survive. Then open the command palette and confirm all entries still fire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR

---
_Generated by [Claude Code](https://claude.ai/code/session_01FyMuH8pj2v24DadsamKwDR)_