### PR TITLE
ci: give release builds their own concurrency group

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,8 +16,12 @@ on:
         type: boolean
         default: false
 
+# Builds of the same ref supersede each other, but a release — a tag push,
+# or a manual dispatch with the release input — must not be cancelled by a
+# later push to main (that is what happened to the first v0.9.1 build), so
+# a release run gets its own group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release)) && '-release' || '' }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
## Why

`build.yml` groups runs by workflow and ref with `cancel-in-progress: true`, so a manual release dispatch on `main` shares a concurrency group with every push-triggered build of `main` — and the next push cancels it. Both v0.9.1 release attempts tonight went that way: the first eleven minutes into E2E when a file upload landed on `main`, the second when #539 merged.

## What

Suffix the group with `-release` for a tag push or a `workflow_dispatch` with the `release` input:

```yaml
group: ${{ github.workflow }}-${{ github.ref }}${{ (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release)) && '-release' || '' }}
```

A release run and the ordinary builds of `main` never compete; builds of the same kind still supersede each other as before. One line, no job changes — the file parses, and `inputs` is available in the workflow-level `concurrency` context.

## After merge

Dispatch `build.yml` on `main` with `release: true` to cut v0.9.1; it can no longer be cancelled by activity on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VGjSYQNZFh4witAHCUq2MT

---
_Generated by [Claude Code](https://claude.ai/code/session_01VGjSYQNZFh4witAHCUq2MT)_