### PR TITLE
site: version asset URLs at deploy time so replaced images are not cached

### DIFF
--- a/.github/scripts/version-site-assets.mjs
+++ b/.github/scripts/version-site-assets.mjs
@@ -1,0 +1,82 @@
+/**
+ * Versions the asset URLs in the website before it is deployed.
+ *
+ * gitnado.dev is served through Cloudflare and GitHub Pages, both of which
+ * cache images for hours, and browsers cache them for as long again. An asset
+ * replaced under the same name therefore keeps showing its old contents until
+ * every cache expires. Appending `?v=<content hash>` to each reference gives a
+ * changed file a new URL, so caches fetch it immediately, while an unchanged
+ * file keeps its URL and stays cached.
+ *
+ * Run by .github/workflows/pages.yml against the checked-out site/ directory
+ * just before upload; the committed HTML keeps the plain paths so local
+ * previews need no build step.
+ */
+
+import { createHash } from "node:crypto";
+import { readFileSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+/** Matches `assets/<file>.<ext>` wherever it appears in an attribute value. */
+const ASSET_REF =
+  /assets\/([A-Za-z0-9_.-]+\.(?:webp|png|jpe?g|gif|svg|ico))(?=["'\s),?])/g;
+
+/** Short content hash used as the version tag. */
+export function hashFile(path) {
+  return createHash("sha256")
+    .update(readFileSync(path))
+    .digest("hex")
+    .slice(0, 8);
+}
+
+/**
+ * Rewrites every asset reference in `html` to carry `?v=<hash>`, where
+ * `hashFor(fileName)` returns the hash for that asset. References that already
+ * carry a query string are left alone. Returns the new HTML and the list of
+ * files it versioned.
+ */
+export function versionAssets(html, hashFor) {
+  const versioned = new Set();
+  const out = html.replace(ASSET_REF, (match, file, offset, whole) => {
+    if (whole[offset + match.length] === "?") return match;
+    versioned.add(file);
+    return `${match}?v=${hashFor(file)}`;
+  });
+  return { html: out, files: [...versioned].sort() };
+}
+
+/**
+ * Versions `index.html` inside `siteDir` in place, hashing files from its
+ * `assets/` directory. A reference to a file that does not exist is an error:
+ * shipping a dangling asset URL is exactly what this step exists to prevent.
+ */
+export function versionSite(siteDir, { log = console.log } = {}) {
+  const page = join(siteDir, "index.html");
+  const { html, files } = versionAssets(readFileSync(page, "utf8"), (file) => {
+    try {
+      return hashFile(join(siteDir, "assets", file));
+    } catch (error) {
+      throw new Error(
+        `index.html references assets/${file}, which does not exist (${error.code})`,
+      );
+    }
+  });
+  writeFileSync(page, html);
+  for (const file of files) log(`versioned assets/${file}`);
+  return files;
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  const dir = process.argv[2];
+  if (!dir) {
+    console.error("usage: node version-site-assets.mjs <site directory>");
+    process.exit(1);
+  }
+  try {
+    versionSite(dir);
+  } catch (error) {
+    console.error(error.message);
+    process.exit(1);
+  }
+}

--- a/.github/scripts/version-site-assets.test.mjs
+++ b/.github/scripts/version-site-assets.test.mjs
@@ -1,0 +1,170 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  cpSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  hashFile,
+  versionAssets,
+  versionSite,
+} from "./version-site-assets.mjs";
+
+const SCRIPT = fileURLToPath(
+  new URL("./version-site-assets.mjs", import.meta.url),
+);
+const REAL_SITE = fileURLToPath(new URL("../../site/", import.meta.url));
+const PAGES_YML = readFileSync(
+  fileURLToPath(new URL("../workflows/pages.yml", import.meta.url)),
+  "utf8",
+);
+
+const hashes = {
+  "a.png": "11111111",
+  "b.webp": "22222222",
+  "c.svg": "33333333",
+};
+const hashFor = (file) => {
+  if (!(file in hashes)) throw new Error(`no hash for ${file}`);
+  return hashes[file];
+};
+
+test("versionAssets tags every kind of reference and reports the files", () => {
+  const html = [
+    '<link rel="icon" href="assets/a.png">',
+    '<meta property="og:image" content="https://gitnado.dev/assets/b.webp">',
+    '<img src="assets/b.webp" srcset="assets/a.png 256w, assets/c.svg 512w">',
+    "<div style=\"background:url('assets/a.png')\"></div>",
+  ].join("\n");
+  const { html: out, files } = versionAssets(html, hashFor);
+  assert.equal(
+    out,
+    [
+      '<link rel="icon" href="assets/a.png?v=11111111">',
+      '<meta property="og:image" content="https://gitnado.dev/assets/b.webp?v=22222222">',
+      '<img src="assets/b.webp?v=22222222" srcset="assets/a.png?v=11111111 256w, assets/c.svg?v=33333333 512w">',
+      "<div style=\"background:url('assets/a.png?v=11111111')\"></div>",
+    ].join("\n"),
+  );
+  assert.deepEqual(files, ["a.png", "b.webp", "c.svg"]);
+});
+
+test("versionAssets leaves references that already carry a query string alone", () => {
+  const html = '<img src="assets/a.png?v=old"> <img src="assets/b.webp">';
+  const { html: out, files } = versionAssets(html, hashFor);
+  assert.equal(
+    out,
+    '<img src="assets/a.png?v=old"> <img src="assets/b.webp?v=22222222">',
+  );
+  assert.deepEqual(files, ["b.webp"]);
+});
+
+test("versionAssets is idempotent and ignores non-asset paths", () => {
+  const html =
+    '<a href="https://github.com/hegsie/gitnado/releases">x</a> <script src="app.js"></script> <img src="assets/a.png">';
+  const once = versionAssets(html, hashFor).html;
+  assert.equal(versionAssets(once, hashFor).html, once);
+  assert.match(once, /assets\/a\.png\?v=11111111/);
+  assert.doesNotMatch(once, /releases\?v=|app\.js\?v=/);
+});
+
+test("hashFile is a short, stable content hash", () => {
+  const dir = mkdtempSync(join(tmpdir(), "site-hash-"));
+  const file = join(dir, "x.bin");
+  writeFileSync(file, "gitnado");
+  assert.equal(hashFile(file), "9ced9f4c");
+  writeFileSync(file, "gitnado!");
+  assert.notEqual(hashFile(file), "9ced9f4c");
+});
+
+function siteFixture() {
+  const dir = mkdtempSync(join(tmpdir(), "site-fixture-"));
+  mkdirSync(join(dir, "assets"));
+  writeFileSync(join(dir, "assets", "shot.webp"), "first");
+  writeFileSync(
+    join(dir, "index.html"),
+    '<img src="assets/shot.webp"><meta content="https://gitnado.dev/assets/shot.webp">',
+  );
+  return dir;
+}
+
+test("versionSite rewrites index.html in place and the tag changes with the file", () => {
+  const dir = siteFixture();
+  const logs = [];
+  assert.deepEqual(versionSite(dir, { log: (l) => logs.push(l) }), [
+    "shot.webp",
+  ]);
+  const first = readFileSync(join(dir, "index.html"), "utf8");
+  const tag = hashFile(join(dir, "assets", "shot.webp"));
+  assert.equal(
+    first,
+    `<img src="assets/shot.webp?v=${tag}"><meta content="https://gitnado.dev/assets/shot.webp?v=${tag}">`,
+  );
+  assert.deepEqual(logs, ["versioned assets/shot.webp"]);
+
+  // A replaced asset gets a new URL on the next deploy.
+  writeFileSync(join(dir, "assets", "shot.webp"), "second");
+  writeFileSync(join(dir, "index.html"), '<img src="assets/shot.webp">');
+  versionSite(dir, { log() {} });
+  assert.notEqual(
+    readFileSync(join(dir, "index.html"), "utf8"),
+    `<img src="assets/shot.webp?v=${tag}">`,
+  );
+});
+
+test("versionSite fails on a reference to a missing asset", () => {
+  const dir = siteFixture();
+  writeFileSync(join(dir, "index.html"), '<img src="assets/missing.png">');
+  assert.throws(
+    () => versionSite(dir, { log() {} }),
+    /assets\/missing\.png, which does not exist/,
+  );
+});
+
+test("the real site versions cleanly and every referenced asset exists", () => {
+  const dir = mkdtempSync(join(tmpdir(), "site-real-"));
+  cpSync(REAL_SITE, dir, { recursive: true });
+  const files = versionSite(dir, { log() {} });
+  assert.ok(files.includes("main-window.webp"));
+  assert.ok(files.includes("icon-256.png"));
+  const html = readFileSync(join(dir, "index.html"), "utf8");
+  assert.doesNotMatch(
+    html,
+    /assets\/[A-Za-z0-9_.-]+\.(?:webp|png|svg|ico)["'\s)]/,
+    "an asset reference was left unversioned",
+  );
+  assert.match(
+    html,
+    /og:image" content="https:\/\/gitnado\.dev\/assets\/main-window\.webp\?v=[0-9a-f]{8}"/,
+  );
+});
+
+test("the CLI versions a directory and reports a missing asset with exit code 1", () => {
+  const dir = siteFixture();
+  const ok = spawnSync(process.execPath, [SCRIPT, dir], { encoding: "utf8" });
+  assert.equal(ok.status, 0, ok.stderr);
+  assert.match(ok.stdout, /versioned assets\/shot\.webp/);
+  writeFileSync(join(dir, "index.html"), '<img src="assets/nope.png">');
+  const bad = spawnSync(process.execPath, [SCRIPT, dir], { encoding: "utf8" });
+  assert.equal(bad.status, 1);
+  assert.match(bad.stderr, /nope\.png/);
+  const noArg = spawnSync(process.execPath, [SCRIPT], { encoding: "utf8" });
+  assert.equal(noArg.status, 1);
+});
+
+test("pages.yml runs the versioning step before uploading the site", () => {
+  const run = PAGES_YML.indexOf(
+    "node .github/scripts/version-site-assets.mjs site",
+  );
+  const upload = PAGES_YML.indexOf("actions/upload-pages-artifact");
+  assert.ok(run > 0, "pages.yml does not run version-site-assets.mjs");
+  assert.ok(run < upload, "versioning must happen before the upload");
+});

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -36,6 +36,11 @@ jobs:
       - name: Configure Pages
         uses: actions/configure-pages@v5
 
+      # Append ?v=<content hash> to every asset URL so a replaced image gets a
+      # new URL and is not served stale from Cloudflare, Pages or browser caches.
+      - name: Version asset URLs
+        run: node .github/scripts/version-site-assets.mjs site
+
       - name: Upload site
         uses: actions/upload-pages-artifact@v3
         with:

--- a/docs/website.md
+++ b/docs/website.md
@@ -7,6 +7,14 @@ page, a few assets, no build step) and is published to GitHub Pages by
 API at load time to fill in version-specific download links, and falls back to
 the Releases page if that request fails.
 
+Asset URLs are versioned at deploy time: the workflow runs
+[`.github/scripts/version-site-assets.mjs`](../.github/scripts/version-site-assets.mjs),
+which appends `?v=<content hash>` to every `assets/…` reference in
+`index.html`. Replace an image under the same file name and the deployed page
+points at a new URL, so Cloudflare, GitHub Pages and browsers (which cache
+images for hours) pick it up on the next load. The committed HTML keeps plain
+paths, so opening `site/index.html` locally needs no build step.
+
 ## One-time setup
 
 1. **Enable Pages from Actions.** Repository *Settings → Pages → Build and


### PR DESCRIPTION
## Summary

After #540 the origin served the new screenshot, but gitnado.dev sits behind Cloudflare and GitHub Pages, which cache images with `max-age=14400` (4 h), and browsers cache them for as long again. Because the file kept its name, visitors kept seeing the old Leviathan screenshot until every cache expired.

This makes that impossible to repeat:

- `.github/scripts/version-site-assets.mjs` appends `?v=<8-char content hash>` to every `assets/…` reference in `site/index.html` (`img src` and `srcset`, icon `link`s, `og:image`). A changed file gets a new URL and is fetched fresh; an unchanged file keeps its URL and stays cached. A reference to a missing asset fails the deploy.
- `pages.yml` runs it against the checked-out `site/` before `upload-pages-artifact`. The committed HTML keeps plain paths, so opening `site/index.html` locally needs no build step.
- `docs/website.md` explains the mechanism.
- Nine node tests in `version-site-assets.test.mjs`, including one that runs the real `site/` through it and asserts nothing is left unversioned and every referenced asset exists. Picked up by the existing `node --test .github/scripts/*.test.mjs` CI step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoUA6Psr1kPCJK3pFMie8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoUA6Psr1kPCJK3pFMie8F)_