### PR TITLE
ci: sync the winget fork before submitting, and stop rebuilding on tag push

### DIFF
--- a/.github/scripts/winget-manifests.test.mjs
+++ b/.github/scripts/winget-manifests.test.mjs
@@ -371,6 +371,12 @@ test("publish-packages.yml renders the manifests with this script and submits th
   assert.match(WORKFLOW, /node \.github\/scripts\/winget-manifests\.mjs/);
   assert.match(WORKFLOW, /komac analyze setup\.msi/);
   assert.match(WORKFLOW, /komac submit --yes/);
+  // The fork must be synced before the branch is created (Komac #1142).
+  assert.ok(
+    WORKFLOW.indexOf("komac sync") > 0 &&
+      WORKFLOW.indexOf("komac sync") < WORKFLOW.indexOf("komac submit --yes"),
+    "komac sync must run before komac submit",
+  );
   // A comment may mention it; a run step must never invoke it.
   assert.doesNotMatch(
     WORKFLOW,

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-    tags:
-      - 'v*'
   pull_request:
     branches:
       - main
@@ -16,12 +14,12 @@ on:
         type: boolean
         default: false
 
-# Builds of the same ref supersede each other, but a release — a tag push,
-# or a manual dispatch with the release input — must not be cancelled by a
-# later push to main (that is what happened to the first v0.9.1 build), so
-# a release run gets its own group.
+# Builds of the same ref supersede each other, but a release build (a manual
+# dispatch with the release input) must not be cancelled by a later push to
+# main (that is what happened to the first v0.9.1 build), so a release run
+# gets its own group.
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}${{ (startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release)) && '-release' || '' }}
+  group: ${{ github.workflow }}-${{ github.ref }}${{ ((github.event_name == 'workflow_dispatch' && inputs.release)) && '-release' || '' }}
   cancel-in-progress: true
 
 permissions:
@@ -33,7 +31,7 @@ env:
 jobs:
   test-e2e:
     name: E2E Tests
-    if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release)
+    if: (github.event_name == 'workflow_dispatch' && inputs.release)
     runs-on: ubuntu-latest
 
     steps:
@@ -146,16 +144,19 @@ jobs:
       - name: Build frontend
         run: npm run build
 
-      # Build without release for non-tag pushes (skip signing, use specific bundles)
+      # Build without release for ordinary pushes and pull requests (skip signing, use specific bundles)
       - name: Build Tauri app
-        if: ${{ !(startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release)) }}
+        if: ${{ !((github.event_name == 'workflow_dispatch' && inputs.release)) }}
         run: npm run tauri build -- --target ${{ matrix.target }} --bundles ${{ matrix.bundles }} --no-sign
 
-      # Build with release for tagged pushes, or a manual dispatch with the
-      # release input — tauri-action then creates the v__VERSION__ tag (from
-      # tauri.conf.json) and the draft release itself.
+      # Build with release for a manual dispatch with the release input —
+      # tauri-action creates the draft release named after the version in
+      # tauri.conf.json, and publishing that draft creates the tag. A tag push
+      # deliberately does not trigger a build: a second build after publishing
+      # replaced the v0.9.0 assets that the package channels had already
+      # hashed, and opened a duplicate draft for v0.9.1.
       - name: Build Tauri app (Release)
-        if: startsWith(github.ref, 'refs/tags/v') || (github.event_name == 'workflow_dispatch' && inputs.release)
+        if: (github.event_name == 'workflow_dispatch' && inputs.release)
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-packages.yml
+++ b/.github/workflows/publish-packages.yml
@@ -147,6 +147,11 @@ jobs:
             --release-date "$release_date" \
             --out winget | tail -n 1)
           cat "${manifests}"/*.yaml
+          # Komac creates the PR branch on the fork from upstream's latest
+          # commit; if the fork has fallen behind, GitHub refuses with a
+          # misleading "permissions to execute CreateRef" error (Komac #1142),
+          # so bring the fork's default branch up to date first.
+          komac sync
           komac submit --yes "${manifests}"
 
   homebrew:

--- a/docs/packaging.md
+++ b/docs/packaging.md
@@ -38,9 +38,12 @@ One-time setup:
    manifests from the templates in [`packaging/winget/`](../packaging/winget/)
    with [`.github/scripts/winget-manifests.mjs`](../.github/scripts/winget-manifests.mjs)
    (installer hashes from the downloaded assets, the MSI `ProductCode` from
-   `komac analyze`, the release date from the GitHub release) and submits the
-   directory with [Komac](https://github.com/russellbanks/Komac)
-   `submit --yes`, which opens the "New package" PR. `komac new` is not used
+   `komac analyze`, the release date from the GitHub release), syncs the
+   winget-pkgs fork (Komac creates the PR branch from upstream's latest
+   commit, and an out-of-date fork makes GitHub refuse with a misleading
+   "permissions to execute CreateRef" error), and submits the directory with
+   [Komac](https://github.com/russellbanks/Komac) `submit --yes`, which opens
+   the "New package" PR. `komac new` is not used
    because it always prompts for install modes and cannot run unattended.
    Once that PR is merged, every later release takes the update path via
    winget-releaser.
@@ -113,6 +116,16 @@ bootstrap never executes; the manifest's `notes` tell users where to get
 WebView2 in the unlikely case it is missing. The manifest also carries
 `checkver`/`autoupdate` metadata so it could be adopted into a community
 bucket (e.g. Extras) unchanged.
+
+## Assets must not change after publishing
+
+Every channel records the SHA-256 of the assets at the moment the release is
+published, so the assets must never be replaced afterwards. `build.yml`
+therefore builds a release only from the manual dispatch that creates the
+draft; publishing the draft creates the tag, and a tag push does not start
+another build. (The v0.9.0 assets were rebuilt by a tag-push build minutes
+after publishing, which left the winget submission with stale hashes.) If a
+release ever needs different binaries, cut a new version instead.
 
 ## Release asset naming
 


### PR DESCRIPTION
## Summary

Two release-pipeline defects surfaced by v0.9.0 and v0.9.1.

**1. winget submission for v0.9.1 failed: "hegsie does not have the correct permissions to execute `CreateRef`".** Komac creates the PR branch on the `hegsie/winget-pkgs` fork from upstream's latest commit. The fork's `master` is still at its Sep 2 fork point, and GitHub reports the missing object as a permissions error ([Komac #1142](https://github.com/russellbanks/Komac/issues/1142)). `publish-packages.yml` now runs `komac sync` before `komac submit`; the render test asserts the order.

**2. The v0.9.0 assets were replaced after publishing.** Publishing the draft created the tag, the `push: tags: v*` trigger started a second release build, and tauri-action re-uploaded all assets at 13:34–13:37, after `publish-packages` had hashed the originals at 13:04 and after the winget PR was opened with those hashes. That PR now fails `Error-Hash-Mismatch`. For v0.9.1 the same path opened a duplicate draft instead. `build.yml` no longer builds on tag push: the manual dispatch with the release input is the only release build, and publishing the draft it creates is the end of the process. The `-release` concurrency group from #541 is kept for the dispatch path.

`docs/packaging.md` documents both: the fork sync, and that assets must not change after publishing.

## Follow-ups outside this PR

- Close [microsoft/winget-pkgs#431940](https://github.com/microsoft/winget-pkgs/pull/431940) (0.9.0 with stale hashes) and dispatch `publish-packages` for `v0.9.1` once this is merged; it will open a fresh submission with correct hashes, ProductCode and the dependency block from #544.
- Delete the leftover draft "Gitnado v0.9.1" (release 386125227) created by the tag-push build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LoUA6Psr1kPCJK3pFMie8F

---
_Generated by [Claude Code](https://claude.ai/code/session_01LoUA6Psr1kPCJK3pFMie8F)_