### PR TITLE
fix(graph): bound the graph column so wide histories keep the message visible

### DIFF
--- a/e2e/tests/graph.spec.ts
+++ b/e2e/tests/graph.spec.ts
@@ -1410,3 +1410,183 @@ test.describe('Graph multi-selection actions', () => {
     ).toContainText('3 selected');
   });
 });
+
+/**
+ * A repository with dozens of unmerged branches has more graph lanes than
+ * fit the canvas. The lanes live in a bounded column that scrolls on its
+ * own; the commit message and the other text columns must stay on screen.
+ */
+test.describe('Graph with more lanes than fit', () => {
+  let graph: GraphPanelPage;
+
+  const BRANCHES = 80;
+  // One root and BRANCHES tips branching straight off it: every tip holds
+  // its own lane until the root, so the graph is BRANCHES lanes wide
+  const commits = [
+    ...Array.from({ length: BRANCHES }, (_, i) => makeCommit(i, ['root'])),
+    { ...makeCommit(BRANCHES, []), oid: 'root', shortId: 'root' },
+  ];
+
+  type ColumnState = {
+    left: number;
+    right: number;
+    width: number;
+    fullLaneWidth: number;
+    maxScrollLeft: number;
+    scrollLeft: number;
+    canvasWidth: number;
+    laneWidth: number;
+    handles: { graphEnd: number; refsEnd: number; statsStart: number };
+  };
+
+  async function readColumn(page: import('@playwright/test').Page): Promise<ColumnState> {
+    const handle = await getGraphCanvasHandle(page);
+    return page.evaluate((el) => {
+      const canvas = el as HTMLElement & {
+        getGraphColumn(): Omit<ColumnState, 'scrollLeft' | 'canvasWidth' | 'laneWidth' | 'handles'>;
+        getResizeHandlePositions(): ColumnState['handles'];
+        scrollState: { getScroll(): { scrollLeft: number } };
+        canvasEl: HTMLCanvasElement;
+        LANE_WIDTH: number;
+      };
+      const column = canvas.getGraphColumn();
+      return {
+        ...column,
+        scrollLeft: canvas.scrollState.getScroll().scrollLeft,
+        canvasWidth: canvas.canvasEl.width / (window.devicePixelRatio || 1),
+        laneWidth: canvas.LANE_WIDTH,
+        handles: canvas.getResizeHandlePositions(),
+      };
+    }, handle);
+  }
+
+  async function waitForScrollLeft(
+    page: import('@playwright/test').Page,
+    expected: number
+  ): Promise<void> {
+    const handle = await getGraphCanvasHandle(page);
+    await page.waitForFunction(
+      ([el, value]) => {
+        const canvas = el as HTMLElement & { scrollState: { getScroll(): { scrollLeft: number } } };
+        return Math.abs(canvas.scrollState.getScroll().scrollLeft - (value as number)) < 0.5;
+      },
+      [handle, expected] as const
+    );
+  }
+
+  test.beforeEach(async ({ page }) => {
+    graph = new GraphPanelPage(page);
+    // Wide enough that the automatic column is not already at the cap that
+    // protects the message column, so the resize test has room to widen it
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await setupOpenRepository(page, { commits });
+    await expect(graph.canvas).toBeVisible();
+    await waitForNodeCount(page, BRANCHES + 1);
+  });
+
+  test('keeps the commit message column on screen and shows a lane scrollbar', async ({ page }) => {
+    const column = await readColumn(page);
+
+    // The lanes alone are wider than the canvas, yet the column is bounded
+    expect(column.fullLaneWidth).toBeGreaterThan(column.canvasWidth);
+    expect(column.width).toBeLessThan(column.canvasWidth / 2);
+    expect(column.maxScrollLeft).toBeGreaterThan(0);
+
+    // ...so the avatar/refs/message/stats columns all fit on the canvas
+    expect(column.handles.graphEnd).toBe(column.right);
+    expect(column.handles.refsEnd).toBeGreaterThan(column.handles.graphEnd);
+    expect(column.handles.statsStart).toBeGreaterThan(column.handles.refsEnd + 160);
+    expect(column.handles.statsStart).toBeLessThan(column.canvasWidth);
+
+    // The view starts on the mainline side (lane 0 at the right edge)
+    expect(column.scrollLeft).toBe(column.maxScrollLeft);
+
+    // The lane scrollbar sits under the graph column
+    const hscroll = page.locator('lv-graph-canvas .hscroll-container');
+    await expect(hscroll).toBeVisible();
+    const box = (await hscroll.boundingBox())!;
+    const canvasBox = (await page.locator('lv-graph-canvas canvas[role="img"]').boundingBox())!;
+    expect(Math.round(box.x - canvasBox.x)).toBe(column.left);
+    expect(Math.round(box.width)).toBe(column.width);
+    expect(Math.round(box.y + box.height)).toBe(Math.round(canvasBox.y + canvasBox.height));
+  });
+
+  test('scrolls the lanes with a sideways wheel but never the text columns', async ({ page }) => {
+    const before = await readColumn(page);
+    const canvasBox = (await page.locator('lv-graph-canvas canvas[role="img"]').boundingBox())!;
+
+    await page.mouse.move(canvasBox.x + before.left + before.width / 2, canvasBox.y + 100);
+    await page.mouse.wheel(-120, 0);
+    await waitForScrollLeft(page, before.maxScrollLeft - 120);
+
+    const after = await readColumn(page);
+    expect(after.handles).toEqual(before.handles);
+    // The native scrollbar follows the wheel
+    const hscroll = page.locator('lv-graph-canvas .hscroll-container');
+    await expect(hscroll).toHaveJSProperty('scrollLeft', before.maxScrollLeft - 120);
+
+    // Cannot scroll past the mainline side
+    await page.mouse.wheel(100000, 0);
+    await waitForScrollLeft(page, before.maxScrollLeft);
+  });
+
+  test('reveals hidden lanes with the arrow keys', async ({ page }) => {
+    const column = await readColumn(page);
+    await focusGraphInternalCanvas(page);
+
+    await page.keyboard.press('ArrowLeft');
+    await waitForScrollLeft(page, column.maxScrollLeft - 3 * column.laneWidth);
+    expect(await getSelectedNodeOid(page)).toBeNull();
+
+    await page.keyboard.press('ArrowRight');
+    await waitForScrollLeft(page, column.maxScrollLeft);
+  });
+
+  test('follows the lane scrollbar', async ({ page }) => {
+    const hscroll = page.locator('lv-graph-canvas .hscroll-container');
+    await hscroll.evaluate((el) => {
+      el.scrollLeft = 0;
+    });
+    await waitForScrollLeft(page, 0);
+
+    // Scrolled fully to the far lanes: the text columns did not move
+    const column = await readColumn(page);
+    expect(column.handles.statsStart).toBeLessThan(column.canvasWidth);
+  });
+
+  test('widens the graph column by dragging its handle and remembers it', async ({ page }) => {
+    const before = await readColumn(page);
+    const handle = page.locator('lv-graph-canvas .resize-handle[title="Resize graph column"]');
+    await expect(handle).toBeAttached();
+    const canvasBox = (await page.locator('lv-graph-canvas canvas[role="img"]').boundingBox())!;
+
+    const startX = canvasBox.x + before.right;
+    const y = canvasBox.y + 150;
+    await page.mouse.move(startX, y);
+    await page.mouse.down();
+    await page.mouse.move(startX + 30, y, { steps: 3 });
+    await page.mouse.move(startX + 60, y, { steps: 3 });
+    await page.mouse.up();
+
+    const handleEl = await getGraphCanvasHandle(page);
+    await page.waitForFunction(
+      ([el, expected]) => {
+        const canvas = el as HTMLElement & { getGraphColumn(): { width: number } };
+        return canvas.getGraphColumn().width === expected;
+      },
+      [handleEl, before.width + 60] as const
+    );
+
+    const after = await readColumn(page);
+    expect(after.width).toBe(before.width + 60);
+    // Still parked on the mainline; the extra room shows more lanes
+    expect(after.scrollLeft).toBe(after.maxScrollLeft);
+    expect(after.maxScrollLeft).toBe(before.maxScrollLeft - 60);
+    // The text columns moved right by the same amount and still fit
+    expect(after.handles.refsEnd).toBe(before.handles.refsEnd + 60);
+    expect(after.handles.statsStart).toBeLessThan(after.canvasWidth);
+
+    const saved = await page.evaluate(() => localStorage.getItem('gitnado-graph-columns'));
+    expect(JSON.parse(saved!).graph).toBe(before.width + 60);
+  });
+});

--- a/src/components/graph/__tests__/lv-graph-canvas-graph-column.test.ts
+++ b/src/components/graph/__tests__/lv-graph-canvas-graph-column.test.ts
@@ -1,0 +1,410 @@
+/**
+ * lv-graph-canvas: bounded, horizontally scrollable graph column.
+ *
+ * A repository with dozens of unmerged branches has more lanes than fit
+ * the canvas. The lanes must scroll inside their own column while the
+ * commit message, refs and stats columns stay on screen, with the
+ * scrollbar, wheel, keyboard, resize handle and hit-testing all agreeing
+ * on the column's geometry.
+ */
+
+// ── Tauri mock (must be set before any imports) ────────────────────────────
+type MockInvoke = (command: string, args?: unknown) => Promise<unknown>;
+
+let cbId = 0;
+let mockInvoke: MockInvoke = () => Promise.resolve(null);
+
+(globalThis as Record<string, unknown>).__TAURI_INTERNALS__ = {
+  invoke: (command: string, args?: unknown) => mockInvoke(command, args),
+  transformCallback: () => cbId++,
+};
+
+// ── Imports (after Tauri mock) ─────────────────────────────────────────────
+import { expect, fixture, html } from '@open-wc/testing';
+import type { Commit, RefsByCommit } from '../../../types/git.types.ts';
+import type { GraphColumnLayout } from '../../../graph/graph-column.ts';
+import type { HitTestResult } from '../../../graph/spatial-index.ts';
+
+import '../lv-graph-canvas.ts';
+import type { LvGraphCanvas } from '../lv-graph-canvas.ts';
+import { clearGraphCacheForTests } from '../lv-graph-canvas.ts';
+
+const REPO_PATH = '/test/wide-repo';
+const COLUMN_STORAGE_KEY = 'gitnado-graph-columns';
+const BRANCH_COUNT = 80;
+
+type Internals = {
+  layout: { maxLane: number } | null;
+  LANE_WIDTH: number;
+  PADDING: number;
+  HEADER_HEIGHT: number;
+  graphColumnWidth: number | null;
+  scrollState: { getScroll(): { scrollTop: number; scrollLeft: number } };
+  spatialIndex: { hitTest(x: number, y: number): HitTestResult };
+  renderer: { getConfig?: unknown; config: { graphColumnWidth: number | null } };
+  getGraphColumn(): GraphColumnLayout | null;
+  getResizeHandlePositions(): { graphEnd: number; refsEnd: number; statsStart: number } | null;
+  hitTest(e: MouseEvent): HitTestResult;
+  canvasEl: HTMLCanvasElement;
+  hscrollEl?: HTMLDivElement;
+  selectedNode: { oid: string } | null;
+};
+
+function makeCommit(overrides: Partial<Commit> = {}): Commit {
+  return {
+    oid: 'abc1234567890abcdef1234567890abcdef123456',
+    shortId: 'abc1234',
+    message: 'Commit',
+    summary: 'Commit',
+    body: '',
+    author: { name: 'Test Author', email: 'test@example.com', timestamp: 1700000000 },
+    committer: { name: 'Test Author', email: 'test@example.com', timestamp: 1700000000 },
+    parentIds: [],
+    timestamp: 1700000000,
+    ...overrides,
+  };
+}
+
+const ROOT = makeCommit({
+  oid: '0'.repeat(40),
+  shortId: '0000000',
+  summary: 'Root',
+  message: 'Root',
+  timestamp: 1700000000,
+});
+
+/** One root and BRANCH_COUNT tips that all branch straight off it */
+function makeWideHistory(): { commits: Commit[]; refs: RefsByCommit } {
+  const tips: Commit[] = [];
+  const refs: RefsByCommit = {};
+  for (let i = 0; i < BRANCH_COUNT; i++) {
+    const oid = (i + 1).toString(16).padStart(40, 'a');
+    tips.push(
+      makeCommit({
+        oid,
+        shortId: oid.slice(0, 7),
+        summary: `Tip ${i}`,
+        message: `Tip ${i}`,
+        timestamp: 1700100000 - i,
+        parentIds: [ROOT.oid],
+      })
+    );
+    refs[oid] = [
+      {
+        name: `refs/heads/pr-${i}`,
+        shorthand: `pr-${i}`,
+        refType: 'localBranch',
+        isHead: i === 0,
+      },
+    ];
+  }
+  return { commits: [...tips, ROOT], refs };
+}
+
+const NARROW: Commit[] = [
+  makeCommit({ oid: 'b'.repeat(40), shortId: 'bbbbbbb', summary: 'Second', parentIds: ['a'.repeat(40)] }),
+  makeCommit({ oid: 'a'.repeat(40), shortId: 'aaaaaaa', summary: 'First' }),
+];
+
+function setupMocks(commits: Commit[], refs: RefsByCommit = {}): void {
+  mockInvoke = async (command: string) => {
+    switch (command) {
+      case 'get_commit_history':
+        return commits;
+      case 'get_commit_total':
+        return commits.length;
+      case 'get_refs_by_commit':
+        return refs;
+      case 'get_commits_stats':
+      case 'get_commits_signatures':
+      case 'search_commits':
+        return [];
+      default:
+        return null;
+    }
+  };
+}
+
+async function renderCanvas(): Promise<{ el: LvGraphCanvas; internals: Internals }> {
+  const el = await fixture<LvGraphCanvas>(
+    html`<lv-graph-canvas
+      style="display: block; width: 1000px; height: 400px"
+      .repositoryPath=${REPO_PATH}
+      .commitCount=${100}
+    ></lv-graph-canvas>`
+  );
+  await el.updateComplete;
+  await new Promise((r) => setTimeout(r, 200));
+  await el.updateComplete;
+  return { el, internals: el as unknown as Internals };
+}
+
+const nextFrame = () => new Promise((r) => requestAnimationFrame(() => r(null)));
+
+function wheel(canvas: HTMLCanvasElement, init: WheelEventInit): void {
+  canvas.dispatchEvent(new WheelEvent('wheel', { cancelable: true, bubbles: true, ...init }));
+}
+
+describe('lv-graph-canvas graph column', () => {
+  beforeEach(() => {
+    clearGraphCacheForTests();
+    try {
+      localStorage.removeItem(COLUMN_STORAGE_KEY);
+    } catch {
+      // Ignore
+    }
+  });
+
+  describe('with more lanes than fit', () => {
+    let el: LvGraphCanvas;
+    let internals: Internals;
+    let column: GraphColumnLayout;
+
+    beforeEach(async () => {
+      const { commits, refs } = makeWideHistory();
+      setupMocks(commits, refs);
+      ({ el, internals } = await renderCanvas());
+      expect(internals.layout, 'layout').to.not.be.null;
+      expect(internals.layout!.maxLane).to.be.at.least(BRANCH_COUNT - 1);
+      column = internals.getGraphColumn()!;
+      expect(column.maxScrollLeft).to.be.greaterThan(0);
+    });
+
+    it('bounds the column so the text columns stay on the canvas', () => {
+      const canvasWidth = internals.canvasEl.width / (window.devicePixelRatio || 1);
+      expect(column.fullLaneWidth).to.be.greaterThan(canvasWidth);
+      expect(column.width).to.be.lessThan(canvasWidth / 2);
+
+      const handles = internals.getResizeHandlePositions()!;
+      expect(handles.graphEnd).to.equal(column.right);
+      expect(handles.refsEnd).to.be.greaterThan(handles.graphEnd);
+      expect(handles.statsStart).to.be.greaterThan(handles.refsEnd);
+      expect(handles.statsStart).to.be.lessThan(canvasWidth);
+    });
+
+    it('starts parked on the mainline (lane 0 at the right edge)', () => {
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(column.maxScrollLeft);
+    });
+
+    it('renders a horizontal scrollbar sized to the column and its lanes', () => {
+      const hscroll = el.shadowRoot!.querySelector<HTMLDivElement>('.hscroll-container');
+      expect(hscroll).to.not.be.null;
+      expect(hscroll!.style.left).to.equal(`${column.left}px`);
+      expect(hscroll!.style.width).to.equal(`${column.width}px`);
+
+      const content = hscroll!.querySelector<HTMLDivElement>('.hscroll-content');
+      expect(content!.style.width).to.equal(`${column.fullLaneWidth}px`);
+      // Native scroll range matches the column's own
+      expect(hscroll!.scrollWidth - hscroll!.clientWidth).to.equal(column.maxScrollLeft);
+      expect(hscroll!.scrollLeft).to.equal(column.maxScrollLeft);
+    });
+
+    it('scrolls the lanes with a sideways wheel and clamps at both ends', async () => {
+      wheel(internals.canvasEl, { deltaX: -100 });
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(column.maxScrollLeft - 100);
+
+      wheel(internals.canvasEl, { deltaX: -100000 });
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(0);
+
+      wheel(internals.canvasEl, { deltaX: 100000 });
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(column.maxScrollLeft);
+
+      // The native scrollbar follows
+      await nextFrame();
+      expect(internals.hscrollEl!.scrollLeft).to.equal(column.maxScrollLeft);
+    });
+
+    it('treats shift+wheel reported as a vertical delta as sideways', () => {
+      const before = internals.scrollState.getScroll();
+      wheel(internals.canvasEl, { deltaY: -60, shiftKey: true });
+      const after = internals.scrollState.getScroll();
+
+      expect(after.scrollLeft).to.equal(before.scrollLeft - 60);
+      expect(after.scrollTop).to.equal(before.scrollTop);
+    });
+
+    it('never scrolls the text columns: a plain wheel only moves rows', () => {
+      const before = internals.scrollState.getScroll();
+      wheel(internals.canvasEl, { deltaY: 40 });
+      const after = internals.scrollState.getScroll();
+
+      expect(after.scrollLeft).to.equal(before.scrollLeft);
+      expect(after.scrollTop).to.equal(before.scrollTop + 40);
+    });
+
+    it('follows the native horizontal scrollbar', async () => {
+      const hscroll = internals.hscrollEl!;
+      // Let any programmatic sync settle so the scroll event is treated
+      // as the user's
+      await nextFrame();
+      await nextFrame();
+
+      hscroll.scrollLeft = 48;
+      hscroll.dispatchEvent(new Event('scroll'));
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(48);
+    });
+
+    it('steps sideways by a few lanes with the arrow keys', () => {
+      const step = 3 * internals.LANE_WIDTH;
+      internals.canvasEl.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft', cancelable: true })
+      );
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(column.maxScrollLeft - step);
+
+      internals.canvasEl.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowRight', cancelable: true })
+      );
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(column.maxScrollLeft);
+
+      // Arrow keys never touch the row selection
+      expect(internals.selectedNode).to.be.null;
+    });
+
+    it('only hit-tests lanes inside the column', () => {
+      const calls: number[] = [];
+      const original = internals.spatialIndex.hitTest.bind(internals.spatialIndex);
+      internals.spatialIndex.hitTest = (x: number, y: number) => {
+        calls.push(x);
+        return original(x, y);
+      };
+
+      const rect = internals.canvasEl.getBoundingClientRect();
+      const rowY = rect.top + internals.HEADER_HEIGHT + internals.PADDING;
+
+      // Over the avatar/refs columns: a hidden lane may sit "under" here
+      internals.hitTest(
+        new MouseEvent('mousemove', { clientX: rect.left + column.right + 40, clientY: rowY })
+      );
+      expect(calls).to.have.length(0);
+
+      // Inside the column
+      internals.hitTest(
+        new MouseEvent('mousemove', { clientX: rect.left + column.right - 8, clientY: rowY })
+      );
+      expect(calls).to.have.length(1);
+    });
+
+    it('still selects the row when clicking in the message column', () => {
+      const rect = internals.canvasEl.getBoundingClientRect();
+      const rowY = rect.top + internals.HEADER_HEIGHT + internals.PADDING;
+      const result = internals.hitTest(
+        new MouseEvent('click', { clientX: rect.left + column.right + 200, clientY: rowY })
+      );
+
+      expect(result.type).to.equal('node');
+      expect(result.node?.row).to.equal(0);
+    });
+
+    it('resizes the column with its handle, persists it and stays parked', async () => {
+      const handle = el.shadowRoot!.querySelector<HTMLDivElement>(
+        '.resize-handle[title="Resize graph column"]'
+      );
+      expect(handle).to.not.be.null;
+      expect(handle!.style.left).to.equal(`${column.right}px`);
+
+      handle!.dispatchEvent(new MouseEvent('mousedown', { clientX: 300, bubbles: true }));
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 340 }));
+      document.dispatchEvent(new MouseEvent('mouseup'));
+      await el.updateComplete;
+
+      const widened = internals.getGraphColumn()!;
+      expect(internals.graphColumnWidth).to.equal(column.width + 40);
+      expect(widened.width).to.equal(column.width + 40);
+      expect(internals.renderer.config.graphColumnWidth).to.equal(column.width + 40);
+      expect(JSON.parse(localStorage.getItem(COLUMN_STORAGE_KEY)!).graph).to.equal(
+        column.width + 40
+      );
+
+      // The wider column reveals more lanes on the left; lane 0 stays put
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(widened.maxScrollLeft);
+      expect(widened.maxScrollLeft).to.equal(column.maxScrollLeft - 40);
+
+      // DOM follows the new geometry
+      const hscroll = el.shadowRoot!.querySelector<HTMLDivElement>('.hscroll-container')!;
+      expect(hscroll.style.width).to.equal(`${widened.width}px`);
+      expect(handle!.style.left).to.equal(`${widened.right}px`);
+    });
+
+    it('never shrinks the column below a few lanes', async () => {
+      const handle = el.shadowRoot!.querySelector<HTMLDivElement>(
+        '.resize-handle[title="Resize graph column"]'
+      )!;
+      handle.dispatchEvent(new MouseEvent('mousedown', { clientX: 300, bubbles: true }));
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: -5000 }));
+      document.dispatchEvent(new MouseEvent('mouseup'));
+      await el.updateComplete;
+
+      expect(internals.getGraphColumn()!.width).to.equal(3 * internals.LANE_WIDTH);
+    });
+
+    it('keeps a scrolled-away view in place while resizing the refs column', async () => {
+      wheel(internals.canvasEl, { deltaX: -200 });
+      const scrolled = internals.scrollState.getScroll().scrollLeft;
+
+      const refsHandle = el.shadowRoot!.querySelectorAll<HTMLDivElement>('.resize-handle')[1];
+      refsHandle.dispatchEvent(new MouseEvent('mousedown', { clientX: 500, bubbles: true }));
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 520 }));
+      document.dispatchEvent(new MouseEvent('mouseup'));
+      await el.updateComplete;
+
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(scrolled);
+    });
+
+    it('keeps the home position across a zoom and scales a scrolled view', async () => {
+      el.setZoom(1.5);
+      await el.updateComplete;
+      const zoomed = internals.getGraphColumn()!;
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(zoomed.maxScrollLeft);
+
+      wheel(internals.canvasEl, { deltaX: -300 });
+      const scrolled = internals.scrollState.getScroll().scrollLeft;
+      const laneWidthBefore = internals.LANE_WIDTH;
+
+      el.setZoom(1);
+      await el.updateComplete;
+      const ratio = internals.LANE_WIDTH / laneWidthBefore;
+      expect(internals.scrollState.getScroll().scrollLeft).to.be.closeTo(scrolled * ratio, 1);
+    });
+  });
+
+  describe('with lanes that fit', () => {
+    it('renders no horizontal scrollbar and hugs the lanes', async () => {
+      setupMocks(NARROW);
+      const { el, internals } = await renderCanvas();
+
+      const column = internals.getGraphColumn()!;
+      expect(column.maxScrollLeft).to.equal(0);
+      expect(column.width).to.equal(column.fullLaneWidth);
+      expect(el.shadowRoot!.querySelector('.hscroll-container')).to.be.null;
+
+      // Sideways input is a no-op
+      wheel(internals.canvasEl, { deltaX: -100 });
+      internals.canvasEl.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft', cancelable: true })
+      );
+      expect(internals.scrollState.getScroll().scrollLeft).to.equal(0);
+    });
+  });
+
+  describe('persisted column width', () => {
+    it('restores the saved graph column width', async () => {
+      localStorage.setItem(COLUMN_STORAGE_KEY, JSON.stringify({ refs: 200, stats: 80, graph: 150 }));
+      const { commits, refs } = makeWideHistory();
+      setupMocks(commits, refs);
+      const { internals } = await renderCanvas();
+
+      expect(internals.graphColumnWidth).to.equal(150);
+      expect(internals.getGraphColumn()!.width).to.equal(150);
+    });
+
+    it('falls back to the automatic width for older saved settings', async () => {
+      localStorage.setItem(COLUMN_STORAGE_KEY, JSON.stringify({ refs: 200, stats: 80 }));
+      const { commits, refs } = makeWideHistory();
+      setupMocks(commits, refs);
+      const { internals } = await renderCanvas();
+
+      expect(internals.graphColumnWidth).to.be.null;
+      expect(internals.getGraphColumn()!.maxScrollLeft).to.be.greaterThan(0);
+    });
+  });
+});

--- a/src/components/graph/lv-graph-canvas.ts
+++ b/src/components/graph/lv-graph-canvas.ts
@@ -19,6 +19,14 @@ import {
 } from '../../graph/virtual-scroll.ts';
 import { CanvasRenderer, getThemeFromCSS } from '../../graph/canvas-renderer.ts';
 import {
+  MIN_VISIBLE_LANES,
+  clampScrollLeft,
+  isInsideGraphColumn,
+  laneScreenX,
+  reconcileScrollLeft,
+  type GraphColumnLayout,
+} from '../../graph/graph-column.ts';
+import {
   getCommitHistory,
   getCommitTotal,
   getRefsByCommit,
@@ -182,6 +190,41 @@ export class LvGraphCanvas extends LitElement {
 
       .scroll-content {
         position: relative;
+      }
+
+      /* Horizontal scrollbar for the graph column. Only rendered when the
+         lanes overflow the column; positioned under the column so it is
+         obvious what it scrolls. */
+      .hscroll-container {
+        position: absolute;
+        bottom: 0;
+        height: 10px;
+        overflow-x: scroll;
+        overflow-y: hidden;
+        z-index: 3; /* Above canvas for scrollbar interaction */
+      }
+
+      .hscroll-container::-webkit-scrollbar {
+        height: 10px;
+      }
+
+      .hscroll-container::-webkit-scrollbar-track {
+        background: var(--color-bg-secondary);
+        border-top: 1px solid var(--color-border);
+      }
+
+      .hscroll-container::-webkit-scrollbar-thumb {
+        background: var(--color-text-muted);
+        border-radius: 5px;
+        border: 2px solid var(--color-bg-secondary);
+      }
+
+      .hscroll-container::-webkit-scrollbar-thumb:hover {
+        background: var(--color-text-secondary);
+      }
+
+      .hscroll-content {
+        height: 1px;
       }
 
       .overlay-canvas {
@@ -725,15 +768,28 @@ export class LvGraphCanvas extends LitElement {
   // Column resize state
   @state() private refsColumnWidth = 200;
   @state() private statsColumnWidth = 80;
-  @state() private resizing: 'refs' | 'stats' | null = null;
+  /**
+   * User-chosen width of the graph (lane) column, or null for the
+   * automatic default. Lanes beyond it scroll horizontally inside the
+   * column instead of pushing the text columns off the canvas.
+   */
+  @state() private graphColumnWidth: number | null = null;
+  @state() private resizing: 'refs' | 'stats' | 'graph' | null = null;
   private resizeStartX = 0;
   private resizeStartWidth = 0;
+  /**
+   * `maxScrollLeft` of the graph column as of the last layout pass. A view
+   * parked at that limit (lane 0 against the column's right edge) is kept
+   * there when the lane count, zoom or column width changes.
+   */
+  private lastMaxScrollX = 0;
   private readonly COLUMN_STORAGE_KEY = 'gitnado-graph-columns';
   private readonly BRANCH_VISIBILITY_KEY = 'gitnado-hidden-branches';
 
   @query('.canvas-container') private containerEl!: HTMLDivElement;
   @query('canvas[role="img"]') private canvasEl!: HTMLCanvasElement;
   @query('.scroll-container') private scrollEl!: HTMLDivElement;
+  @query('.hscroll-container') private hscrollEl?: HTMLDivElement;
   @query('.minimap-canvas') private minimapEl?: HTMLCanvasElement;
 
   private commits: GraphCommit[] = [];
@@ -955,12 +1011,11 @@ export class LvGraphCanvas extends LitElement {
       const size = this.virtualScroll.getContentSize();
       const viewport = this.getViewport();
       const maxScrollY = Math.max(0, size.height - viewport.height);
-      const maxScrollX = Math.max(0, size.width - viewport.width);
       this.scrollState.setScroll(
         Math.min(previousScroll.scrollTop * ratioY, maxScrollY),
-        Math.min(previousScroll.scrollLeft * ratioX, maxScrollX)
+        previousScroll.scrollLeft
       );
-      this.syncScrollbarPosition();
+      this.reconcileHorizontalScroll(ratioX);
     }
 
     this.renderer?.markDirty();
@@ -988,6 +1043,9 @@ export class LvGraphCanvas extends LitElement {
     if (changedProperties.has('repositoryPath') && changedProperties.get('repositoryPath') !== undefined) {
       // Clear existing state when switching repositories
       this.layout = null;
+      // The new repository's graph opens on its mainline, wherever the
+      // previous one was scrolled to
+      this.lastMaxScrollX = 0;
       this.selectedNode = null;
       this.selectedNodes.clear();
       this.lastClickedNode = null;
@@ -1112,6 +1170,7 @@ export class LvGraphCanvas extends LitElement {
         showFps: false, // We show our own FPS
         refsColumnWidth: this.refsColumnWidth,
         statsColumnWidth: this.statsColumnWidth,
+        graphColumnWidth: this.graphColumnWidth,
         showAuthorColumn: this.showAuthorColumn,
         showDateColumn: this.showDateColumn,
         // The "Show Avatars" app setting controls whether author avatars
@@ -1924,6 +1983,10 @@ export class LvGraphCanvas extends LitElement {
     // Update scroll content size (spans the full history when unfiltered)
     this.updateVirtualTotalRows();
 
+    // The lane count may have changed: keep a view parked on the mainline
+    // parked there, and pull any other view back inside the graph column
+    this.reconcileHorizontalScroll();
+
     // Build spatial index (once per layout — scroll-independent)
     this.buildSpatialIndex();
 
@@ -2348,7 +2411,45 @@ export class LvGraphCanvas extends LitElement {
       scrollLeft: scroll.scrollLeft,
       width: this.containerEl?.clientWidth ?? 800,
       height: this.containerEl?.clientHeight ?? 600,
+      graphColumnWidth: this.getGraphColumn()?.width,
     };
+  }
+
+  /**
+   * Geometry of the graph column for the current layout, canvas size and
+   * column widths, or null before the graph exists.
+   */
+  private getGraphColumn(): GraphColumnLayout | null {
+    if (!this.renderer || !this.layout) return null;
+    return this.renderer.getGraphColumnLayout(this.layout.maxLane, this.PADDING);
+  }
+
+  /** Largest valid horizontal scroll of the graph column */
+  private getMaxScrollX(): number {
+    return this.getGraphColumn()?.maxScrollLeft ?? 0;
+  }
+
+  /**
+   * Re-fit the horizontal scroll after anything that changes the graph
+   * column's geometry (lane count, zoom, canvas or column resize). A view
+   * parked on the mainline stays parked there — that is the home position
+   * and where the lanes arrive as older commits load — while any other
+   * view is scaled by `scaleX` (zoom) and clamped into the new range.
+   */
+  private reconcileHorizontalScroll(scaleX = 1): void {
+    const column = this.getGraphColumn();
+    if (!column || !this.scrollState) return;
+
+    const { scrollTop, scrollLeft } = this.scrollState.getScroll();
+    const next = reconcileScrollLeft(column, scrollLeft, this.lastMaxScrollX, scaleX);
+    this.lastMaxScrollX = column.maxScrollLeft;
+    if (next !== scrollLeft) {
+      this.scrollState.setScroll(scrollTop, next);
+    }
+    this.syncScrollbarPosition();
+    // The horizontal scrollbar and the resize handles are DOM, positioned
+    // from the column geometry inside render()
+    this.requestUpdate();
   }
 
   private onResize(): void {
@@ -2359,6 +2460,8 @@ export class LvGraphCanvas extends LitElement {
     const height = this.containerEl.clientHeight;
 
     this.renderer.resize(width, height);
+    // The automatic column width follows the canvas width
+    this.reconcileHorizontalScroll();
     this.resizeMinimap();
     this.rebuildMinimapDots();
     this.scheduleRender();
@@ -2408,10 +2511,16 @@ export class LvGraphCanvas extends LitElement {
     const size = this.virtualScroll.getContentSize();
     const viewport = this.getViewport();
 
-    const maxScrollX = Math.max(0, size.width - viewport.width);
+    // Sideways wheel (trackpad, or shift+wheel — which some platforms
+    // report as a vertical delta with the shift key held) scrolls the
+    // lanes inside the graph column; the text columns never move
+    const maxScrollX = this.getMaxScrollX();
+    const sideways = e.shiftKey && e.deltaX === 0 && maxScrollX > 0;
+    const deltaX = sideways ? e.deltaY : e.deltaX;
+    const deltaY = sideways ? 0 : e.deltaY;
     const maxScrollY = Math.max(0, size.height - viewport.height);
 
-    this.scrollState.handleWheel(e.deltaX, e.deltaY, maxScrollX, maxScrollY);
+    this.scrollState.handleWheel(deltaX, deltaY, maxScrollX, maxScrollY);
 
     // Sync the native scrollbar position
     this.syncScrollbarPosition();
@@ -2422,13 +2531,23 @@ export class LvGraphCanvas extends LitElement {
       return;
     }
 
-    // Update internal scroll state from native scrollbar
+    // Update internal scroll state from native scrollbar (vertical only —
+    // the graph column has its own horizontal scrollbar)
     const scrollTop = this.scrollEl.scrollTop;
-    const scrollLeft = this.scrollEl.scrollLeft;
+    const { scrollLeft } = this.scrollState.getScroll();
 
     this.scrollState.setScroll(scrollTop, scrollLeft);
     this.checkLoadMore();
   }
+
+  /** The graph column's native horizontal scrollbar was dragged */
+  private handleNativeHScroll = (): void => {
+    if (!this.hscrollEl || !this.scrollState || this.isSyncingScroll) {
+      return;
+    }
+    const { scrollTop } = this.scrollState.getScroll();
+    this.scrollState.setScroll(scrollTop, this.hscrollEl.scrollLeft);
+  };
 
   private isSyncingScroll = false;
 
@@ -2440,12 +2559,29 @@ export class LvGraphCanvas extends LitElement {
     // Prevent feedback loop
     this.isSyncingScroll = true;
     this.scrollEl.scrollTop = scroll.scrollTop;
-    this.scrollEl.scrollLeft = scroll.scrollLeft;
+    if (this.hscrollEl) {
+      this.hscrollEl.scrollLeft = scroll.scrollLeft;
+    }
 
     // Reset flag after scroll event processes
     requestAnimationFrame(() => {
       this.isSyncingScroll = false;
     });
+  }
+
+  /**
+   * Scroll the graph column sideways by a number of lanes (negative =
+   * towards the higher-numbered lanes on the left). No-op when every lane
+   * already fits.
+   */
+  private scrollGraphColumnByLanes(lanes: number): void {
+    const column = this.getGraphColumn();
+    if (!column || !this.scrollState || column.maxScrollLeft === 0) return;
+    const { scrollTop, scrollLeft } = this.scrollState.getScroll();
+    const next = clampScrollLeft(column, scrollLeft + lanes * this.LANE_WIDTH);
+    if (next === scrollLeft) return;
+    this.scrollState.setScroll(scrollTop, next);
+    this.syncScrollbarPosition();
   }
 
   private handleMouseMove = (e: MouseEvent): void => {
@@ -2753,6 +2889,17 @@ export class LvGraphCanvas extends LitElement {
         newIndex = this.sortedNodesByRow.length - 1;
         break;
 
+      // Sideways: reveal lanes hidden beyond the graph column's edges
+      case 'ArrowLeft':
+        e.preventDefault();
+        this.scrollGraphColumnByLanes(-MIN_VISIBLE_LANES);
+        return;
+
+      case 'ArrowRight':
+        e.preventDefault();
+        this.scrollGraphColumnByLanes(MIN_VISIBLE_LANES);
+        return;
+
       case 'PageDown':
         e.preventDefault();
         if (currentIndex === -1) {
@@ -2822,18 +2969,15 @@ export class LvGraphCanvas extends LitElement {
     if (!this.scrollState || !this.virtualScroll) return;
 
     const viewport = this.getViewport();
+    const column = this.getGraphColumn();
     const nodeY = this.PADDING + node.row * this.ROW_HEIGHT;
-    const nodeX = this.PADDING + node.lane * this.LANE_WIDTH;
 
     // Calculate visible area
     const visibleTop = viewport.scrollTop;
     const visibleBottom = viewport.scrollTop + viewport.height;
-    const visibleLeft = viewport.scrollLeft;
-    const visibleRight = viewport.scrollLeft + viewport.width;
 
     // Scroll margins for keeping node comfortably in view
     const marginY = this.ROW_HEIGHT * 2;
-    const marginX = this.LANE_WIDTH * 2;
 
     let targetScrollTop = viewport.scrollTop;
     let targetScrollLeft = viewport.scrollLeft;
@@ -2847,13 +2991,24 @@ export class LvGraphCanvas extends LitElement {
       targetScrollTop = Math.min(maxScrollY, nodeY - viewport.height + marginY + this.ROW_HEIGHT);
     }
 
-    // Horizontal scrolling
-    if (nodeX < visibleLeft + marginX) {
-      targetScrollLeft = Math.max(0, nodeX - marginX);
-    } else if (nodeX > visibleRight - marginX - this.LANE_WIDTH) {
-      const size = this.virtualScroll.getContentSize();
-      const maxScrollX = Math.max(0, size.width - viewport.width);
-      targetScrollLeft = Math.min(maxScrollX, nodeX - viewport.width + marginX + this.LANE_WIDTH);
+    // Horizontal scrolling: bring the node's lane inside the graph column.
+    // The graph is mirrored (lane 0 drawn rightmost), so measure the lane's
+    // on-screen x rather than assuming lanes grow to the right.
+    if (column && column.maxScrollLeft > 0 && this.layout) {
+      const marginX = Math.min(this.LANE_WIDTH * 2, column.width / 4);
+      const nodeScreenX = laneScreenX(
+        column,
+        this.LANE_WIDTH,
+        this.layout.maxLane,
+        node.lane,
+        viewport.scrollLeft
+      );
+      if (nodeScreenX < column.left + marginX) {
+        targetScrollLeft = viewport.scrollLeft - (column.left + marginX - nodeScreenX);
+      } else if (nodeScreenX > column.right - marginX) {
+        targetScrollLeft = viewport.scrollLeft + (nodeScreenX - (column.right - marginX));
+      }
+      targetScrollLeft = clampScrollLeft(column, targetScrollLeft);
     }
 
     // Apply scroll if needed
@@ -3114,11 +3269,16 @@ export class LvGraphCanvas extends LitElement {
     const viewport = this.getViewport();
 
     // Convert screen coords to graph coords, accounting for header offset
-    const graphX = e.clientX - rect.left + viewport.scrollLeft;
+    const screenX = e.clientX - rect.left;
+    const graphX = screenX + viewport.scrollLeft;
     const graphY = e.clientY - rect.top + viewport.scrollTop - this.HEADER_HEIGHT;
 
-    // First check spatial index for node hits
-    if (this.spatialIndex) {
+    // First check spatial index for node hits. Lanes scrolled out of the
+    // graph column are clipped, so a pointer outside the column can only
+    // be over a row, never over a (hidden) node or edge.
+    const column = this.getGraphColumn();
+    const overLanes = column === null || isInsideGraphColumn(column, screenX);
+    if (this.spatialIndex && overLanes) {
       const result = this.spatialIndex.hitTest(graphX, graphY);
       if (result.type === 'node' && result.node) {
         return result;
@@ -3226,9 +3386,10 @@ export class LvGraphCanvas extends LitElement {
     try {
       const saved = localStorage.getItem(this.COLUMN_STORAGE_KEY);
       if (saved) {
-        const { refs, stats } = JSON.parse(saved);
+        const { refs, stats, graph } = JSON.parse(saved);
         this.refsColumnWidth = refs ?? 200;
         this.statsColumnWidth = stats ?? 80;
+        this.graphColumnWidth = typeof graph === 'number' && graph > 0 ? graph : null;
       }
     } catch {
       // Ignore parse errors, use defaults
@@ -3240,6 +3401,7 @@ export class LvGraphCanvas extends LitElement {
       localStorage.setItem(this.COLUMN_STORAGE_KEY, JSON.stringify({
         refs: this.refsColumnWidth,
         stats: this.statsColumnWidth,
+        graph: this.graphColumnWidth,
       }));
     } catch {
       // Ignore storage errors
@@ -3549,17 +3711,30 @@ export class LvGraphCanvas extends LitElement {
     this.renderer?.setConfig({
       refsColumnWidth: this.refsColumnWidth,
       statsColumnWidth: this.statsColumnWidth,
+      graphColumnWidth: this.graphColumnWidth,
     });
+    // Any of these can move the graph column's right edge or its cap
+    this.reconcileHorizontalScroll();
   }
 
-  private handleResizeStart(e: MouseEvent, column: 'refs' | 'stats'): void {
+  private handleResizeStart(e: MouseEvent, column: 'refs' | 'stats' | 'graph'): void {
     e.preventDefault();
     e.stopPropagation();
     this.resizing = column;
     this.resizeStartX = e.clientX;
-    this.resizeStartWidth = column === 'refs'
-      ? this.refsColumnWidth
-      : this.statsColumnWidth;
+    switch (column) {
+      case 'refs':
+        this.resizeStartWidth = this.refsColumnWidth;
+        break;
+      case 'stats':
+        this.resizeStartWidth = this.statsColumnWidth;
+        break;
+      case 'graph':
+        // Start from the width actually on screen, so the drag continues
+        // from where the handle is rather than from a stale preference
+        this.resizeStartWidth = this.getGraphColumn()?.width ?? 0;
+        break;
+    }
 
     document.addEventListener('mousemove', this.handleResizeMove);
     document.addEventListener('mouseup', this.handleResizeEnd);
@@ -3573,6 +3748,14 @@ export class LvGraphCanvas extends LitElement {
     if (this.resizing === 'refs') {
       // Refs column: wider when dragging right
       this.refsColumnWidth = Math.max(80, Math.min(400, this.resizeStartWidth + delta));
+    } else if (this.resizing === 'graph') {
+      // Graph column: wider when dragging right. The renderer caps it so
+      // the message column keeps its minimum width; the floor keeps a few
+      // lanes visible.
+      this.graphColumnWidth = Math.max(
+        MIN_VISIBLE_LANES * this.LANE_WIDTH,
+        Math.round(this.resizeStartWidth + delta)
+      );
     } else {
       // Stats column: wider when dragging left (inverted)
       this.statsColumnWidth = Math.max(50, Math.min(150, this.resizeStartWidth - delta));
@@ -3590,9 +3773,26 @@ export class LvGraphCanvas extends LitElement {
     this.saveColumnWidths();
   };
 
-  private getResizeHandlePositions(): { refsEnd: number; statsStart: number } | null {
+  private getResizeHandlePositions(): {
+    graphEnd: number;
+    refsEnd: number;
+    statsStart: number;
+  } | null {
     if (!this.renderer || !this.layout) return null;
     return this.renderer.getColumnBoundaries(this.layout.maxLane, this.PADDING);
+  }
+
+  /**
+   * The graph column's horizontal scrollbar is DOM; it exists only while
+   * lanes overflow the column, so a freshly rendered one starts at
+   * scrollLeft 0 and has to be moved to the current position.
+   */
+  protected updated(): void {
+    if (!this.hscrollEl || !this.scrollState) return;
+    const { scrollLeft } = this.scrollState.getScroll();
+    if (Math.abs(this.hscrollEl.scrollLeft - scrollLeft) > 0.5) {
+      this.syncScrollbarPosition();
+    }
   }
 
   private renderGraph(): void {
@@ -3757,6 +3957,7 @@ export class LvGraphCanvas extends LitElement {
 
   render() {
     const handlePositions = this.getResizeHandlePositions();
+    const graphColumn = this.getGraphColumn();
 
     return html`
       <div class="container">
@@ -3764,6 +3965,21 @@ export class LvGraphCanvas extends LitElement {
           <div class="scroll-container">
             <div class="scroll-content"></div>
           </div>
+          ${graphColumn && graphColumn.maxScrollLeft > 0
+            ? html`
+                <div
+                  class="hscroll-container"
+                  title="Scroll graph lanes"
+                  style="left: ${graphColumn.left}px; width: ${graphColumn.width}px"
+                  @scroll=${this.handleNativeHScroll}
+                >
+                  <div
+                    class="hscroll-content"
+                    style="width: ${graphColumn.fullLaneWidth}px"
+                  ></div>
+                </div>
+              `
+            : ''}
           <canvas
             tabindex="0"
             role="img"
@@ -3782,6 +3998,12 @@ export class LvGraphCanvas extends LitElement {
 
           ${handlePositions
             ? html`
+                <div
+                  class="resize-handle ${this.resizing === 'graph' ? 'dragging' : ''}"
+                  title="Resize graph column"
+                  style="left: ${handlePositions.graphEnd}px"
+                  @mousedown=${(e: MouseEvent) => this.handleResizeStart(e, 'graph')}
+                ></div>
                 <div
                   class="resize-handle ${this.resizing === 'refs' ? 'dragging' : ''}"
                   style="left: ${handlePositions.refsEnd}px"

--- a/src/graph/__tests__/canvas-renderer.test.ts
+++ b/src/graph/__tests__/canvas-renderer.test.ts
@@ -439,6 +439,7 @@ describe('CanvasRenderer merge edge dashing', () => {
       ],
       range: { startRow: 0, endRow: 2, startLane: 0, endLane: 1 },
       offsetX: 20,
+      scrollLeft: 0,
       offsetY: 20,
       refsByCommit: {},
       authorEmails: {},
@@ -632,6 +633,278 @@ describe('CanvasRenderer commit-size node scaling', () => {
     const internals = renderer as unknown as NodeRadiusInternals;
 
     expect(internals.getNodeRadius('missing')).to.equal(6);
+    renderer.destroy();
+  });
+});
+
+describe('CanvasRenderer graph column', () => {
+  const LANE = 16;
+  const PADDING = 20;
+
+  function makeWideRenderer(
+    canvasWidth: number,
+    config: Record<string, unknown> = {}
+  ): CanvasRenderer {
+    const canvas = document.createElement('canvas');
+    canvas.width = canvasWidth;
+    canvas.height = 300;
+    return new CanvasRenderer(canvas, { laneWidth: LANE, ...config });
+  }
+
+  it('hugs the lanes of a narrow graph', () => {
+    const renderer = makeWideRenderer(1200);
+    const column = renderer.getGraphColumnLayout(2, PADDING);
+
+    expect(column.width).to.equal(3 * LANE);
+    expect(column.maxScrollLeft).to.equal(0);
+    renderer.destroy();
+  });
+
+  it('caps a wide graph at a share of the canvas by default', () => {
+    const renderer = makeWideRenderer(1200);
+    const column = renderer.getGraphColumnLayout(99, PADDING);
+
+    expect(column.fullLaneWidth).to.equal(100 * LANE);
+    expect(column.width).to.equal(Math.round(1200 * 0.35));
+    expect(column.maxScrollLeft).to.equal(100 * LANE - column.width);
+    renderer.destroy();
+  });
+
+  it('honours a user-chosen column width', () => {
+    const renderer = makeWideRenderer(1200, { graphColumnWidth: 200 });
+    const column = renderer.getGraphColumnLayout(99, PADDING);
+
+    expect(column.width).to.equal(200);
+    renderer.destroy();
+  });
+
+  it('never lets the column squeeze the message below its minimum width', () => {
+    const renderer = makeWideRenderer(700, { graphColumnWidth: 2000 });
+    const column = renderer.getGraphColumnLayout(99, PADDING);
+    const bounds = renderer.getColumnBoundaries(99, PADDING);
+    const internals = renderer as unknown as {
+      getRightColumnLayout(messageColumnX?: number): { messageRightEdge: number };
+    };
+    // Message starts after avatar (20 + 22 + 8), refs (200) and gap (12)
+    const messageColumnX = bounds.refsEnd + 12;
+    const { messageRightEdge } = internals.getRightColumnLayout(messageColumnX);
+
+    expect(column.width).to.be.lessThan(2000);
+    expect(bounds.graphEnd).to.equal(column.right);
+    expect(messageRightEdge - messageColumnX).to.be.at.least(160);
+    renderer.destroy();
+  });
+
+  it('anchors the resize handles to the capped column, not the lane count', () => {
+    const renderer = makeWideRenderer(1200);
+    const bounds = renderer.getColumnBoundaries(99, PADDING);
+    const column = renderer.getGraphColumnLayout(99, PADDING);
+
+    expect(bounds.graphEnd).to.equal(column.right);
+    expect(bounds.refsEnd).to.equal(column.right + 20 + 22 + 8 + 200);
+    expect(bounds.refsEnd).to.be.lessThan(bounds.statsStart);
+    expect(bounds.statsStart).to.be.lessThan(1200);
+    renderer.destroy();
+  });
+
+  function makeNode(oid: string, row: number, lane: number) {
+    return {
+      oid,
+      row,
+      lane,
+      commit: { oid, parentIds: [], timestamp: 1, message: 'msg', author: 'a' },
+      childLanes: [],
+      parentLanes: [],
+      colorIndex: 0,
+      hasMissingParents: false,
+    };
+  }
+
+  function renderWide(
+    renderer: CanvasRenderer,
+    scrollLeft: number,
+    nodes = [makeNode('main', 0, 0), makeNode('far', 1, 99)]
+  ): number[] {
+    const internals = renderer as unknown as { ctx: CanvasRenderingContext2D };
+    const arcXs: number[] = [];
+    const originalArc = internals.ctx.arc.bind(internals.ctx);
+    internals.ctx.arc = (x: number, ...rest: [number, number, number, number, boolean?]) => {
+      arcXs.push(x);
+      originalArc(x, ...rest);
+    };
+
+    renderer.markDirty();
+    renderer.render({
+      nodes,
+      edges: [],
+      range: { startRow: 0, endRow: 1, startLane: 0, endLane: 99 },
+      offsetX: PADDING,
+      scrollLeft,
+      offsetY: PADDING,
+      refsByCommit: {},
+      authorEmails: {},
+      maxLane: 99,
+    });
+    internals.ctx.arc = originalArc;
+    return arcXs;
+  }
+
+  it('draws lane 0 against the column edge at the home position', () => {
+    const renderer = makeWideRenderer(1200, { graphColumnWidth: 200 });
+    const column = renderer.getGraphColumnLayout(99, PADDING);
+
+    const arcXs = renderWide(renderer, column.maxScrollLeft);
+
+    // Node circles (plus the avatar circle in the text column) are drawn
+    // with arc(); the mainline node sits half a lane inside the right edge
+    expect(arcXs).to.include(column.right - LANE / 2);
+    renderer.destroy();
+  });
+
+  it('reveals the far lane when scrolled fully left', () => {
+    const renderer = makeWideRenderer(1200, { graphColumnWidth: 200 });
+    const column = renderer.getGraphColumnLayout(99, PADDING);
+
+    const arcXs = renderWide(renderer, 0);
+
+    expect(arcXs).to.include(column.left + LANE / 2);
+    renderer.destroy();
+  });
+
+  it('clamps an out-of-range scroll to the home position', () => {
+    const renderer = makeWideRenderer(1200, { graphColumnWidth: 200 });
+    const column = renderer.getGraphColumnLayout(99, PADDING);
+
+    const arcXs = renderWide(renderer, 99999);
+
+    expect(arcXs).to.include(column.right - LANE / 2);
+    renderer.destroy();
+  });
+
+  it('clips lane drawing to the column when lanes overflow it', () => {
+    const renderer = makeWideRenderer(1200, { graphColumnWidth: 200 });
+    const column = renderer.getGraphColumnLayout(99, PADDING);
+    const internals = renderer as unknown as { ctx: CanvasRenderingContext2D };
+
+    const clipRects: Array<[number, number, number, number]> = [];
+    const originalRect = internals.ctx.rect.bind(internals.ctx);
+    internals.ctx.rect = (x: number, y: number, w: number, h: number) => {
+      clipRects.push([x, y, w, h]);
+      originalRect(x, y, w, h);
+    };
+    renderWide(renderer, column.maxScrollLeft);
+    internals.ctx.rect = originalRect;
+
+    const columnClip = clipRects.find(([x]) => x === column.left);
+    expect(columnClip, 'a clip rect starting at the column edge').to.not.be.undefined;
+    // Wide enough for the column plus the overhang of a node on lane 0
+    expect(columnClip![2]).to.equal(column.width + 10);
+    renderer.destroy();
+  });
+
+  it('does not clip when every lane fits', () => {
+    const renderer = makeWideRenderer(1200);
+    const internals = renderer as unknown as { ctx: CanvasRenderingContext2D };
+
+    const clipRects: number[] = [];
+    const originalRect = internals.ctx.rect.bind(internals.ctx);
+    internals.ctx.rect = (x: number, y: number, w: number, h: number) => {
+      clipRects.push(x);
+      originalRect(x, y, w, h);
+    };
+    renderer.markDirty();
+    renderer.render({
+      nodes: [makeNode('main', 0, 0)],
+      edges: [],
+      range: { startRow: 0, endRow: 0, startLane: 0, endLane: 0 },
+      offsetX: PADDING,
+      scrollLeft: 0,
+      offsetY: PADDING,
+      refsByCommit: {},
+      authorEmails: {},
+      maxLane: 0,
+    });
+    internals.ctx.rect = originalRect;
+
+    // Only the header clip (which starts at x = 0)
+    expect(clipRects.every((x) => x === 0)).to.be.true;
+    renderer.destroy();
+  });
+
+  it('places the text columns after the capped column at any scroll', () => {
+    const renderer = makeWideRenderer(1200, { graphColumnWidth: 200 });
+    const column = renderer.getGraphColumnLayout(99, PADDING);
+    const internals = renderer as unknown as { ctx: CanvasRenderingContext2D };
+
+    for (const scrollLeft of [0, column.maxScrollLeft / 2, column.maxScrollLeft]) {
+      const textXs: number[] = [];
+      const originalFillText = internals.ctx.fillText.bind(internals.ctx);
+      internals.ctx.fillText = (text: string, x: number, y: number, maxWidth?: number) => {
+        if (text === 'msg') textXs.push(x);
+        originalFillText(text, x, y, maxWidth);
+      };
+      renderWide(renderer, scrollLeft);
+      internals.ctx.fillText = originalFillText;
+
+      const expectedMessageX = column.right + 20 + 22 + 8 + 200 + 12;
+      expect(textXs, `scrollLeft ${scrollLeft}`).to.deep.equal([
+        expectedMessageX,
+        expectedMessageX,
+      ]);
+    }
+    renderer.destroy();
+  });
+
+  it('shows a "more" hint for the lanes hidden beyond the column', () => {
+    const renderer = makeWideRenderer(1200, { graphColumnWidth: 320 });
+    const column = renderer.getGraphColumnLayout(99, PADDING);
+    const internals = renderer as unknown as { ctx: CanvasRenderingContext2D };
+
+    const texts: string[] = [];
+    const originalFillText = internals.ctx.fillText.bind(internals.ctx);
+    internals.ctx.fillText = (text: string, x: number, y: number, maxWidth?: number) => {
+      texts.push(text);
+      originalFillText(text, x, y, maxWidth);
+    };
+    renderWide(renderer, column.maxScrollLeft);
+
+    const hiddenLeft = (column.fullLaneWidth - column.width) / LANE;
+    expect(texts).to.include(`◂ ${hiddenLeft} more`);
+    expect(texts.some((t) => t.endsWith('more ▸'))).to.be.false;
+
+    texts.length = 0;
+    renderWide(renderer, 0);
+    expect(texts).to.include(`${hiddenLeft} more ▸`);
+    expect(texts.some((t) => t.startsWith('◂'))).to.be.false;
+    internals.ctx.fillText = originalFillText;
+    renderer.destroy();
+  });
+
+  it('shows no hint when every lane fits', () => {
+    const renderer = makeWideRenderer(1200);
+    const internals = renderer as unknown as { ctx: CanvasRenderingContext2D };
+
+    const texts: string[] = [];
+    const originalFillText = internals.ctx.fillText.bind(internals.ctx);
+    internals.ctx.fillText = (text: string, x: number, y: number, maxWidth?: number) => {
+      texts.push(text);
+      originalFillText(text, x, y, maxWidth);
+    };
+    renderer.markDirty();
+    renderer.render({
+      nodes: [makeNode('main', 0, 0)],
+      edges: [],
+      range: { startRow: 0, endRow: 0, startLane: 0, endLane: 0 },
+      offsetX: PADDING,
+      scrollLeft: 0,
+      offsetY: PADDING,
+      refsByCommit: {},
+      authorEmails: {},
+      maxLane: 0,
+    });
+    internals.ctx.fillText = originalFillText;
+
+    expect(texts.some((t) => t.includes('more'))).to.be.false;
     renderer.destroy();
   });
 });

--- a/src/graph/__tests__/graph-column.test.ts
+++ b/src/graph/__tests__/graph-column.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Unit tests for the graph column geometry: the bounded, horizontally
+ * scrollable lane area that keeps the text columns on screen however many
+ * lanes the graph has.
+ */
+import { expect } from '@open-wc/testing';
+import {
+  AUTO_GRAPH_COLUMN_SHARE,
+  MIN_VISIBLE_LANES,
+  clampScrollLeft,
+  computeGraphColumnLayout,
+  hiddenLaneCounts,
+  isInsideGraphColumn,
+  laneScreenX,
+  reconcileScrollLeft,
+} from '../graph-column.ts';
+
+const LANE = 16;
+const LEFT = 20;
+
+describe('computeGraphColumnLayout', () => {
+  it('hugs the lanes when they fit, so narrow graphs are unchanged', () => {
+    const layout = computeGraphColumnLayout({
+      maxLane: 2,
+      laneWidth: LANE,
+      left: LEFT,
+      preferredWidth: 400,
+      maxWidth: 600,
+    });
+
+    expect(layout.fullLaneWidth).to.equal(3 * LANE);
+    expect(layout.width).to.equal(3 * LANE);
+    expect(layout.left).to.equal(LEFT);
+    expect(layout.right).to.equal(LEFT + 3 * LANE);
+    expect(layout.maxScrollLeft).to.equal(0);
+  });
+
+  it('caps a wide graph at the preferred width and exposes the overflow', () => {
+    const layout = computeGraphColumnLayout({
+      maxLane: 79,
+      laneWidth: LANE,
+      left: LEFT,
+      preferredWidth: 300,
+      maxWidth: 600,
+    });
+
+    expect(layout.fullLaneWidth).to.equal(80 * LANE);
+    expect(layout.width).to.equal(300);
+    expect(layout.right).to.equal(LEFT + 300);
+    expect(layout.maxScrollLeft).to.equal(80 * LANE - 300);
+  });
+
+  it('never exceeds the cap that keeps the text columns on screen', () => {
+    const layout = computeGraphColumnLayout({
+      maxLane: 79,
+      laneWidth: LANE,
+      left: LEFT,
+      preferredWidth: 900,
+      maxWidth: 250,
+    });
+
+    expect(layout.width).to.equal(250);
+  });
+
+  it('keeps a few lanes visible even when the cap is tiny', () => {
+    const layout = computeGraphColumnLayout({
+      maxLane: 79,
+      laneWidth: LANE,
+      left: LEFT,
+      preferredWidth: 900,
+      maxWidth: 5,
+    });
+
+    expect(layout.width).to.equal(MIN_VISIBLE_LANES * LANE);
+    expect(layout.maxScrollLeft).to.equal(80 * LANE - MIN_VISIBLE_LANES * LANE);
+  });
+
+  it('does not force the minimum on a graph with fewer lanes than it', () => {
+    const layout = computeGraphColumnLayout({
+      maxLane: 0,
+      laneWidth: LANE,
+      left: LEFT,
+      preferredWidth: 900,
+      maxWidth: 5,
+    });
+
+    expect(layout.width).to.equal(LANE);
+    expect(layout.maxScrollLeft).to.equal(0);
+  });
+
+  it('rounds the width down to whole pixels', () => {
+    const layout = computeGraphColumnLayout({
+      maxLane: 79,
+      laneWidth: LANE,
+      left: LEFT,
+      preferredWidth: 300.7,
+      maxWidth: 600,
+    });
+
+    expect(layout.width).to.equal(300);
+  });
+
+  it('treats a negative maxLane as a single lane', () => {
+    const layout = computeGraphColumnLayout({
+      maxLane: -1,
+      laneWidth: LANE,
+      left: LEFT,
+      preferredWidth: 300,
+      maxWidth: 600,
+    });
+
+    expect(layout.fullLaneWidth).to.equal(LANE);
+  });
+
+  it('exports the automatic share used for the default width', () => {
+    expect(AUTO_GRAPH_COLUMN_SHARE).to.be.greaterThan(0).and.lessThan(1);
+  });
+});
+
+describe('laneScreenX', () => {
+  const layout = computeGraphColumnLayout({
+    maxLane: 79,
+    laneWidth: LANE,
+    left: LEFT,
+    preferredWidth: 300,
+    maxWidth: 600,
+  });
+
+  it('puts lane 0 against the right edge at the home position', () => {
+    const x = laneScreenX(layout, LANE, 79, 0, layout.maxScrollLeft);
+    expect(x).to.equal(layout.right - LANE / 2);
+  });
+
+  it('puts the highest lane against the left edge when scrolled fully left', () => {
+    const x = laneScreenX(layout, LANE, 79, 79, 0);
+    expect(x).to.equal(layout.left + LANE / 2);
+  });
+
+  it('matches the spatial index coordinate minus the scroll offset', () => {
+    // The spatial index places lane L at left + (maxLane - L) * lane + lane/2
+    const scrollLeft = 123;
+    for (const lane of [0, 7, 79]) {
+      const indexX = LEFT + (79 - lane) * LANE + LANE / 2;
+      expect(laneScreenX(layout, LANE, 79, lane, scrollLeft)).to.equal(indexX - scrollLeft);
+    }
+  });
+
+  it('is unaffected by scrolling when every lane fits', () => {
+    const small = computeGraphColumnLayout({
+      maxLane: 1,
+      laneWidth: LANE,
+      left: LEFT,
+      preferredWidth: 300,
+      maxWidth: 600,
+    });
+    expect(laneScreenX(small, LANE, 1, 0, 0)).to.equal(small.right - LANE / 2);
+    expect(laneScreenX(small, LANE, 1, 1, 0)).to.equal(small.left + LANE / 2);
+  });
+});
+
+describe('clampScrollLeft', () => {
+  const layout = computeGraphColumnLayout({
+    maxLane: 79,
+    laneWidth: LANE,
+    left: LEFT,
+    preferredWidth: 300,
+    maxWidth: 600,
+  });
+
+  it('clamps into [0, maxScrollLeft]', () => {
+    expect(clampScrollLeft(layout, -5)).to.equal(0);
+    expect(clampScrollLeft(layout, 50)).to.equal(50);
+    expect(clampScrollLeft(layout, 99999)).to.equal(layout.maxScrollLeft);
+  });
+
+  it('falls back to the home position for a non-finite value', () => {
+    expect(clampScrollLeft(layout, Number.NaN)).to.equal(layout.maxScrollLeft);
+  });
+});
+
+describe('reconcileScrollLeft', () => {
+  const before = computeGraphColumnLayout({
+    maxLane: 39,
+    laneWidth: LANE,
+    left: LEFT,
+    preferredWidth: 300,
+    maxWidth: 600,
+  });
+  const after = computeGraphColumnLayout({
+    maxLane: 79,
+    laneWidth: LANE,
+    left: LEFT,
+    preferredWidth: 300,
+    maxWidth: 600,
+  });
+
+  it('keeps a view parked on the mainline parked there as lanes arrive', () => {
+    const next = reconcileScrollLeft(after, before.maxScrollLeft, before.maxScrollLeft);
+    expect(next).to.equal(after.maxScrollLeft);
+  });
+
+  it('treats the very first layout (no previous overflow) as home', () => {
+    expect(reconcileScrollLeft(after, 0, 0)).to.equal(after.maxScrollLeft);
+  });
+
+  it('keeps a scrolled-away view where it was', () => {
+    const next = reconcileScrollLeft(after, 100, before.maxScrollLeft);
+    expect(next).to.equal(100);
+  });
+
+  it('clamps a scrolled-away view when the graph shrinks', () => {
+    const next = reconcileScrollLeft(before, after.maxScrollLeft - 10, after.maxScrollLeft);
+    expect(next).to.equal(before.maxScrollLeft);
+  });
+
+  it('scales a scrolled-away view with the lane width on zoom', () => {
+    const zoomed = computeGraphColumnLayout({
+      maxLane: 79,
+      laneWidth: LANE * 2,
+      left: LEFT,
+      preferredWidth: 300,
+      maxWidth: 600,
+    });
+    expect(reconcileScrollLeft(zoomed, 100, after.maxScrollLeft, 2)).to.equal(200);
+  });
+
+  it('keeps a home view at home across a zoom', () => {
+    const zoomed = computeGraphColumnLayout({
+      maxLane: 79,
+      laneWidth: LANE * 2,
+      left: LEFT,
+      preferredWidth: 300,
+      maxWidth: 600,
+    });
+    expect(reconcileScrollLeft(zoomed, after.maxScrollLeft, after.maxScrollLeft, 2)).to.equal(
+      zoomed.maxScrollLeft
+    );
+  });
+});
+
+describe('hiddenLaneCounts', () => {
+  const layout = computeGraphColumnLayout({
+    maxLane: 79,
+    laneWidth: LANE,
+    left: LEFT,
+    preferredWidth: 20 * LANE,
+    maxWidth: 600,
+  });
+
+  it('reports every overflowing lane on the left at the home position', () => {
+    expect(hiddenLaneCounts(layout, LANE, layout.maxScrollLeft)).to.deep.equal({
+      left: 60,
+      right: 0,
+    });
+  });
+
+  it('reports the mainline side hidden when scrolled fully left', () => {
+    expect(hiddenLaneCounts(layout, LANE, 0)).to.deep.equal({ left: 0, right: 60 });
+  });
+
+  it('counts whole lanes only', () => {
+    expect(hiddenLaneCounts(layout, LANE, 5 * LANE + 3)).to.deep.equal({
+      left: 5,
+      right: 54,
+    });
+  });
+
+  it('reports nothing hidden when every lane fits', () => {
+    const small = computeGraphColumnLayout({
+      maxLane: 1,
+      laneWidth: LANE,
+      left: LEFT,
+      preferredWidth: 300,
+      maxWidth: 600,
+    });
+    expect(hiddenLaneCounts(small, LANE, 0)).to.deep.equal({ left: 0, right: 0 });
+  });
+});
+
+describe('isInsideGraphColumn', () => {
+  const layout = computeGraphColumnLayout({
+    maxLane: 79,
+    laneWidth: LANE,
+    left: LEFT,
+    preferredWidth: 300,
+    maxWidth: 600,
+  });
+
+  it('accepts the column and its edges, rejects the text columns', () => {
+    expect(isInsideGraphColumn(layout, layout.left)).to.be.true;
+    expect(isInsideGraphColumn(layout, layout.right)).to.be.true;
+    expect(isInsideGraphColumn(layout, layout.left - 1)).to.be.false;
+    expect(isInsideGraphColumn(layout, layout.right + 30)).to.be.false;
+  });
+});

--- a/src/graph/__tests__/virtual-scroll.test.ts
+++ b/src/graph/__tests__/virtual-scroll.test.ts
@@ -3,7 +3,7 @@
  * the numeric edge index, and direct (momentum-free) wheel scrolling.
  */
 import { expect } from '@open-wc/testing';
-import { VirtualScrollManager, ScrollStateManager } from '../virtual-scroll.ts';
+import { VirtualScrollManager, ScrollStateManager, type Viewport } from '../virtual-scroll.ts';
 import {
   assignLanes,
   type GraphCommit,
@@ -331,5 +331,176 @@ describe('VirtualScrollManager wide-graph lane culling', () => {
           Math.max(e.fromRow, e.toRow) >= data.range.startRow
       )
     ).to.be.true;
+  });
+});
+
+/**
+ * With a bounded graph column the lanes scroll inside the column, so the
+ * horizontally visible strip is [scrollLeft, scrollLeft + column width]
+ * rather than the whole viewport.
+ */
+describe('VirtualScrollManager bounded graph column', () => {
+  const ROW_HEIGHT = 22;
+  const LANE_WIDTH = 16;
+  const PADDING = 20;
+  const MAX_LANE = 99;
+  const COLUMN_W = 20 * LANE_WIDTH;
+  const FULL_W = (MAX_LANE + 1) * LANE_WIDTH;
+  const HOME = FULL_W - COLUMN_W;
+
+  function makeNode(row: number, lane: number): LayoutNode {
+    const oid = `n${row}`;
+    return {
+      oid,
+      row,
+      lane,
+      commit: { oid, parentIds: [], timestamp: 100 - row, message: `Commit ${row}`, author: 'T' },
+      childLanes: [],
+      parentLanes: [],
+      colorIndex: lane,
+      hasMissingParents: false,
+    };
+  }
+
+  function makeManager(): VirtualScrollManager {
+    // One node per row: rows cycle through lanes 0, 50 and 99 with a
+    // straight edge back to the previous row in the same lane
+    const nodes = new Map<string, LayoutNode>();
+    const edges: LayoutEdge[] = [];
+    const lanes = [0, 50, MAX_LANE];
+    for (let row = 0; row < 30; row++) {
+      const lane = lanes[row % 3];
+      nodes.set(`n${row}`, makeNode(row, lane));
+      if (row >= 3) {
+        edges.push({
+          fromOid: `n${row}`,
+          toOid: `n${row - 3}`,
+          fromRow: row,
+          toRow: row - 3,
+          fromLane: lane,
+          toLane: lane,
+          isMerge: false,
+          colorIndex: lane,
+        });
+      }
+    }
+    const manager = new VirtualScrollManager({
+      rowHeight: ROW_HEIGHT,
+      laneWidth: LANE_WIDTH,
+      padding: PADDING,
+      overscanRows: 2,
+    });
+    manager.setLayout({ nodes, edges, maxLane: MAX_LANE, totalRows: 30 });
+    return manager;
+  }
+
+  function viewport(scrollLeft: number): Viewport {
+    return {
+      scrollTop: 0,
+      scrollLeft,
+      width: 1200,
+      height: 10 * ROW_HEIGHT,
+      graphColumnWidth: COLUMN_W,
+    };
+  }
+
+  it('culls to the lanes inside the column at the home position', () => {
+    const range = makeManager().getVisibleRange(viewport(HOME));
+
+    // Columns 80..99 are on screen (plus 2 of overscan each side):
+    // lanes 0..19, widened to 0..21
+    expect(range.startLane).to.equal(0);
+    expect(range.endLane).to.equal(21);
+  });
+
+  it('culls to the far lanes when scrolled fully left', () => {
+    const range = makeManager().getVisibleRange(viewport(0));
+
+    expect(range.endLane).to.equal(MAX_LANE);
+    expect(range.startLane).to.equal(MAX_LANE - 22);
+  });
+
+  it('drops edges of lanes hidden beyond the column', () => {
+    const home = makeManager().getRenderData(viewport(HOME));
+    expect(home.edges.length).to.be.greaterThan(0);
+    expect(home.edges.every((e) => e.fromLane === 0)).to.be.true;
+
+    const left = makeManager().getRenderData(viewport(0));
+    expect(left.edges.length).to.be.greaterThan(0);
+    expect(left.edges.every((e) => e.fromLane === MAX_LANE)).to.be.true;
+  });
+
+  it('still returns every visible row at any scroll', () => {
+    const manager = makeManager();
+    for (const scrollLeft of [0, HOME / 2, HOME]) {
+      const data = manager.getRenderData(viewport(scrollLeft));
+      const expectedRows = data.range.endRow - data.range.startRow + 1;
+      expect(data.nodes.length, `scrollLeft ${scrollLeft}`).to.equal(expectedRows);
+    }
+  });
+
+  it('passes the scroll offset through unchanged and keeps offsetX at the padding', () => {
+    const data = makeManager().getRenderData(viewport(123));
+
+    expect(data.scrollLeft).to.equal(123);
+    expect(data.offsetX).to.equal(PADDING);
+  });
+
+  it('falls back to viewport-wide culling without a column width', () => {
+    const wide = makeManager().getVisibleRange({
+      scrollTop: 0,
+      scrollLeft: 0,
+      width: 5000,
+      height: 10 * ROW_HEIGHT,
+    });
+
+    expect(wide.startLane).to.equal(0);
+    expect(wide.endLane).to.equal(MAX_LANE);
+  });
+
+  describe('scrollToNode', () => {
+    it('leaves a lane that already fits alone (no overflow)', () => {
+      const manager = new VirtualScrollManager({
+        rowHeight: ROW_HEIGHT,
+        laneWidth: LANE_WIDTH,
+        padding: PADDING,
+        overscanRows: 2,
+      });
+      const nodes = new Map([['n0', makeNode(0, 1)]]);
+      manager.setLayout({ nodes, edges: [], maxLane: 1, totalRows: 1 });
+
+      const { scrollLeft } = manager.scrollToNode(makeNode(0, 1), {
+        scrollTop: 0,
+        scrollLeft: 0,
+        width: 800,
+        height: 200,
+        graphColumnWidth: 2 * LANE_WIDTH,
+      });
+      expect(scrollLeft).to.equal(0);
+    });
+
+    it('brings the mainline to the right edge of the column', () => {
+      const { scrollLeft } = makeManager().scrollToNode(makeNode(0, 0), viewport(0), 'end');
+      expect(scrollLeft).to.equal(HOME);
+    });
+
+    it('brings the far lane to the left edge of the column', () => {
+      const { scrollLeft } = makeManager().scrollToNode(
+        makeNode(2, MAX_LANE),
+        viewport(HOME),
+        'start'
+      );
+      expect(scrollLeft).to.equal(0);
+    });
+
+    it('centres a middle lane and clamps into the scroll range', () => {
+      const { scrollLeft } = makeManager().scrollToNode(makeNode(1, 50), viewport(HOME));
+      // Lane 50 is drawn at column 49; centred means its middle sits at
+      // half the column width
+      expect(scrollLeft).to.equal(49 * LANE_WIDTH + LANE_WIDTH / 2 - COLUMN_W / 2);
+
+      const clamped = makeManager().scrollToNode(makeNode(0, 0), viewport(0));
+      expect(clamped.scrollLeft).to.equal(HOME);
+    });
   });
 });

--- a/src/graph/canvas-renderer.ts
+++ b/src/graph/canvas-renderer.ts
@@ -10,6 +10,14 @@
 import type { RenderData, GraphPullRequest } from './virtual-scroll.ts';
 import type { RefInfo, RefType } from '../types/git.types.ts';
 import { md5 } from '../utils/md5.ts';
+import {
+  AUTO_GRAPH_COLUMN_SHARE,
+  clampScrollLeft,
+  computeGraphColumnLayout,
+  hiddenLaneCounts,
+  laneScreenX,
+  type GraphColumnLayout,
+} from './graph-column.ts';
 
 export interface RenderConfig {
   /** Row height in pixels */
@@ -57,6 +65,14 @@ export interface RenderConfig {
   showAuthorColumn: boolean;
   /** Show the absolute-date column */
   showDateColumn: boolean;
+  /**
+   * Preferred on-screen width of the graph (lane) column in pixels, or
+   * null for the automatic default (a share of the canvas width). The
+   * column never grows past what the lanes need, and never so wide that
+   * the message column loses its minimum width; wider graphs scroll
+   * horizontally inside the column. See `graph-column.ts`.
+   */
+  graphColumnWidth: number | null;
 }
 
 export interface RenderTheme {
@@ -137,6 +153,7 @@ const DEFAULT_CONFIG: RenderConfig = {
   showRefIcons: true,
   refsColumnWidth: 200,
   statsColumnWidth: 80,
+  graphColumnWidth: null,
   showAuthorColumn: false,
   showDateColumn: false,
 };
@@ -778,6 +795,131 @@ export class CanvasRenderer {
     };
   }
 
+  /** Gap between the graph column and the avatar column */
+  private static readonly GRAPH_TO_AVATAR_GAP = 20;
+  private static readonly AVATAR_SIZE = 22;
+  /** Gap between the avatar and the refs column */
+  private static readonly AVATAR_TO_REFS_GAP = 8;
+  /** Gap between the refs column and the message column */
+  private static readonly REFS_TO_MESSAGE_GAP = 12;
+
+  /**
+   * Widest the graph column may be on this canvas before the text columns
+   * (avatar, refs, a minimum-width message, stats, time) stop fitting.
+   */
+  private getMaxGraphColumnWidth(left: number): number {
+    const { statsColumnX } = this.getRightColumnLayout();
+    const textColumnsWidth =
+      CanvasRenderer.GRAPH_TO_AVATAR_GAP +
+      CanvasRenderer.AVATAR_SIZE +
+      CanvasRenderer.AVATAR_TO_REFS_GAP +
+      this.config.refsColumnWidth +
+      CanvasRenderer.REFS_TO_MESSAGE_GAP +
+      CanvasRenderer.MIN_MESSAGE_WIDTH +
+      8;
+    return statsColumnX - textColumnsWidth - left;
+  }
+
+  /**
+   * Geometry of the graph (lane) column: where it starts and ends on
+   * screen and how far it can scroll horizontally. Every text column is
+   * laid out from `right`, so a graph with more lanes than fit never
+   * pushes the commit message off the canvas.
+   *
+   * @param maxLane Highest lane number in the layout
+   * @param left Screen x of the column's left edge (the graph padding)
+   */
+  getGraphColumnLayout(maxLane: number, left: number): GraphColumnLayout {
+    const canvasWidth = this.canvas.width / this.dpr;
+    const preferredWidth =
+      this.config.graphColumnWidth ?? Math.round(canvasWidth * AUTO_GRAPH_COLUMN_SHARE);
+    return computeGraphColumnLayout({
+      maxLane,
+      laneWidth: this.config.laneWidth,
+      left,
+      preferredWidth,
+      maxWidth: this.getMaxGraphColumnWidth(left),
+    });
+  }
+
+  /** Screen x of a lane's centre for the frame being rendered */
+  private laneX(column: GraphColumnLayout, maxLane: number, lane: number, scrollLeft: number): number {
+    return laneScreenX(column, this.config.laneWidth, maxLane, lane, scrollLeft);
+  }
+
+  /**
+   * Clip drawing to the graph column when lanes overflow it. Nodes on the
+   * rightmost lane may be wider than half a lane, so the clip extends by
+   * one node radius on the right: that side is only ever hidden after the
+   * user scrolls away from the mainline, and the 20px gap before the
+   * avatar column absorbs the overhang.
+   */
+  private clipToGraphColumn(column: GraphColumnLayout): void {
+    const { ctx } = this;
+    const height = this.canvas.height / this.dpr;
+    ctx.save();
+    ctx.beginPath();
+    ctx.rect(
+      column.left,
+      this.HEADER_HEIGHT,
+      column.width + this.config.maxNodeRadius,
+      height - this.HEADER_HEIGHT
+    );
+    ctx.clip();
+  }
+
+  /**
+   * Fade the column's cut edges so a clipped lane reads as "more this way"
+   * rather than as a rendering glitch.
+   */
+  private renderGraphColumnFades(column: GraphColumnLayout, scrollLeft: number): void {
+    if (column.maxScrollLeft === 0) return;
+    const { ctx, theme } = this;
+    const height = this.canvas.height / this.dpr;
+    const hidden = hiddenLaneCounts(column, this.config.laneWidth, scrollLeft);
+    const fadeWidth = Math.min(24, column.width / 3);
+    const transparent = this.toTransparent(theme.background);
+
+    if (hidden.left > 0) {
+      const gradient = ctx.createLinearGradient(column.left, 0, column.left + fadeWidth, 0);
+      gradient.addColorStop(0, theme.background);
+      gradient.addColorStop(1, transparent);
+      ctx.fillStyle = gradient;
+      ctx.fillRect(column.left, this.HEADER_HEIGHT, fadeWidth, height - this.HEADER_HEIGHT);
+    }
+    if (hidden.right > 0) {
+      const gradient = ctx.createLinearGradient(column.right - fadeWidth, 0, column.right, 0);
+      gradient.addColorStop(0, transparent);
+      gradient.addColorStop(1, theme.background);
+      ctx.fillStyle = gradient;
+      ctx.fillRect(column.right - fadeWidth, this.HEADER_HEIGHT, fadeWidth, height - this.HEADER_HEIGHT);
+    }
+  }
+
+  /**
+   * A fully transparent version of a CSS color, for gradient end stops.
+   * Handles the #rgb / #rrggbb / rgb() forms the theme uses; anything else
+   * falls back to plain transparent (which only matters for the very edge
+   * pixel of the fade).
+   */
+  private toTransparent(color: string): string {
+    const hex = color.trim().match(/^#([0-9a-f]{3}|[0-9a-f]{6})$/i);
+    if (hex) {
+      const digits = hex[1].length === 3
+        ? hex[1].split('').map((d) => d + d).join('')
+        : hex[1];
+      const r = parseInt(digits.slice(0, 2), 16);
+      const g = parseInt(digits.slice(2, 4), 16);
+      const b = parseInt(digits.slice(4, 6), 16);
+      return `rgba(${r}, ${g}, ${b}, 0)`;
+    }
+    const rgb = color.trim().match(/^rgba?\(\s*([\d.]+)\s*,\s*([\d.]+)\s*,\s*([\d.]+)/i);
+    if (rgb) {
+      return `rgba(${rgb[1]}, ${rgb[2]}, ${rgb[3]}, 0)`;
+    }
+    return 'transparent';
+  }
+
   /**
    * Format a timestamp as an absolute date (e.g. "12 Jan 25"), cached per
    * timestamp
@@ -902,20 +1044,31 @@ export class CanvasRenderer {
     ctx.rect(0, this.HEADER_HEIGHT, width, height - this.HEADER_HEIGHT);
     ctx.clip();
 
+    // Lanes that overflow the graph column are clipped to it; rows (which
+    // span the whole canvas) are painted outside that clip
+    const column = this.getGraphColumnLayout(data.maxLane, data.offsetX);
+    const scrollLeft = clampScrollLeft(column, data.scrollLeft);
+    const overflows = column.maxScrollLeft > 0;
+    if (overflows) this.clipToGraphColumn(column);
+
     // Draw edges (behind nodes)
-    this.renderEdges(data);
+    this.renderEdges(data, column, scrollLeft);
 
     // Draw nodes
-    this.renderNodes(data);
+    this.renderNodes(data, column, scrollLeft);
+
+    if (overflows) ctx.restore();
 
     // Draw ref labels (on top of nodes)
-    this.renderRefLabels(data);
+    this.renderRefLabels(data, column);
+
+    this.renderGraphColumnFades(column, scrollLeft);
 
     // Restore context (remove clipping)
     ctx.restore();
 
     // Draw column headers LAST (on top of everything)
-    this.renderColumnHeaders(data);
+    this.renderColumnHeaders(column, scrollLeft);
 
     // Draw FPS counter
     if (config.showFps) {
@@ -928,22 +1081,27 @@ export class CanvasRenderer {
   /**
    * Render column headers (GRAPH, COMMIT MESSAGE, STATS, TIME)
    */
-  private renderColumnHeaders(data: RenderData): void {
+  private renderColumnHeaders(column: GraphColumnLayout, scrollLeft: number): void {
     const { ctx, config, theme } = this;
-    const { offsetX, maxLane } = data;
 
     const headerY = this.HEADER_HEIGHT / 2;
     const canvasWidth = this.canvas.width / this.dpr;
 
-    // Calculate column positions
-    const graphEndX = offsetX + (maxLane + 1) * config.laneWidth;
-    const avatarColumnX = graphEndX + 20;
-    const avatarSize = 22;
+    // Calculate column positions from the graph column's right edge
+    const graphEndX = column.right;
+    const avatarColumnX = graphEndX + CanvasRenderer.GRAPH_TO_AVATAR_GAP;
+    const avatarSize = CanvasRenderer.AVATAR_SIZE;
     const messageColumnX = avatarColumnX + avatarSize + 12;
     // Rows start the message AFTER the refs column — the optional-column
     // drop decision must use the same origin as renderRefLabels or headers
     // and cells could disagree about which columns exist
-    const rowMessageColumnX = avatarColumnX + avatarSize + 8 + config.refsColumnWidth + 12;
+    const rowMessageColumnX =
+      avatarColumnX +
+      avatarSize +
+      CanvasRenderer.AVATAR_TO_REFS_GAP +
+      config.refsColumnWidth +
+      CanvasRenderer.REFS_TO_MESSAGE_GAP;
+    const hidden = hiddenLaneCounts(column, config.laneWidth, scrollLeft);
 
     // Right-aligned columns (use config values)
     const { timeColumnX, timeColumnWidth, statsColumnX, dateColumnX, authorColumnX } =
@@ -959,10 +1117,26 @@ export class CanvasRenderer {
     ctx.globalAlpha = 0.5;
     ctx.textBaseline = 'middle';
 
-    // Graph header - centered over graph area
-    const graphCenterX = offsetX + ((maxLane + 1) * config.laneWidth) / 2;
+    // Graph header - centered over the graph column
+    const graphCenterX = column.left + column.width / 2;
     ctx.textAlign = 'center';
     ctx.fillText('GRAPH', graphCenterX, headerY);
+
+    // "N more" hints for lanes scrolled out of the column. Only when the
+    // column is wide enough that they do not collide with the GRAPH label.
+    const graphLabelWidth = ctx.measureText('GRAPH').width;
+    if (column.width >= graphLabelWidth + 2 * 56) {
+      ctx.font = '9px -apple-system, BlinkMacSystemFont, sans-serif';
+      if (hidden.left > 0) {
+        ctx.textAlign = 'left';
+        ctx.fillText(`◂ ${hidden.left} more`, column.left + 2, headerY);
+      }
+      if (hidden.right > 0) {
+        ctx.textAlign = 'right';
+        ctx.fillText(`${hidden.right} more ▸`, column.right - 2, headerY);
+      }
+      ctx.font = 'bold 10px -apple-system, BlinkMacSystemFont, sans-serif';
+    }
 
     // Commit message header
     ctx.textAlign = 'left';
@@ -999,21 +1173,19 @@ export class CanvasRenderer {
   /**
    * Render edges with smooth bezier curves (GitKraken style)
    */
-  private renderEdges(data: RenderData): void {
+  private renderEdges(data: RenderData, column: GraphColumnLayout, scrollLeft: number): void {
     const { ctx, config } = this;
-    const { edges, offsetX, offsetY, maxLane } = data;
+    const { edges, offsetY, maxLane } = data;
 
     ctx.lineWidth = config.lineWidth;
     ctx.lineCap = 'round';
     ctx.lineJoin = 'round';
 
     // Graph is mirrored: lane 0 is on the right, higher lanes extend left
-    const graphEndX = offsetX + (maxLane + 1) * config.laneWidth;
-
     for (const edge of edges) {
-      const fromX = graphEndX - (edge.fromLane + 1) * config.laneWidth + config.laneWidth / 2;
+      const fromX = this.laneX(column, maxLane, edge.fromLane, scrollLeft);
       const fromY = offsetY + edge.fromRow * config.rowHeight + this.HEADER_HEIGHT;
-      const toX = graphEndX - (edge.toLane + 1) * config.laneWidth + config.laneWidth / 2;
+      const toX = this.laneX(column, maxLane, edge.toLane, scrollLeft);
       const toY = offsetY + edge.toRow * config.rowHeight + this.HEADER_HEIGHT;
 
       ctx.strokeStyle = this.getBranchColor(edge.colorIndex);
@@ -1082,18 +1254,16 @@ export class CanvasRenderer {
   /**
    * Render nodes with avatars
    */
-  private renderNodes(data: RenderData): void {
+  private renderNodes(data: RenderData, column: GraphColumnLayout, scrollLeft: number): void {
     const { ctx, config, theme } = this;
-    const { nodes, offsetX, offsetY, authorEmails, maxLane } = data;
-
-    // Graph is mirrored: lane 0 is on the right, higher lanes extend left
-    const graphEndX = offsetX + (maxLane + 1) * config.laneWidth;
+    const { nodes, offsetY, authorEmails, maxLane } = data;
 
     // Check if search highlighting is active
     const hasHighlighting = this.highlightedOids.size > 0;
 
     for (const node of nodes) {
-      const x = graphEndX - (node.lane + 1) * config.laneWidth + config.laneWidth / 2;
+      // Graph is mirrored: lane 0 is on the right, higher lanes extend left
+      const x = this.laneX(column, maxLane, node.lane, scrollLeft);
       const y = offsetY + node.row * config.rowHeight + this.HEADER_HEIGHT;
       const color = this.getBranchColor(node.colorIndex);
       const radius = this.getNodeRadius(node.oid);
@@ -1284,20 +1454,21 @@ export class CanvasRenderer {
    * Render ref labels and commit messages in fixed columns
    * Layout: [Branch Labels] | [Graph] | [Avatar] | [Message + Refs]
    */
-  private renderRefLabels(data: RenderData): void {
+  private renderRefLabels(data: RenderData, column: GraphColumnLayout): void {
     const { ctx, config, theme } = this;
-    const { nodes, offsetX, offsetY, refsByCommit, maxLane } = data;
+    const { nodes, offsetY, refsByCommit } = data;
 
     // Get canvas width for responsive layout
     const canvasWidth = this.canvas.width / this.dpr;
 
-    // Calculate column positions (left to right)
-    const graphEndX = offsetX + (maxLane + 1) * config.laneWidth;
-    const avatarColumnX = graphEndX + 20;
-    const avatarSize = 22;
-    const refsColumnX = avatarColumnX + avatarSize + 8;
+    // Calculate column positions (left to right) from the graph column's
+    // right edge, so they stay on screen however many lanes the graph has
+    const graphEndX = column.right;
+    const avatarColumnX = graphEndX + CanvasRenderer.GRAPH_TO_AVATAR_GAP;
+    const avatarSize = CanvasRenderer.AVATAR_SIZE;
+    const refsColumnX = avatarColumnX + avatarSize + CanvasRenderer.AVATAR_TO_REFS_GAP;
     const refsColumnWidth = config.refsColumnWidth;
-    const messageColumnX = refsColumnX + refsColumnWidth + 12;
+    const messageColumnX = refsColumnX + refsColumnWidth + CanvasRenderer.REFS_TO_MESSAGE_GAP;
 
     // Right-aligned columns (use config values)
     const {
@@ -2222,21 +2393,23 @@ export class CanvasRenderer {
    * @returns Object with column boundary X positions
    */
   getColumnBoundaries(maxLane: number, offsetX: number): {
+    graphEnd: number;
     refsEnd: number;
     statsStart: number;
   } {
     const { config } = this;
 
     // Calculate column positions (must match renderRefLabels logic)
-    const graphEndX = offsetX + (maxLane + 1) * config.laneWidth;
-    const avatarColumnX = graphEndX + 20;
-    const avatarSize = 22;
-    const refsColumnX = avatarColumnX + avatarSize + 8;
+    const graphEndX = this.getGraphColumnLayout(maxLane, offsetX).right;
+    const avatarColumnX = graphEndX + CanvasRenderer.GRAPH_TO_AVATAR_GAP;
+    const refsColumnX =
+      avatarColumnX + CanvasRenderer.AVATAR_SIZE + CanvasRenderer.AVATAR_TO_REFS_GAP;
     const refsColumnWidth = config.refsColumnWidth;
 
     const { statsColumnX } = this.getRightColumnLayout();
 
     return {
+      graphEnd: graphEndX,
       refsEnd: refsColumnX + refsColumnWidth,
       statsStart: statsColumnX,
     };

--- a/src/graph/graph-column.ts
+++ b/src/graph/graph-column.ts
@@ -1,0 +1,139 @@
+/**
+ * Graph column geometry.
+ *
+ * The lane area of the commit graph used to be as wide as its lane count:
+ * a repository with dozens of unmerged branches pushed the commit message,
+ * author and stats columns off the right edge of the canvas, and nothing
+ * could scroll them back into view. The graph now lives in a bounded
+ * column that scrolls horizontally on its own, and every text column is
+ * anchored to that column's right edge instead of to the lane count.
+ *
+ * Coordinate model (all values in CSS pixels):
+ *
+ * - The lanes are laid out mirrored: lane 0 (the mainline) is the rightmost
+ *   drawn column and higher lanes extend to the left, so the most important
+ *   lanes sit next to the commit message.
+ * - `scrollLeft` is a normal left-to-right scroll offset over the full lane
+ *   strip: 0 shows the leftmost (highest-numbered) lanes, `maxScrollLeft`
+ *   shows lane 0 against the column's right edge. The "home" position is
+ *   `maxScrollLeft`; callers keep the view pinned there while the lane
+ *   count grows (see `reconcileScrollLeft`).
+ * - The screen x of a lane is `left + (maxLane - lane) * laneWidth +
+ *   laneWidth / 2 - scrollLeft`, which is exactly the spatial index's graph
+ *   coordinate minus the scroll offset.
+ */
+
+/** Fewest lanes the column keeps visible, whatever the text columns need */
+export const MIN_VISIBLE_LANES = 3;
+
+/** Share of the canvas width the column takes when the user has not sized it */
+export const AUTO_GRAPH_COLUMN_SHARE = 0.35;
+
+export interface GraphColumnParams {
+  /** Highest lane number in the layout */
+  maxLane: number;
+  /** Width of one lane in pixels */
+  laneWidth: number;
+  /** Screen x of the column's left edge */
+  left: number;
+  /** Width the user (or the automatic default) asked for */
+  preferredWidth: number;
+  /**
+   * Hard cap that keeps the text columns at their minimum widths. May be
+   * smaller than `MIN_VISIBLE_LANES` lanes on tiny canvases; the lane
+   * minimum wins then.
+   */
+  maxWidth: number;
+}
+
+export interface GraphColumnLayout {
+  /** Screen x of the column's left edge */
+  left: number;
+  /** Screen x of the column's right edge (text columns start after this) */
+  right: number;
+  /** On-screen width of the lane area */
+  width: number;
+  /** Width of every lane laid side by side */
+  fullLaneWidth: number;
+  /** Largest valid `scrollLeft`; 0 when every lane fits */
+  maxScrollLeft: number;
+}
+
+/**
+ * Size the graph column. The column hugs the lanes when they fit, so
+ * narrow graphs look exactly as they did before the cap existed.
+ */
+export function computeGraphColumnLayout(params: GraphColumnParams): GraphColumnLayout {
+  const { maxLane, laneWidth, left, preferredWidth, maxWidth } = params;
+  const fullLaneWidth = (Math.max(0, maxLane) + 1) * laneWidth;
+  const minWidth = Math.min(fullLaneWidth, MIN_VISIBLE_LANES * laneWidth);
+  const capped = Math.min(fullLaneWidth, preferredWidth, maxWidth);
+  const width = Math.max(minWidth, Math.floor(capped));
+
+  return {
+    left,
+    right: left + width,
+    width,
+    fullLaneWidth,
+    maxScrollLeft: Math.max(0, fullLaneWidth - width),
+  };
+}
+
+/** Clamp a scroll offset into the column's valid range */
+export function clampScrollLeft(layout: GraphColumnLayout, scrollLeft: number): number {
+  if (!Number.isFinite(scrollLeft)) return layout.maxScrollLeft;
+  return Math.max(0, Math.min(scrollLeft, layout.maxScrollLeft));
+}
+
+/**
+ * Carry a scroll offset across a layout change. A view parked at the home
+ * position (lane 0 against the right edge) stays there even when more
+ * lanes arrive, because that is where the user expects the mainline; any
+ * other offset is scaled (for zoom changes) and clamped.
+ *
+ * @param previousMaxScrollLeft The old layout's `maxScrollLeft`
+ * @param scaleX Ratio of new to old lane width (1 when unchanged)
+ */
+export function reconcileScrollLeft(
+  layout: GraphColumnLayout,
+  scrollLeft: number,
+  previousMaxScrollLeft: number,
+  scaleX = 1
+): number {
+  const wasHome = scrollLeft >= previousMaxScrollLeft - 0.5;
+  if (wasHome) return layout.maxScrollLeft;
+  return clampScrollLeft(layout, scrollLeft * scaleX);
+}
+
+/** Screen x of a lane's centre for the given scroll offset */
+export function laneScreenX(
+  layout: GraphColumnLayout,
+  laneWidth: number,
+  maxLane: number,
+  lane: number,
+  scrollLeft: number
+): number {
+  return layout.left + (maxLane - lane) * laneWidth + laneWidth / 2 - scrollLeft;
+}
+
+/**
+ * How many whole lanes are scrolled out of view on each side. Drives the
+ * "N more" hints in the column header.
+ */
+export function hiddenLaneCounts(
+  layout: GraphColumnLayout,
+  laneWidth: number,
+  scrollLeft: number
+): { left: number; right: number } {
+  if (layout.maxScrollLeft === 0 || laneWidth <= 0) return { left: 0, right: 0 };
+  const clamped = clampScrollLeft(layout, scrollLeft);
+  return {
+    left: Math.floor(clamped / laneWidth + 1e-6),
+    right: Math.floor((layout.maxScrollLeft - clamped) / laneWidth + 1e-6),
+  };
+}
+
+/** Whether a screen x falls inside the column (where lanes are painted) */
+export function isInsideGraphColumn(layout: GraphColumnLayout, x: number): boolean {
+  return x >= layout.left && x <= layout.right;
+}

--- a/src/graph/virtual-scroll.ts
+++ b/src/graph/virtual-scroll.ts
@@ -22,12 +22,21 @@ export interface VirtualScrollConfig {
 export interface Viewport {
   /** Scroll position from top */
   scrollTop: number;
-  /** Scroll position from left */
+  /**
+   * Horizontal scroll of the graph (lane) column, in pixels over the full
+   * lane strip: 0 shows the highest-numbered lanes, the maximum shows
+   * lane 0 against the column's right edge. See `graph-column.ts`.
+   */
   scrollLeft: number;
   /** Visible width */
   width: number;
   /** Visible height */
   height: number;
+  /**
+   * On-screen width of the graph column. Lanes outside it are clipped, so
+   * horizontal culling uses this instead of `width` when set.
+   */
+  graphColumnWidth?: number;
 }
 
 export interface VisibleRange {
@@ -63,9 +72,16 @@ export interface RenderData {
   edges: LayoutEdge[];
   /** Visible range */
   range: VisibleRange;
-  /** Offset for rendering (accounts for scroll position) */
+  /**
+   * Screen x of the graph column's left edge (the graph padding). Unlike
+   * `offsetY` it does NOT include the scroll: the renderer scrolls lanes
+   * inside the column using `scrollLeft`.
+   */
   offsetX: number;
+  /** Vertical offset for rendering (accounts for scroll position) */
   offsetY: number;
+  /** Horizontal scroll of the graph column (see `Viewport.scrollLeft`) */
+  scrollLeft: number;
   /** Refs by commit OID */
   refsByCommit: RefsByCommit;
   /** Author emails by commit OID for avatar loading */
@@ -231,10 +247,18 @@ export class VirtualScrollManager {
     );
 
     // Visible drawn columns, measured from the left edge of the graph, +/-2
-    // columns of overscan
-    const startColumn = Math.floor((viewport.scrollLeft - padding) / laneWidth) - 2;
-    const endColumn =
-      Math.ceil((viewport.scrollLeft + viewport.width - padding) / laneWidth) + 2;
+    // columns of overscan. With a bounded graph column the lanes scroll
+    // inside it, so the visible strip is [scrollLeft, scrollLeft + column
+    // width]; without one the whole viewport shows lanes.
+    let startColumn: number;
+    let endColumn: number;
+    if (viewport.graphColumnWidth !== undefined) {
+      startColumn = Math.floor(viewport.scrollLeft / laneWidth) - 2;
+      endColumn = Math.ceil((viewport.scrollLeft + viewport.graphColumnWidth) / laneWidth) + 2;
+    } else {
+      startColumn = Math.floor((viewport.scrollLeft - padding) / laneWidth) - 2;
+      endColumn = Math.ceil((viewport.scrollLeft + viewport.width - padding) / laneWidth) + 2;
+    }
 
     // The graph is mirrored — lane L is DRAWN at column (maxLane - L), lane 0
     // on the right (see renderEdges/renderNodes in canvas-renderer) — so the
@@ -258,8 +282,9 @@ export class VirtualScrollManager {
       nodes,
       edges,
       range,
-      offsetX: this.config.padding - viewport.scrollLeft,
+      offsetX: this.config.padding,
       offsetY: this.config.padding - viewport.scrollTop,
+      scrollLeft: viewport.scrollLeft,
       refsByCommit: this.refsByCommit,
       authorEmails: this.authorEmails,
       maxLane: this.layout?.maxLane ?? 0,
@@ -350,38 +375,47 @@ export class VirtualScrollManager {
   }
 
   /**
-   * Scroll to bring a specific node into view
+   * Scroll to bring a specific node into view.
+   *
+   * Horizontally the node's lane is measured on the mirrored strip (lane 0
+   * is the rightmost drawn column) and brought inside the graph column;
+   * when every lane already fits, `scrollLeft` is 0.
    */
   scrollToNode(
     node: LayoutNode,
     viewport: Viewport,
     align: 'start' | 'center' | 'end' = 'center'
   ): { scrollTop: number; scrollLeft: number } {
-    const nodeY = node.row * this.config.rowHeight + this.config.padding;
-    const nodeX = node.lane * this.config.laneWidth + this.config.padding;
+    const { rowHeight, laneWidth, padding } = this.config;
+    const maxLane = this.layout?.maxLane ?? 0;
+    const nodeY = node.row * rowHeight + padding;
+    // Lane offset along the strip, from its left edge
+    const laneX = (maxLane - node.lane) * laneWidth;
+    const columnWidth = viewport.graphColumnWidth ?? viewport.width - padding * 2;
 
     let scrollTop: number;
     let scrollLeft: number;
 
     switch (align) {
       case 'start':
-        scrollTop = nodeY - this.config.padding;
-        scrollLeft = nodeX - this.config.padding;
+        scrollTop = nodeY - padding;
+        scrollLeft = laneX;
         break;
       case 'end':
-        scrollTop = nodeY - viewport.height + this.config.rowHeight + this.config.padding;
-        scrollLeft = nodeX - viewport.width + this.config.laneWidth + this.config.padding;
+        scrollTop = nodeY - viewport.height + rowHeight + padding;
+        scrollLeft = laneX - columnWidth + laneWidth;
         break;
       case 'center':
       default:
         scrollTop = nodeY - viewport.height / 2;
-        scrollLeft = nodeX - viewport.width / 2;
+        scrollLeft = laneX + laneWidth / 2 - columnWidth / 2;
     }
 
     // Clamp to valid range
-    const { width, height } = this.getContentSize();
+    const { height } = this.getContentSize();
+    const fullLaneWidth = (maxLane + 1) * laneWidth;
     scrollTop = Math.max(0, Math.min(scrollTop, height - viewport.height));
-    scrollLeft = Math.max(0, Math.min(scrollLeft, width - viewport.width));
+    scrollLeft = Math.max(0, Math.min(scrollLeft, fullLaneWidth - columnWidth));
 
     return { scrollTop, scrollLeft };
   }


### PR DESCRIPTION
## Problem

A repository with dozens of unmerged branches (e.g. many open `pr-*` branches) lays out more graph lanes than the canvas is wide. Every text column was positioned from the lane count (`offsetX + (maxLane + 1) * laneWidth`), so the avatar, refs, commit message, author and date columns were pushed off the right edge, the right-anchored stats and time columns painted over the lanes, and nothing could scroll them back into view: the horizontal scroll range covered the lanes only, and the scrollbar container hid the horizontal axis.

## Fix

The graph now lives in a bounded column that scrolls horizontally on its own. The text columns are anchored to the column's right edge, so they stay on screen however many lanes the graph has.

- **`src/graph/graph-column.ts`** (new): pure geometry. The column hugs the lanes when they fit, so narrow repos are unchanged. Otherwise it is capped at a user-set width or an automatic 35% of the canvas, and never wider than what keeps the message column at its 160px minimum. A floor keeps at least three lanes visible.
- **Renderer**: lanes are drawn relative to the column and clipped to it; the cut edges fade, and the GRAPH header shows `◂ N more` / `N more ▸` for lanes hidden on each side. `getColumnBoundaries` gains `graphEnd`.
- **Component**: a native horizontal scrollbar under the column (only while lanes overflow), a third resize handle at the column edge persisted with the other column widths, sideways wheel scrolling (trackpad and shift+wheel), and Left/Right arrow keys stepping three lanes. Hit-testing only consults the spatial index inside the column, so a clipped node cannot be hovered through the message text. Scroll-to-node now measures the mirrored lane position (the old code assumed lanes grew to the right).
- **Home position**: lane 0 (the mainline) sits against the column's right edge by default and stays there as older pages add lanes, across zoom, window resize and column resize. A view scrolled away from home is scaled on zoom and clamped instead.
- **Virtual scroller**: culls lanes by the column width and reports `scrollLeft` separately from the column origin (`offsetX` is now the padding).

## Tests

- `src/graph/__tests__/graph-column.test.ts` (new): geometry, clamping, home-position reconciliation, hidden-lane counts.
- `canvas-renderer.test.ts`: column cap, message minimum, resize-handle anchoring, lane positions at each scroll, clipping, header hints.
- `virtual-scroll.test.ts`: column-aware culling and `scrollToNode`.
- `lv-graph-canvas-graph-column.test.ts` (new): scrollbar, wheel, shift+wheel, arrow keys, native scrollbar sync, hit-testing, resize handle + persistence, zoom, narrow-graph no-op, restored settings.
- `e2e/tests/graph.spec.ts`: five cases on an 80-branch fixture covering layout, wheel, arrow keys, the native scrollbar and the resize handle.

Full gate run locally: lint, typecheck, unit tests (6824 passing), graph E2E (57 passing), `cargo fmt --check`. No Rust changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ADc1kMheMbskgJQcCQTuek

---
_Generated by [Claude Code](https://claude.ai/code/session_01ADc1kMheMbskgJQcCQTuek)_