### PR TITLE
packaging: declare VC++ and WebView2 dependencies in the winget manifest

### DIFF
--- a/.github/scripts/winget-manifests.test.mjs
+++ b/.github/scripts/winget-manifests.test.mjs
@@ -174,6 +174,12 @@ test("renderManifests produces the three winget manifests with no placeholders l
     installer,
     /InstallModes:\n- interactive\n- silent\n- silentWithProgress/,
   );
+  // The app imports MSVCP140.dll (VC++ 2015+ redistributable) and needs WebView2;
+  // declaring both lets winget install them first on a clean machine.
+  assert.match(
+    installer,
+    /Dependencies:\n {2}PackageDependencies:\n {2}- PackageIdentifier: Microsoft\.VCRedist\.2015\+\.x64\n {2}- PackageIdentifier: Microsoft\.EdgeWebView2Runtime\n/,
+  );
 
   const locale = manifests["hegsie.Gitnado.locale.en-US.yaml"];
   assert.equal(topLevel(locale, "ManifestType"), "defaultLocale");

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -48,9 +48,14 @@ One-time setup:
 Users install with `winget install hegsie.Gitnado`.
 
 New-package PRs go through winget-pkgs moderation and typically take a few
-days; the automated executable check may flag a
-`Validation-Executable-Error` because the app needs the WebView2 runtime and
-a desktop session — a short comment on the PR saying so helps the moderator.
+days. The installer manifest declares `Microsoft.VCRedist.2015+.x64` and
+`Microsoft.EdgeWebView2Runtime` as package dependencies: `gitnado.exe`
+imports `MSVCP140.dll`, which only ships with the VC++ redistributable, so
+without it the app exits with `STATUS_DLL_NOT_FOUND` on a clean Windows
+install (this is what the winget validation sandbox hit on the first
+submission). If the executable check still flags a
+`Validation-Executable-Error`, a short comment on the PR explaining that the
+app needs a desktop session helps the moderator.
 If the Komac step ever fails, render the manifests locally with the same
 script and submit them by hand: `node .github/scripts/winget-manifests.mjs
 --version <v> --exe <exe> --msi <msi> --msi-analysis <komac analyze output>

--- a/packaging/winget/hegsie.Gitnado.installer.yaml.template
+++ b/packaging/winget/hegsie.Gitnado.installer.yaml.template
@@ -10,6 +10,13 @@ InstallModes:
 - silent
 - silentWithProgress
 UpgradeBehavior: install
+# gitnado.exe imports MSVCP140.dll, which only ships with the VC++ 2015+
+# redistributable; WebView2 is the embedded browser. winget installs both
+# first, so the app starts on a clean Windows (winget-pkgs#431940 review).
+Dependencies:
+  PackageDependencies:
+  - PackageIdentifier: Microsoft.VCRedist.2015+.x64
+  - PackageIdentifier: Microsoft.EdgeWebView2Runtime
 ReleaseDate: {{RELEASE_DATE}}
 Installers:
 - Architecture: x64


### PR DESCRIPTION
## Summary

The winget validation sandbox for [microsoft/winget-pkgs#431940](https://github.com/microsoft/winget-pkgs/pull/431940) ran `gitnado.exe` and got exit code -1073741515 (`STATUS_DLL_NOT_FOUND`). Inspecting the 0.9.0 binary's import table shows it links `MSVCP140.dll`, which only ships with the Visual C++ 2015+ redistributable, so on a clean Windows install the app cannot start.

- `packaging/winget/hegsie.Gitnado.installer.yaml.template` now declares `Microsoft.VCRedist.2015+.x64` and `Microsoft.EdgeWebView2Runtime` as package dependencies, so winget installs them before Gitnado. winget-releaser carries the block forward on later releases.
- The render test asserts the block is present; `docs/packaging.md` explains why.

The open winget-pkgs PR gets the same block added by hand (it lives on the `hegsie/winget-pkgs` fork, outside this repository).

Follow-up worth considering separately: link the CRT statically (`-C target-feature=+crt-static` for the MSVC target) so direct downloads don't depend on the redistributable either.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoUA6Psr1kPCJK3pFMie8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoUA6Psr1kPCJK3pFMie8F)_