### PR TITLE
Fix credential handling for multi-account clones and keychain reads

### DIFF
--- a/e2e/tests/clone-from-account.spec.ts
+++ b/e2e/tests/clone-from-account.spec.ts
@@ -444,6 +444,55 @@ test.describe('Clone Dialog - from a connected account', () => {
       await expect(repoItems(page)).toHaveCount(2);
     });
 
+    test('switching provider shows that provider\'s account, not the previous one\'s', async ({
+      page,
+    }) => {
+      // The account selector used to keep the accounts of the provider it was
+      // mounted with: after GitHub → GitLab it showed the GitLab account as
+      // "No account selected" and its dropdown still offered the GitHub one.
+      const gitlabAccount: MockIntegrationAccount = {
+        id: 'gl-acc-1',
+        name: 'Work GitLab',
+        integrationType: 'gitlab',
+        config: { type: 'gitlab', instanceUrl: 'https://gitlab.com' },
+        color: '#fc6d26',
+        cachedUser: { username: 'gl-user', displayName: 'GitLab User', avatarUrl: null },
+        urlPatterns: [],
+        isDefault: true,
+      };
+      await initializeUnifiedProfileStore(page, {
+        profiles: [defaultProfile],
+        accounts: [githubAccount, gitlabAccount],
+        connectedAccounts: ['gh-acc-1', 'gl-acc-1'],
+      });
+      await injectCommandMock(page, {
+        list_gitlab_projects: {
+          repositories: [
+            repository('gl-project', {
+              owner: 'gl-user',
+              fullName: 'gl-user/gl-project',
+              cloneUrl: 'https://gitlab.com/gl-user/gl-project.git',
+            }),
+          ],
+          nextPage: null,
+        },
+      });
+      await openAccountSource(page, dialogs);
+      await expect(repoItems(page)).toHaveCount(2);
+
+      await page.locator('lv-clone-dialog #repo-provider').selectOption('gitlab');
+      await expect(repoItems(page)).toHaveCount(1);
+      await expect(repoItems(page).first()).toContainText('gl-project');
+
+      const selector = page.locator('lv-clone-dialog lv-account-selector');
+      await expect(selector.locator('.account-name')).toHaveText('Work GitLab');
+      await expect(selector.locator('.no-account')).toHaveCount(0);
+
+      await selector.locator('.selector-btn').click();
+      await expect(selector.locator('.dropdown-item')).toHaveCount(1);
+      await expect(selector.locator('.dropdown-item')).toContainText('Work GitLab');
+    });
+
     test('does not list anything until the account source is chosen', async ({ page }) => {
       await startCommandCapture(page);
       await new AppPage(page).cloneButton.click();
@@ -451,6 +500,136 @@ test.describe('Clone Dialog - from a connected account', () => {
       await expect(dialogs.clone.urlInput).toBeVisible();
 
       expect(await findCommand(page, 'list_github_repositories')).toHaveLength(0);
+    });
+  });
+
+  test.describe('with two GitHub accounts', () => {
+    const personalAccount: MockIntegrationAccount = {
+      id: 'gh-acc-2',
+      name: 'Personal GitHub',
+      integrationType: 'github',
+      config: { type: 'github' },
+      color: '#6e40c9',
+      cachedUser: { username: 'octodev', displayName: 'Octo Dev', avatarUrl: null },
+      urlPatterns: [],
+      isDefault: false,
+    };
+
+    test.beforeEach(async ({ page }) => {
+      await initializeUnifiedProfileStore(page, {
+        profiles: [defaultProfile],
+        accounts: [githubAccount, personalAccount],
+        connectedAccounts: ['gh-acc-1', 'gh-acc-2'],
+      });
+      // A token per account, and a listing that depends on which token asked,
+      // so both the listing's and the clone's choice of identity is visible.
+      await page.evaluate(() => {
+        const internals = (
+          window as unknown as {
+            __TAURI_INTERNALS__: { invoke: (cmd: string, args?: unknown) => Promise<unknown> };
+          }
+        ).__TAURI_INTERNALS__;
+        const original = internals.invoke;
+        const tokens: Record<string, string> = {
+          'github_token_gh-acc-1': 'work-tok',
+          'github_token_gh-acc-2': 'personal-tok',
+        };
+        const entry = (name: string, owner: string) => ({
+          id: name,
+          name,
+          owner,
+          fullName: `${owner}/${name}`,
+          description: null,
+          isPrivate: true,
+          cloneUrl: `https://github.com/${owner}/${name}.git`,
+          webUrl: null,
+          defaultBranch: 'main',
+          lastPushedAt: null,
+        });
+        internals.invoke = async (command: string, args?: unknown) => {
+          if (command === 'get_keyring_token') {
+            return tokens[(args as { key?: string }).key ?? ''] ?? null;
+          }
+          if (command === 'list_github_repositories') {
+            const token = (args as { token?: string }).token;
+            return {
+              repositories: [
+                token === 'personal-tok'
+                  ? entry('side-project', 'octodev')
+                  : entry('work-service', 'octocat'),
+              ],
+              nextPage: null,
+            };
+          }
+          if (command === 'clone_repository') {
+            return {
+              path: '/home/user/projects/side-project',
+              name: 'side-project',
+              headRef: null,
+              isBare: false,
+            };
+          }
+          return original(command, args);
+        };
+      });
+    });
+
+    test('clones a repository picked from the second account with that account\'s token', async ({
+      page,
+    }) => {
+      // The URL-host lookup lands on the DEFAULT GitHub account, so a private
+      // repository picked from the personal account cloned with the work
+      // token and failed as "not found".
+      await openAccountSource(page, dialogs);
+      await expect(repoItems(page)).toHaveCount(1);
+      await expect(repoItems(page).first()).toContainText('work-service');
+
+      const selector = page.locator('lv-clone-dialog lv-account-selector');
+      await selector.locator('.selector-btn').click();
+      await selector.locator('.dropdown-item', { hasText: 'Personal GitHub' }).click();
+      await expect(selector.locator('.account-name')).toHaveText('Personal GitHub');
+      await expect(repoItems(page).first()).toContainText('side-project');
+
+      await repoItems(page).first().click();
+      await expect(dialogs.clone.urlInput).toHaveValue(
+        'https://github.com/octodev/side-project.git',
+      );
+      await dialogs.clone.fillPath('/home/user/projects');
+
+      await startCommandCapture(page);
+      await dialogs.clone.clone();
+      await waitForCommand(page, 'clone_repository');
+
+      const args = (await findCommand(page, 'clone_repository'))[0].args as {
+        url?: string;
+        token?: string;
+      };
+      expect(args.url).toBe('https://github.com/octodev/side-project.git');
+      expect(args.token).toBe('personal-tok');
+    });
+
+    test('a URL typed over the picked one clones with the host default account again', async ({
+      page,
+    }) => {
+      await openAccountSource(page, dialogs);
+      const selector = page.locator('lv-clone-dialog lv-account-selector');
+      await selector.locator('.selector-btn').click();
+      await selector.locator('.dropdown-item', { hasText: 'Personal GitHub' }).click();
+      await expect(repoItems(page).first()).toContainText('side-project');
+      await repoItems(page).first().click();
+      await dialogs.clone.fillPath('/home/user/projects');
+
+      // The typed URL may belong to anyone: the personal token must not
+      // follow it, and the confirmation line must stop naming the pick.
+      await dialogs.clone.urlInput.fill('https://github.com/octocat/other.git');
+      await expect(page.getByText('Selected: octodev/side-project')).toHaveCount(0);
+
+      await startCommandCapture(page);
+      await dialogs.clone.clone();
+      await waitForCommand(page, 'clone_repository');
+
+      const args = (await findCommand(page, 'clone_repository'))[0].args as { token?: string };
+      expect(args.token).toBe('work-tok');
     });
   });
 

--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -1035,6 +1035,15 @@ fn write_keyring_token(service: &str, key: &str, value: &str) -> Result<()> {
                 "Failed to store token: {stderr}"
             )));
         }
+
+        // `security` exiting 0 is not proof the value landed: the password is
+        // handed over on stdin (kept out of argv on purpose) and a `security`
+        // that reads that prompt differently stores an empty item and still
+        // exits 0. That left a connected account whose token could never be
+        // read back — the sign-in reported success and every later read said
+        // "no stored credential". Read it back before reporting success, so
+        // the failure is seen at connect time, where reconnecting can fix it.
+        verify_keychain_write(key, value, read_keyring_token(service, key))?;
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -1048,7 +1057,86 @@ fn write_keyring_token(service: &str, key: &str, value: &str) -> Result<()> {
     Ok(())
 }
 
-/// Read `key` from `service`; `Ok(None)` when absent.
+/// `security` exit status for errSecItemNotFound: the one failure that means
+/// "no such entry" rather than "the keychain could not be read".
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+const SEC_ITEM_NOT_FOUND: i32 = 44;
+
+/// Turn a `security find-generic-password -w` result into the entry's value.
+///
+/// Only errSecItemNotFound is "absent". Everything else `security` can fail
+/// with — a locked keychain, "User interaction is not allowed", an access
+/// prompt the user declined, a keychain the item's ACL refuses this caller —
+/// used to be reported as `Ok(None)` too, so every one of them reached the UI
+/// as "this account has no stored credential, reconnect it". Reconnecting
+/// cannot fix a keychain that refuses reads, and the message sent the user
+/// round in circles. An entry that exists but is empty is an error for the
+/// same reason: it is a failed write, not a missing credential.
+///
+/// Pure over the process output so it is unit-tested on every platform.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn interpret_keychain_read(
+    key: &str,
+    success: bool,
+    status_code: Option<i32>,
+    stdout: &[u8],
+    stderr: &[u8],
+) -> Result<Option<String>> {
+    if success {
+        let password = String::from_utf8_lossy(stdout).trim().to_string();
+        if password.is_empty() {
+            return Err(GitnadoError::OperationFailed(format!(
+                "Keychain entry for {key} exists but holds no value. Reconnect the account to store its token again."
+            )));
+        }
+        return Ok(Some(password));
+    }
+
+    let stderr = String::from_utf8_lossy(stderr).trim().to_string();
+    if status_code == Some(SEC_ITEM_NOT_FOUND) || stderr.contains("could not be found") {
+        return Ok(None);
+    }
+
+    let status = status_code
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "a signal".to_string());
+    Err(GitnadoError::OperationFailed(format!(
+        "Keychain read failed for {key} (security exited with {status}): {}",
+        if stderr.is_empty() {
+            "no error output".to_string()
+        } else {
+            stderr
+        }
+    )))
+}
+
+/// Confirm a value just written under `key` reads back as itself.
+///
+/// Pure over the read-back result so it is unit-tested on every platform.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn verify_keychain_write(
+    key: &str,
+    expected: &str,
+    read_back: Result<Option<String>>,
+) -> Result<()> {
+    match read_back {
+        Ok(Some(actual)) if actual == expected => Ok(()),
+        Ok(Some(actual)) => Err(GitnadoError::OperationFailed(format!(
+            "Keychain entry for {key} was stored but reads back differently ({} bytes written, {} read).",
+            expected.len(),
+            actual.len()
+        ))),
+        Ok(None) => Err(GitnadoError::OperationFailed(format!(
+            "Keychain entry for {key} was stored but could not be found when read back."
+        ))),
+        Err(e) => Err(GitnadoError::OperationFailed(format!(
+            "Keychain entry for {key} was stored but could not be read back: {e}"
+        ))),
+    }
+}
+
+/// Read `key` from `service`; `Ok(None)` when absent, `Err` when the keychain
+/// could not be read (see `interpret_keychain_read`).
 fn read_keyring_token(service: &str, key: &str) -> Result<Option<String>> {
     #[cfg(target_os = "macos")]
     {
@@ -1057,17 +1145,13 @@ fn read_keyring_token(service: &str, key: &str) -> Result<Option<String>> {
             .output()
             .map_err(|e| GitnadoError::OperationFailed(format!("Failed to run security: {e}")))?;
 
-        if output.status.success() {
-            let password = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if password.is_empty() {
-                Ok(None)
-            } else {
-                Ok(Some(password))
-            }
-        } else {
-            // Item not found
-            Ok(None)
-        }
+        interpret_keychain_read(
+            key,
+            output.status.success(),
+            output.status.code(),
+            &output.stdout,
+            &output.stderr,
+        )
     }
 
     #[cfg(not(target_os = "macos"))]
@@ -2334,6 +2418,106 @@ mod tests {
         assert!(args.contains(&"key"));
         assert!(args.contains(&"-U"));
         assert!(args.contains(&"-w"));
+    }
+
+    // ── interpret_keychain_read / verify_keychain_write ─────────────────
+    //
+    // The macOS reader used to report EVERY `security` failure as "not
+    // found", so a keychain that refused to be read surfaced as "this account
+    // has no stored credential — reconnect it", which reconnecting could not
+    // fix. These pin the one status that means absent apart from the rest.
+
+    #[test]
+    fn keychain_read_returns_the_value_on_success() {
+        let value = interpret_keychain_read("k", true, Some(0), b"ghp_tok\n", b"").unwrap();
+        assert_eq!(value, Some("ghp_tok".to_string()));
+    }
+
+    #[test]
+    fn keychain_read_treats_item_not_found_as_absent() {
+        let stderr = b"security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.";
+        assert_eq!(
+            interpret_keychain_read("k", false, Some(SEC_ITEM_NOT_FOUND), b"", stderr).unwrap(),
+            None
+        );
+        // Belt and braces: the message alone identifies it too.
+        assert_eq!(
+            interpret_keychain_read("k", false, Some(1), b"", stderr).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn keychain_read_reports_any_other_failure_with_its_output() {
+        let err = interpret_keychain_read(
+            "github_token_acc",
+            false,
+            Some(36),
+            b"",
+            b"security: SecKeychainSearchCopyNext: User interaction is not allowed.",
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(err.contains("github_token_acc"), "names the key: {err}");
+        assert!(err.contains("36"), "carries the exit status: {err}");
+        assert!(
+            err.contains("User interaction is not allowed"),
+            "carries security's own message: {err}"
+        );
+    }
+
+    #[test]
+    fn keychain_read_reports_a_failure_with_no_output_or_status() {
+        let err = interpret_keychain_read("k", false, None, b"", b"")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("a signal"), "{err}");
+        assert!(err.contains("no error output"), "{err}");
+    }
+
+    #[test]
+    fn keychain_read_reports_an_empty_entry_instead_of_calling_it_absent() {
+        // An entry that exists but holds nothing is a failed write; reporting
+        // it as "no credential" hid that from the connect flow.
+        let err = interpret_keychain_read("k", true, Some(0), b"\n", b"")
+            .unwrap_err()
+            .to_string();
+        assert!(err.contains("holds no value"), "{err}");
+    }
+
+    #[test]
+    fn keychain_write_verification_accepts_the_same_value_back() {
+        assert!(verify_keychain_write("k", "tok", Ok(Some("tok".to_string()))).is_ok());
+    }
+
+    #[test]
+    fn keychain_write_verification_rejects_a_missing_or_different_value() {
+        let missing = verify_keychain_write("k", "tok", Ok(None))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            missing.contains("could not be found when read back"),
+            "{missing}"
+        );
+
+        let different = verify_keychain_write("k", "tok", Ok(Some("other".to_string())))
+            .unwrap_err()
+            .to_string();
+        assert!(different.contains("reads back differently"), "{different}");
+        assert!(
+            !different.contains("tok") && !different.contains("other"),
+            "never echoes a secret: {different}"
+        );
+
+        let failed = verify_keychain_write(
+            "k",
+            "tok",
+            Err(GitnadoError::OperationFailed("locked".to_string())),
+        )
+        .unwrap_err()
+        .to_string();
+        assert!(failed.contains("could not be read back"), "{failed}");
+        assert!(failed.contains("locked"), "{failed}");
     }
 
     // ========================================================================

--- a/src-tauri/src/commands/credentials.rs
+++ b/src-tauri/src/commands/credentials.rs
@@ -994,6 +994,30 @@ pub(crate) fn build_security_add_args<'a>(service: &'a str, key: &'a str) -> Vec
     }
 }
 
+/// Build the stdin payload for `security add-generic-password ... -w`.
+///
+/// `-w` with no inline value does not simply read the secret from stdin: it
+/// prompts TWICE — "password data for new item:", then "retype password for
+/// new item:". Feeding the token once leaves the confirmation at EOF, so
+/// `security` reports "passwords don't match", re-prompts, reads EOF for both
+/// prompts, matches empty against empty, stores an EMPTY entry and still exits
+/// 0. That is why connecting an account on macOS stored a token that every
+/// later read found blank. Answering both prompts is what makes the write
+/// land; the value stays off argv, where `ps -E` would expose it.
+///
+/// A value containing a line break cannot survive these line-oriented prompts
+/// (`security` would keep only its first line), so reject it rather than
+/// silently store a truncated token.
+#[cfg_attr(not(target_os = "macos"), allow(dead_code))]
+fn build_security_add_stdin(value: &str) -> Result<String> {
+    if value.contains('\n') || value.contains('\r') {
+        return Err(GitnadoError::OperationFailed(
+            "Cannot store a token containing a line break in the macOS keychain.".to_string(),
+        ));
+    }
+    Ok(format!("{value}\n{value}\n"))
+}
+
 /// Write `value` under `key` for `service`.
 ///
 /// On macOS, uses the `security` CLI. In debug builds `-A` is added so that
@@ -1003,14 +1027,19 @@ pub(crate) fn build_security_add_args<'a>(service: &'a str, key: &'a str) -> Vec
 fn write_keyring_token(service: &str, key: &str, value: &str) -> Result<()> {
     #[cfg(target_os = "macos")]
     {
+        // Built before the delete below: a value we cannot write must not cost
+        // the caller the entry they already had.
+        let stdin_payload = build_security_add_stdin(value)?;
+
         // Delete existing entry first (add-generic-password fails if it exists)
         let _ = std::process::Command::new("security")
             .args(["delete-generic-password", "-s", service, "-a", key])
             .output();
 
-        // `-w` last with no value => password read from stdin. This avoids
-        // exposing the token via argv (`ps -E` is readable by any process
-        // running under the same user).
+        // `-w` last with no value => password read from the prompts on stdin
+        // (see `build_security_add_stdin` for why the value is sent twice).
+        // This avoids exposing the token via argv (`ps -E` is readable by any
+        // process running under the same user).
         use std::io::Write as _;
         let security_args = build_security_add_args(service, key);
         let mut child = std::process::Command::new("security")
@@ -1021,7 +1050,7 @@ fn write_keyring_token(service: &str, key: &str, value: &str) -> Result<()> {
             .spawn()
             .map_err(|e| GitnadoError::OperationFailed(format!("Failed to run security: {e}")))?;
         if let Some(mut stdin) = child.stdin.take() {
-            stdin.write_all(value.as_bytes()).map_err(|e| {
+            stdin.write_all(stdin_payload.as_bytes()).map_err(|e| {
                 GitnadoError::OperationFailed(format!("Failed to write token: {e}"))
             })?;
         }
@@ -2518,6 +2547,90 @@ mod tests {
         .to_string();
         assert!(failed.contains("could not be read back"), "{failed}");
         assert!(failed.contains("locked"), "{failed}");
+    }
+
+    // ── build_security_add_stdin ────────────────────────────────────────
+    //
+    // `security add-generic-password -w` prompts for the password AND for a
+    // retype. Sending the token once left the retype at EOF; `security` then
+    // re-prompted, read EOF for both, stored an empty entry and exited 0 — so
+    // every macOS account connect wrote a token that read back blank.
+
+    #[test]
+    fn security_add_stdin_answers_both_of_securitys_prompts() {
+        // One line per prompt: the password, then the retype. Anything less
+        // and `security` stores an empty entry while reporting success.
+        assert_eq!(
+            build_security_add_stdin("ghp_tok").unwrap(),
+            "ghp_tok\nghp_tok\n"
+        );
+        assert_eq!(
+            build_security_add_stdin("ghp_tok").unwrap().lines().count(),
+            2
+        );
+    }
+
+    #[test]
+    fn security_add_stdin_keeps_the_value_off_the_argument_list() {
+        // The payload exists so the token travels on stdin; the args must
+        // still carry `-w` with no inline value beside it.
+        #[cfg(target_os = "macos")]
+        {
+            let args = build_security_add_args("svc", "key");
+            assert_eq!(
+                args.last(),
+                Some(&"-w"),
+                "-w must be last so no value follows it on argv: {args:?}"
+            );
+            assert!(
+                !args.contains(&"ghp_tok"),
+                "the token must never reach argv: {args:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn security_add_stdin_rejects_a_line_break_instead_of_truncating() {
+        // These prompts are line-oriented, so a value with a newline would be
+        // stored as its first line only — a silently corrupted token.
+        for value in ["gh\np_tok", "gh\rp_tok", "ghp_tok\n"] {
+            let err = build_security_add_stdin(value).unwrap_err().to_string();
+            assert!(err.contains("line break"), "{value:?} -> {err}");
+            assert!(
+                !err.contains("ghp_tok") && !err.contains("p_tok"),
+                "never echoes the secret: {err}"
+            );
+        }
+    }
+
+    /// End-to-end against the real keychain: the pure-argument test above
+    /// passed all along while `security` stored nothing, so pin the round
+    /// trip that actually broke. Skips when `security` cannot be run at all.
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn keychain_write_round_trips_through_security() {
+        let service = "gitnado-test-keychain-roundtrip";
+        let key = &format!("roundtrip-{}", std::process::id());
+        let token = "ghp_round_trip_value";
+
+        if std::process::Command::new("security")
+            .arg("help")
+            .output()
+            .is_err()
+        {
+            return; // no `security` on this box — nothing to assert
+        }
+
+        let written = write_keyring_token(service, key, token);
+        let read_back = read_keyring_token(service, key);
+        let _ = remove_keyring_token(service, key);
+
+        written.expect("writing a token must succeed and verify");
+        assert_eq!(
+            read_back.expect("reading the token back must succeed"),
+            Some(token.to_string()),
+            "the value must survive the write, not land as an empty entry"
+        );
     }
 
     // ========================================================================

--- a/src-tauri/src/commands/repository.rs
+++ b/src-tauri/src/commands/repository.rs
@@ -206,7 +206,13 @@ fn build_clone_command(
     // same way, so an ssh:// or git:// clone keeps using the user's own
     // credentials exactly as before.
     if let (Some(token_value), true) = (token, url.starts_with("https://")) {
-        cmd.env("GITNADO_CLONE_TOKEN", token_value);
+        // The same username rules as the git2 path: `git` for every provider
+        // that ignores the username, and Bitbucket's app-password split or
+        // `x-token-auth` where it does not.
+        let (username, password) =
+            crate::services::credentials_service::token_credential_for(url, None, token_value);
+        cmd.env("GITNADO_CLONE_USERNAME", username);
+        cmd.env("GITNADO_CLONE_TOKEN", password);
         // Two entries: the empty helper resets the list, so the token the
         // caller gave us wins outright the way in-URL credentials did. Without
         // the reset, a system helper holding a stale credential for the same
@@ -217,12 +223,12 @@ fn build_clone_command(
         cmd.env("GIT_CONFIG_KEY_0", "credential.helper");
         cmd.env("GIT_CONFIG_VALUE_0", "");
         cmd.env("GIT_CONFIG_KEY_1", "credential.helper");
-        // `git` as the username matches the git2 path's fallback; every
-        // provider we support authenticates a token as the password and
-        // ignores the username.
+        // Both halves come from the environment, never from argv: a
+        // username can be a real account name (Bitbucket app passwords) and
+        // is as private as the password beside it.
         cmd.env(
             "GIT_CONFIG_VALUE_1",
-            "!f() { echo username=git; echo \"password=$GITNADO_CLONE_TOKEN\"; }; f",
+            "!f() { echo \"username=$GITNADO_CLONE_USERNAME\"; echo \"password=$GITNADO_CLONE_TOKEN\"; }; f",
         );
     }
 
@@ -1940,9 +1946,71 @@ mod tests {
             helper
         );
         assert!(
-            helper.contains("username=git"),
-            "helper must supply a username: {}",
+            helper.contains("username=$GITNADO_CLONE_USERNAME"),
+            "helper must read the username from the environment: {}",
             helper
+        );
+        assert_eq!(
+            env_of(&cmd, "GITNADO_CLONE_USERNAME"),
+            Some("git".to_string()),
+            "a plain token authenticates as `git`"
+        );
+    }
+
+    /// A Bitbucket app password is a username/password pair carried in the
+    /// one token slot: the clone must hand git BOTH halves, not `git` and the
+    /// prefixed blob.
+    #[test]
+    fn test_build_clone_command_splits_a_bitbucket_app_password() {
+        let cmd = build_clone_command(
+            "https://bitbucket.org/ws/repo.git",
+            Path::new("/tmp/x"),
+            false,
+            None,
+            Some(1),
+            None,
+            false,
+            Some("bbapp:alice:app-pass"),
+        );
+
+        assert_eq!(
+            env_of(&cmd, "GITNADO_CLONE_USERNAME"),
+            Some("alice".to_string())
+        );
+        assert_eq!(
+            env_of(&cmd, "GITNADO_CLONE_TOKEN"),
+            Some("app-pass".to_string())
+        );
+        let args = args_of(&cmd);
+        assert!(
+            args.iter()
+                .all(|a| !a.contains("alice") && !a.contains("app-pass")),
+            "neither half may reach argv: {:?}",
+            args
+        );
+    }
+
+    /// A Bitbucket OAuth access token authenticates only as `x-token-auth`.
+    #[test]
+    fn test_build_clone_command_sends_a_bitbucket_token_as_x_token_auth() {
+        let cmd = build_clone_command(
+            "https://alice@bitbucket.org/ws/repo.git",
+            Path::new("/tmp/x"),
+            false,
+            None,
+            Some(1),
+            None,
+            false,
+            Some("oauth-tok"),
+        );
+
+        assert_eq!(
+            env_of(&cmd, "GITNADO_CLONE_USERNAME"),
+            Some("x-token-auth".to_string())
+        );
+        assert_eq!(
+            env_of(&cmd, "GITNADO_CLONE_TOKEN"),
+            Some("oauth-tok".to_string())
         );
     }
 
@@ -1995,6 +2063,7 @@ mod tests {
         // credential.helper override, and that must still be absent.
         for key in [
             "GITNADO_CLONE_TOKEN",
+            "GITNADO_CLONE_USERNAME",
             "GIT_CONFIG_COUNT",
             "GIT_CONFIG_KEY_0",
             "GIT_CONFIG_VALUE_0",
@@ -2022,6 +2091,7 @@ mod tests {
             Some("ghp_s3cret"),
         );
         assert_eq!(env_of(&ssh, "GITNADO_CLONE_TOKEN"), None);
+        assert_eq!(env_of(&ssh, "GITNADO_CLONE_USERNAME"), None);
         assert_eq!(env_of(&ssh, "GIT_CONFIG_COUNT"), None);
         assert!(args_of(&ssh).contains(&"ssh://git@host/o/r.git".to_string()));
     }

--- a/src-tauri/src/services/credentials_service.rs
+++ b/src-tauri/src/services/credentials_service.rs
@@ -251,8 +251,9 @@ impl CredentialsHelper {
                 if allowed_types.contains(CredentialType::USER_PASS_PLAINTEXT) && !tried_token {
                     tried_token = true;
                     tracing::debug!("Using provided token for authentication");
-                    let username = username_from_url.unwrap_or("git");
-                    return Cred::userpass_plaintext(username, token_value);
+                    let (username, password) =
+                        token_credential_for(url, username_from_url, token_value);
+                    return Cred::userpass_plaintext(&username, &password);
                 }
             }
 
@@ -501,6 +502,54 @@ pub fn delete_credentials(url: &str) -> Result<(), String> {
 /// host is missed, and it is re-prompted for once.
 fn extract_host(url: &str) -> Option<String> {
     crate::services::security::url_host(url)
+}
+
+/// Sentinel prefix of a Bitbucket app-password credential stored in a token
+/// slot: `bbapp:<username>:<app password>`. Must stay in sync with
+/// `APP_PASSWORD_PREFIX` in `commands/bitbucket.rs` and
+/// `BITBUCKET_APP_PASSWORD_PREFIX` in `src/services/credential.service.ts`.
+const BITBUCKET_APP_PASSWORD_PREFIX: &str = "bbapp:";
+
+/// The username Bitbucket expects alongside an OAuth access token over git
+/// HTTPS. Any other username is refused with the token as the password.
+const BITBUCKET_TOKEN_USERNAME: &str = "x-token-auth";
+
+/// The `(username, password)` pair a stored token authenticates a git HTTPS
+/// transfer to `url` with.
+///
+/// Every provider but Bitbucket takes the token as the password and ignores
+/// the username, so `git` (or the one the URL names) does. Bitbucket is the
+/// exception twice over: an app password is a real username/password pair,
+/// carried in the one token slot behind the `bbapp:` prefix and split back
+/// apart here; and an OAuth access token authenticates only as `x-token-auth`
+/// — the account's own username, which Bitbucket's clone URLs embed
+/// (`https://<user>@bitbucket.org/...`), is refused with a token as the
+/// password. Without this the clone dialog's "From account" flow listed a
+/// Bitbucket account's repositories and then could not clone one of them.
+pub fn token_credential_for(
+    url: &str,
+    username_from_url: Option<&str>,
+    token: &str,
+) -> (String, String) {
+    if let Some(rest) = token.strip_prefix(BITBUCKET_APP_PASSWORD_PREFIX) {
+        // Split on the FIRST colon only: usernames never contain a colon, and
+        // an app password may.
+        if let Some((username, password)) = rest.split_once(':') {
+            if !username.is_empty() && !password.is_empty() {
+                return (username.to_string(), password.to_string());
+            }
+        }
+    }
+
+    let host = extract_host(url).unwrap_or_default();
+    if host == "bitbucket.org" || host.ends_with(".bitbucket.org") {
+        return (BITBUCKET_TOKEN_USERNAME.to_string(), token.to_string());
+    }
+
+    (
+        username_from_url.unwrap_or("git").to_string(),
+        token.to_string(),
+    )
 }
 
 /// Why a transfer callback aborted the transfer.
@@ -775,6 +824,67 @@ mod tests {
         if let Ok(mut cache) = CREDENTIAL_CACHE.lock() {
             *cache = None;
         }
+    }
+
+    // ── token_credential_for ────────────────────────────────────────────
+
+    #[test]
+    fn token_credential_uses_git_as_the_username_for_a_plain_token() {
+        assert_eq!(
+            token_credential_for("https://github.com/o/r.git", None, "ghp_tok"),
+            ("git".to_string(), "ghp_tok".to_string())
+        );
+    }
+
+    #[test]
+    fn token_credential_keeps_the_username_the_url_names() {
+        // Azure DevOps clone URLs carry the organization as userinfo; a PAT
+        // works with any username, so the URL's own is kept as before.
+        assert_eq!(
+            token_credential_for(
+                "https://org@dev.azure.com/org/proj/_git/repo",
+                Some("org"),
+                "pat"
+            ),
+            ("org".to_string(), "pat".to_string())
+        );
+    }
+
+    #[test]
+    fn token_credential_splits_a_bitbucket_app_password_credential() {
+        assert_eq!(
+            token_credential_for(
+                "https://bitbucket.org/ws/repo.git",
+                None,
+                "bbapp:alice:s3cr:et"
+            ),
+            ("alice".to_string(), "s3cr:et".to_string()),
+            "everything after the first colon is the app password"
+        );
+    }
+
+    #[test]
+    fn token_credential_sends_a_bitbucket_access_token_as_x_token_auth() {
+        // The account's own username, as Bitbucket's clone links embed it,
+        // must NOT be used: Bitbucket refuses a token under it.
+        assert_eq!(
+            token_credential_for(
+                "https://alice@bitbucket.org/ws/repo.git",
+                Some("alice"),
+                "oauth-access-token"
+            ),
+            ("x-token-auth".to_string(), "oauth-access-token".to_string())
+        );
+    }
+
+    #[test]
+    fn token_credential_treats_a_malformed_app_password_prefix_as_a_token() {
+        // No colon after the prefix: nothing to split, so it goes through as
+        // whatever the host takes a bare token as.
+        assert_eq!(
+            token_credential_for("https://github.com/o/r.git", None, "bbapp:nocolon"),
+            ("git".to_string(), "bbapp:nocolon".to_string())
+        );
     }
 
     #[test]

--- a/src/components/dialogs/__tests__/lv-account-repo-picker.test.ts
+++ b/src/components/dialogs/__tests__/lv-account-repo-picker.test.ts
@@ -515,6 +515,34 @@ describe('lv-account-repo-picker', () => {
       expect(el.shadowRoot!.querySelector('.repo-item')!.textContent).to.contain('infra');
     });
 
+    it('shows the keychain error when the stored token cannot be read', async () => {
+      // A keychain that refuses to be read is not "no credential": saying so
+      // sent the user to reconnect an account whose token was sitting right
+      // there, and a re-added account failed the same way. The keychain's own
+      // message is shown, with Retry.
+      unifiedProfileStore.getState().setAccounts([githubAccount]);
+      mockInvoke = (command) => {
+        if (command === 'get_keyring_token') {
+          return Promise.reject({
+            code: 'OPERATION_FAILED',
+            message: 'Keychain read failed for github_token_gh-1 (security exited with 36): User interaction is not allowed.',
+          });
+        }
+        return Promise.resolve(null);
+      };
+
+      const el = await mount();
+      const state = await waitForState(el, 'error');
+
+      expect(state.textContent).to.contain('User interaction is not allowed');
+      expect(stateEl(el, 'no-credential'), 'not reported as a missing credential').to.equal(null);
+      expect(state.querySelector('.link-btn')!.textContent!.trim()).to.equal('Retry');
+      expect(
+        invoked.some((i) => i.command === 'list_github_repositories'),
+        'no listing call is made without a token to make it with',
+      ).to.be.false;
+    });
+
     it('offers to reconnect when the token is rejected', async () => {
       unifiedProfileStore.getState().setAccounts([githubAccount]);
       withStoredToken((command) => {

--- a/src/components/dialogs/__tests__/lv-account-repo-picker.test.ts
+++ b/src/components/dialogs/__tests__/lv-account-repo-picker.test.ts
@@ -605,9 +605,45 @@ describe('lv-account-repo-picker', () => {
       expect(event.detail.repository.cloneUrl).to.equal(
         'https://github.com/octocat/alpha.git',
       );
+      // The account the repository was listed under travels with it: the
+      // clone must authenticate as that account, not as the host's default.
+      expect(event.detail.account?.id).to.equal('gh-1');
 
       await el.updateComplete;
       expect(el.shadowRoot!.querySelector('.repo-item.selected')).to.exist;
+    });
+
+    it('hands over the account the repository was listed under, not the default one', async () => {
+      const personal: IntegrationAccount = {
+        ...githubAccount,
+        id: 'gh-2',
+        name: 'Personal GitHub',
+        isDefault: false,
+      };
+      unifiedProfileStore.getState().setAccounts([githubAccount, personal]);
+      withStoredToken((command) =>
+        command === 'list_github_repositories'
+          ? { repositories: [repo('alpha')], nextPage: null }
+          : null,
+      );
+
+      const el = await mount();
+      await waitForRepoItems(el, 1);
+
+      const selector = el.shadowRoot!.querySelector('lv-account-selector')!;
+      selector.dispatchEvent(
+        new CustomEvent('account-change', {
+          detail: { account: personal },
+          bubbles: true,
+          composed: true,
+        }),
+      );
+      await waitForRepoItems(el, 1);
+
+      const row = el.shadowRoot!.querySelector('.repo-item') as HTMLButtonElement;
+      setTimeout(() => row.click());
+      const event = (await oneEvent(el, 'repository-selected')) as CustomEvent;
+      expect(event.detail.account?.id).to.equal('gh-2');
     });
   });
 
@@ -880,6 +916,54 @@ describe('lv-account-repo-picker', () => {
       expect((call!.args as { instanceUrl?: string }).instanceUrl).to.equal(
         'https://gitlab.com',
       );
+    });
+
+    it('shows the newly chosen provider account in its selector', async () => {
+      // The selector used to keep the accounts of the provider it was mounted
+      // with, so after switching it showed the GitLab account as "No account
+      // selected" and its dropdown still offered the GitHub accounts.
+      unifiedProfileStore.getState().setAccounts([githubAccount, gitlabAccount]);
+      withStoredToken((command) => {
+        if (command === 'list_github_repositories') {
+          return { repositories: [repo('alpha')], nextPage: null };
+        }
+        if (command === 'list_gitlab_projects') {
+          return { repositories: [repo('gl-project')], nextPage: null };
+        }
+        return null;
+      });
+
+      const el = await mount();
+      await waitForRepoItems(el, 1);
+
+      const select = el.shadowRoot!.querySelector('#repo-provider') as HTMLSelectElement;
+      select.value = 'gitlab';
+      select.dispatchEvent(new Event('change'));
+      await waitUntil(
+        async () => {
+          await el.updateComplete;
+          const row = el.shadowRoot!.querySelector('.repo-item');
+          return !!row && row.textContent!.includes('gl-project');
+        },
+        'the GitLab account listing replaces the GitHub one',
+        { timeout: 2000 },
+      );
+
+      const selector = el.shadowRoot!.querySelector('lv-account-selector') as HTMLElement & {
+        updateComplete: Promise<unknown>;
+      };
+      await selector.updateComplete;
+      expect(selector.shadowRoot!.querySelector('.no-account')).to.equal(null);
+      expect(selector.shadowRoot!.querySelector('.account-name')!.textContent).to.include(
+        'GitLab',
+      );
+
+      (selector.shadowRoot!.querySelector('.selector-btn') as HTMLButtonElement).click();
+      await selector.updateComplete;
+      const items = Array.from(selector.shadowRoot!.querySelectorAll('.dropdown-item'));
+      expect(items.length, 'only the GitLab account is offered').to.equal(1);
+      expect(items[0].textContent).to.include('GitLab');
+      expect(items[0].textContent).to.not.include('Work GitHub');
     });
   });
 });

--- a/src/components/dialogs/__tests__/lv-account-selector.test.ts
+++ b/src/components/dialogs/__tests__/lv-account-selector.test.ts
@@ -125,6 +125,53 @@ describe('lv-account-selector', () => {
     expect(items.length).to.equal(2);
   });
 
+  it('re-reads its accounts when the integration type changes', async () => {
+    // The clone dialog's account picker swaps the provider on ONE selector.
+    // The accounts used to be read only when the element connected (and on
+    // store updates), so after GitHub → GitLab it still listed the GitHub
+    // accounts and showed the GitLab account as "No account selected".
+    const el = await fixture<LvAccountSelector>(html`
+      <lv-account-selector
+        integrationType="github"
+        .selectedAccountId=${'acc-1'}
+      ></lv-account-selector>
+    `);
+    await el.updateComplete;
+
+    el.integrationType = 'gitlab';
+    el.selectedAccountId = 'acc-3';
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector('.no-account')).to.equal(null);
+    expect(el.shadowRoot!.querySelector('.account-name')!.textContent).to.include('My GitLab');
+
+    (el.shadowRoot!.querySelector('.selector-btn') as HTMLButtonElement).click();
+    await el.updateComplete;
+    const items = Array.from(el.shadowRoot!.querySelectorAll('.dropdown-item'));
+    expect(items.length, 'only the GitLab account is listed').to.equal(1);
+    expect(items[0].textContent).to.include('My GitLab');
+  });
+
+  it('folds an open dropdown away when the integration type changes', async () => {
+    const el = await fixture<LvAccountSelector>(html`
+      <lv-account-selector
+        integrationType="github"
+        .selectedAccountId=${'acc-1'}
+      ></lv-account-selector>
+    `);
+    await el.updateComplete;
+    (el.shadowRoot!.querySelector('.selector-btn') as HTMLButtonElement).click();
+    await el.updateComplete;
+    expect(el.shadowRoot!.querySelector('.dropdown')).to.exist;
+
+    // The open dropdown lists the previous provider's accounts; it must not
+    // stay on screen offering them under the new provider's label.
+    el.integrationType = 'gitlab';
+    await el.updateComplete;
+
+    expect(el.shadowRoot!.querySelector('.dropdown')).to.equal(null);
+  });
+
   it('shows "No account selected" when selectedAccountId is null', async () => {
     const el = await fixture<LvAccountSelector>(html`
       <lv-account-selector

--- a/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-azure-devops-dialog.test.ts
@@ -433,6 +433,53 @@ describe('lv-azure-devops-dialog', () => {
       expect((el as any).createPrTitle, 'retained draft title').to.equal('');
     });
 
+    it('reports a keychain read failure when switching account instead of going blank', async () => {
+      // A keyring read failure now throws (it is not "no token"). This click
+      // handler had no catch, so the rejection escaped: no error text, the
+      // previous account's stored-token state left standing, and nothing
+      // reloaded for the account just picked.
+      const other = createTestAccount({
+        id: 'ado-acc-2',
+        name: 'Other ADO',
+        integrationType: 'azure-devops',
+        config: { type: 'azure-devops', organization: 'otherorg' },
+        isDefault: false,
+      });
+      unifiedProfileStore.getState().setAccounts([mockAccount, other]);
+
+      const el = await fixture<LvAzureDevOpsDialog>(html`
+        <lv-azure-devops-dialog .open=${true}></lv-azure-devops-dialog>
+      `);
+      await waitForLoad(el);
+
+      const readable = mockInvoke;
+      mockInvoke = (command, args) => {
+        if (command === 'get_keyring_token') {
+          return Promise.reject({
+            code: 'OPERATION_FAILED',
+            message: 'Keychain read failed for azure-devops_token_ado-acc-2 (security exited with 36): User interaction is not allowed.',
+          });
+        }
+        return readable(command, args);
+      };
+
+      const selector = el.shadowRoot!.querySelector('lv-account-selector')!;
+      selector.dispatchEvent(
+        new CustomEvent('account-change', {
+          detail: { account: other },
+          bubbles: true,
+          composed: true,
+        })
+      );
+      await el.updateComplete;
+      await new Promise((r) => setTimeout(r, 0));
+      await el.updateComplete;
+
+      const errorBanner = el.shadowRoot!.querySelector('.error');
+      expect(errorBanner, 'the keychain error is shown').to.not.be.null;
+      expect(errorBanner!.textContent).to.include('User interaction is not allowed');
+    });
+
     it('shows account selector when accounts exist', async () => {
       unifiedProfileStore.getState().setAccounts([mockAccount]);
 

--- a/src/components/dialogs/__tests__/lv-clone-dialog.test.ts
+++ b/src/components/dialogs/__tests__/lv-clone-dialog.test.ts
@@ -654,6 +654,138 @@ describe('lv-clone-dialog', () => {
       expect(args.path).to.equal('/home/user/projects/my-repo');
     });
 
+    /** Two connected GitHub accounts, each with its own stored token. */
+    const workAccount = {
+      id: 'gh-work',
+      name: 'Work GitHub',
+      integrationType: 'github' as const,
+      urlPatterns: [],
+      isDefault: true,
+      color: null,
+      config: { type: 'github' as const },
+      cachedUser: null,
+    };
+    const personalAccount = { ...workAccount, id: 'gh-personal', name: 'Personal', isDefault: false };
+
+    function mockTwoAccountKeyring(calls: { command: string; args?: unknown }[]): void {
+      mockInvoke = (command: string, args?: unknown) => {
+        calls.push({ command, args });
+        if (command === 'get_keyring_token') {
+          const key = (args as { key?: string })?.key ?? '';
+          if (key.endsWith('_oauth')) return Promise.resolve(null);
+          if (key === 'github_token_gh-work') return Promise.resolve('work-tok');
+          if (key === 'github_token_gh-personal') return Promise.resolve('personal-tok');
+          return Promise.resolve(null);
+        }
+        if (command === 'clone_repository') {
+          return Promise.resolve({ path: '/home/user/projects/my-repo', name: 'my-repo' });
+        }
+        return Promise.resolve(null);
+      };
+    }
+
+    it('clones as the account the repository was picked from, not the host default', async () => {
+      // The URL-host lookup lands on the DEFAULT GitHub account. A private
+      // repository picked from the personal account then cloned with the work
+      // token and failed as "not found".
+      settingsStore.getState().setDefaultClonePath('/home/user/projects');
+      unifiedProfileStore.getState().setAccounts([workAccount, personalAccount]);
+      const calls: { command: string; args?: unknown }[] = [];
+      mockTwoAccountKeyring(calls);
+      try {
+        selectSource('account');
+        await el.updateComplete;
+        picker()!.dispatchEvent(
+          new CustomEvent('repository-selected', {
+            detail: { repository: pickedRepository, account: personalAccount },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        await el.updateComplete;
+
+        await (el as unknown as { handleClone: () => Promise<void> }).handleClone();
+
+        const clone = calls.find((c) => c.command === 'clone_repository');
+        expect(clone, 'the clone command runs').to.exist;
+        expect((clone!.args as { token?: string }).token).to.equal('personal-tok');
+      } finally {
+        unifiedProfileStore.getState().reset();
+      }
+    });
+
+    it('stops cloning as the picked account once the URL is typed over', async () => {
+      settingsStore.getState().setDefaultClonePath('/home/user/projects');
+      unifiedProfileStore.getState().setAccounts([workAccount, personalAccount]);
+      const calls: { command: string; args?: unknown }[] = [];
+      mockTwoAccountKeyring(calls);
+      try {
+        selectSource('account');
+        await el.updateComplete;
+        picker()!.dispatchEvent(
+          new CustomEvent('repository-selected', {
+            detail: { repository: pickedRepository, account: personalAccount },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        await el.updateComplete;
+
+        // The typed URL may belong to anyone; the picked account's token must
+        // not follow it. The host lookup (default account) applies again.
+        const urlInput = el.shadowRoot!.querySelector('#url') as HTMLInputElement;
+        urlInput.value = 'https://github.com/someone/else.git';
+        urlInput.dispatchEvent(new Event('input'));
+        await el.updateComplete;
+
+        await (el as unknown as { handleClone: () => Promise<void> }).handleClone();
+
+        const clone = calls.find((c) => c.command === 'clone_repository');
+        expect(clone, 'the clone command runs').to.exist;
+        expect((clone!.args as { token?: string }).token).to.equal('work-tok');
+      } finally {
+        unifiedProfileStore.getState().reset();
+      }
+    });
+
+    it('forgets the picked account on reset', async () => {
+      settingsStore.getState().setDefaultClonePath('/home/user/projects');
+      unifiedProfileStore.getState().setAccounts([workAccount, personalAccount]);
+      const calls: { command: string; args?: unknown }[] = [];
+      mockTwoAccountKeyring(calls);
+      try {
+        selectSource('account');
+        await el.updateComplete;
+        picker()!.dispatchEvent(
+          new CustomEvent('repository-selected', {
+            detail: { repository: pickedRepository, account: personalAccount },
+            bubbles: true,
+            composed: true,
+          }),
+        );
+        await el.updateComplete;
+
+        (el as unknown as { reset: () => void }).reset();
+        await el.updateComplete;
+        // A fresh session that pastes a URL by hand.
+        const urlInput = el.shadowRoot!.querySelector('#url') as HTMLInputElement;
+        urlInput.value = 'https://github.com/octocat/my-repo.git';
+        urlInput.dispatchEvent(new Event('input'));
+        const destInput = el.shadowRoot!.querySelector('#destination') as HTMLInputElement;
+        destInput.value = '/home/user/projects';
+        destInput.dispatchEvent(new Event('input'));
+        await el.updateComplete;
+
+        await (el as unknown as { handleClone: () => Promise<void> }).handleClone();
+
+        const clone = calls.find((c) => c.command === 'clone_repository');
+        expect(clone, 'the clone command runs').to.exist;
+        expect((clone!.args as { token?: string }).token).to.equal('work-tok');
+      } finally {
+        unifiedProfileStore.getState().reset();
+      }
+    });
+
     it('drops the selected-repository label once the URL is edited by hand', async () => {
       selectSource('account');
       await el.updateComplete;

--- a/src/components/dialogs/lv-account-repo-picker.ts
+++ b/src/components/dialogs/lv-account-repo-picker.ts
@@ -28,7 +28,7 @@ import {
 import type { CommandResult } from '../../types/api.types.ts';
 import { unifiedProfileStore, getAccountsByType } from '../../stores/unified-profile.store.ts';
 import { settingsStore } from '../../stores/settings.store.ts';
-import { getFreshAccountToken } from '../../services/credential.service.ts';
+import { getFreshTokenForAccount } from '../../services/credential.service.ts';
 import type { IntegrationAccount } from '../../types/unified-profile.types.ts';
 import { INTEGRATION_TYPE_NAMES } from '../../types/unified-profile.types.ts';
 import './lv-account-selector.ts';
@@ -50,6 +50,13 @@ export const REPO_PICKER_PROVIDERS: RepoPickerProvider[] = [
  * command modules, so the number the hint quotes is the number requested.
  */
 export const REPO_PICKER_PAGE_SIZE = 30;
+
+/** Payload of the `repository-selected` event. */
+export interface RepositorySelectedDetail {
+  repository: ProviderRepository;
+  /** The account the repository was listed under; the clone authenticates as it. */
+  account: IntegrationAccount | null;
+}
 
 /** What stopped the listing, so the UI can say what to do about it. */
 type PickerErrorKind =
@@ -455,26 +462,12 @@ export class LvAccountRepoPicker extends LitElement {
   /**
    * The account's stored token, refreshing an expiring OAuth one first — the
    * same resolution the provider dialogs use, so a picker load never fails for
-   * a credential the rest of the app would have renewed.
+   * a credential the rest of the app would have renewed. Shared with the clone
+   * that follows a selection, so the repository is listed and cloned with one
+   * and the same credential.
    */
-  private async resolveToken(account: IntegrationAccount): Promise<string | null> {
-    switch (account.integrationType) {
-      case 'github':
-        return getFreshAccountToken('github', account.id, 'github');
-      case 'gitlab':
-        return getFreshAccountToken(
-          'gitlab',
-          account.id,
-          'gitlab',
-          account.config.type === 'gitlab' ? account.config.instanceUrl : undefined,
-        );
-      case 'bitbucket':
-        return getFreshAccountToken('bitbucket', account.id, 'bitbucket');
-      case 'azure-devops':
-        return getFreshAccountToken('azure-devops', account.id, 'azure');
-      default:
-        return null;
-    }
+  private resolveToken(account: IntegrationAccount): Promise<string | null> {
+    return getFreshTokenForAccount(account);
   }
 
   /**
@@ -570,11 +563,20 @@ export class LvAccountRepoPicker extends LitElement {
     this.filter = (e.target as HTMLInputElement).value;
   }
 
+  /**
+   * Hand the repository to the host WITH the account it was listed under. The
+   * clone that follows must authenticate as that account: resolving the token
+   * from the URL's host alone lands on the host's default account, which is
+   * the wrong identity as soon as a second GitHub account is connected — and
+   * for Bitbucket there was no host-based lookup at all, so a private
+   * repository picked from a Bitbucket account cloned unauthenticated and
+   * failed.
+   */
   private handleSelectRepository(repo: ProviderRepository): void {
     this.selectedRepoId = repo.id;
     this.dispatchEvent(
-      new CustomEvent('repository-selected', {
-        detail: { repository: repo },
+      new CustomEvent<RepositorySelectedDetail>('repository-selected', {
+        detail: { repository: repo, account: this.selectedAccount },
         bubbles: true,
         composed: true,
       }),

--- a/src/components/dialogs/lv-account-selector.ts
+++ b/src/components/dialogs/lv-account-selector.ts
@@ -308,6 +308,19 @@ export class LvAccountSelector extends LitElement {
   };
 
   willUpdate(changed: Map<PropertyKey, unknown>): void {
+    // The accounts are read for the integration type the selector was
+    // connected with, and the store subscription re-reads them for whatever
+    // type is CURRENT — but nothing re-read them when the type itself changed
+    // with no store update. The clone dialog's account picker swaps its
+    // provider on one selector, so after switching GitHub → GitLab it kept
+    // listing the GitHub accounts, showed the GitLab account as "No account
+    // selected", and handed back a GitHub account when one was picked.
+    if (changed.has('integrationType')) {
+      this.accounts = getAccountsByType(this.integrationType);
+      // The dropdown that is open belongs to the previous provider.
+      this.isOpen = false;
+      this.clearPendingAction();
+    }
     // Disabled while the dropdown is up: fold it away, so the actions inside
     // it are not left on screen for a host that has locked everything else.
     if (changed.has('disabled') && this.disabled && this.isOpen) {

--- a/src/components/dialogs/lv-azure-devops-dialog.ts
+++ b/src/components/dialogs/lv-azure-devops-dialog.ts
@@ -1038,8 +1038,16 @@ export class LvAzureDevOpsDialog extends LitElement {
       this.organizationInput = account.config.organization;
     }
 
-    // Check if this account has a stored token
-    await this.checkStoredToken();
+    // Check if this account has a stored token. A keyring that cannot be read
+    // throws (it is not "no token"): say so here rather than leave the panel
+    // blank with the previous account's state, which is what an unhandled
+    // rejection out of this click handler did.
+    try {
+      await this.checkStoredToken();
+    } catch (err) {
+      this.error = err instanceof Error ? err.message : 'Failed to read the stored token';
+      return;
+    }
 
     // Re-check connection with new account
     await this.loadInitialData();

--- a/src/components/dialogs/lv-clone-dialog.ts
+++ b/src/components/dialogs/lv-clone-dialog.ts
@@ -13,7 +13,6 @@ import {
   cancelClone,
   getSubmodules,
   updateSubmodules,
-  type ProviderRepository,
 } from '../../services/git.service.ts';
 import { openCloneDestinationDialog } from '../../services/dialog.service.ts';
 import { showToast } from '../../services/notification.service.ts';
@@ -22,7 +21,9 @@ import { settingsStore } from '../../stores/settings.store.ts';
 import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import './lv-modal.ts';
 import './lv-account-repo-picker.ts';
+import type { RepositorySelectedDetail } from './lv-account-repo-picker.ts';
 import type { LvModal } from './lv-modal.ts';
+import type { IntegrationAccount } from '../../types/unified-profile.types.ts';
 
 /** Where the repository to clone comes from. */
 type CloneSource = 'url' | 'account';
@@ -238,6 +239,15 @@ export class LvCloneDialog extends LitElement {
   @state() private source: CloneSource = 'url';
   /** "owner/name" of the repository picked from an account, for confirmation. */
   @state() private selectedRepoLabel = '';
+  /**
+   * The account the URL was picked from. The clone authenticates as THIS
+   * account: resolving a token from the URL's host alone picks the host's
+   * default account, which is the wrong identity as soon as a second account
+   * for the same provider is connected, and a private clone under the wrong
+   * identity fails as "not found". Cleared whenever the URL is typed over,
+   * because the typed URL may belong to someone else entirely.
+   */
+  private selectedAccount: IntegrationAccount | null = null;
   @state() private url = '';
   @state() private destination = '';
   @state() private repoName = '';
@@ -335,6 +345,7 @@ export class LvCloneDialog extends LitElement {
   private reset(): void {
     this.source = 'url';
     this.selectedRepoLabel = '';
+    this.selectedAccount = null;
     this.url = '';
     this.destination = '';
     this.repoName = '';
@@ -362,8 +373,11 @@ export class LvCloneDialog extends LitElement {
     this.repoName = this.extractRepoName(this.url);
     this.error = '';
     // Typing over the URL means the picked repository is no longer what will
-    // be cloned, so its confirmation line must not keep claiming otherwise.
+    // be cloned, so its confirmation line must not keep claiming otherwise —
+    // and the picked account's token must not be sent to whatever host the
+    // typed URL names.
     this.selectedRepoLabel = '';
+    this.selectedAccount = null;
   }
 
   /** Switch between pasting a URL and picking from a connected account. */
@@ -378,9 +392,7 @@ export class LvCloneDialog extends LitElement {
    * destination exactly as typing them would, so the clone below (progress,
    * cancellation, token resolution) runs completely unchanged.
    */
-  private handleRepositorySelected(
-    e: CustomEvent<{ repository: ProviderRepository }>,
-  ): void {
+  private handleRepositorySelected(e: CustomEvent<RepositorySelectedDetail>): void {
     const repo = e.detail?.repository;
     if (!repo) return;
     this.url = repo.cloneUrl;
@@ -388,6 +400,7 @@ export class LvCloneDialog extends LitElement {
     // project's path segment and its display name can differ.
     this.repoName = this.extractRepoName(repo.cloneUrl) || repo.name;
     this.selectedRepoLabel = repo.fullName;
+    this.selectedAccount = e.detail.account ?? null;
     if (!this.destination) {
       this.destination = settingsStore.getState().defaultClonePath;
     }
@@ -560,12 +573,16 @@ export class LvCloneDialog extends LitElement {
           ...(this.filter ? { filter: this.filter } : {}),
           ...(this.singleBranch ? { singleBranch: true } : {}),
         },
-        // The footer already offers "Cancel Clone" while the service is still
-        // awaiting the network gate and the token lookup. A cancel pressed
-        // before the command is sent would otherwise be reset by the backend
-        // when the clone starts, and this dialog would wait on "Cancelling…"
-        // for a cancellation that never comes.
-        { isCancelled: () => this.isCancelling },
+        {
+          // The footer already offers "Cancel Clone" while the service is
+          // still awaiting the network gate and the token lookup. A cancel
+          // pressed before the command is sent would otherwise be reset by the
+          // backend when the clone starts, and this dialog would wait on
+          // "Cancelling…" for a cancellation that never comes.
+          isCancelled: () => this.isCancelling,
+          // Clone as the account the repository was picked from, when it was.
+          account: this.selectedAccount,
+        },
       );
 
       if (result.success && result.data) {

--- a/src/services/__tests__/credential.service.test.ts
+++ b/src/services/__tests__/credential.service.test.ts
@@ -10,6 +10,8 @@ import { expect } from '@open-wc/testing';
 const credentialStorage = new Map<string, string>();
 const invokeCallArgs: Array<{ command: string; args: Record<string, unknown> }> = [];
 let storeFailure = false;
+/** Set to make `get_keyring_token` fail with this message (a keychain error, not an absent key). */
+let getFailure: string | null = null;
 
 const mockInvoke = async (command: string, args?: unknown): Promise<unknown> => {
   const params = args as Record<string, unknown> | undefined;
@@ -24,6 +26,7 @@ const mockInvoke = async (command: string, args?: unknown): Promise<unknown> => 
   }
 
   if (command === 'get_keyring_token') {
+    if (getFailure) return Promise.reject({ code: 'OPERATION_FAILED', message: getFailure });
     const key = params?.key as string;
     return credentialStorage.get(key) ?? null;
   }
@@ -115,6 +118,26 @@ describe('credential.service - Keyring Operations via invokeCommand', () => {
 
       const result = await getCredential(CredentialKeys.GITHUB_TOKEN);
       expect(result).to.equal('stored-token');
+    });
+
+    it('throws with the keychain error when the read itself fails', async () => {
+      // A failed read used to come back as null, indistinguishable from "never
+      // stored" — so a locked or refusing keychain told the user to reconnect
+      // an account whose token was sitting right there.
+      getFailure = 'Keychain read failed for github_token (security exited with 36): User interaction is not allowed.';
+      try {
+        let thrown: unknown = null;
+        try {
+          await getCredential(CredentialKeys.GITHUB_TOKEN);
+        } catch (err) {
+          thrown = err;
+        }
+        expect(thrown, 'the failure is thrown, not swallowed').to.be.instanceOf(Error);
+        expect((thrown as Error).message).to.contain('User interaction is not allowed');
+        expect((thrown as Error).message).to.contain('github_token');
+      } finally {
+        getFailure = null;
+      }
     });
 
     it('should return null for missing credential', async () => {

--- a/src/services/__tests__/git.service.clone-token.test.ts
+++ b/src/services/__tests__/git.service.clone-token.test.ts
@@ -57,8 +57,10 @@ const mockInvoke: MockInvoke = async (command: string, args?: unknown) => {
   },
 };
 
+type TokenProvider = 'github' | 'gitlab' | 'azure-devops' | 'bitbucket';
+
 function account(
-  integrationType: 'github' | 'gitlab' | 'azure-devops',
+  integrationType: TokenProvider,
   id: string,
   instanceOrOrg?: string,
   isDefault = true,
@@ -73,7 +75,7 @@ function account(
 
 /** Seed a per-account keyring token, plus the OAuth bundle ADO refreshes from. */
 function seedAccountToken(
-  integrationType: 'github' | 'gitlab' | 'azure-devops',
+  integrationType: TokenProvider,
   accountId: string,
   token: string,
   withOAuthBundle = false,
@@ -91,8 +93,12 @@ function seedAccountToken(
   }
 }
 
-async function cloneAndReadArgs(url: string, extra: Record<string, unknown> = {}) {
-  const result = await cloneRepository({ url, path: '/dest/repo', ...extra });
+async function cloneAndReadArgs(
+  url: string,
+  extra: Record<string, unknown> = {},
+  options?: Parameters<typeof cloneRepository>[1],
+) {
+  const result = await cloneRepository({ url, path: '/dest/repo', ...extra }, options);
   expect(result.success, 'clone resolved').to.be.true;
   return (cloneArgs ?? {}) as { token?: string };
 }
@@ -292,6 +298,155 @@ describe('git.service - cloneRepository token lookup', () => {
 
     expect(result.success).to.be.true;
     expect(invokedCommands).to.include('clone_repository');
+  });
+
+  // ── The account the URL was picked from (clone dialog's account picker) ──
+
+  it("uses the picked account's token ahead of the host's default account", async () => {
+    // Two GitHub accounts: the host lookup lands on the default (work) one,
+    // which is the wrong identity for a repository picked from the personal
+    // account — a private clone under it fails as "not found".
+    const work = account('github', 'gh-work');
+    const personal = account('github', 'gh-personal', undefined, false);
+    unifiedProfileStore.getState().setAccounts([work, personal]);
+    seedAccountToken('github', 'gh-work', 'work-tok');
+    seedAccountToken('github', 'gh-personal', 'personal-tok');
+
+    const args = await cloneAndReadArgs('https://github.com/me/private.git', {}, {
+      account: personal,
+    });
+
+    expect(args.token).to.equal('personal-tok');
+  });
+
+  it('falls back to the host lookup when the picked account has no stored token', async () => {
+    const work = account('github', 'gh-work');
+    const personal = account('github', 'gh-personal', undefined, false);
+    unifiedProfileStore.getState().setAccounts([work, personal]);
+    seedAccountToken('github', 'gh-work', 'work-tok');
+
+    const args = await cloneAndReadArgs('https://github.com/me/private.git', {}, {
+      account: personal,
+    });
+
+    expect(args.token, 'another account for the host can still work').to.equal('work-tok');
+  });
+
+  it("refreshes the picked account's expiring OAuth token", async () => {
+    const gl = account('gitlab', 'gl-1', 'https://gitlab.com');
+    unifiedProfileStore.getState().setAccounts([gl]);
+    keyring.set('gitlab_token_gl-1', 'old-tok');
+    keyring.set(
+      'gitlab_token_gl-1_oauth',
+      JSON.stringify({ accessToken: 'old-tok', refreshToken: 'r', expiresAt: Date.now() - 1 }),
+    );
+    refreshedAccessToken = 'fresh-tok';
+
+    const args = await cloneAndReadArgs('https://gitlab.com/g/p.git', {}, { account: gl });
+
+    expect(args.token).to.equal('fresh-tok');
+  });
+
+  it("uses the picked self-hosted GitLab account's token", async () => {
+    const hosted = account('gitlab', 'gl-acme', 'https://git.acme.dev', false);
+    unifiedProfileStore.getState().setAccounts([
+      account('gitlab', 'gl-com', 'https://gitlab.com'),
+      hosted,
+    ]);
+    seedAccountToken('gitlab', 'gl-com', 'com-tok');
+    seedAccountToken('gitlab', 'gl-acme', 'acme-tok');
+
+    const args = await cloneAndReadArgs('https://git.acme.dev/g/p.git', {}, { account: hosted });
+
+    expect(args.token).to.equal('acme-tok');
+  });
+
+  it("uses the picked Azure DevOps account's token", async () => {
+    const ado = account('azure-devops', 'ado-1', 'contoso');
+    unifiedProfileStore.getState().setAccounts([ado]);
+    seedAccountToken('azure-devops', 'ado-1', 'ado-tok');
+
+    const args = await cloneAndReadArgs(
+      'https://dev.azure.com/contoso/proj/_git/repo',
+      {},
+      { account: ado },
+    );
+
+    expect(args.token).to.equal('ado-tok');
+  });
+
+  it("uses the picked Bitbucket account's credential", async () => {
+    // Bitbucket had no clone-token resolution at all, so a private repository
+    // picked from a Bitbucket account cloned unauthenticated and failed. The
+    // one token slot carries either an OAuth access token or the prefixed
+    // app-password credential; the backend tells them apart.
+    const bb = account('bitbucket', 'bb-1', 'team');
+    unifiedProfileStore.getState().setAccounts([bb]);
+    seedAccountToken('bitbucket', 'bb-1', 'bbapp:alice:app-pass');
+
+    const args = await cloneAndReadArgs('https://alice@bitbucket.org/team/repo.git', {}, {
+      account: bb,
+    });
+
+    expect(args.token).to.equal('bbapp:alice:app-pass');
+  });
+
+  it('does not attach the picked account token to a plaintext clone URL', async () => {
+    const personal = account('github', 'gh-personal');
+    unifiedProfileStore.getState().setAccounts([personal]);
+    seedAccountToken('github', 'gh-personal', 'personal-tok');
+
+    const args = await cloneAndReadArgs('http://github.com/me/private.git', {}, {
+      account: personal,
+    });
+
+    expect(args.token, 'a token must not go over http in clear').to.equal(undefined);
+  });
+
+  it('ignores the picked account when the caller supplied a token', async () => {
+    const personal = account('github', 'gh-personal');
+    unifiedProfileStore.getState().setAccounts([personal]);
+    seedAccountToken('github', 'gh-personal', 'personal-tok');
+
+    const args = await cloneAndReadArgs(
+      'https://github.com/me/private.git',
+      { token: 'explicit' },
+      { account: personal },
+    );
+
+    expect(args.token).to.equal('explicit');
+    expect(invokedCommands).to.not.include('get_keyring_token');
+  });
+
+  // ── Bitbucket by host ────────────────────────────────────────────────────
+
+  it("attaches the default Bitbucket account's credential for a bitbucket.org clone", async () => {
+    unifiedProfileStore.getState().setAccounts([account('bitbucket', 'bb-1', 'team')]);
+    seedAccountToken('bitbucket', 'bb-1', 'bb-oauth-tok');
+
+    const args = await cloneAndReadArgs('https://bitbucket.org/team/repo.git');
+
+    expect(args.token).to.equal('bb-oauth-tok');
+  });
+
+  it('falls back to the legacy Bitbucket username and app password', async () => {
+    keyring.set('bitbucket_username', 'alice');
+    keyring.set('bitbucket_password', 'app-pass');
+
+    const args = await cloneAndReadArgs('https://bitbucket.org/team/repo.git');
+
+    expect(args.token, 'carried in the prefixed form the backend splits').to.equal(
+      'bbapp:alice:app-pass',
+    );
+  });
+
+  it('attaches no Bitbucket credential to a look-alike host', async () => {
+    unifiedProfileStore.getState().setAccounts([account('bitbucket', 'bb-1', 'team')]);
+    seedAccountToken('bitbucket', 'bb-1', 'bb-oauth-tok');
+
+    const args = await cloneAndReadArgs('https://bitbucket.org.evil.test/team/repo.git');
+
+    expect(args.token).to.equal(undefined);
   });
 
   it('clones without a token when the credential lookup fails', async () => {

--- a/src/services/__tests__/remote.service.test.ts
+++ b/src/services/__tests__/remote.service.test.ts
@@ -862,6 +862,32 @@ describe('git.service - Remote operations', () => {
       expect(args.tokens, "the default account's token must not stand in").to.deep.equal({});
     });
 
+    it('still prunes, unauthenticated, when the keyring cannot be read', async () => {
+      // A keyring read failure now throws instead of reading as "no token".
+      // The branch-cleanup dialog calls this while holding the repository's
+      // ref-op lock and reads the outcome off the result, so a throw here left
+      // that lock held for the life of the app. The lookup failure is logged
+      // and the prune goes ahead without a token, as fetch and clone do.
+      const gh = account('github', 'gh-1');
+      unifiedProfileStore.getState().setAccounts([gh]);
+      preferredAccount = gh;
+      mockRepo([{ name: 'origin', url: 'https://github.com/acme/repo.git' }]);
+      const readable = mockInvoke;
+      mockInvoke = async (command, args) => {
+        if (command === 'get_keyring_token') {
+          throw { code: 'OPERATION_FAILED', message: 'Keychain read failed: locked' };
+        }
+        return readable(command, args);
+      };
+
+      await pruneRemoteTrackingBranches('/test/repo');
+
+      expect(lastInvokedCommand).to.equal('prune_remote_tracking_branches');
+      const args = lastInvokedArgs as { remotes: string[]; tokens: Record<string, string> };
+      expect(args.remotes).to.deep.equal(['origin']);
+      expect(args.tokens).to.deep.equal({});
+    });
+
     it("ignores a preferred Azure DevOps account from a DIFFERENT organization", async () => {
       // Every ADO account is scoped to one organization, and a
       // `{org}.visualstudio.com` host is per organization — so the resolver's

--- a/src/services/credential.service.ts
+++ b/src/services/credential.service.ts
@@ -190,7 +190,10 @@ export const AzureDevOpsCredentials = {
 // Multi-Account Credential Support
 // =============================================================================
 
-import type { IntegrationType } from '../types/integration-accounts.types.ts';
+import type {
+  IntegrationAccount,
+  IntegrationType,
+} from '../types/integration-accounts.types.ts';
 import type { OAuthProvider } from '../types/oauth.types.ts';
 import type { GitHubConnectionStatus } from './git.service.ts';
 
@@ -511,6 +514,37 @@ export async function getFreshAccountToken(
 
 /** In-flight OAuth refreshes keyed by `${integrationType}:${accountId}` (single-flight). */
 const inFlightTokenRefreshes = new Map<string, Promise<string | null>>();
+
+/**
+ * `getFreshAccountToken` for an account object: picks the OAuth provider and
+ * the GitLab instance URL the refresh needs from the account itself, so every
+ * caller that holds an `IntegrationAccount` (the clone dialog's account picker,
+ * the clone that follows it) resolves the credential the same way and none of
+ * them can pair an account with the wrong provider by hand.
+ *
+ * Returns null for an account type that has no git-hosting token (OIDC).
+ */
+export async function getFreshTokenForAccount(
+  account: IntegrationAccount
+): Promise<string | null> {
+  switch (account.integrationType) {
+    case 'github':
+      return getFreshAccountToken('github', account.id, 'github');
+    case 'gitlab':
+      return getFreshAccountToken(
+        'gitlab',
+        account.id,
+        'gitlab',
+        account.config.type === 'gitlab' ? account.config.instanceUrl : undefined
+      );
+    case 'bitbucket':
+      return getFreshAccountToken('bitbucket', account.id, 'bitbucket');
+    case 'azure-devops':
+      return getFreshAccountToken('azure-devops', account.id, 'azure');
+    default:
+      return null;
+  }
+}
 
 // ========================================================================
 // GitHub App Installation

--- a/src/services/credential.service.ts
+++ b/src/services/credential.service.ts
@@ -58,9 +58,24 @@ async function keyringStore(key: string, value: string): Promise<void> {
   log.debug(`Stored credential: ${key}`);
 }
 
+/**
+ * Read `key` from the keyring: null when the entry is absent, an Error when
+ * the keyring could not be read.
+ *
+ * A failed command used to come back as null too, so a locked or refusing
+ * keychain was indistinguishable from "never connected": every reader told
+ * the user the account had no stored credential and to reconnect it, which
+ * cannot fix a keychain that refuses reads — and a freshly re-added account
+ * failed the very same way. The failure is thrown with the backend's own
+ * message (it names the key, the exit status and the keychain's error), the
+ * same way `keyringStore` already reports a failed write.
+ */
 async function keyringGet(key: string): Promise<string | null> {
   const result = await invokeCommand<string | null>('get_keyring_token', { key });
-  if (result.success && result.data) {
+  if (!result.success) {
+    throw new Error(result.error?.message ?? `Failed to read credential: ${key}`);
+  }
+  if (result.data) {
     log.debug(`Retrieved credential: ${key}`);
     return result.data;
   }

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -8917,47 +8917,56 @@ export async function pruneRemoteTrackingBranches(
         target,
         remoteUrl,
       );
-      if (account) {
-        const { AccountCredentials, getFreshAccountToken } = await import(
-          './credential.service.ts'
-        );
-        if (integrationType === 'azure-devops') {
-          // Every ADO account is scoped to exactly one organization, and a
-          // `{org}.visualstudio.com` host varies per organization just as a
-          // GitLab instance host varies per account — so the same hazard as
-          // the gitlab arm below applies. The resolver's last tier is the
-          // GLOBAL default, reported as a match like any other; trusting it
-          // would scope one org's PAT to another org's host and still fail to
-          // authenticate there. Only the account for THIS organization may
-          // answer; otherwise leave the token unset and let `getCloneToken`
-          // below pick by organization.
-          const accountOrg =
-            account.config.type === 'azure-devops' ? account.config.organization : undefined;
-          if (accountOrg && adoOrg && accountOrg.toLowerCase() === adoOrg.toLowerCase()) {
-            token =
-              await getFreshAccountToken('azure-devops', account.id, 'azure') ?? undefined;
+      // A keyring that cannot be read must not fail the prune: the same
+      // posture as `getCloneToken` and `resolveRepoToken`, which proceed
+      // unauthenticated and log. This loop's callers read the outcome off the
+      // result and one of them holds the repository's ref-op lock across the
+      // call, so a throw here left that lock held for the life of the app.
+      try {
+        if (account) {
+          const { AccountCredentials, getFreshAccountToken } = await import(
+            './credential.service.ts'
+          );
+          if (integrationType === 'azure-devops') {
+            // Every ADO account is scoped to exactly one organization, and a
+            // `{org}.visualstudio.com` host varies per organization just as a
+            // GitLab instance host varies per account — so the same hazard as
+            // the gitlab arm below applies. The resolver's last tier is the
+            // GLOBAL default, reported as a match like any other; trusting it
+            // would scope one org's PAT to another org's host and still fail to
+            // authenticate there. Only the account for THIS organization may
+            // answer; otherwise leave the token unset and let `getCloneToken`
+            // below pick by organization.
+            const accountOrg =
+              account.config.type === 'azure-devops' ? account.config.organization : undefined;
+            if (accountOrg && adoOrg && accountOrg.toLowerCase() === adoOrg.toLowerCase()) {
+              token =
+                await getFreshAccountToken('azure-devops', account.id, 'azure') ?? undefined;
+            } else {
+              wrongInstance = true;
+            }
+          } else if (integrationType === 'gitlab') {
+            // GitLab is the one provider whose host varies per account, and the
+            // resolver's last tier is the GLOBAL default — reported as a match
+            // like any other. Trusting it here would hand, say, a gitlab.com PAT
+            // to an unrelated self-hosted server that has never seen it, and the
+            // prune would still fail to authenticate there. Only the account that
+            // serves THIS host may answer; otherwise leave the token unset and
+            // let `getCloneToken` below pick by host.
+            const instanceUrl =
+              account.config.type === 'gitlab' ? account.config.instanceUrl : undefined;
+            if (instanceUrl && cloneUrlHost(instanceUrl) === host) {
+              token =
+                await getFreshAccountToken('gitlab', account.id, 'gitlab', instanceUrl) ?? undefined;
+            } else {
+              wrongInstance = true;
+            }
           } else {
-            wrongInstance = true;
+            token = await AccountCredentials.getToken('github', account.id) ?? undefined;
           }
-        } else if (integrationType === 'gitlab') {
-          // GitLab is the one provider whose host varies per account, and the
-          // resolver's last tier is the GLOBAL default — reported as a match
-          // like any other. Trusting it here would hand, say, a gitlab.com PAT
-          // to an unrelated self-hosted server that has never seen it, and the
-          // prune would still fail to authenticate there. Only the account that
-          // serves THIS host may answer; otherwise leave the token unset and
-          // let `getCloneToken` below pick by host.
-          const instanceUrl =
-            account.config.type === 'gitlab' ? account.config.instanceUrl : undefined;
-          if (instanceUrl && cloneUrlHost(instanceUrl) === host) {
-            token =
-              await getFreshAccountToken('gitlab', account.id, 'gitlab', instanceUrl) ?? undefined;
-          } else {
-            wrongInstance = true;
-          }
-        } else {
-          token = await AccountCredentials.getToken('github', account.id) ?? undefined;
         }
+      } catch (err) {
+        console.error(`Failed to read the stored token for remote '${target}':`, err);
       }
       if (!token && (!repoSpecific || wrongInstance)) {
         token = await getCloneToken(remoteUrl);

--- a/src/services/git.service.ts
+++ b/src/services/git.service.ts
@@ -875,17 +875,36 @@ async function findGitLabAccountForHost(host: string) {
  * clone dialog has no token field to work around it with).
  *
  * There is no repository on disk yet, so the remote-based detection
- * `getRepoToken` relies on cannot run here; the URL's host is all we have.
+ * `getRepoToken` relies on cannot run here; the URL's host is all we have —
+ * unless the caller names the `account` the URL came from. The clone dialog's
+ * account picker does: the repository was listed under a specific account, so
+ * that account's token is used ahead of any host lookup. The host lookup
+ * lands on the host's DEFAULT account, which is the wrong identity the moment
+ * a second account for the same provider is connected, and a private clone
+ * under the wrong identity fails as "not found".
  *
- * Bitbucket is absent for the same reason it is absent from `getRepoToken`: no
- * git network operation resolves Bitbucket credentials, and an app password is
- * a username/password pair the single-token clone command cannot carry.
+ * Bitbucket resolves here even though `getRepoToken` still cannot: the backend
+ * clone splits a `bbapp:<user>:<app password>` credential back into the
+ * username/password pair Bitbucket wants and sends an OAuth access token as
+ * `x-token-auth`, so the one token slot carries either kind.
  */
-async function getCloneToken(url: string): Promise<string | undefined> {
+async function getCloneToken(
+  url: string,
+  account?: IntegrationAccount | null,
+): Promise<string | undefined> {
   const host = cloneUrlHost(url);
   if (!host || !cloneUrlIsCredentialSafe(url)) return undefined;
 
   try {
+    if (account) {
+      const { getFreshTokenForAccount } = await import("./credential.service.ts");
+      const token = await getFreshTokenForAccount(account);
+      if (token) return token;
+      // The picked account has no stored credential (or was disconnected in
+      // the meantime): fall through to the host lookup rather than clone
+      // unauthenticated when another account for the host could still work.
+    }
+
     if (host === "github.com" || host.endsWith(".github.com")) {
       const result = await getGitHubToken();
       return result.success && result.data ? result.data : undefined;
@@ -937,6 +956,26 @@ async function getCloneToken(url: string): Promise<string | undefined> {
       const token = await GitLabCredentials.getToken();
       if (token) return token;
     }
+
+    if (host === "bitbucket.org" || host.endsWith(".bitbucket.org")) {
+      const { selectDefaultGlobalAccount } = await import("../stores/unified-profile.store.ts");
+      const {
+        getFreshTokenForAccount,
+        BitbucketCredentials,
+        formatBitbucketAppPasswordCredential,
+      } = await import("./credential.service.ts");
+      const bitbucketAccount = selectDefaultGlobalAccount("bitbucket");
+      if (bitbucketAccount) {
+        const token = await getFreshTokenForAccount(bitbucketAccount);
+        if (token) return token;
+      }
+      // Legacy single-credential storage: a username/app-password pair, carried
+      // in the same prefixed form the per-account slot uses.
+      const legacy = await BitbucketCredentials.getCredentials();
+      if (legacy) {
+        return formatBitbucketAppPasswordCredential(legacy.username, legacy.password);
+      }
+    }
   } catch (err) {
     // Same posture as getRepoToken: a credential lookup failure must not stop
     // the clone — it just proceeds unauthenticated, as it does today.
@@ -963,6 +1002,13 @@ export interface CloneRepositoryOptions {
    * from ever starting.
    */
   isCancelled?: () => boolean;
+  /**
+   * The connected account the clone URL was picked from (the clone dialog's
+   * account picker). Its token is attached ahead of the host-based lookup, so
+   * the clone runs as the identity the repository was listed under rather
+   * than as the host's default account. Ignored when `args.token` is set.
+   */
+  account?: IntegrationAccount | null;
 }
 
 /** The result every cancellable operation returns for the user's own Cancel. */
@@ -983,10 +1029,10 @@ export async function cloneRepository(
     return blockedResult();
   }
 
-  // No token supplied: fall back to the one stored for the account that owns
-  // this URL's host.
+  // No token supplied: use the account the URL was picked from, else fall
+  // back to the one stored for the account that owns this URL's host.
   if (args && !args.token) {
-    const token = await getCloneToken(args.url);
+    const token = await getCloneToken(args.url, options?.account);
     if (token) {
       args.token = token;
     }


### PR DESCRIPTION
## Summary

This PR fixes critical issues with credential resolution in multi-account scenarios and improves error reporting for keychain failures. The main problems addressed:

1. **Multi-account clone failure**: When multiple accounts exist for the same provider (e.g., two GitHub accounts), cloning a repository picked from a non-default account would fail because the clone used the default account's token instead of the account the repository was listed under.

2. **Keychain read errors masked as missing credentials**: All keychain read failures (locked keychain, permission denied, etc.) were reported as "no stored credential," sending users to reconnect accounts whose tokens were actually present. This created an unrecoverable loop.

3. **Bitbucket app-password handling**: Bitbucket app passwords (username/password pairs) were not properly split when used for cloning, and Bitbucket OAuth tokens required a specific username (`x-token-auth`) that was not being set.

4. **Write verification gap**: A successful `security` exit code did not guarantee the token was actually stored—it could have been stored empty—leaving accounts in a broken state where sign-in reported success but reads always failed.

## Key Changes

### Backend (Rust)

- **Keychain write verification** (`src-tauri/src/commands/credentials.rs`):
  - Added `verify_keychain_write()` to read back stored tokens before reporting success
  - Added `interpret_keychain_read()` to distinguish "item not found" (exit code 44) from other failures
  - Updated `read_keyring_token()` to throw on keychain read failures instead of treating them as absent
  - Added comprehensive unit tests for keychain read/write scenarios

- **Bitbucket credential handling** (`src-tauri/src/services/credentials_service.rs`):
  - Added `token_credential_for()` to split Bitbucket app passwords (`bbapp:user:pass`) back into username/password pairs
  - Bitbucket OAuth tokens now authenticate as `x-token-auth` (required by Bitbucket)
  - Updated clone command builder to pass both username and password via environment variables

- **Clone command building** (`src-tauri/src/commands/repository.rs`):
  - Changed from hardcoded `username=git` to dynamic username from `token_credential_for()`
  - Both username and password now come from environment variables (never argv) for security

### Frontend (TypeScript)

- **Clone token resolution** (`src/services/git.service.ts`):
  - `getCloneToken()` now accepts an optional `account` parameter (the account the URL was picked from)
  - When an account is provided, its token is used ahead of the host-based default lookup
  - Falls back to host lookup if the picked account has no stored token
  - Added Bitbucket support with app-password formatting

- **Clone dialog** (`src/components/dialogs/lv-clone-dialog.ts`):
  - Tracks the account the repository was picked from
  - Clears the picked account when the URL is manually edited (since a typed URL may belong to anyone)
  - Passes the picked account to `cloneRepository()` via new `CloneRepositoryOptions.account` field

- **Account repo picker** (`src/components/dialogs/lv-account-repo-picker.ts`):
  - `repository-selected` event now includes the account the repository was listed under
  - Dispatches account with every repository selection

- **Account selector** (`src/components/dialogs/lv-account-selector.ts`):
  - Re-reads accounts when `integrationType` changes (fixes stale account list after provider switch)
  - Closes dropdown when integration type changes

- **Credential service** (`src/services/credential.service.ts`):
  - `keyringGet()` now throws on read failures instead of returning null
  - Callers must distinguish between "absent" (null) and "read failed" (thrown error)
  - Added `getFreshTokenForAccount()` for per-account token resolution with OAuth refresh

- **Error handling across dialogs**:
  - Account repo picker shows keychain read errors with "Retry" button instead of "No credential"
  - Azure DevOps dialog catches

https://claude.ai/code/session_01VyhwdyJZrSGgCHAuTJc4HR